### PR TITLE
Stub some ScePower functions

### DIFF
--- a/src/emulator/modules/ScePower/ScePower.cpp
+++ b/src/emulator/modules/ScePower/ScePower.cpp
@@ -48,7 +48,7 @@ EXPORT(int, scePowerGetBatteryFullCapacity) {
 }
 
 EXPORT(int, scePowerGetBatteryLifePercent) {
-    return unimplemented("scePowerGetBatteryLifePercent");
+    return 100;
 }
 
 EXPORT(int, scePowerGetBatteryLifeTime) {
@@ -100,7 +100,7 @@ EXPORT(int, scePowerGetUsingWireless) {
 }
 
 EXPORT(int, scePowerIsBatteryCharging) {
-    return unimplemented("scePowerIsBatteryCharging");
+    return SCE_TRUE;
 }
 
 EXPORT(int, scePowerIsBatteryExist) {
@@ -108,7 +108,7 @@ EXPORT(int, scePowerIsBatteryExist) {
 }
 
 EXPORT(int, scePowerIsLowBattery) {
-    return unimplemented("scePowerIsLowBattery");
+    return SCE_FALSE;
 }
 
 EXPORT(int, scePowerIsLowBatteryInhibitUpdateDownload) {


### PR DESCRIPTION
Probably doesn't fix any games, but this should at least help clean up the log of useless stuff. I did notice that the homebrew "FlppyBird" now correctly draws the battery icon instead of complaining in the log about an unimplemented function.

Before: 
![](https://cdn.discordapp.com/attachments/418026683015233546/421888133349507079/unknown.png)

After:
![](https://cdn.discordapp.com/attachments/418026683015233546/421901897792749572/unknown.png)



Again, nothing major here...