### PR TITLE
Setting min/mag filters to linear filtering on init.

### DIFF
--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1667,7 +1667,7 @@ EXPORT(int, sceGxmTextureInitLinear, SceGxmTexture *texture, Ptr<const void> dat
     texture->data_addr = data.address() >> 2;
     texture->swizzle_format = (texFormat & 0x7000) >> 12;
     texture->normalize_mode = 1;
-	texture->min_filter = texture->mag_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
+    texture->min_filter = texture->mag_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
 
     return 0;
 }

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1668,7 +1668,7 @@ EXPORT(int, sceGxmTextureInitLinear, SceGxmTexture *texture, Ptr<const void> dat
     texture->swizzle_format = (texFormat & 0x7000) >> 12;
     texture->normalize_mode = 1;
     texture->min_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
-	texture->mag_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
+    texture->mag_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
 
     return 0;
 }

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1667,7 +1667,8 @@ EXPORT(int, sceGxmTextureInitLinear, SceGxmTexture *texture, Ptr<const void> dat
     texture->data_addr = data.address() >> 2;
     texture->swizzle_format = (texFormat & 0x7000) >> 12;
     texture->normalize_mode = 1;
-    texture->min_filter = texture->mag_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
+    texture->min_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
+	texture->mag_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
 
     return 0;
 }

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1667,6 +1667,7 @@ EXPORT(int, sceGxmTextureInitLinear, SceGxmTexture *texture, Ptr<const void> dat
     texture->data_addr = data.address() >> 2;
     texture->swizzle_format = (texFormat & 0x7000) >> 12;
     texture->normalize_mode = 1;
+	texture->min_filter = texture->mag_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
 
     return 0;
 }
@@ -1744,6 +1745,7 @@ EXPORT(int, sceGxmTextureSetMagFilter, SceGxmTexture *texture, SceGxmTextureFilt
     if (texture == nullptr){
         return error("sceGxmTextureSetMagFilter", SCE_GXM_ERROR_INVALID_POINTER);
     }
+	
     texture->mag_filter = (uint32_t)magFilter;
     return 0;
 }
@@ -1752,6 +1754,7 @@ EXPORT(int, sceGxmTextureSetMinFilter, SceGxmTexture *texture, SceGxmTextureFilt
     if (texture == nullptr){
         return error("sceGxmTextureSetMinFilter", SCE_GXM_ERROR_INVALID_POINTER);
     }
+	
     texture->min_filter = (uint32_t)minFilter;
     return 0;
 }


### PR DESCRIPTION
This fixes graphics in some homebrews (Happy Land for example) and stops homebrews from spamming on console for unimplemented mag/min filters translations.