### PR TITLE
Support all 16 paletted texture formats (fixes VitaDoom)

### DIFF
--- a/src/emulator/gxm/include/gxm/functions.h
+++ b/src/emulator/gxm/include/gxm/functions.h
@@ -34,7 +34,12 @@ void set_uniforms(GLuint program, const SceGxmContext &context, const MemState &
 void flip_vertically(uint32_t *pixels, size_t width, size_t height, size_t stride_in_pixels);
 GLenum translate_blend_func(SceGxmBlendFunc src);
 GLenum translate_blend_factor(SceGxmBlendFactor src);
-GLenum translate_internal_format(SceGxmTextureFormat src);
-GLenum translate_format(SceGxmTextureFormat src);
+namespace texture {
+    SceGxmTextureBaseFormat get_base_format(SceGxmTextureFormat src);
+    std::uint32_t get_swizzle(SceGxmTextureFormat src);
+    bool is_paletted_format(SceGxmTextureFormat src);
+    GLenum translate_internal_format(SceGxmTextureFormat src);
+    GLenum translate_format(SceGxmTextureFormat src);
+}
 GLenum translate_primitive(SceGxmPrimitiveType primType);
 bool operator<(const FragmentProgramCacheKey& a, const FragmentProgramCacheKey &b);

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -386,10 +386,10 @@ EXPORT(int, sceGxmDraw, SceGxmContext *context, SceGxmPrimitiveType primType, Sc
     // TODO Use some kind of caching to avoid setting every draw call?
     const SharedGLObject program = get_program(*context, host.mem);
     glUseProgram(program->get());
-    
+
     // TODO Use some kind of caching to avoid setting every draw call?
     set_uniforms(program->get(), *context, host.mem);
-    
+
     const GLenum mode = translate_primitive(primType);
     const GLenum type = indexType == SCE_GXM_INDEX_FORMAT_U16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT;
     glDrawElements(mode, indexCount, type, indexData);
@@ -868,7 +868,7 @@ EXPORT(int, sceGxmReserveFragmentDefaultUniformBuffer, SceGxmContext *context, P
 
     *uniformBuffer = context->params.fragmentRingBufferMem.cast<uint8_t>() + static_cast<int32_t>(context->fragment_ring_buffer_used);
     context->fragment_ring_buffer_used = next_used;
-    
+
     context->fragment_uniform_buffers[14] = *uniformBuffer;
 
     return 0;
@@ -891,7 +891,7 @@ EXPORT(int, sceGxmReserveVertexDefaultUniformBuffer, SceGxmContext *context, Ptr
 
     *uniformBuffer = context->params.vertexRingBufferMem.cast<uint8_t>() + static_cast<int32_t>(context->vertex_ring_buffer_used);
     context->vertex_ring_buffer_used = next_used;
-    
+
     context->vertex_uniform_buffers[14] = *uniformBuffer;
 
     return 0;
@@ -992,7 +992,7 @@ EXPORT(void, sceGxmSetFragmentProgram, SceGxmContext *context, Ptr<const SceGxmF
     assert(fragmentProgram);
 
     context->fragment_program = fragmentProgram;
-    
+
     const SceGxmFragmentProgram &fragment_program = *fragmentProgram.get(host.mem);
     glColorMask(fragment_program.color_mask_red, fragment_program.color_mask_green, fragment_program.color_mask_blue, fragment_program.color_mask_alpha);
     if (fragment_program.blend_enabled) {
@@ -1247,18 +1247,18 @@ EXPORT(int, sceGxmSetYuvProfile) {
 EXPORT(int, sceGxmShaderPatcherAddRefFragmentProgram, SceGxmShaderPatcher *shaderPatcher, SceGxmFragmentProgram *fragmentProgram) {
     assert(shaderPatcher != nullptr);
     assert(fragmentProgram != nullptr);
-    
+
     ++fragmentProgram->reference_count;
-    
+
     return 0;
 }
 
 EXPORT(int, sceGxmShaderPatcherAddRefVertexProgram, SceGxmShaderPatcher *shaderPatcher, SceGxmVertexProgram *vertexProgram) {
     assert(shaderPatcher != nullptr);
     assert(vertexProgram != nullptr);
-    
+
     ++vertexProgram->reference_count;
-    
+
     return 0;
 }
 
@@ -1283,7 +1283,7 @@ EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shade
     assert(multisampleMode == SCE_GXM_MULTISAMPLE_NONE);
     assert(vertexProgram);
     assert(fragmentProgram != nullptr);
-    
+
     static const emu::SceGxmBlendInfo default_blend_info = {
         SCE_GXM_COLOR_MASK_ALL,
         SCE_GXM_BLEND_FUNC_NONE,
@@ -1304,13 +1304,13 @@ EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shade
         *fragmentProgram = cached->second;
         return 0;
     }
-    
+
     *fragmentProgram = alloc<SceGxmFragmentProgram>(mem, __FUNCTION__);
     assert(*fragmentProgram);
     if (!*fragmentProgram) {
         return SCE_GXM_ERROR_OUT_OF_MEMORY;
     }
-    
+
     SceGxmFragmentProgram *const fp = fragmentProgram->get(mem);
     fp->program = programId->program;
     fp->glsl = get_fragment_glsl(*shaderPatcher, *programId->program.get(mem), host.base_path.c_str());
@@ -1331,7 +1331,7 @@ EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shade
     }
 
     shaderPatcher->fragment_program_cache.emplace(key, *fragmentProgram);
-    
+
     return 0;
 }
 

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1010,27 +1010,65 @@ EXPORT(int, sceGxmSetFragmentTexture, SceGxmContext *context, unsigned int textu
 
     glActiveTexture((GLenum)(GL_TEXTURE0 + textureIndex));
     glBindTexture(GL_TEXTURE_2D, context->texture[0]);
+
+    // Disable mip-maps
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 
-    if (texture->format == SCE_GXM_TEXTURE_FORMAT_P8_ABGR) {
+    if (texture::is_paletted_format(texture->format)) {
+        const auto base_format = texture::get_base_format(texture->format);
+        const auto is_byte_indexed = (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_P8); // only altenative is SCE_GXM_TEXTURE_BASE_FORMAT_P4
+        const auto palette_indexes = is_byte_indexed ? 256 : 16;
+
         glPixelTransferi(GL_MAP_COLOR, GL_TRUE);
+
+        // second dimension should be palette_indexes sized instead of 256, but prefer to keep it constant/stack-allocated
+        // TODO: Cache palette map instead of calculating here every time
         GLfloat map[4][256];
+
         const uint8_t(*const src)[4] = static_cast<uint8_t(*)[4]>(texture->palette.get(host.mem));
-        for (size_t i = 0; i < 256; ++i) {
+        for (size_t i = 0; i < palette_indexes; ++i) {
             map[0][i] = src[i][0] / 255.0f;
             map[1][i] = src[i][1] / 255.0f;
             map[2][i] = src[i][2] / 255.0f;
             map[3][i] = src[i][3] / 255.0f;
         }
-        glPixelMapfv(GL_PIXEL_MAP_I_TO_R, 256, map[0]);
-        glPixelMapfv(GL_PIXEL_MAP_I_TO_G, 256, map[1]);
-        glPixelMapfv(GL_PIXEL_MAP_I_TO_B, 256, map[2]);
-        glPixelMapfv(GL_PIXEL_MAP_I_TO_A, 256, map[3]);
+
+        // map channel indexes for each channel
+        // A == A_max means alpha channel is unused (max)
+        std::uint8_t R = 0, G = 0, B = 0, A = 0;
+        constexpr auto A_max = std::numeric_limits<decltype(A)>::max();
+
+        switch (texture::get_swizzle(texture->format)) {
+        case SCE_GXM_TEXTURE_SWIZZLE4_ABGR: R = 0; G = 1; B = 2; A = 3; break;
+        case SCE_GXM_TEXTURE_SWIZZLE4_ARGB: R = 2; G = 1; B = 0; A = 3; break;
+        case SCE_GXM_TEXTURE_SWIZZLE4_RGBA: R = 3; G = 2; B = 1; A = 0; break;
+        case SCE_GXM_TEXTURE_SWIZZLE4_BGRA: R = 1; G = 2; B = 3; A = 0; break;
+        case SCE_GXM_TEXTURE_SWIZZLE4_1BGR: R = 0; G = 1; B = 2; A = A_max; break;
+        case SCE_GXM_TEXTURE_SWIZZLE4_1RGB: R = 2; G = 1; B = 0; A = A_max; break;
+        case SCE_GXM_TEXTURE_SWIZZLE4_RGB1: R = 3; G = 2; B = 1; A = A_max; break;
+        case SCE_GXM_TEXTURE_SWIZZLE4_BGR1: R = 1; G = 2; B = 3; A = A_max; break;
+        default:
+        {
+            LOG_ERROR("Invalid swizzle for paletted texture foramt.");
+        }
+        }
+
+        glPixelMapfv(GL_PIXEL_MAP_I_TO_R, palette_indexes, map[R]);
+        glPixelMapfv(GL_PIXEL_MAP_I_TO_G, palette_indexes, map[G]);
+        glPixelMapfv(GL_PIXEL_MAP_I_TO_B, palette_indexes, map[B]);
+        if (A == A_max) {
+            static std::array<GLfloat, 255> max_alpha;
+            std::fill(max_alpha.begin(), max_alpha.end(), 255.0);
+            glPixelMapfv(GL_PIXEL_MAP_I_TO_A, palette_indexes, (GLfloat*)max_alpha.data());
+        } else {
+            glPixelMapfv(GL_PIXEL_MAP_I_TO_A, palette_indexes, map[A]);
+        }
     }
 
     const void *const pixels = texture->data.get(host.mem);
-    const GLenum internal_format = translate_internal_format(texture->format);
-    const GLenum format = translate_format(texture->format);
+    const GLenum internal_format = texture::translate_internal_format(texture->format);
+    const GLenum format = texture::translate_format(texture->format);
+
     glPixelStorei(GL_UNPACK_ROW_LENGTH, (texture->width + 7) & ~7);
     glTexImage2D(GL_TEXTURE_2D, 0, internal_format, texture->width, texture->height, 0, format, GL_UNSIGNED_BYTE, pixels);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
@@ -1525,7 +1563,7 @@ EXPORT(int, sceGxmTextureGetNormalizeMode) {
 
 EXPORT(Ptr<void>, sceGxmTextureGetPalette, const emu::SceGxmTexture *texture) {
     assert(texture != nullptr);
-    assert(texture->format == SCE_GXM_TEXTURE_FORMAT_P8_ABGR);
+    assert(is_paletted_format(texture->format));
 
     return texture->palette;
 }
@@ -1563,9 +1601,26 @@ EXPORT(int, sceGxmTextureInitCubeArbitrary) {
 EXPORT(int, sceGxmTextureInitLinear, emu::SceGxmTexture *texture, Ptr<const void> data, SceGxmTextureFormat texFormat, unsigned int width, unsigned int height, unsigned int mipCount) {
     assert(texture != nullptr);
     assert(data);
-    assert((texFormat == SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR) || (texFormat == SCE_GXM_TEXTURE_FORMAT_U8_R111) || (texFormat == SCE_GXM_TEXTURE_FORMAT_P8_ABGR));
     assert(width > 0);
     assert(height > 0);
+
+    switch(texFormat) {
+    case SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR:
+    case SCE_GXM_TEXTURE_FORMAT_U8_R111:
+        break;
+
+    default:
+        if (texture::is_paletted_format(texFormat)) {
+            switch (texFormat) {
+            case SCE_GXM_TEXTURE_FORMAT_P8_ABGR:
+            case SCE_GXM_TEXTURE_FORMAT_P8_1BGR:
+                break;
+            default:
+                LOG_WARN("Initialized texture with untested paletted texture format: {:#08X}", texFormat);
+            }
+        } else
+            LOG_ERROR("Initialized texture with unsupported texture format: {:#08X}", texFormat);
+    }
 
     texture->format = texFormat;
     texture->width = width;
@@ -1650,7 +1705,7 @@ EXPORT(int, sceGxmTextureSetNormalizeMode) {
 
 EXPORT(int, sceGxmTextureSetPalette, emu::SceGxmTexture *texture, Ptr<void> paletteData) {
     assert(texture != nullptr);
-    assert(texture->format == SCE_GXM_TEXTURE_FORMAT_P8_ABGR);
+    assert(is_paletted_format(SCE_GXM_TEXTURE_FORMAT_P8_ABGR));
     assert(paletteData);
 
     texture->palette = paletteData;


### PR DESCRIPTION
Fixes VitaDoom (**doom.wad**, **doom2.wad**, and some other fan .wads work).
Runs at 35 fps for me, pretty playable. Only other issue at the moment is garbled audio.

From commit message:

- Extend current support of `SCE_GXM_TEXTURE_FORMAT_P8_ABGR` to the 15 more palleted formats.

- Only tested ones are `SCE_GXM_TEXTURE_FORMAT_P8_ABGR` and `SCE_GXM_TEXTURE_FORMAT_P8_1BGR`.

- A warning message is generated if one of the untested ones is used, just to be sure.
  Can be removed in the future when more of them are tested.


---
#### To reviewers:
I included a refactoring commit (VS does this automatically on Save for me and it was too anoying trying to separate the lines I wanted) so go [here](https://github.com/Vita3K/Vita3K/pull/105/commits/d754d9ce1a25327ab613640e0e8cd61a8d706608) to review main commit only, for convenience.