### PR TITLE
More work on shaders and uniform buffers

### DIFF
--- a/src/emulator/gxm/include/gxm/functions.h
+++ b/src/emulator/gxm/include/gxm/functions.h
@@ -12,6 +12,7 @@ namespace glbinding {
 }
 
 class GLObject;
+struct MemState;
 
 namespace emu {
     struct SceGxmBlendInfo;
@@ -26,7 +27,7 @@ void after_callback(const glbinding::FunctionCall &fn);
 std::string get_fragment_glsl(SceGxmShaderPatcher &shader_patcher, const SceGxmProgram &fragment_program, const char *base_path);
 std::string get_vertex_glsl(SceGxmShaderPatcher &shader_patcher, const SceGxmProgram &vertex_program, const char *base_path);
 AttributeLocations attribute_locations(const SceGxmProgram &vertex_program);
-SharedGLObject get_program(SceGxmContext &context, const SceGxmFragmentProgram &fragment_program);
+SharedGLObject get_program(SceGxmContext &context, const MemState &mem);
 GLenum attribute_format_to_gl_type(SceGxmAttributeFormat format);
 bool attribute_format_normalised(SceGxmAttributeFormat format);
 void flip_vertically(uint32_t *pixels, size_t width, size_t height, size_t stride_in_pixels);

--- a/src/emulator/gxm/include/gxm/functions.h
+++ b/src/emulator/gxm/include/gxm/functions.h
@@ -30,6 +30,7 @@ AttributeLocations attribute_locations(const SceGxmProgram &vertex_program);
 SharedGLObject get_program(SceGxmContext &context, const MemState &mem);
 GLenum attribute_format_to_gl_type(SceGxmAttributeFormat format);
 bool attribute_format_normalised(SceGxmAttributeFormat format);
+void set_uniforms(GLuint program, const SceGxmContext &context, const MemState &mem);
 void flip_vertically(uint32_t *pixels, size_t width, size_t height, size_t stride_in_pixels);
 GLenum translate_blend_func(SceGxmBlendFunc src);
 GLenum translate_blend_factor(SceGxmBlendFactor src);

--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -10,6 +10,7 @@
 #include <psp2/gxm.h>
 #include <SDL_video.h>
 
+#include <array>
 #include <map>
 #include <tuple>
 
@@ -63,6 +64,7 @@ typedef std::unique_ptr<void, std::function<void(SDL_GLContext)>> GLContextPtr;
 typedef std::shared_ptr<GLObject> SharedGLObject;
 typedef std::tuple<std::string, std::string> ProgramGLSLs;
 typedef std::map<ProgramGLSLs, SharedGLObject> ProgramCache;
+typedef std::array<Ptr<void>, 16> UniformBuffers;
 
 struct SceGxmContext {
     // This is an opaque type.
@@ -74,6 +76,8 @@ struct SceGxmContext {
     ProgramCache program_cache;
     Ptr<const SceGxmFragmentProgram> fragment_program;
     Ptr<const SceGxmVertexProgram> vertex_program;
+    UniformBuffers fragment_uniform_buffers;
+    UniformBuffers vertex_uniform_buffers;
     GLObjectArray<1> texture;
     SceGxmCullMode cull_mode = SCE_GXM_CULL_NONE;
 };
@@ -91,6 +95,7 @@ namespace emu {
 struct SceGxmFragmentProgram {
     size_t reference_count = 1;
     
+    Ptr<const SceGxmProgram> program;
     std::string glsl;
     
     GLboolean color_mask_red = GL_TRUE;
@@ -218,7 +223,10 @@ typedef std::map<GLuint, std::string> AttributeLocations;
 struct SceGxmVertexProgram {
     // TODO I think this is an opaque type.
     size_t reference_count = 1;
+    
+    Ptr<const SceGxmProgram> program;
     std::string glsl;
+    
     AttributeLocations attribute_locations;
     std::vector<SceGxmVertexStream> streams;
     std::vector<emu::SceGxmVertexAttribute> attributes;

--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -72,7 +72,8 @@ struct SceGxmContext {
     size_t vertex_ring_buffer_used = 0;
     emu::SceGxmColorSurface color_surface;
     ProgramCache program_cache;
-    const SceGxmVertexProgram *vertex_program = nullptr;
+    Ptr<const SceGxmFragmentProgram> fragment_program;
+    Ptr<const SceGxmVertexProgram> vertex_program;
     GLObjectArray<1> texture;
     SceGxmCullMode cull_mode = SCE_GXM_CULL_NONE;
 };
@@ -87,14 +88,10 @@ namespace emu {
     };
 }
 
-typedef std::map<GLuint, std::string> AttributeLocations;
-
 struct SceGxmFragmentProgram {
     size_t reference_count = 1;
     
-    std::string fragment_glsl;
-    std::string vertex_glsl;
-    AttributeLocations attribute_locations;
+    std::string glsl;
     
     GLboolean color_mask_red = GL_TRUE;
     GLboolean color_mask_green = GL_TRUE;
@@ -216,9 +213,13 @@ namespace emu {
     static_assert(sizeof(SceGxmVertexAttribute) == 8, "Structure has been incorrectly packed.");
 }
 
+typedef std::map<GLuint, std::string> AttributeLocations;
+
 struct SceGxmVertexProgram {
     // TODO I think this is an opaque type.
     size_t reference_count = 1;
+    std::string glsl;
+    AttributeLocations attribute_locations;
     std::vector<SceGxmVertexStream> streams;
     std::vector<emu::SceGxmVertexAttribute> attributes;
 };

--- a/src/emulator/gxm/src/gxm.cpp
+++ b/src/emulator/gxm/src/gxm.cpp
@@ -341,7 +341,6 @@ std::string get_fragment_glsl(SceGxmShaderPatcher &shader_patcher, const SceGxmP
     
     const std::array<char, 65> hash_text = hex(hash_bytes);
     std::string source = load_shader(hash_text.data(), base_path);
-    assert(source.find("_v.") == std::string::npos);
     if (source.empty()) {
         source = generate_fragment_glsl(fragment_program);
         dump_missing_shader(hash_text.data(), fragment_program, source.c_str());
@@ -361,7 +360,6 @@ std::string get_vertex_glsl(SceGxmShaderPatcher &shader_patcher, const SceGxmPro
     
     const std::array<char, 65> hash_text = hex(hash_bytes);
     std::string source = load_shader(hash_text.data(), base_path);
-    assert(source.find("_f.") == std::string::npos);
     if (source.empty()) {
         source = generate_vertex_glsl(vertex_program);
         dump_missing_shader(hash_text.data(), vertex_program, source.c_str());

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -976,18 +976,18 @@ EXPORT(int, sceGxmSetFragmentDefaultUniformBuffer) {
     return unimplemented("sceGxmSetFragmentDefaultUniformBuffer");
 }
 
-EXPORT(void, sceGxmSetFragmentProgram, SceGxmContext *context, const SceGxmFragmentProgram *fragmentProgram) {
+EXPORT(void, sceGxmSetFragmentProgram, SceGxmContext *context, Ptr<const SceGxmFragmentProgram> fragmentProgram) {
     assert(context != nullptr);
-    assert(fragmentProgram != nullptr);
+    assert(fragmentProgram);
 
-    const SharedGLObject program = get_program(*context, *fragmentProgram);
+    context->fragment_program = fragmentProgram;
     
-    glUseProgram(program->get());
-    glColorMask(fragmentProgram->color_mask_red, fragmentProgram->color_mask_green, fragmentProgram->color_mask_blue, fragmentProgram->color_mask_alpha);
-    if (fragmentProgram->blend_enabled) {
+    const SceGxmFragmentProgram &fragment_program = *fragmentProgram.get(host.mem);
+    glColorMask(fragment_program.color_mask_red, fragment_program.color_mask_green, fragment_program.color_mask_blue, fragment_program.color_mask_alpha);
+    if (fragment_program.blend_enabled) {
         glEnable(GL_BLEND);
-        glBlendEquationSeparate(fragmentProgram->color_func, fragmentProgram->alpha_func);
-        glBlendFuncSeparate(fragmentProgram->color_src, fragmentProgram->color_dst, fragmentProgram->alpha_src, fragmentProgram->alpha_dst);
+        glBlendEquationSeparate(fragment_program.color_func, fragment_program.alpha_func);
+        glBlendFuncSeparate(fragment_program.color_src, fragment_program.color_dst, fragment_program.alpha_src, fragment_program.alpha_dst);
     } else {
         glDisable(GL_BLEND);
     }
@@ -1144,9 +1144,9 @@ EXPORT(int, sceGxmSetVertexDefaultUniformBuffer) {
     return unimplemented("sceGxmSetVertexDefaultUniformBuffer");
 }
 
-EXPORT(void, sceGxmSetVertexProgram, SceGxmContext *context, const SceGxmVertexProgram *vertexProgram) {
+EXPORT(void, sceGxmSetVertexProgram, SceGxmContext *context, Ptr<const SceGxmVertexProgram> vertexProgram) {
     assert(context != nullptr);
-    assert(vertexProgram != nullptr);
+    assert(vertexProgram);
 
     context->vertex_program = vertexProgram;
 }
@@ -1154,13 +1154,15 @@ EXPORT(void, sceGxmSetVertexProgram, SceGxmContext *context, const SceGxmVertexP
 EXPORT(int, sceGxmSetVertexStream, SceGxmContext *context, unsigned int streamIndex, const uint8_t *streamData) {
     assert(context != nullptr);
     assert(streamData != nullptr);
+    assert(context->vertex_program);
 
-    for (const emu::SceGxmVertexAttribute &attribute : context->vertex_program->attributes) {
+    const SceGxmVertexProgram &vertex_program = *context->vertex_program.get(host.mem);
+    for (const emu::SceGxmVertexAttribute &attribute : vertex_program.attributes) {
         if (attribute.streamIndex != streamIndex) {
             continue;
         }
 
-        const SceGxmVertexStream &stream = context->vertex_program->streams[attribute.streamIndex];
+        const SceGxmVertexStream &stream = vertex_program.streams[attribute.streamIndex];
 
         const GLenum type = attribute_format_to_gl_type(static_cast<SceGxmAttributeFormat>(attribute.format));
         const GLboolean normalised = attribute_format_normalised(static_cast<SceGxmAttributeFormat>(attribute.format)) ? GL_TRUE : GL_FALSE;
@@ -1281,9 +1283,7 @@ EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shade
     }
     
     SceGxmFragmentProgram *const fp = fragmentProgram->get(mem);
-    fp->fragment_glsl = get_fragment_glsl(*shaderPatcher, *programId->program.get(mem), host.base_path.c_str());
-    fp->vertex_glsl = get_vertex_glsl(*shaderPatcher, *vertexProgram.get(mem), host.base_path.c_str());
-    fp->attribute_locations = attribute_locations(*vertexProgram.get(mem));
+    fp->glsl = get_fragment_glsl(*shaderPatcher, *programId->program.get(mem), host.base_path.c_str());
 
     // Translate blending.
     if (blendInfo != nullptr) {
@@ -1326,6 +1326,8 @@ EXPORT(int, sceGxmShaderPatcherCreateVertexProgram, SceGxmShaderPatcher *shaderP
     }
 
     SceGxmVertexProgram *const vp = vertexProgram->get(mem);
+    vp->glsl = get_vertex_glsl(*shaderPatcher, *programId->program.get(mem), host.base_path.c_str());
+    vp->attribute_locations = attribute_locations(*programId->program.get(mem));
     vp->streams.insert(vp->streams.end(), &streams[0], &streams[streamCount]);
     vp->attributes.insert(vp->attributes.end(), &attributes[0], &attributes[attributeCount]);
 


### PR DESCRIPTION
When VitaGL creates fragment programs (`SceGxmFragmentProgram`), it passes fragment rather than vertex `SceGxmProgram`. Because of this, we can no longer maintain a logical connection between fragment and vertex programs, and store vertex program information in the fragment program structure.

As a result, the OpenGL program is only linkable (and able to be made current) when fragment and vertex shaders have _both_ been set, rather than just when the current fragment program is set.

Because of that, we can't rely on the current OpenGL program being the correct one when GXM uniforms are set. Instead we store uniform values in uniform buffers, and pass the values to OpenGL at the point of draw.

There is scope for caching and optimisation, but I think this is good enough for now.