### PR TITLE
Added several sceGxm implementations.

### DIFF
--- a/src/emulator/gxm/include/gxm/state.h
+++ b/src/emulator/gxm/include/gxm/state.h
@@ -16,4 +16,5 @@ namespace emu {
 
 struct GxmState {
     emu::SceGxmInitializeParams params;
+    bool isInScene = false;
 };

--- a/src/emulator/modules/SceGxm/src/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/src/SceGxm.cpp
@@ -313,6 +313,21 @@ EXPORT(int, sceGxmBeginScene, SceGxmContext *context, unsigned int flags, const 
     
     glBindFramebuffer(GL_FRAMEBUFFER, renderTarget->framebuffer[0]);
 
+    // Re-load GL machine settings for multiple contexts support
+    switch (context->cull_mode){
+    case SCE_GXM_CULL_CCW:
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_FRONT);
+        break;
+    case SCE_GXM_CULL_CW:
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_BACK);
+        break;
+    case SCE_GXM_CULL_NONE:
+        glDisable(GL_CULL_FACE);
+        break;
+    }
+    
     // TODO This is just for debugging.
     glClear(GL_COLOR_BUFFER_BIT);
 

--- a/src/emulator/modules/SceGxm/src/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/src/SceGxm.cpp
@@ -297,6 +297,13 @@ EXPORT(int, sceGxmBeginScene, SceGxmContext *context, unsigned int flags, const 
     assert(colorSurface != nullptr);
     assert(depthStencil != nullptr);
 
+    if (context->isInScene){
+        return SCE_GXM_ERROR_WITHIN_SCENE;
+    }
+    if (depthStencil == nullptr && colorSurface == nullptr){
+        return SCE_GXM_ERROR_INVALID_VALUE;
+    }
+    
     // TODO This may not be right.
     context->fragment_ring_buffer_used = 0;
     context->vertex_ring_buffer_used = 0;
@@ -590,6 +597,10 @@ EXPORT(int, sceGxmDraw, SceGxmContext *context, SceGxmPrimitiveType primType, Sc
     assert(indexData != nullptr);
     assert(indexCount > 0);
 
+    if (!context->isInScene){
+        return SCE_GXM_ERROR_NOT_WITHIN_SCENE;
+    }
+    
     GLenum mode = translate_primitive(primType);
     const GLenum type = indexType == SCE_GXM_INDEX_FORMAT_U16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT;
     glDrawElements(mode, indexCount, type, indexData);
@@ -615,6 +626,10 @@ EXPORT(int, sceGxmEndScene, SceGxmContext *context, const emu::SceGxmNotificatio
     assert(vertexNotification == nullptr);
     assert(fragmentNotification == nullptr);
 
+    if (!context->isInScene){
+        return SCE_GXM_ERROR_NOT_WITHIN_SCENE;
+    }
+    
     const GLsizei width = context->color_surface.pbeEmitWords[0];
     const GLsizei height = context->color_surface.pbeEmitWords[1];
     const GLsizei stride_in_pixels = context->color_surface.pbeEmitWords[2];

--- a/src/emulator/modules/SceGxm/src/gxm.h
+++ b/src/emulator/modules/SceGxm/src/gxm.h
@@ -65,7 +65,6 @@ struct SceGxmContext {
     emu::SceGxmColorSurface color_surface;
     const SceGxmVertexProgram *vertex_program = nullptr;
     GLObjectArray<1> texture;
-    bool isInScene = false;
     SceGxmCullMode cull_mode = SCE_GXM_CULL_NONE;
 };
 

--- a/src/emulator/modules/SceGxm/src/gxm.h
+++ b/src/emulator/modules/SceGxm/src/gxm.h
@@ -65,6 +65,8 @@ struct SceGxmContext {
     emu::SceGxmColorSurface color_surface;
     const SceGxmVertexProgram *vertex_program = nullptr;
     GLObjectArray<1> texture;
+    bool isInScene = false;
+    SceGxmCullMode cull_mode = SCE_GXM_CULL_NONE;
 };
 
 namespace emu {


### PR DESCRIPTION
This commit adds:

- sceGxmSetCullMode implementation
- sceGxmTextureSetData implementation.
- sceGxmTextureSetWidth implementation.
- sceGxmTextureSetHeight implementation.
- Support for multitexturing (TEXUNIT1 and biggers support for fragment shaders)
- Support for almost all SceGxm primitives (except SCE_GXM_PRIMITIVE_TRIANGLE_EDGES)