### PR TITLE
[sceNet] Using correct errorcode ranges.

### DIFF
--- a/src/emulator/modules/SceNet/SceNet.cpp
+++ b/src/emulator/modules/SceNet/SceNet.cpp
@@ -30,9 +30,9 @@
 #endif
 
 #ifdef WIN32
-# define ERROR_CASE(errname) case(WSA##errname): return SCE_NET_ERROR_##errname;
+# define ERROR_CASE(errname) case(WSA##errname): return SCE_NET_##errname;
 #else
-# define ERROR_CASE(errname) case(errname): return SCE_NET_ERROR_##errname; 
+# define ERROR_CASE(errname) case(errname): return SCE_NET_##errname; 
 #endif
 
 static int translate_errorcode(){


### PR DESCRIPTION
sceNet returns SCE_NET_* errors instead of SCE_NET_ERROR_* (the second are probably kernel errors returned internally by called syscalls to perform net operations).