### PR TITLE
Add short type aliases and port existing code

### DIFF
--- a/src/emulator/audio/include/audio/state.h
+++ b/src/emulator/audio/include/audio/state.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include <psp2/types.h>
+#include <util/types.h>
 
 #include <SDL_audio.h>
 
@@ -32,13 +33,13 @@ typedef std::shared_ptr<SDL_AudioStream> AudioStreamPtr;
 typedef std::function<void(SceUID)> ResumeAudioThread;
 
 struct AudioOutput {
-    const uint8_t *buf = nullptr;
-    int len_bytes = 0;
+    const u8 *buf = nullptr;
+    s32 len_bytes = 0;
     SceUID thread = -1;
 };
 
 struct ReadOnlyAudioOutPortState {
-    int len_bytes = 0;
+    s32 len_bytes = 0;
 };
 
 struct AudioCallbackOutPortState {
@@ -57,7 +58,7 @@ struct AudioOutPort {
 };
 
 typedef std::shared_ptr<AudioOutPort> AudioOutPortPtr;
-typedef std::map<int, AudioOutPortPtr> AudioOutPortPtrs;
+typedef std::map<s32, AudioOutPortPtr> AudioOutPortPtrs;
 typedef std::shared_ptr<void> AudioDevicePtr;
 
 struct ReadOnlyAudioState {
@@ -66,12 +67,12 @@ struct ReadOnlyAudioState {
 };
 
 struct AudioCallbackState {
-    std::vector<uint8_t> temp_buffer;
+    std::vector<u8> temp_buffer;
 };
 
 struct SharedAudioState {
     std::mutex mutex;
-    int next_port_id = 0;
+    s32 next_port_id = 0;
     AudioOutPortPtrs out_ports;
 };
 

--- a/src/emulator/audio/src/audio.cpp
+++ b/src/emulator/audio/src/audio.cpp
@@ -19,14 +19,15 @@
 
 #include <audio/state.h>
 #include <util/log.h>
+#include <util/types.h>
 
 #include <cassert>
 #include <cstring>
 
-static const int stream_put_granularity = 512;
+static const s32 stream_put_granularity = 512;
 
-static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOutPort &port, const ResumeAudioThread &resume_thread) {
-    int available_to_get = SDL_AudioStreamAvailable(port.callback.stream.get());
+static void mix_out_port(u8 *stream, u8 *temp_buffer, s32 len, AudioOutPort &port, const ResumeAudioThread &resume_thread) {
+    s32 available_to_get = SDL_AudioStreamAvailable(port.callback.stream.get());
     assert(available_to_get >= 0);
 
     while (available_to_get < len) {
@@ -37,8 +38,8 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
             break;
         } else {
             AudioOutput &output = port.shared.outputs.front();
-            const int bytes_to_put = std::min(stream_put_granularity, output.len_bytes);
-            const int ret = SDL_AudioStreamPut(port.callback.stream.get(), output.buf, bytes_to_put);
+            const s32 bytes_to_put = std::min(stream_put_granularity, output.len_bytes);
+            const s32 ret = SDL_AudioStreamPut(port.callback.stream.get(), output.buf, bytes_to_put);
             assert(ret == 0);
             output.buf += bytes_to_put;
             output.len_bytes -= bytes_to_put;
@@ -52,14 +53,14 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
         assert(available_to_get >= 0);
     }
 
-    const int bytes_to_get = std::min(len, available_to_get);
-    const int get_result = SDL_AudioStreamGet(port.callback.stream.get(), temp_buffer, bytes_to_get);
+    const s32 bytes_to_get = std::min(len, available_to_get);
+    const s32 get_result = SDL_AudioStreamGet(port.callback.stream.get(), temp_buffer, bytes_to_get);
     if (get_result > 0) {
         SDL_MixAudio(stream, temp_buffer, bytes_to_get, SDL_MIX_MAXVOLUME);
     }
 }
 
-static void SDLCALL audio_callback(void *userdata, Uint8 *stream, int len) {
+static void SDLCALL audio_callback(void *userdata, Uint8 *stream, s32 len) {
     assert(userdata != nullptr);
     assert(stream != nullptr);
     AudioState &state = *static_cast<AudioState *>(userdata);

--- a/src/emulator/cpu/include/cpu/functions.h
+++ b/src/emulator/cpu/include/cpu/functions.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <mem/mem.h> // Address.
+#include <util/types.h>
 
 #include <cstdint>
 #include <functional>
@@ -25,13 +26,13 @@
 struct CPUState;
 struct MemState;
 
-typedef std::function<void(uint32_t, Address)> CallSVC;
+typedef std::function<void(u32, Address)> CallSVC;
 typedef std::unique_ptr<CPUState, std::function<void(CPUState *)>> CPUStatePtr;
 
 CPUStatePtr init_cpu(Address pc, Address sp, bool log_code, CallSVC call_svc, MemState &mem);
 bool run(CPUState &state);
 void stop(CPUState &state);
-uint32_t read_reg(CPUState &state, size_t index);
-uint32_t read_sp(CPUState &state);
-void write_reg(CPUState &state, size_t index, uint32_t value);
-void write_pc(CPUState &state, uint32_t value);
+u32 read_reg(CPUState &state, size_t index);
+u32 read_sp(CPUState &state);
+void write_reg(CPUState &state, size_t index, u32 value);
+void write_pc(CPUState &state, u32 value);

--- a/src/emulator/disasm/CMakeLists.txt
+++ b/src/emulator/disasm/CMakeLists.txt
@@ -9,3 +9,4 @@ add_library(
 target_include_directories(disasm PUBLIC include)
 target_include_directories(disasm PRIVATE ${capstone_INCLUDE_DIRS})
 target_link_libraries(disasm PRIVATE capstone-static)
+target_link_libraries(disasm PUBLIC util)

--- a/src/emulator/disasm/include/disasm/functions.h
+++ b/src/emulator/disasm/include/disasm/functions.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
+#include <util/types.h>
+
 #include <string>
 
 struct DisasmState;
 
 bool init(DisasmState &state);
-std::string disassemble(DisasmState &state, const uint8_t *code, size_t size, uint64_t address, bool thumb);
+std::string disassemble(DisasmState &state, const u8 *code, size_t size, u64 address, bool thumb);

--- a/src/emulator/disasm/src/disasm.cpp
+++ b/src/emulator/disasm/src/disasm.cpp
@@ -18,6 +18,7 @@
 #include <disasm/functions.h>
 
 #include <disasm/state.h>
+#include <util/types.h>
 
 #include <capstone.h>
 
@@ -46,7 +47,7 @@ bool init(DisasmState &state) {
     return true;
 }
 
-std::string disassemble(DisasmState &state, const uint8_t *code, size_t size, uint64_t address, bool thumb) {
+std::string disassemble(DisasmState &state, const u8 *code, size_t size, u64 address, bool thumb) {
     const cs_err err = cs_option(state.csh, CS_OPT_MODE, thumb ? CS_MODE_THUMB : CS_MODE_ARM);
     assert(err == CS_ERR_OK);
 

--- a/src/emulator/gxm/include/gxm/state.h
+++ b/src/emulator/gxm/include/gxm/state.h
@@ -6,11 +6,11 @@ namespace emu {
     typedef void SceGxmDisplayQueueCallback(Ptr<const void> callbackData);
 
     struct SceGxmInitializeParams {
-        uint32_t flags = 0;
-        uint32_t displayQueueMaxPendingCount = 0;
+        u32 flags = 0;
+        u32 displayQueueMaxPendingCount = 0;
         Ptr<SceGxmDisplayQueueCallback> displayQueueCallback;
-        uint32_t displayQueueCallbackDataSize = 0;
-        uint32_t parameterBufferSize = 0;
+        u32 displayQueueCallbackDataSize = 0;
+        u32 parameterBufferSize = 0;
     };
 }
 

--- a/src/emulator/host/include/host/functions.h
+++ b/src/emulator/host/include/host/functions.h
@@ -18,9 +18,10 @@
 #pragma once
 
 #include <psp2/types.h>
+#include <util/types.h>
 
 struct HostState;
 
 bool init(HostState &state);
 bool handle_events(HostState &host);
-void call_import(HostState &host, uint32_t nid, SceUID thread_id);
+void call_import(HostState &host, u32 nid, SceUID thread_id);

--- a/src/emulator/host/include/host/rtc.h
+++ b/src/emulator/host/include/host/rtc.h
@@ -18,18 +18,19 @@
 #pragma once
 
 #include <host/state.h>
+#include <util/types.h>
 
 #include <chrono>
 #include <cstdint>
 
 #define VITA_CLOCKS_PER_SEC 1000000
-using VitaClocks = std::chrono::duration<std::uint64_t, std::ratio<1, VITA_CLOCKS_PER_SEC>>;
+using VitaClocks = std::chrono::duration<u64, std::ratio<1, VITA_CLOCKS_PER_SEC>>;
 
 // Grabbed from JPSCP
 // This is the # of microseconds between January 1, 0001 and January 1, 1970.
 const auto rtcMagicOffset = 62135596800000000ULL;
 
-inline std::uint64_t rtc_base_ticks()
+inline u64 rtc_base_ticks()
 {
     const auto now = std::chrono::system_clock::now();
     const auto now_timepoint = std::chrono::time_point_cast<VitaClocks>(now);
@@ -41,13 +42,13 @@ inline std::uint64_t rtc_base_ticks()
     return rtcMagicOffset + clocks_since_unix_time - host_clock_offset;
 }
 
-inline std::uint64_t rtc_get_ticks(const HostState& host)
+inline u64 rtc_get_ticks(const HostState& host)
 {
-    const uint64_t base_ticks = host.kernel.base_tick.tick;
+    const u64 base_ticks = host.kernel.base_tick.tick;
 
     const auto now = std::chrono::high_resolution_clock::now();
     const auto now_timepoint = std::chrono::time_point_cast<VitaClocks>(now);
-    const uint64_t now_ticks = now_timepoint.time_since_epoch().count();
+    const u64 now_ticks = now_timepoint.time_since_epoch().count();
 
     return base_ticks + now_ticks;
 }

--- a/src/emulator/host/include/host/state.h
+++ b/src/emulator/host/include/host/state.h
@@ -23,6 +23,7 @@
 #include <io/state.h>
 #include <kernel/state.h>
 #include <net/state.h>
+#include <util/types.h>
 
 struct SDL_Window;
 
@@ -32,7 +33,7 @@ struct HostState {
     std::string base_path;
     std::string pref_path;
     size_t frame_count = 0;
-    uint32_t t1 = 0;
+    u32 t1 = 0;
     WindowPtr window;
     MemState mem;
     CtrlState ctrl;

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -29,6 +29,7 @@
 #include <nids/functions.h>
 #include <util/lock_and_find.h>
 #include <util/log.h>
+#include <util/types.h>
 
 #include <SDL_events.h>
 #include <SDL_filesystem.h>
@@ -44,7 +45,7 @@ static const bool LOG_IMPORT_CALLS = false;
 #include <nids/nids.h>
 #undef NID
 
-static ImportFn *resolve_import(uint32_t nid) {
+static ImportFn *resolve_import(u32 nid) {
     switch (nid) {
 #define NID(name, nid) \
     case nid:          \
@@ -92,7 +93,7 @@ bool handle_events(HostState &host) {
     return true;
 }
 
-void call_import(HostState &host, uint32_t nid, SceUID thread_id) {
+void call_import(HostState &host, u32 nid, SceUID thread_id) {
     if (LOG_IMPORT_CALLS) {
         const char *const name = import_name(nid);
 		LOG_TRACE("NID {:#08x} ({})) called", nid, name);

--- a/src/emulator/io/include/io/functions.h
+++ b/src/emulator/io/include/io/functions.h
@@ -18,23 +18,24 @@
 #pragma once
 
 #include <psp2/types.h>
+#include <util/types.h>
 
 struct IOState;
 struct SceIoStat;
 struct SceIoDirent;
 
 bool init(IOState &io, const char *pref_path);
-SceUID open_file(IOState &io, const char *path, int flags, const char *pref_path);
-int read_file(void *data, IOState &io, SceUID fd, SceSize size);
-int write_file(SceUID fd, const void *data, SceSize size, const IOState &io);
-int seek_file(SceUID fd, int offset, int whence, const IOState &io);
+SceUID open_file(IOState &io, const char *path, s32 flags, const char *pref_path);
+s32 read_file(void *data, IOState &io, SceUID fd, SceSize size);
+s32 write_file(SceUID fd, const void *data, SceSize size, const IOState &io);
+s32 seek_file(SceUID fd, s32 offset, s32 whence, const IOState &io);
 void close_file(IOState &io, SceUID fd);
-int create_dir(const char *dir, int mode, const char *pref_path);
-int remove_file(const char *file, const char *pref_path);
-int create_dir(const char *dir, int mode, const char *pref_path);
-int remove_dir(const char *dir, const char *pref_path);
-int stat_file(const char* file, SceIoStat* stat, const char *pref_path);
+s32 create_dir(const char *dir, s32 mode, const char *pref_path);
+s32 remove_file(const char *file, const char *pref_path);
+s32 create_dir(const char *dir, s32 mode, const char *pref_path);
+s32 remove_dir(const char *dir, const char *pref_path);
+s32 stat_file(const char* file, SceIoStat* stat, const char *pref_path);
 
-int open_dir(IOState &io, const char *path, const char *pref_path);
-int read_dir(IOState &io, SceUID fd, SceIoDirent *dent);
-int close_dir(IOState &io, SceUID fd);
+s32 open_dir(IOState &io, const char *path, const char *pref_path);
+s32 read_dir(IOState &io, SceUID fd, SceIoDirent *dent);
+s32 close_dir(IOState &io, SceUID fd);

--- a/src/emulator/kernel/include/kernel/functions.h
+++ b/src/emulator/kernel/include/kernel/functions.h
@@ -18,11 +18,12 @@
 #pragma once
 
 #include <psp2/types.h>
+#include <util/types.h>
 
 template <class T>
 class Ptr;
 struct KernelState;
 struct MemState;
 
-Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID thread_id, int key);
+Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID thread_id, s32 key);
 void stop_all_threads(KernelState &kernel);

--- a/src/emulator/kernel/include/kernel/state.h
+++ b/src/emulator/kernel/include/kernel/state.h
@@ -21,6 +21,7 @@
 
 #include <psp2/types.h>
 #include <psp2/rtc.h>
+#include <util/types.h>
 
 #include <map>
 #include <mutex>
@@ -42,7 +43,7 @@ typedef std::shared_ptr<SDL_Thread> ThreadPtr;
 typedef std::map<SceUID, ThreadPtr> ThreadPtrs;
 
 namespace emu {
-    typedef Ptr<int(SceSize args, Ptr<void> argp)> SceKernelThreadEntry;
+    typedef Ptr<s32(SceSize args, Ptr<void> argp)> SceKernelThreadEntry;
 }
 
 struct WaitingThreadState {

--- a/src/emulator/kernel/include/kernel/thread_functions.h
+++ b/src/emulator/kernel/include/kernel/thread_functions.h
@@ -25,7 +25,7 @@
 struct CPUState;
 struct ThreadState;
 
-typedef std::function<void(uint32_t)> CallImport;
+typedef std::function<void(u32)> CallImport;
 typedef std::shared_ptr<ThreadState> ThreadStatePtr;
 
 ThreadStatePtr init_thread(Ptr<const void> entry_point, size_t stack_size, bool log_code, MemState &mem, CallImport call_import);

--- a/src/emulator/kernel/src/kernel.cpp
+++ b/src/emulator/kernel/src/kernel.cpp
@@ -24,7 +24,7 @@
 #include <mem/mem.h>
 #include <mem/ptr.h>
 
-Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID thread_id, int key) {
+Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID thread_id, s32 key) {
     SlotToAddress &slot_to_address = kernel.tls[thread_id];
 
     const SlotToAddress::const_iterator existing = slot_to_address.find(key);

--- a/src/emulator/kernel/src/thread.cpp
+++ b/src/emulator/kernel/src/thread.cpp
@@ -21,6 +21,7 @@
 
 #include <cpu/functions.h>
 #include <util/resource.h>
+#include <util/types.h>
 
 #include <cassert>
 #include <cstring>
@@ -35,9 +36,9 @@ ThreadStatePtr init_thread(Ptr<const void> entry_point, size_t stack_size, bool 
     const Address stack_top = thread->stack->get() + stack_size;
     memset(Ptr<void>(thread->stack->get()).get(mem), 0xcc, stack_size);
 
-    const CallSVC call_svc = [call_import, &mem](uint32_t imm, Address pc) {
+    const CallSVC call_svc = [call_import, &mem](u32 imm, Address pc) {
         assert(imm == 0);
-        const uint32_t nid = *Ptr<uint32_t>(pc + 4).get(mem);
+        const u32 nid = *Ptr<u32>(pc + 4).get(mem);
         call_import(nid);
     };
 

--- a/src/emulator/load_self.cpp
+++ b/src/emulator/load_self.cpp
@@ -21,6 +21,7 @@
 
 #include <nids/functions.h>
 #include <util/log.h>
+#include <util/types.h>
 
 #include <elfio/elf_types.hpp>
 #define SCE_ELF_DEFS_TARGET
@@ -39,17 +40,17 @@ using namespace ELFIO;
 
 static const bool LOG_IMPORTS = false;
 
-static bool load_func_imports(const uint32_t *nids, const Ptr<uint32_t> *entries, size_t count, const MemState &mem) {
+static bool load_func_imports(const u32 *nids, const Ptr<u32> *entries, size_t count, const MemState &mem) {
     for (size_t i = 0; i < count; ++i) {
-        const uint32_t nid = nids[i];
-        const Ptr<uint32_t> entry = entries[i];
+        const u32 nid = nids[i];
+        const Ptr<u32> entry = entries[i];
 
         if (LOG_IMPORTS) {
             const char *const name = import_name(nid);
 			LOG_DEBUG( "\tNID {:#08x} ({}) at {:#x}", nid, name, entry.address());
         }
 
-        uint32_t *const stub = entry.get(mem);
+        u32 *const stub = entry.get(mem);
         stub[0] = 0xef000000; // svc #0 - Call our interrupt hook.
         stub[1] = 0xe1a0f00e; // mov pc, lr - Return to the caller.
         stub[2] = nid; // Our interrupt hook will read this.
@@ -59,11 +60,11 @@ static bool load_func_imports(const uint32_t *nids, const Ptr<uint32_t> *entries
 }
 
 static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segment_address, const MemState &mem) {
-    const uint8_t *const base = segment_address.cast<const uint8_t>().get(mem);
+    const u8 *const base = segment_address.cast<const u8>().get(mem);
     const sce_module_imports_raw *const imports_begin = reinterpret_cast<const sce_module_imports_raw *>(base + module.import_top);
     const sce_module_imports_raw *const imports_end = reinterpret_cast<const sce_module_imports_raw *>(base + module.import_end);
 
-    for (const sce_module_imports_raw *imports = imports_begin; imports < imports_end; imports = reinterpret_cast<const sce_module_imports_raw *>(reinterpret_cast<const uint8_t *>(imports) + imports->size)) {
+    for (const sce_module_imports_raw *imports = imports_begin; imports < imports_end; imports = reinterpret_cast<const sce_module_imports_raw *>(reinterpret_cast<const u8 *>(imports) + imports->size)) {
         if (LOG_IMPORTS) {
             const char *const lib_name = Ptr<const char>(imports->module_name).get(mem);
             LOG_INFO("Loading imports from {}", lib_name);
@@ -73,8 +74,8 @@ static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segm
         assert(imports->num_syms_vars == 0);
         assert(imports->num_syms_unk == 0);
 
-        const uint32_t *const nids = Ptr<const uint32_t>(imports->func_nid_table).get(mem);
-        const Ptr<uint32_t> *const entries = Ptr<Ptr<uint32_t>>(imports->func_entry_table).get(mem);
+        const u32 *const nids = Ptr<const u32>(imports->func_nid_table).get(mem);
+        const Ptr<u32> *const entries = Ptr<Ptr<u32>>(imports->func_entry_table).get(mem);
         if (!load_func_imports(nids, entries, imports->num_syms_funcs, mem)) {
             return false;
         }
@@ -84,7 +85,7 @@ static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segm
 }
 
 bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
-    const uint8_t *const self_bytes = static_cast<const uint8_t *>(self);
+    const u8 *const self_bytes = static_cast<const u8 *>(self);
     const SCE_header &self_header = *static_cast<const SCE_header *>(self);
 
     // assumes little endian host
@@ -95,10 +96,10 @@ bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
         return false;
     }
 
-    const uint8_t *const elf_bytes = self_bytes + self_header.elf_offset;
+    const u8 *const elf_bytes = self_bytes + self_header.elf_offset;
     const Elf32_Ehdr &elf = *reinterpret_cast<const Elf32_Ehdr *>(elf_bytes);
-    const unsigned int module_info_segment_index = static_cast<unsigned int>(elf.e_entry >> 30);
-    const uint32_t module_info_offset = elf.e_entry & 0x3fffffff;
+    const u32 module_info_segment_index = static_cast<u32>(elf.e_entry >> 30);
+    const u32 module_info_offset = elf.e_entry & 0x3fffffff;
     const Elf32_Phdr *const segments = reinterpret_cast<const Elf32_Phdr *>(self_bytes + self_header.phdr_offset);
     const Elf32_Phdr &module_info_segment = segments[module_info_segment_index];
 
@@ -107,7 +108,7 @@ bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
     SegmentAddresses segment_addrs;
     for (Elf_Half segment_index = 0; segment_index < elf.e_phnum; ++segment_index) {
         const Elf32_Phdr &src = segments[segment_index];
-        const uint8_t *const segment_bytes = self_bytes + self_header.header_len + src.p_offset;
+        const u8 *const segment_bytes = self_bytes + self_header.header_len + src.p_offset;
 
         assert(segment_infos[segment_index].encryption==2);
         if (src.p_type == PT_LOAD) {
@@ -118,10 +119,10 @@ bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
             }
 
             if(segment_infos[segment_index].compression==2) {
-                unsigned long dest_bytes = src.p_filesz;
-                const uint8_t *const compressed_segment_bytes = self_bytes + segment_infos[segment_index].offset;
+                ulong dest_bytes = src.p_filesz;
+                const u8 *const compressed_segment_bytes = self_bytes + segment_infos[segment_index].offset;
 
-                int res = mz_uncompress(reinterpret_cast<uint8_t *>(address.get(mem)), &dest_bytes, compressed_segment_bytes, segment_infos[segment_index].length);
+                s32 res = mz_uncompress(reinterpret_cast<u8 *>(address.get(mem)), &dest_bytes, compressed_segment_bytes, segment_infos[segment_index].length);
                 assert(res == MZ_OK);
             } else {
                 memcpy(address.get(mem), segment_bytes, src.p_filesz);
@@ -130,11 +131,11 @@ bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
             segment_addrs[segment_index] = address;
         } else if (src.p_type == PT_LOOS) {
             if(segment_infos[segment_index].compression==2) {
-                unsigned long dest_bytes = src.p_filesz;
-                const uint8_t *const compressed_segment_bytes = self_bytes + segment_infos[segment_index].offset;
-                std::unique_ptr<uint8_t> uncompressed(new uint8_t[dest_bytes]);
+                ulong dest_bytes = src.p_filesz;
+                const u8 *const compressed_segment_bytes = self_bytes + segment_infos[segment_index].offset;
+                std::unique_ptr<u8> uncompressed(new u8[dest_bytes]);
 
-                int res = mz_uncompress(uncompressed.get(), &dest_bytes, compressed_segment_bytes, segment_infos[segment_index].length);
+                s32 res = mz_uncompress(uncompressed.get(), &dest_bytes, compressed_segment_bytes, segment_infos[segment_index].length);
                 assert(res == MZ_OK);
                 if (!relocate(uncompressed.get(), src.p_filesz, segment_addrs, mem)) {
                     return false;
@@ -147,8 +148,8 @@ bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
         }
     }
 
-    const Ptr<const uint8_t> module_info_segment_address = segment_addrs[module_info_segment_index].cast<const uint8_t>();
-    const uint8_t *const module_info_segment_bytes = module_info_segment_address.get(mem);
+    const Ptr<const u8> module_info_segment_address = segment_addrs[module_info_segment_index].cast<const u8>();
+    const u8 *const module_info_segment_bytes = module_info_segment_address.get(mem);
     const sce_module_info_raw *const module_info = reinterpret_cast<const sce_module_info_raw *>(module_info_segment_bytes + module_info_offset);
 
     entry_point = module_info_segment_address + module_info->module_start;

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -23,6 +23,7 @@
 #include <kernel/thread_functions.h>
 #include <util/string_convert.h>
 #include <util/log.h>
+#include <util/types.h>
 
 #include <SDL.h>
 
@@ -58,7 +59,7 @@ static void term_sdl(const void *succeeded) {
     SDL_Quit();
 }
 
-int main(int argc, char *argv[]) {
+s32 main(s32 argc, char *argv[]) {
 	init_logging();
 
 	LOG_INFO("{}", window_title);
@@ -113,7 +114,7 @@ int main(int argc, char *argv[]) {
     // TODO This is hacky. Belongs in kernel?
     const SceUID main_thread_id = host.kernel.next_uid++;
 
-    const CallImport call_import = [&host, main_thread_id](uint32_t nid) {
+    const CallImport call_import = [&host, main_thread_id](u32 nid) {
         ::call_import(host, nid, main_thread_id);
     };
 

--- a/src/emulator/mem/include/mem/mem.h
+++ b/src/emulator/mem/include/mem/mem.h
@@ -17,15 +17,17 @@
 
 #pragma once
 
+#include <util/types.h>
+
 #include <functional>
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-typedef uint32_t Address;
+typedef u32 Address;
 typedef size_t Generation;
-typedef std::unique_ptr<uint8_t[], std::function<void(uint8_t *)>> Memory;
+typedef std::unique_ptr<u8[], std::function<void(u8 *)>> Memory;
 typedef std::vector<Generation> Allocated;
 typedef std::map<Generation, std::string> GenerationNames;
 

--- a/src/emulator/mem/include/mem/ptr.h
+++ b/src/emulator/mem/include/mem/ptr.h
@@ -68,7 +68,7 @@ private:
 static_assert(sizeof(Ptr<const void>) == 4, "Size of Ptr isn't 4 bytes.");
 
 template <class T>
-Ptr<T> operator+(const Ptr<T> &base, int32_t offset) {
+Ptr<T> operator+(const Ptr<T> &base, s32 offset) {
     return Ptr<T>(base.address() + (offset * sizeof(T)));
 }
 

--- a/src/emulator/mem/src/mem.cpp
+++ b/src/emulator/mem/src/mem.cpp
@@ -31,7 +31,7 @@
 #include <unistd.h>
 #endif
 
-static void delete_memory(uint8_t *memory) {
+static void delete_memory(u8 *memory) {
     if (memory != nullptr) {
 #ifdef WIN32
         const BOOL ret = VirtualFree(memory, 0, MEM_RELEASE);
@@ -43,7 +43,7 @@ static void delete_memory(uint8_t *memory) {
 }
 
 static void alloc_inner(MemState &state, Address address, size_t page_count, Allocated::iterator block, const char *name) {
-    uint8_t *const memory = &state.memory[address];
+    u8 *const memory = &state.memory[address];
     const size_t aligned_size = page_count * state.page_size;
 
     const Generation generation = ++state.generation;
@@ -71,15 +71,15 @@ bool init(MemState &state) {
 
     const size_t length = GB(4);
 #ifdef WIN32
-    state.memory = Memory(static_cast<uint8_t *>(VirtualAlloc(nullptr, length, MEM_RESERVE, PAGE_NOACCESS)), delete_memory);
+    state.memory = Memory(static_cast<u8 *>(VirtualAlloc(nullptr, length, MEM_RESERVE, PAGE_NOACCESS)), delete_memory);
 #else
     // http://man7.org/linux/man-pages/man2/mmap.2.html
     void *const addr = nullptr;
-    const int prot = PROT_NONE;
-    const int flags = MAP_PRIVATE | MAP_ANONYMOUS;
-    const int fd = 0;
+    const s32 prot = PROT_NONE;
+    const s32 flags = MAP_PRIVATE | MAP_ANONYMOUS;
+    const s32 fd = 0;
     const off_t offset = 0;
-    state.memory = Memory(static_cast<uint8_t *>(mmap(addr, length, prot, flags, fd, offset)), delete_memory);
+    state.memory = Memory(static_cast<u8 *>(mmap(addr, length, prot, flags, fd, offset)), delete_memory);
 #endif
     if (!state.memory) {
         LOG_CRITICAL("VirtualAlloc failed");

--- a/src/emulator/module/include/module/bridge_args.h
+++ b/src/emulator/module/include/module/bridge_args.h
@@ -40,7 +40,7 @@ struct StackLayout {
 // Simple case - argument can be cast from integer.
 template <typename T>
 struct RegArg {
-    static T bridge(const MemState &, uint32_t value) {
+    static T bridge(const MemState &, u32 value) {
         return static_cast<T>(value);
     }
 };
@@ -48,7 +48,7 @@ struct RegArg {
 // Emulated pointer constructed from address in register.
 template <typename Pointee>
 struct RegArg<Ptr<Pointee>> {
-    static Ptr<Pointee> bridge(const MemState &, uint32_t value) {
+    static Ptr<Pointee> bridge(const MemState &, u32 value) {
         return Ptr<Pointee>(value);
     }
 };
@@ -56,7 +56,7 @@ struct RegArg<Ptr<Pointee>> {
 // Real pointer bridged from address in register.
 template <typename Pointee>
 struct RegArg<Pointee *> {
-    static Pointee *bridge(const MemState &mem, uint32_t value) {
+    static Pointee *bridge(const MemState &mem, u32 value) {
         const Ptr<Pointee> ptr(value);
         return ptr.get(mem);
     }
@@ -91,7 +91,7 @@ template <typename... Args>
 struct ArgLayout {
     template <typename T, size_t index>
     static T read(CPUState &cpu, const MemState &mem) {
-        const uint32_t value = read_reg(cpu, index);
+        const u32 value = read_reg(cpu, index);
         return RegArg<T>::bridge(mem, value);
     }
 };
@@ -103,7 +103,7 @@ struct ArgLayout<R0, R1, R2, R3, StackHead, StackTail...> {
 
     template <typename T, size_t index>
         static typename std::enable_if < index<4, T>::type read(CPUState &cpu, const MemState &mem) {
-        const uint32_t value = read_reg(cpu, index);
+        const u32 value = read_reg(cpu, index);
         return RegArg<T>::bridge(mem, value);
     }
 

--- a/src/emulator/module/include/module/module.h
+++ b/src/emulator/module/include/module/module.h
@@ -23,11 +23,12 @@
 
 #include <host/import_fn.h>
 #include <host/state.h>
+#include <util/types.h>
 
 #include <cassert>
 
-int unimplemented(const char *name);
-int error(const char *name, int error);
+s32 unimplemented(const char *name);
+s32 error(const char *name, s32 error);
 
 #define BRIDGE_DECL(name) extern ImportFn *const import_##name;
 #define BRIDGE_IMPL(name) ImportFn *const import_##name = &Bridge<decltype(&export_##name), &export_##name>::call;

--- a/src/emulator/module/src/bridge_return.cpp
+++ b/src/emulator/module/src/bridge_return.cpp
@@ -20,22 +20,22 @@
 #include <cpu/functions.h>
 
 template <>
-void bridge_return<uint16_t>(CPUState &cpu, uint16_t ret) {
+void bridge_return<u16>(CPUState &cpu, u16 ret) {
     write_reg(cpu, 0, ret);
 }
 
 template <>
-void bridge_return<int32_t>(CPUState &cpu, int32_t ret) {
+void bridge_return<s32>(CPUState &cpu, s32 ret) {
     write_reg(cpu, 0, ret);
 }
 
 template <>
-void bridge_return<uint32_t>(CPUState &cpu, uint32_t ret) {
+void bridge_return<u32>(CPUState &cpu, u32 ret) {
     write_reg(cpu, 0, ret);
 }
 
 template <>
-void bridge_return<uint64_t>(CPUState &cpu, uint64_t ret) {
+void bridge_return<u64>(CPUState &cpu, u64 ret) {
     write_reg(cpu, 0, ret & UINT32_MAX);
     write_reg(cpu, 1, ret >> 32);
 }

--- a/src/emulator/module/src/module.cpp
+++ b/src/emulator/module/src/module.cpp
@@ -17,6 +17,7 @@
 
 #include <module/module.h>
 #include <util/log.h>
+#include <util/types.h>
 
 #include <iostream>
 #include <mutex>
@@ -27,7 +28,7 @@ typedef std::set<std::string> NameSet;
 static std::mutex mutex;
 static NameSet logged;
 
-int unimplemented(const char *name) {
+s32 unimplemented(const char *name) {
     bool inserted = false;
     {
         const std::lock_guard<std::mutex> lock(mutex);
@@ -41,7 +42,7 @@ int unimplemented(const char *name) {
     return 0;
 }
 
-int error(const char *name, int error) {
+s32 error(const char *name, s32 error) {
     bool inserted = false;
 
     {

--- a/src/emulator/modules/SceAudio/SceAudio.cpp
+++ b/src/emulator/modules/SceAudio/SceAudio.cpp
@@ -47,18 +47,18 @@ EXPORT(int, sceAudioOutOpenPort, SceAudioOutPortType type, int len, int freq, Sc
         return error("sceAudioOutOpenPort", SCE_AUDIO_OUT_ERROR_INVALID_SIZE);   
     }
     
-    const int channels = (mode == SCE_AUDIO_OUT_MODE_MONO) ? 1 : 2;
+    const s32 channels = (mode == SCE_AUDIO_OUT_MODE_MONO) ? 1 : 2;
     const AudioStreamPtr stream(SDL_NewAudioStream(AUDIO_S16LSB, channels, freq, host.audio.ro.spec.format, host.audio.ro.spec.channels, host.audio.ro.spec.freq), SDL_FreeAudioStream);
     if (!stream) {
         return error("sceAudioOutOpenPort", SCE_AUDIO_OUT_ERROR_NOT_OPENED);
     }
 
     const AudioOutPortPtr port = std::make_shared<AudioOutPort>();
-    port->ro.len_bytes = len * channels * sizeof(int16_t);
+    port->ro.len_bytes = len * channels * sizeof(s16);
     port->callback.stream = stream;
 
     const std::unique_lock<std::mutex> lock(host.audio.shared.mutex);
-    const int port_id = host.audio.shared.next_port_id++;
+    const s32 port_id = host.audio.shared.next_port_id++;
     host.audio.shared.out_ports.emplace(port_id, port);
 
     return port_id;
@@ -81,7 +81,7 @@ EXPORT(int, sceAudioOutOutput, int port, const void *buf) {
     stop(*thread->cpu);
 
     AudioOutput output;
-    output.buf = static_cast<const uint8_t *>(buf);
+    output.buf = static_cast<const u8 *>(buf);
     output.len_bytes = prt->ro.len_bytes;
     output.thread = thread_id;
 

--- a/src/emulator/modules/SceDisplay/SceDisplayUser.cpp
+++ b/src/emulator/modules/SceDisplay/SceDisplayUser.cpp
@@ -29,12 +29,12 @@ static bool SAVE_SURFACE_IMAGES = false;
 
 namespace emu {
     struct SceDisplayFrameBuf {
-        uint32_t size = 0;
+        u32 size = 0;
         Ptr<const void> base;
-        uint32_t pitch = 0;
-        uint32_t pixelformat = SCE_DISPLAY_PIXELFORMAT_A8B8G8R8;
-        uint32_t width = 0;
-        uint32_t height = 0;
+        u32 pitch = 0;
+        u32 pixelformat = SCE_DISPLAY_PIXELFORMAT_A8B8G8R8;
+        u32 width = 0;
+        u32 height = 0;
     };
 }
 
@@ -98,11 +98,11 @@ EXPORT(int, sceDisplaySetFrameBuf, const emu::SceDisplayFrameBuf *pParam, SceDis
     SDL_GL_MakeCurrent(prev_gl_window, prev_gl_context);
 
     ++host.frame_count;
-    const uint32_t t2 = SDL_GetTicks();
-    const uint32_t ms = t2 - host.t1;
+    const u32 t2 = SDL_GetTicks();
+    const u32 ms = t2 - host.t1;
     if (ms >= 1000) {
-        const uint32_t fps = (host.frame_count * 1000) / ms;
-        const uint32_t ms_per_frame = ms / host.frame_count;
+        const u32 fps = (host.frame_count * 1000) / ms;
+        const u32 ms_per_frame = ms / host.frame_count;
         std::ostringstream title;
         title << window_title << " - " << ms_per_frame << " ms/frame (" << fps << " frames/sec)";
         SDL_SetWindowTitle(host.window.get(), title.str().c_str());

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -33,14 +33,14 @@ using namespace glbinding;
 #define GXM_PROFILE(name) MICROPROFILE_SCOPEI("GXM", name, MP_BLUE)
 
 // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1a_hash
-static uint64_t fnv1a(const void *data, size_t size) {
+static u64 fnv1a(const void *data, size_t size) {
     GXM_PROFILE(__FUNCTION__);
 
-    const uint8_t *const begin = static_cast<const uint8_t *>(data);
-    const uint8_t *const end = begin + size;
-    uint64_t result = 0xcbf29ce484222325;
+    const u8 *const begin = static_cast<const u8 *>(data);
+    const u8 *const end = begin + size;
+    u64 result = 0xcbf29ce484222325;
 
-    for (const uint8_t *p = begin; p != end; ++p) {
+    for (const u8 *p = begin; p != end; ++p) {
         result ^= *p;
         result *= 0x100000001b3;
     }
@@ -94,7 +94,7 @@ static bool compile_shader(GLuint shader, const GLchar *source) {
 static bool compile_shader(GLuint shader, const SceGxmProgram *program, const char *base_path) {
     GXM_PROFILE(__FUNCTION__);
 
-    const uint64_t hash = fnv1a(program, program->size);
+    const u64 hash = fnv1a(program, program->size);
     std::ostringstream path;
     path << base_path << "shaders/" << hash << ".glsl";
 
@@ -158,11 +158,11 @@ static bool attribute_format_normalised(SceGxmAttributeFormat format) {
 static void bind_attribute_locations(GLuint gl_program, const SceGxmProgram *program) {
     GXM_PROFILE(__FUNCTION__);
 
-    const SceGxmProgramParameter *const parameters = reinterpret_cast<const SceGxmProgramParameter *>(reinterpret_cast<const uint8_t *>(&program->parameters_offset) + program->parameters_offset);
-    for (uint32_t i = 0; i < program->parameter_count; ++i) {
+    const SceGxmProgramParameter *const parameters = reinterpret_cast<const SceGxmProgramParameter *>(reinterpret_cast<const u8 *>(&program->parameters_offset) + program->parameters_offset);
+    for (u32 i = 0; i < program->parameter_count; ++i) {
         const SceGxmProgramParameter *const parameter = &parameters[i];
         if (parameter->category == SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE) {
-            const uint8_t *const parameter_bytes = reinterpret_cast<const uint8_t *>(parameter);
+            const u8 *const parameter_bytes = reinterpret_cast<const u8 *>(parameter);
             const char *const parameter_name = reinterpret_cast<const char *>(parameter_bytes + parameter->name_offset);
 
             glBindAttribLocation(gl_program, parameter->resource_index, parameter_name);
@@ -170,11 +170,11 @@ static void bind_attribute_locations(GLuint gl_program, const SceGxmProgram *pro
     }
 }
 
-static void flip_vertically(uint32_t *pixels, size_t width, size_t height, size_t stride_in_pixels) {
+static void flip_vertically(u32 *pixels, size_t width, size_t height, size_t stride_in_pixels) {
     GXM_PROFILE(__FUNCTION__);
 
-    uint32_t *row1 = &pixels[0];
-    uint32_t *row2 = &pixels[(height - 1) * stride_in_pixels];
+    u32 *row1 = &pixels[0];
+    u32 *row2 = &pixels[(height - 1) * stride_in_pixels];
 
     while (row1 < row2) {
         std::swap_ranges(&row1[0], &row1[width], &row2[0]);

--- a/src/emulator/modules/SceGxm/gxm.h
+++ b/src/emulator/modules/SceGxm/gxm.h
@@ -3,6 +3,7 @@
 #include <glutil/object.h>
 #include <glutil/object_array.h>
 #include <mem/ptr.h>
+#include <util/types.h>
 
 #include <psp2/gxm.h>
 
@@ -22,10 +23,10 @@ namespace emu {
     static_assert(sizeof(SceGxmBlendInfo) == 4, "Incorrect size.");
 
     struct SceGxmTexture {
-        //uint32_t controlWords[4];
+        //u32 controlWords[4];
         SceGxmTextureFormat format;
-        uint16_t width;
-        uint16_t height;
+        u16 width;
+        u16 height;
         Ptr<const void> data;
         Ptr<void> palette;
     };
@@ -33,24 +34,24 @@ namespace emu {
     static_assert(sizeof(SceGxmTexture) == 16, "Incorrect size.");
 
     struct SceGxmColorSurface {
-        uint32_t pbeSidebandWord;
-        uint32_t pbeEmitWords[6];
-        uint32_t outputRegisterSize;
+        u32 pbeSidebandWord;
+        u32 pbeEmitWords[6];
+        u32 outputRegisterSize;
         SceGxmTexture backgroundTex;
     };
 
     struct SceGxmContextParams {
         Ptr<void> hostMem;
-        uint32_t hostMemSize;
+        u32 hostMemSize;
         Ptr<void> vdmRingBufferMem;
-        uint32_t vdmRingBufferMemSize;
+        u32 vdmRingBufferMemSize;
         Ptr<void> vertexRingBufferMem;
-        uint32_t vertexRingBufferMemSize;
+        u32 vertexRingBufferMemSize;
         Ptr<void> fragmentRingBufferMem;
-        uint32_t fragmentRingBufferMemSize;
+        u32 fragmentRingBufferMemSize;
         Ptr<void> fragmentUsseRingBufferMem;
-        uint32_t fragmentUsseRingBufferMemSize;
-        uint32_t fragmentUsseRingBufferOffset;
+        u32 fragmentUsseRingBufferMemSize;
+        u32 fragmentUsseRingBufferOffset;
     };
 }
 
@@ -70,11 +71,11 @@ struct SceGxmContext {
 
 namespace emu {
     struct SceGxmDepthStencilSurface {
-        uint32_t zlsControl;
+        u32 zlsControl;
         Ptr<void> depthData;
         Ptr<void> stencilData;
         float backgroundDepth;
-        uint32_t backgroundControl;
+        u32 backgroundControl;
     };
 }
 
@@ -96,8 +97,8 @@ struct SceGxmFragmentProgram {
 
 namespace emu {
     struct SceGxmNotification {
-        Ptr<volatile uint32_t> address;
-        uint32_t value;
+        Ptr<volatile u32> address;
+        u32 value;
     };
 }
 
@@ -105,24 +106,24 @@ struct SceGxmProgram {
     char magic[4];
     char maybe_version[2];
     char maybe_padding[2];
-    uint32_t size;
-    uint8_t unknown1[8];
-    uint16_t maybe_type;
-    uint16_t unknown2[7];
-    uint32_t parameter_count;
-    uint32_t parameters_offset; // Number of bytes from the start of this field to the first parameter.
+    u32 size;
+    u8 unknown1[8];
+    u16 maybe_type;
+    u16 unknown2[7];
+    u32 parameter_count;
+    u32 parameters_offset; // Number of bytes from the start of this field to the first parameter.
 };
 
 struct SceGxmProgramParameter {
-    int32_t name_offset; // Number of bytes from the start of this structure to the name string.
-    uint8_t category; // SceGxmParameterCategory.
-    uint8_t container_index : 4;
-    uint8_t component_count : 4;
-    uint8_t unknown1[2];
-    uint8_t array_size;
-    uint8_t unknown2[3];
-    uint8_t resource_index;
-    uint8_t unknown3[3];
+    s32 name_offset; // Number of bytes from the start of this structure to the name string.
+    u8 category; // SceGxmParameterCategory.
+    u8 container_index : 4;
+    u8 component_count : 4;
+    u8 unknown1[2];
+    u8 array_size;
+    u8 unknown2[3];
+    u8 resource_index;
+    u8 unknown3[3];
 };
 
 static_assert(sizeof(SceGxmProgramParameter) == 16, "Incorrect structure layout.");
@@ -148,11 +149,11 @@ struct SceGxmShaderPatcher {
 namespace emu {
     typedef Ptr<SceGxmRegisteredProgram> SceGxmShaderPatcherId;
 
-    typedef Ptr<void> SceGxmShaderPatcherHostAllocCallback(Ptr<void> userData, uint32_t size);
+    typedef Ptr<void> SceGxmShaderPatcherHostAllocCallback(Ptr<void> userData, u32 size);
     typedef void SceGxmShaderPatcherHostFreeCallback(Ptr<void> userData, Ptr<void> mem);
-    typedef Ptr<void> SceGxmShaderPatcherBufferAllocCallback(Ptr<void> userData, uint32_t size);
+    typedef Ptr<void> SceGxmShaderPatcherBufferAllocCallback(Ptr<void> userData, u32 size);
     typedef void SceGxmShaderPatcherBufferFreeCallback(Ptr<void> userData, Ptr<void> mem);
-    typedef Ptr<void> SceGxmShaderPatcherUsseAllocCallback(Ptr<void> userData, uint32_t size, Ptr<uint32_t> usseOffset);
+    typedef Ptr<void> SceGxmShaderPatcherUsseAllocCallback(Ptr<void> userData, u32 size, Ptr<u32> usseOffset);
     typedef void SceGxmShaderPatcherUsseFreeCallback(Ptr<void> userData, Ptr<void> mem);
 
     struct SceGxmShaderPatcherParams {
@@ -162,17 +163,17 @@ namespace emu {
         Ptr<SceGxmShaderPatcherBufferAllocCallback> bufferAllocCallback;
         Ptr<SceGxmShaderPatcherBufferFreeCallback> bufferFreeCallback;
         Ptr<void> bufferMem;
-        uint32_t bufferMemSize;
+        u32 bufferMemSize;
         Ptr<SceGxmShaderPatcherUsseAllocCallback> vertexUsseAllocCallback;
         Ptr<SceGxmShaderPatcherUsseFreeCallback> vertexUsseFreeCallback;
         Ptr<void> vertexUsseMem;
-        uint32_t vertexUsseMemSize;
-        uint32_t vertexUsseOffset;
+        u32 vertexUsseMemSize;
+        u32 vertexUsseOffset;
         Ptr<SceGxmShaderPatcherUsseAllocCallback> fragmentUsseAllocCallback;
         Ptr<SceGxmShaderPatcherUsseFreeCallback> fragmentUsseFreeCallback;
         Ptr<void> fragmentUsseMem;
-        uint32_t fragmentUsseMemSize;
-        uint32_t fragmentUsseOffset;
+        u32 fragmentUsseMemSize;
+        u32 fragmentUsseOffset;
     };
 }
 
@@ -181,11 +182,11 @@ struct SceGxmSyncObject {
 
 namespace emu {
     struct SceGxmVertexAttribute {
-        uint16_t streamIndex;
-        uint16_t offset;
-        uint8_t format; // SceGxmAttributeFormat.
-        uint8_t componentCount;
-        uint16_t regIndex; // Returned from sceGxmProgramParameterGetResourceIndex().
+        u16 streamIndex;
+        u16 offset;
+        u8 format; // SceGxmAttributeFormat.
+        u8 componentCount;
+        u16 regIndex; // Returned from sceGxmProgramParameterGetResourceIndex().
     };
 
     static_assert(sizeof(SceGxmVertexAttribute) == 8, "Structure has been incorrectly packed.");

--- a/src/emulator/net/CMakeLists.txt
+++ b/src/emulator/net/CMakeLists.txt
@@ -7,7 +7,7 @@ src/net.cpp
 )
 
 target_include_directories(net PUBLIC include)
-target_link_libraries(net PUBLIC sdl2 vita-headers)
+target_link_libraries(net PUBLIC sdl2 vita-headers util)
 if (WIN32)
     target_link_libraries(net PRIVATE winsock)
 endif()

--- a/src/emulator/net/include/net/functions.h
+++ b/src/emulator/net/include/net/functions.h
@@ -17,17 +17,19 @@
 
 #pragma once
 
+#include <util/types.h>
+
 struct NetState;
 struct SceNetSockaddr;
 
 bool init(NetState &state);
-int open_socket(NetState &net, int domain, int type, int protocol);
-int close_socket(NetState &net, int id);
-int bind_socket(NetState &net,int s, const SceNetSockaddr *name, unsigned int addrlen);
-int send_packet(NetState &net, int s, const void *msg, unsigned int len, int flags, const SceNetSockaddr *to, unsigned int tolen);
-int recv_packet(NetState &net, int s, void *buf, unsigned int len, int flags, SceNetSockaddr *from, unsigned int *fromlen);
-int get_socket_address(NetState &net, int s, SceNetSockaddr *name, unsigned int *namelen);
-int set_socket_options(NetState &net, int s, int level, int optname, const void *optval, unsigned int optlen);
-int connect_socket(NetState &net, int s, const SceNetSockaddr *name, unsigned int namelen);
-int accept_socket(NetState &net, int s, SceNetSockaddr *addr, unsigned int *addrlen);
-int listen_socket(NetState &net, int s, int backlog);
+s32 open_socket(NetState &net, s32 domain, s32 type, s32 protocol);
+s32 close_socket(NetState &net, s32 id);
+s32 bind_socket(NetState &net,s32 s, const SceNetSockaddr *name, u32 addrlen);
+s32 send_packet(NetState &net, s32 s, const void *msg, u32 len, s32 flags, const SceNetSockaddr *to, u32 tolen);
+s32 recv_packet(NetState &net, s32 s, void *buf, u32 len, s32 flags, SceNetSockaddr *from, u32 *fromlen);
+s32 get_socket_address(NetState &net, s32 s, SceNetSockaddr *name, u32 *namelen);
+s32 set_socket_options(NetState &net, s32 s, s32 level, s32 optname, const void *optval, u32 optlen);
+s32 connect_socket(NetState &net, s32 s, const SceNetSockaddr *name, u32 namelen);
+s32 accept_socket(NetState &net, s32 s, SceNetSockaddr *addr, u32 *addrlen);
+s32 listen_socket(NetState &net, s32 s, s32 backlog);

--- a/src/emulator/net/include/net/state.h
+++ b/src/emulator/net/include/net/state.h
@@ -26,7 +26,7 @@
 # include <winsock2.h>
 # include <Ws2tcpip.h>
 typedef SOCKET abs_socket;
-typedef int socklen_t;
+typedef s32 socklen_t;
 #else
 # include <unistd.h>
 # include <sys/socket.h>
@@ -34,13 +34,13 @@ typedef int socklen_t;
 # include <netinet/in.h>
 # include <netdb.h>
 # include <arpa/inet.h>
-typedef int abs_socket;
+typedef s32 abs_socket;
 #endif
 
-typedef std::map<int, abs_socket> sockets;
+typedef std::map<s32, abs_socket> sockets;
 
 struct NetState {
     bool inited = false;
-    int next_id = 0;
+    s32 next_id = 0;
     sockets socks;
 };

--- a/src/emulator/nids/CMakeLists.txt
+++ b/src/emulator/nids/CMakeLists.txt
@@ -7,4 +7,5 @@ add_library(
 )
 
 target_include_directories(nids PUBLIC include)
-target_link_libraries(cpu INTERFACE util spdlog)
+target_link_libraries(nids PUBLIC util)
+target_link_libraries(cpu INTERFACE spdlog)

--- a/src/emulator/nids/include/nids/functions.h
+++ b/src/emulator/nids/include/nids/functions.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <util/types.h>
+
 #include <cstdint>
 
-const char *import_name(uint32_t nid);
+const char *import_name(u32 nid);

--- a/src/emulator/nids/src/nids.cpp
+++ b/src/emulator/nids/src/nids.cpp
@@ -4,7 +4,7 @@
 #include <nids/nids.h>
 #undef NID
 
-const char *import_name(uint32_t nid) {
+const char *import_name(u32 nid) {
     switch (nid) {
 #define NID(name, nid) \
     case nid:          \

--- a/src/emulator/util/CMakeLists.txt
+++ b/src/emulator/util/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
 	include/util/resource.h
 	include/util/string_convert.h
 	include/util/log.h
+	include/util/types.h
 	src/util.cpp
 )
 

--- a/src/emulator/util/include/util/string_convert.h
+++ b/src/emulator/util/include/util/string_convert.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <util/types.h>
+
 #include <vector>
 #include <string>
 
@@ -9,4 +11,4 @@ std::wstring utf_to_wide(const std::string& str);
 
 std::string wide_to_utf(const std::wstring& str);
 
-ProgramArgsWide process_args(int argc, char* argv[]);
+ProgramArgsWide process_args(s32 argc, char* argv[]);

--- a/src/emulator/util/include/util/types.h
+++ b/src/emulator/util/include/util/types.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#ifdef _MSC_VER
+#define ASSUME(cond) __assume(cond)
+#define LIKELY
+#define UNLIKELY
+#define SAFE_BUFFERS __declspec(safebuffers)
+#define NEVER_INLINE __declspec(noinline)
+#define FORCE_INLINE __forceinline
+#else
+#define ASSUME(cond) do { if (!(cond)) __builtin_unreachable(); } while (0)
+#define LIKELY(cond) __builtin_expect(!!(cond), 1)
+#define UNLIKELY(cond) __builtin_expect(!!(cond), 0)
+#define SAFE_BUFFERS
+#define NEVER_INLINE __attribute__((noinline))
+#define FORCE_INLINE __attribute__((always_inline)) inline
+#endif
+
+#define CHECK_SIZE(type, size) static_assert(sizeof(type) == size, "Invalid " #type " type size")
+#define CHECK_ALIGN(type, align) static_assert(alignof(type) == align, "Invalid " #type " type alignment")
+#define CHECK_MAX_SIZE(type, size) static_assert(sizeof(type) <= size, #type " type size is too big")
+#define CHECK_SIZE_ALIGN(type, size, align) CHECK_SIZE(type, size); CHECK_ALIGN(type, align)
+
+
+// Return 32 bit sizeof() to avoid widening/narrowing conversions with size_t
+#define SIZE_32(...) static_cast<u32>(sizeof(__VA_ARGS__))
+
+// Return 32 bit alignof() to avoid widening/narrowing conversions with size_t
+#define ALIGN_32(...) static_cast<u32>(alignof(__VA_ARGS__))
+
+#define CONCATENATE_DETAIL(x, y) x ## y
+#define CONCATENATE(x, y) CONCATENATE_DETAIL(x, y)
+
+#define STRINGIZE_DETAIL(x) #x ""
+#define STRINGIZE(x) STRINGIZE_DETAIL(x)
+
+#define HERE "\n(in file " __FILE__ ":" STRINGIZE(__LINE__) ")"
+
+using schar = signed char;
+using uchar = unsigned char;
+using ushort = unsigned short;
+using uint = unsigned int;
+using ulong = unsigned long;
+using ullong = unsigned long long;
+using llong = long long;
+
+using uptr = std::uintptr_t;
+
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;
+
+using s8 = std::int8_t;
+using s16 = std::int16_t;
+using s32 = std::int32_t;
+using s64 = std::int64_t;
+
+using f32 = float;
+using f64 = double;
+
+using size_t = std::size_t;
+
+// Helper function, used by ""_u16, ""_u32, ""_u64
+constexpr u8 to_u8(char c)
+{
+    return static_cast<u8>(c);
+}
+
+// Convert 2-byte string to u16 value like reinterpret_cast does
+constexpr u16 operator""_u16(const char* s, std::size_t length)
+{
+    return length != 2 ? throw s :
+        to_u8(s[1]) << 8 | to_u8(s[0]);
+}
+
+// Convert 4-byte string to u32 value like reinterpret_cast does
+constexpr u32 operator""_u32(const char* s, std::size_t length)
+{
+    return length != 4 ? throw s :
+        to_u8(s[3]) << 24 | to_u8(s[2]) << 16 | to_u8(s[1]) << 8 | to_u8(s[0]);
+}
+
+// Convert 8-byte string to u64 value like reinterpret_cast does
+constexpr u64 operator""_u64(const char* s, std::size_t length)
+{
+    return length != 8 ? throw s :
+        static_cast<u64>(to_u8(s[7]) << 24 | to_u8(s[6]) << 16 | to_u8(s[5]) << 8 | to_u8(s[4])) << 32 | to_u8(s[3]) << 24 | to_u8(s[2]) << 16 | to_u8(s[1]) << 8 | to_u8(s[0]);
+}
+
+using Buffer = std::vector<u8>;

--- a/src/emulator/util/src/util.cpp
+++ b/src/emulator/util/src/util.cpp
@@ -1,5 +1,6 @@
 #include <util/log.h>
 #include <util/string_convert.h>
+#include <util/types.h>
 
 #ifdef WIN32
 #include <windows.h>
@@ -101,11 +102,11 @@ std::string wide_to_utf(const std::wstring& str)
     return myconv.to_bytes(str);
 }
 
-ProgramArgsWide process_args(int argc, char* argv[])
+ProgramArgsWide process_args(s32 argc, char* argv[])
 {
     ProgramArgsWide args;
 
-    int n_args = argc;
+    s32 n_args = argc;
     args.reserve(n_args);
 
 #ifdef _WIN32

--- a/src/emulator/vpk.cpp
+++ b/src/emulator/vpk.cpp
@@ -21,12 +21,13 @@
 
 #include <io/state.h>
 #include <util/string_convert.h>
+#include <util/types.h>
 
 #include <cassert>
 #include <cstring>
 #include <vector>
 
-typedef std::vector<uint8_t> Buffer;
+typedef std::vector<u8> Buffer;
 
 static void delete_zip(mz_zip_archive *zip) {
     mz_zip_reader_end(zip);
@@ -36,8 +37,8 @@ static void delete_zip(mz_zip_archive *zip) {
 static size_t write_to_buffer(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n) {
     Buffer *const buffer = static_cast<Buffer *>(pOpaque);
     assert(file_ofs == buffer->size());
-    const uint8_t *const first = static_cast<const uint8_t *>(pBuf);
-    const uint8_t *const last = &first[n];
+    const u8 *const first = static_cast<const u8 *>(pBuf);
+    const u8 *const last = &first[n];
     buffer->insert(buffer->end(), first, last);
 
     return n;
@@ -61,7 +62,7 @@ bool load_vpk(Ptr<const void> &entry_point, IOState &io, MemState &mem, const st
         return false;
     }
 
-    const int eboot_index = mz_zip_reader_locate_file(zip.get(), "eboot.bin", nullptr, 0);
+    const s32 eboot_index = mz_zip_reader_locate_file(zip.get(), "eboot.bin", nullptr, 0);
     if (eboot_index < 0) {
         return false;
     }


### PR DESCRIPTION
Sorry for the possible conflicts, but we may as well do this as early as possible.

**Note to developers:** Please include `util/types.h` in new code and **use short-form types** from now on:
`u8`, `u16`, `u32`, `u64` and the `s` variants for signed types. There's also `f32` and `f64` for float/double. I didn't port those.

Should probably be added to the Wiki if this is merged.

The `types.h` code is from RPCS3, but it has no GPL2 header. Should I get one from a file that does and include it?
Btw, some macros in there will make more sense once I import more util files.