### PR TITLE
[mem] Fix VirtualProtect call

### DIFF
--- a/src/emulator/mem/src/mem.cpp
+++ b/src/emulator/mem/src/mem.cpp
@@ -16,12 +16,12 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <mem/mem.h>
+#include <util/log.h>
 
 #include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <cmath>
-#include "util/log.h"
 
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
The last argument being `nullptr` was causing the function to fail.