### PR TITLE
Fix UNIX Build

### DIFF
--- a/src/emulator/vpk.cpp
+++ b/src/emulator/vpk.cpp
@@ -23,6 +23,7 @@
 #include <util/string_convert.h>
 
 #include <cassert>
+#include <cstring>
 #include <vector>
 
 typedef std::vector<uint8_t> Buffer;


### PR DESCRIPTION
Restore cstring is needed for memset reference.
