### PR TITLE
[sceKernel] Implement sceKernelLibcGettimeofday

### DIFF
--- a/src/emulator/host/include/host/rtc.h
+++ b/src/emulator/host/include/host/rtc.h
@@ -22,12 +22,12 @@
 #include <chrono>
 #include <cstdint>
 
-#define VITA_CLOCKS_PER_SEC 1000000
-using VitaClocks = std::chrono::duration<std::uint64_t, std::ratio<1, VITA_CLOCKS_PER_SEC>>;
-
-// Grabbed from JPSCP
 // This is the # of microseconds between January 1, 0001 and January 1, 1970.
-const auto rtcMagicOffset = 62135596800000000ULL;
+// Grabbed from JPSCP
+static constexpr auto RTC_OFFSET = 62135596800000000ULL;
+constexpr auto VITA_CLOCKS_PER_SEC = 1'000'000;
+
+using VitaClocks = std::chrono::duration<std::uint64_t, std::ratio<1, VITA_CLOCKS_PER_SEC>>;
 
 inline std::uint64_t rtc_base_ticks()
 {
@@ -38,7 +38,7 @@ inline std::uint64_t rtc_base_ticks()
     // host high_resolution_clock offset (implementations dependant)
     const auto host_clock_offset = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
-    return rtcMagicOffset + clocks_since_unix_time - host_clock_offset;
+    return RTC_OFFSET + clocks_since_unix_time - host_clock_offset;
 }
 
 inline std::uint64_t rtc_get_ticks(const HostState& host)

--- a/src/emulator/modules/SceProcessmgr/SceProcessmgr.cpp
+++ b/src/emulator/modules/SceProcessmgr/SceProcessmgr.cpp
@@ -19,6 +19,13 @@
 
 #include <psp2/kernel/error.h>
 #include <psp2/kernel/processmgr.h>
+#include <host/rtc.h>
+
+struct VitaTimeval
+{
+    uint32_t tv_sec;
+    uint32_t tv_usec;
+};
 
 EXPORT(int, sceKernelGetStderr) {
     return unimplemented("sceKernelGetStderr");
@@ -44,8 +51,18 @@ EXPORT(int, sceKernelLibcClock) {
     return unimplemented("sceKernelLibcClock");
 }
 
-EXPORT(int, sceKernelLibcGettimeofday) {
-    return unimplemented("sceKernelLibcGettimeofday");
+EXPORT(int, sceKernelLibcGettimeofday, Ptr<VitaTimeval> timeAddr, Ptr<Address> tzAddr) {
+    if (timeAddr)
+    {
+        auto* tv = timeAddr.get(host.mem);
+
+        const auto ticks = rtc_get_ticks(host);
+
+        tv->tv_sec = ticks / VITA_CLOCKS_PER_SEC;
+        tv->tv_usec = ticks % VITA_CLOCKS_PER_SEC;
+    }
+
+    return 0;
 }
 
 EXPORT(int, sceKernelLibcGmtime_r) {


### PR DESCRIPTION
Allows **Vita Doom** to go in-game (still not playable because of other issues).

The `tzAddr` argument is unused, not even PPSSPP implements it apparently.