### PR TITLE
Log asserts

### DIFF
--- a/src/emulator/audio/src/audio.cpp
+++ b/src/emulator/audio/src/audio.cpp
@@ -19,15 +19,15 @@
 
 #include <audio/state.h>
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
-#include <cassert>
 #include <cstring>
 
 static const int stream_put_granularity = 512;
 
 static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOutPort &port, const ResumeAudioThread &resume_thread) {
     int available_to_get = SDL_AudioStreamAvailable(port.callback.stream.get());
-    assert(available_to_get >= 0);
+    v3k_assert(available_to_get >= 0);
 
     while (available_to_get < len) {
         std::unique_lock<std::mutex> lock(port.shared.mutex);
@@ -39,7 +39,7 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
             AudioOutput &output = port.shared.outputs.front();
             const int bytes_to_put = std::min(stream_put_granularity, output.len_bytes);
             const int ret = SDL_AudioStreamPut(port.callback.stream.get(), output.buf, bytes_to_put);
-            assert(ret == 0);
+            v3k_assert(ret == 0);
             output.buf += bytes_to_put;
             output.len_bytes -= bytes_to_put;
             if (output.len_bytes <= 0) {
@@ -49,7 +49,7 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
         }
 
         available_to_get = SDL_AudioStreamAvailable(port.callback.stream.get());
-        assert(available_to_get >= 0);
+        v3k_assert(available_to_get >= 0);
     }
 
     const int bytes_to_get = std::min(len, available_to_get);
@@ -60,11 +60,11 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
 }
 
 static void SDLCALL audio_callback(void *userdata, Uint8 *stream, int len) {
-    assert(userdata != nullptr);
-    assert(stream != nullptr);
+    v3k_assert(userdata != nullptr);
+    v3k_assert(stream != nullptr);
     AudioState &state = *static_cast<AudioState *>(userdata);
-    assert(len == state.ro.spec.size);
-    assert(len == state.callback.temp_buffer.size());
+    v3k_assert(len == state.ro.spec.size);
+    v3k_assert(len == state.callback.temp_buffer.size());
 
     std::vector<AudioOutPortPtr> ports;
     {

--- a/src/emulator/disasm/CMakeLists.txt
+++ b/src/emulator/disasm/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library(
 
 target_include_directories(disasm PUBLIC include)
 target_include_directories(disasm PRIVATE ${capstone_INCLUDE_DIRS})
-target_link_libraries(disasm PRIVATE capstone-static)
+target_link_libraries(disasm PRIVATE capstone-static util)

--- a/src/emulator/disasm/src/disasm.cpp
+++ b/src/emulator/disasm/src/disasm.cpp
@@ -16,12 +16,10 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <disasm/functions.h>
-
 #include <disasm/state.h>
-
 #include <capstone.h>
+#include <util/v3k_assert.h>
 
-#include <assert.h>
 #include <sstream>
 
 static void delete_insn(cs_insn *insn) {
@@ -48,7 +46,7 @@ bool init(DisasmState &state) {
 
 std::string disassemble(DisasmState &state, const uint8_t *code, size_t size, uint64_t address, bool thumb) {
     const cs_err err = cs_option(state.csh, CS_OPT_MODE, thumb ? CS_MODE_THUMB : CS_MODE_ARM);
-    assert(err == CS_ERR_OK);
+    v3k_assert(err == CS_ERR_OK);
 
     const bool success = cs_disasm_iter(state.csh, &code, &size, &address, state.insn.get());
 

--- a/src/emulator/glutil/CMakeLists.txt
+++ b/src/emulator/glutil/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library(
 )
 
 target_include_directories(glutil PUBLIC include)
-target_link_libraries(glutil PUBLIC glbinding)
+target_link_libraries(glutil PUBLIC glbinding util)

--- a/src/emulator/glutil/include/glutil/object_array.h
+++ b/src/emulator/glutil/include/glutil/object_array.h
@@ -18,9 +18,9 @@
 #pragma once
 
 #include <glutil/gl.h>
+#include <util/v3k_assert.h>
 
 #include <array>
-#include <assert.h>
 
 template <size_t Size>
 class GLObjectArray {
@@ -33,14 +33,14 @@ public:
     }
 
     ~GLObjectArray() {
-        assert(deleter != nullptr);
+        v3k_assert(deleter != nullptr);
         deleter(static_cast<GLsizei>(names.size()), &names[0]);
         names.fill(0);
     }
 
     bool init(Generator *generator, Deleter *deleter) {
-        assert(generator != nullptr);
-        assert(deleter != nullptr);
+        v3k_assert(generator != nullptr);
+        v3k_assert(deleter != nullptr);
         this->deleter = deleter;
         generator(static_cast<GLsizei>(names.size()), &names[0]);
 
@@ -48,9 +48,9 @@ public:
     }
 
     const GLuint operator[](size_t i) const {
-        assert(i >= 0);
-        assert(i < names.size());
-        assert(names[i] != 0);
+        v3k_assert(i >= 0);
+        v3k_assert(i < names.size());
+        v3k_assert(names[i] != 0);
         return names[i];
     }
 

--- a/src/emulator/glutil/src/object.cpp
+++ b/src/emulator/glutil/src/object.cpp
@@ -16,8 +16,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <glutil/object.h>
-
-#include <assert.h>
+#include <util/v3k_assert.h>
 
 GLObject::~GLObject() {
     if (deleter != nullptr) {
@@ -27,10 +26,10 @@ GLObject::~GLObject() {
 }
 
 bool GLObject::init(GLuint name, Deleter *deleter) {
-    assert(name != 0);
-    assert(deleter != nullptr);
-    assert(this->name == 0);
-    assert(this->deleter == nullptr);
+    v3k_assert(name != 0);
+    v3k_assert(deleter != nullptr);
+    v3k_assert(this->name == 0);
+    v3k_assert(this->deleter == nullptr);
     this->name = name;
     this->deleter = deleter;
 
@@ -38,6 +37,6 @@ bool GLObject::init(GLuint name, Deleter *deleter) {
 }
 
 GLuint GLObject::get() const {
-    assert(name != 0);
+    v3k_assert(name != 0);
     return name;
 }

--- a/src/emulator/gxm/src/gxm.cpp
+++ b/src/emulator/gxm/src/gxm.cpp
@@ -3,6 +3,7 @@
 #include <crypto/hash.h>
 #include <gxm/types.h>
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
 #include <glbinding/AbstractFunction.h>
 #include <glbinding/FunctionCall.h>
@@ -78,7 +79,7 @@ static const char *vector_prefix(SceGxmParameterType type) {
 }
 
 static void output_scalar_decl(std::ostream &glsl, const SceGxmProgramParameter &parameter) {
-    assert(parameter.component_count == 1);
+    v3k_assert(parameter.component_count == 1);
     
     glsl << scalar_type(parameter_type(parameter)) << " " << parameter_name(parameter);
     if (parameter.array_size > 1) {
@@ -87,8 +88,8 @@ static void output_scalar_decl(std::ostream &glsl, const SceGxmProgramParameter 
 }
 
 static void output_vector_decl(std::ostream &glsl, const SceGxmProgramParameter &parameter) {
-    assert(parameter.component_count >= 2);
-    assert(parameter.component_count <= 4);
+    v3k_assert(parameter.component_count >= 2);
+    v3k_assert(parameter.component_count <= 4);
 
     const auto vector = vector_prefix(parameter_type(parameter));
 
@@ -99,9 +100,9 @@ static void output_vector_decl(std::ostream &glsl, const SceGxmProgramParameter 
 }
 
 static void output_matrix_decl(std::ostream &glsl, const SceGxmProgramParameter &parameter) {
-    assert(parameter.component_count >= 2);
-    assert(parameter.array_size >= 2);
-    assert(parameter.array_size <= 4);
+    v3k_assert(parameter.component_count >= 2);
+    v3k_assert(parameter.array_size >= 2);
+    v3k_assert(parameter.array_size <= 4);
 
     glsl << vector_prefix(parameter_type(parameter)) << "mat";
     if (parameter.component_count == parameter.array_size) {
@@ -145,15 +146,15 @@ static void output_glsl_parameters(std::ostream &glsl, const SceGxmProgram &prog
                 output_glsl_decl(glsl, parameter);
                 break;
             case SCE_GXM_PARAMETER_CATEGORY_SAMPLER:
-                assert(parameter.component_count == 4);
+                v3k_assert(parameter.component_count == 4);
                 glsl << "uniform sampler2D " << parameter_name(parameter);
                 break;
             case SCE_GXM_PARAMETER_CATEGORY_AUXILIARY_SURFACE:
-                assert(parameter.component_count == 0);
+                v3k_assert(parameter.component_count == 0);
                 glsl << "auxiliary_surface";
                 break;
             case SCE_GXM_PARAMETER_CATEGORY_UNIFORM_BUFFER:
-                assert(parameter.component_count == 0);
+                v3k_assert(parameter.component_count == 0);
                 glsl << "uniform_buffer";
                 break;
         }
@@ -244,7 +245,7 @@ static SharedGLObject compile_glsl(GLenum type, const std::string& source) {
 
     GLboolean is_compiled = GL_FALSE;
     glGetShaderiv(shader->get(), GL_COMPILE_STATUS, &is_compiled);
-    assert(is_compiled != GL_FALSE);
+    v3k_assert(is_compiled != GL_FALSE);
     if (!is_compiled) {
         return SharedGLObject();
     }
@@ -354,7 +355,7 @@ void after_callback(const glbinding::FunctionCall &fn) {
         std::stringstream gl_error;
         gl_error << error;
         LOG_ERROR("OpenGL: {} set error {}.", fn.function->name(), gl_error.str());
-        assert(false);
+        v3k_assert(false);
     }
 }
 
@@ -415,8 +416,8 @@ AttributeLocations attribute_locations(const SceGxmProgram &vertex_program) {
 SharedGLObject get_program(SceGxmContext &context, const MemState &mem) {
     GXM_PROFILE(__FUNCTION__);
 
-    assert(context.fragment_program);
-    assert(context.vertex_program);
+    v3k_assert(context.fragment_program);
+    v3k_assert(context.vertex_program);
 
     const SceGxmFragmentProgram &fragment_program = *context.fragment_program.get(mem);
     const SceGxmVertexProgram &vertex_program = *context.vertex_program.get(mem);
@@ -462,7 +463,7 @@ SharedGLObject get_program(SceGxmContext &context, const MemState &mem) {
 
     GLboolean is_linked = GL_FALSE;
     glGetProgramiv(program->get(), GL_LINK_STATUS, &is_linked);
-    assert(is_linked != GL_FALSE);
+    v3k_assert(is_linked != GL_FALSE);
     if (is_linked == GL_FALSE) {
         return SharedGLObject();
     }
@@ -521,13 +522,13 @@ bool attribute_format_normalised(SceGxmAttributeFormat format) {
 void set_uniforms(GLuint program, const SceGxmContext &context, const MemState &mem) {
     GXM_PROFILE(__FUNCTION__);
 
-    assert(context.fragment_program);
-    assert(context.vertex_program);
+    v3k_assert(context.fragment_program);
+    v3k_assert(context.vertex_program);
     
     const SceGxmFragmentProgram &fragment_program = *context.fragment_program.get(mem);
     const SceGxmVertexProgram &vertex_program = *context.vertex_program.get(mem);
-    assert(fragment_program.program);
-    assert(vertex_program.program);
+    v3k_assert(fragment_program.program);
+    v3k_assert(vertex_program.program);
 
     set_uniforms(program, context.fragment_uniform_buffers, *fragment_program.program.get(mem), mem);
     set_uniforms(program, context.vertex_uniform_buffers, *vertex_program.program.get(mem), mem);

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -29,6 +29,7 @@
 #include <nids/functions.h>
 #include <util/lock_and_find.h>
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
 #include <SDL_events.h>
 #include <SDL_filesystem.h>
@@ -36,7 +37,6 @@
 
 #include <glbinding/Binding.h>
 
-#include <cassert>
 #include <iomanip>
 #include <iostream>
 

--- a/src/emulator/io/include/io/file.h
+++ b/src/emulator/io/include/io/file.h
@@ -20,7 +20,6 @@
 #include <psp2/types.h>
 #include <psp2/io/fcntl.h>
 
-#include <cassert>
 #include <cstring>
 #include <vector>
 

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -23,6 +23,7 @@
 
 #include <io/state.h>
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
 #include <psp2/io/fcntl.h>
 
@@ -37,7 +38,6 @@
 #endif
 
 #include <algorithm>
-#include <cassert>
 #include <iostream>
 #include <string>
 #include <tuple>
@@ -160,10 +160,10 @@ SceUID open_file(IOState &io, const char *path, int flags, const char *pref_path
     VitaPartition partition;
     std::string partition_name;
     std::tie(partition, partition_name) = translate_partition(path);
-
+    
     switch (partition) {
     case VitaPartition::TTY0: {
-        assert(flags >= 0);
+        v3k_assert(flags >= 0);
 
         TtyType type;
         if (flags == SCE_O_RDONLY) {
@@ -178,7 +178,7 @@ SceUID open_file(IOState &io, const char *path, int flags, const char *pref_path
         return fd;
     }
     case VitaPartition::APP0: {
-        assert(flags == SCE_O_RDONLY);
+        v3k_assert(flags == SCE_O_RDONLY);
 
         if (!io.vpk) {
             return -1;
@@ -228,9 +228,9 @@ SceUID open_file(IOState &io, const char *path, int flags, const char *pref_path
 }
 
 int read_file(void *data, IOState &io, SceUID fd, SceSize size) {
-    assert(data != nullptr);
-    assert(fd >= 0);
-    assert(size >= 0);
+    v3k_assert(data != nullptr);
+    v3k_assert(fd >= 0);
+    v3k_assert(size >= 0);
 
     AppFiles::iterator app_file = io.app_files.find(fd);
     if (app_file != io.app_files.end()) {
@@ -256,9 +256,9 @@ int read_file(void *data, IOState &io, SceUID fd, SceSize size) {
 }
 
 int write_file(SceUID fd, const void *data, SceSize size, const IOState &io) {
-    assert(data != nullptr);
-    assert(fd >= 0);
-    assert(size >= 0);
+    v3k_assert(data != nullptr);
+    v3k_assert(fd >= 0);
+    v3k_assert(size >= 0);
 
     const StdFiles::const_iterator file = io.std_files.find(fd);
     if (file != io.std_files.end()) {
@@ -285,13 +285,13 @@ int write_file(SceUID fd, const void *data, SceSize size, const IOState &io) {
 }
 
 int seek_file(SceUID fd, int offset, int whence, IOState &io) {
-    assert(fd >= 0);
-    assert((whence == SCE_SEEK_SET) || (whence == SCE_SEEK_CUR) || (whence == SCE_SEEK_END));
+    v3k_assert(fd >= 0);
+    v3k_assert((whence == SCE_SEEK_SET) || (whence == SCE_SEEK_CUR) || (whence == SCE_SEEK_END));
 
     const StdFiles::const_iterator std_file = io.std_files.find(fd);
     AppFiles::iterator app_file = io.app_files.find(fd);
 
-    assert(std_file != io.std_files.end() || app_file != io.app_files.end());
+    v3k_assert(std_file != io.std_files.end() || app_file != io.app_files.end());
 
     if (std_file == io.std_files.end() && app_file == io.app_files.end()) {
         return -1;
@@ -332,7 +332,7 @@ int seek_file(SceUID fd, int offset, int whence, IOState &io) {
 }
 
 void close_file(IOState &io, SceUID fd) {
-    assert(fd >= 0);
+    v3k_assert(fd >= 0);
 
     io.tty_files.erase(fd);
     io.std_files.erase(fd);
@@ -411,8 +411,8 @@ int remove_dir(const char *dir, const char *pref_path) {
 
 int stat_file(const char *file, SceIoStat *statp, const char *pref_path) {
     // TODO Hacky magic numbers.
-    assert((strncmp(file, "ux0:", 4) == 0) || (strncmp(file, "uma0:", 5) == 0));
-    assert(statp != NULL);
+    v3k_assert((strncmp(file, "ux0:", 4) == 0) || (strncmp(file, "uma0:", 5) == 0));
+    v3k_assert(statp != NULL);
 
     memset(statp, '\0', sizeof(SceIoStat));
 
@@ -460,7 +460,7 @@ int stat_file(const char *file, SceIoStat *statp, const char *pref_path) {
 
 int open_dir(IOState &io, const char *path, const char *pref_path) {
     // TODO Hacky magic numbers.
-    assert((strncmp(path, "ux0:", 4) == 0) || (strncmp(path, "uma0:", 5) == 0));
+    v3k_assert((strncmp(path, "ux0:", 4) == 0) || (strncmp(path, "uma0:", 5) == 0));
 
     std::string dir_path;
 
@@ -488,7 +488,7 @@ int open_dir(IOState &io, const char *path, const char *pref_path) {
 }
 
 int read_dir(IOState &io, SceUID fd, SceIoDirent *dent) {
-    assert(dent != nullptr);
+    v3k_assert(dent != nullptr);
 
     memset(dent->d_name, '\0', sizeof(dent->d_name));
 

--- a/src/emulator/kernel/src/thread.cpp
+++ b/src/emulator/kernel/src/thread.cpp
@@ -64,7 +64,8 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
     };
 
     const ThreadStatePtr thread = std::make_shared<ThreadState>();
-    thread->stack = std::make_shared<ThreadStack>(alloc(mem, stack_size, "Stack"), stack_deleter);
+    const auto stack_alloc_name = std::string("stack_") + name;
+    thread->stack = std::make_shared<ThreadStack>(alloc(mem, stack_size, stack_alloc_name), stack_deleter);
     const Address stack_top = thread->stack->get() + stack_size;
     memset(Ptr<void>(thread->stack->get()).get(mem), 0xcc, stack_size);
 

--- a/src/emulator/kernel/src/thread.cpp
+++ b/src/emulator/kernel/src/thread.cpp
@@ -26,10 +26,11 @@
 #include <util/find.h>
 #include <util/lock_and_find.h>
 #include <util/resource.h>
+#include <util/log.h>
+#include <util/v3k_assert.h>
 
 #include <SDL_thread.h>
 
-#include <cassert>
 #include <cstring>
 
 struct ThreadParams {
@@ -41,14 +42,14 @@ struct ThreadParams {
 };
 
 static int SDLCALL thread_function(void *data) {
-    assert(data != nullptr);
+    v3k_assert(data != nullptr);
     const ThreadParams params = *static_cast<const ThreadParams *>(data);
     SDL_SemPost(params.host_may_destroy_params.get());
     const ThreadStatePtr thread = lock_and_find(params.thid, params.kernel->threads, params.kernel->mutex);
     write_reg(*thread->cpu, 0, params.arglen);
     write_reg(*thread->cpu, 1, params.argp.address());
     const bool succeeded = run_thread(*thread, false);
-    assert(succeeded);
+    v3k_assert(succeeded);
     const uint32_t r0 = read_reg(*thread->cpu, 0);
     return r0;
 }
@@ -70,11 +71,12 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
     memset(Ptr<void>(thread->stack->get()).get(mem), 0xcc, stack_size);
 
     const CallSVC call_svc = [call_import, thid, &mem](uint32_t imm, Address pc) {
-        assert(imm == 0);
+        v3k_assert(imm == 0);
         const uint32_t nid = *Ptr<uint32_t>(pc + 4).get(mem);
         call_import(nid, thid);
     };
 
+    LOG_INFO("Creating thread: {{ name: \"{}\", thid: {} stack size: {} KiB }}", name, thid, stack_size / 1024);
     thread->cpu = init_cpu(entry_point.address(), stack_top, log_code, call_svc, mem);
     if (!thread->cpu) {
         return SCE_KERNEL_ERROR_ERROR;
@@ -96,7 +98,7 @@ int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const 
     }
 
     const ThreadStatePtr thread = find(thid, kernel.threads);
-    assert(thread);
+    v3k_assert(thread);
 
     ThreadParams params;
     params.kernel = &kernel;

--- a/src/emulator/load_self.cpp
+++ b/src/emulator/load_self.cpp
@@ -21,6 +21,7 @@
 
 #include <nids/functions.h>
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
 #include <elfio/elf_types.hpp>
 #define SCE_ELF_DEFS_TARGET
@@ -30,7 +31,6 @@
 
 #include <miniz.h>
 
-#include <assert.h>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
@@ -69,9 +69,9 @@ static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segm
             LOG_INFO("Loading imports from {}", lib_name);
         }
 
-        assert(imports->version == 1);
-        assert(imports->num_syms_vars == 0);
-        assert(imports->num_syms_unk == 0);
+        v3k_assert(imports->version == 1);
+        v3k_assert(imports->num_syms_vars == 0);
+        v3k_assert(imports->num_syms_unk == 0);
 
         const uint32_t *const nids = Ptr<const uint32_t>(imports->func_nid_table).get(mem);
         const Ptr<uint32_t> *const entries = Ptr<Ptr<uint32_t>>(imports->func_entry_table).get(mem);
@@ -108,7 +108,7 @@ bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
         const Elf32_Phdr &src = segments[segment_index];
         const uint8_t *const segment_bytes = self_bytes + self_header.header_len + src.p_offset;
 
-        assert(segment_infos[segment_index].encryption==2);
+        v3k_assert(segment_infos[segment_index].encryption==2);
         if (src.p_type == PT_LOAD) {
             const Ptr<void> address(alloc(mem, src.p_memsz, "segment"));
             if (!address) {
@@ -121,7 +121,7 @@ bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
                 const uint8_t *const compressed_segment_bytes = self_bytes + segment_infos[segment_index].offset;
 
                 int res = mz_uncompress(reinterpret_cast<uint8_t *>(address.get(mem)), &dest_bytes, compressed_segment_bytes, segment_infos[segment_index].length);
-                assert(res == MZ_OK);
+                v3k_assert(res == MZ_OK);
             } else {
                 memcpy(address.get(mem), segment_bytes, src.p_filesz);
             }
@@ -134,7 +134,7 @@ bool load_self(Ptr<const void> &entry_point, MemState &mem, const void *self) {
                 std::unique_ptr<uint8_t> uncompressed(new uint8_t[dest_bytes]);
 
                 int res = mz_uncompress(uncompressed.get(), &dest_bytes, compressed_segment_bytes, segment_infos[segment_index].length);
-                assert(res == MZ_OK);
+                v3k_assert(res == MZ_OK);
                 if (!relocate(uncompressed.get(), src.p_filesz, segment_addrs, mem)) {
                     return false;
                 }

--- a/src/emulator/mem/include/mem/mem.h
+++ b/src/emulator/mem/include/mem/mem.h
@@ -50,6 +50,6 @@ constexpr size_t GB(size_t gb) {
 }
 
 bool init(MemState &state);
-Address alloc(MemState &state, size_t size, const char *name);
+Address alloc(MemState &state, size_t size, const std::string &name);
 void free(MemState &state, Address address);
 const char *mem_name(Address address, const MemState &state);

--- a/src/emulator/mem/include/mem/ptr.h
+++ b/src/emulator/mem/include/mem/ptr.h
@@ -83,7 +83,7 @@ bool operator==(const Ptr<T> &a, const Ptr<T> &b) {
 }
 
 template <class T>
-Ptr<T> alloc(MemState &mem, const char *name) {
+Ptr<T> alloc(MemState &mem, const std::string& name) {
     const Address address = alloc(mem, sizeof(T), name);
     const Ptr<T> ptr(address);
     if (!ptr) {

--- a/src/emulator/mem/src/mem.cpp
+++ b/src/emulator/mem/src/mem.cpp
@@ -42,7 +42,7 @@ static void delete_memory(uint8_t *memory) {
     }
 }
 
-static void alloc_inner(MemState &state, Address address, size_t page_count, Allocated::iterator block, const char *name) {
+static void alloc_inner(MemState &state, Address address, size_t page_count, Allocated::iterator block, const std::string& name) {
     uint8_t *const memory = &state.memory[address];
     const size_t aligned_size = page_count * state.page_size;
 
@@ -87,8 +87,8 @@ bool init(MemState &state) {
     }
 
     state.allocated_pages.resize(length / state.page_size);
-    const Address null_address = alloc(state, 1, "NULL");
-    assert(null_address == 0);
+    const Address null_address = alloc(state, 1, "NULL guard page");
+    v3k_assert(null_address == 0);
 #ifdef WIN32
     DWORD old_protect = 0;
     const BOOL res = VirtualProtect(state.memory.get(), state.page_size, PAGE_NOACCESS, &old_protect);
@@ -101,7 +101,7 @@ bool init(MemState &state) {
     return true;
 }
 
-Address alloc(MemState &state, size_t size, const char *name) {
+Address alloc(MemState &state, size_t size, const std::string& name) {
     const size_t page_count = (size + (state.page_size - 1)) / state.page_size;
     const Allocated::iterator block = std::search_n(state.allocated_pages.begin(), state.allocated_pages.end(), page_count, 0);
     if (block == state.allocated_pages.end()) {

--- a/src/emulator/mem/src/mem.cpp
+++ b/src/emulator/mem/src/mem.cpp
@@ -17,9 +17,9 @@
 
 #include <mem/mem.h>
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstring>
 #include <cmath>
 
@@ -35,7 +35,7 @@ static void delete_memory(uint8_t *memory) {
     if (memory != nullptr) {
 #ifdef WIN32
         const BOOL ret = VirtualFree(memory, 0, MEM_RELEASE);
-        assert(ret);
+        v3k_assert(ret);
 #else
         munmap(memory, GB(4));
 #endif
@@ -52,7 +52,7 @@ static void alloc_inner(MemState &state, Address address, size_t page_count, All
 
 #ifdef WIN32
     const void *const ret = VirtualAlloc(memory, aligned_size, MEM_COMMIT, PAGE_READWRITE);
-    assert(ret == memory);
+    v3k_assert(ret == memory);
 #else
     mprotect(memory, aligned_size, PROT_READ | PROT_WRITE);
 #endif
@@ -67,7 +67,7 @@ bool init(MemState &state) {
 #else
     state.page_size = sysconf(_SC_PAGESIZE);
 #endif
-    assert(state.page_size >= 4096); // Limit imposed by Unicorn.
+    v3k_assert(state.page_size >= 4096); // Limit imposed by Unicorn.
 
     const size_t length = GB(4);
 #ifdef WIN32
@@ -105,7 +105,7 @@ Address alloc(MemState &state, size_t size, const std::string& name) {
     const size_t page_count = (size + (state.page_size - 1)) / state.page_size;
     const Allocated::iterator block = std::search_n(state.allocated_pages.begin(), state.allocated_pages.end(), page_count, 0);
     if (block == state.allocated_pages.end()) {
-        assert(false);
+        v3k_assert(false);
         return 0;
     }
 
@@ -119,11 +119,11 @@ Address alloc(MemState &state, size_t size, const std::string& name) {
 
 void free(MemState &state, Address address) {
     const size_t page = address / state.page_size;
-    assert(page >= 0);
-    assert(page < state.allocated_pages.size());
+    v3k_assert(page >= 0);
+    v3k_assert(page < state.allocated_pages.size());
 
     const Generation generation = state.allocated_pages[page];
-    assert(generation != 0);
+    v3k_assert(generation != 0);
 
     const std::binder1st<std::not_equal_to<Generation>> different_generation = std::bind1st(std::not_equal_to<Generation>(), generation);
     const Allocated::iterator first_page = state.allocated_pages.begin() + page;
@@ -135,8 +135,8 @@ void free(MemState &state, Address address) {
 
 const char *mem_name(Address address, const MemState &state) {
     const size_t page = address / state.page_size;
-    assert(page >= 0);
-    assert(page < state.allocated_pages.size());
+    v3k_assert(page >= 0);
+    v3k_assert(page < state.allocated_pages.size());
 
     const Generation generation = state.allocated_pages[page];
     if (generation == 0) {
@@ -144,7 +144,7 @@ const char *mem_name(Address address, const MemState &state) {
     }
 
     const GenerationNames::const_iterator found = state.generation_names.find(generation);
-    assert(found != state.generation_names.end());
+    v3k_assert(found != state.generation_names.end());
     if (found == state.generation_names.end()) {
         return "UNNAMED";
     }

--- a/src/emulator/module/include/module/bridge.h
+++ b/src/emulator/module/include/module/bridge.h
@@ -20,10 +20,9 @@
 #include <host/state.h>
 #include <kernel/thread_state.h>
 #include <util/lock_and_find.h>
+#include <util/v3k_assert.h>
 
 #include <microprofile.h>
-
-#include <cassert>
 
 struct CPUState;
 
@@ -64,7 +63,7 @@ struct Bridge<Ret (*)(HostState &, SceUID, Args...), export_fn> {
         MICROPROFILE_SCOPEI("HLE", "", MP_YELLOW);
 
         const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
-        assert(thread);
+        v3k_assert(thread);
 
         using Indices = std::index_sequence_for<Args...>;
         CallAndBridgeReturn<Ret (*)(HostState &, SceUID, Args...), export_fn, Indices>::call(thread_id, *thread->cpu, host);

--- a/src/emulator/module/include/module/module.h
+++ b/src/emulator/module/include/module/module.h
@@ -24,8 +24,6 @@
 #include <host/import_fn.h>
 #include <host/state.h>
 
-#include <cassert>
-
 int unimplemented(const char *name);
 int error(const char *name, int error);
 

--- a/src/emulator/modules/SceAudio/SceAudio.cpp
+++ b/src/emulator/modules/SceAudio/SceAudio.cpp
@@ -76,7 +76,7 @@ EXPORT(int, sceAudioOutOutput, int port, const void *buf) {
     }
 
     const std::unique_lock<std::mutex> lock(thread->mutex);
-    assert(thread->to_do == ThreadToDo::run);
+    v3k_assert(thread->to_do == ThreadToDo::run);
     thread->to_do = ThreadToDo::wait;
     stop(*thread->cpu);
 

--- a/src/emulator/modules/SceCtrl/SceCtrl.cpp
+++ b/src/emulator/modules/SceCtrl/SceCtrl.cpp
@@ -17,6 +17,8 @@
 
 #include "SceCtrl.h"
 
+#include <util/v3k_assert.h>
+
 #include <psp2/ctrl.h>
 
 #include <SDL_gamecontroller.h>
@@ -107,14 +109,14 @@ static void apply_keyboard(uint32_t *buttons, float axes[4]) {
 
 static float axis_to_axis(int16_t axis) {
     const float unsigned_axis = axis - INT16_MIN;
-    assert(unsigned_axis >= 0);
-    assert(unsigned_axis <= UINT16_MAX);
+    v3k_assert(unsigned_axis >= 0);
+    v3k_assert(unsigned_axis <= UINT16_MAX);
 
     const float f = unsigned_axis / UINT16_MAX;
 
     const float output = (f * 2) - 1;
-    assert(output >= -1);
-    assert(output <= 1);
+    v3k_assert(output >= -1);
+    v3k_assert(output <= 1);
 
     return output;
 }
@@ -136,8 +138,8 @@ static void apply_controller(uint32_t *buttons, float axes[4], SDL_GameControlle
 static uint8_t float_to_byte(float f) {
     const float mapped = (f * 0.5f) + 0.5f;
     const float clamped = std::max(0.0f, std::min(mapped, 1.0f));
-    assert(clamped >= 0);
-    assert(clamped <= 1);
+    v3k_assert(clamped >= 0);
+    v3k_assert(clamped <= 1);
 
     return static_cast<uint8_t>(clamped * 255);
 }
@@ -222,9 +224,9 @@ EXPORT(int, sceCtrlPeekBufferNegative2) {
 }
 
 EXPORT(int, sceCtrlPeekBufferPositive, int port, SceCtrlData *pad_data, int count) {
-    assert(port == 0);
-    assert(pad_data != nullptr);
-    assert(count == 1);
+    v3k_assert(port == 0);
+    v3k_assert(pad_data != nullptr);
+    v3k_assert(count == 1);
 
     CtrlState &state = host.ctrl;
     remove_disconnected_controllers(state);

--- a/src/emulator/modules/SceDisplay/SceDisplayUser.cpp
+++ b/src/emulator/modules/SceDisplay/SceDisplayUser.cpp
@@ -55,7 +55,7 @@ EXPORT(int, sceDisplayGetResolutionInfoInternal) {
 }
 
 EXPORT(int, sceDisplaySetFrameBuf, const emu::SceDisplayFrameBuf *pParam, SceDisplaySetBufSync sync) {
-    assert(pParam != nullptr); // Todo: pParam can be NULL, in that case black screen is shown
+    v3k_assert(pParam != nullptr); // Todo: pParam can be NULL, in that case black screen is shown
     if (pParam->size != sizeof(emu::SceDisplayFrameBuf)) {
         return error("sceDisplaySetFrameBuf", SCE_DISPLAY_ERROR_INVALID_VALUE);
     }

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -20,6 +20,7 @@
 #include <gxm/functions.h>
 #include <gxm/types.h>
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
 #include <glbinding/Binding.h>
 
@@ -45,14 +46,14 @@ EXPORT(int, sceGxmBeginCommandList) {
 }
 
 EXPORT(int, sceGxmBeginScene, SceGxmContext *context, unsigned int flags, const SceGxmRenderTarget *renderTarget, const SceGxmValidRegion *validRegion, SceGxmSyncObject *vertexSyncObject, SceGxmSyncObject *fragmentSyncObject, const emu::SceGxmColorSurface *colorSurface, const emu::SceGxmDepthStencilSurface *depthStencil) {
-    assert(context != nullptr);
-    assert(flags == 0);
-    assert(renderTarget != nullptr);
-    assert(validRegion == nullptr);
-    assert(vertexSyncObject == nullptr);
-    assert(fragmentSyncObject != nullptr);
-    assert(colorSurface != nullptr);
-    assert(depthStencil != nullptr);
+    v3k_assert(context != nullptr);
+    v3k_assert(flags == 0);
+    v3k_assert(renderTarget != nullptr);
+    v3k_assert(validRegion == nullptr);
+    v3k_assert(vertexSyncObject == nullptr);
+    v3k_assert(fragmentSyncObject != nullptr);
+    v3k_assert(colorSurface != nullptr);
+    v3k_assert(depthStencil != nullptr);
 
     if (host.gxm.isInScene) {
         return error(__func__, SCE_GXM_ERROR_WITHIN_SCENE);
@@ -136,15 +137,15 @@ EXPORT(int, sceGxmColorSurfaceGetType) {
 }
 
 EXPORT(int, sceGxmColorSurfaceInit, emu::SceGxmColorSurface *surface, SceGxmColorFormat colorFormat, SceGxmColorSurfaceType surfaceType, SceGxmColorSurfaceScaleMode scaleMode, SceGxmOutputRegisterSize outputRegisterSize, unsigned int width, unsigned int height, unsigned int strideInPixels, Ptr<void> data) {
-    assert(surface != nullptr);
-    assert(colorFormat == SCE_GXM_COLOR_FORMAT_A8B8G8R8);
-    assert(surfaceType == SCE_GXM_COLOR_SURFACE_LINEAR);
-    assert(scaleMode == SCE_GXM_COLOR_SURFACE_SCALE_NONE);
-    assert(outputRegisterSize == SCE_GXM_OUTPUT_REGISTER_SIZE_32BIT);
-    assert(width > 0);
-    assert(height > 0);
-    assert(strideInPixels > 0);
-    assert(data);
+    v3k_assert(surface != nullptr);
+    v3k_assert(colorFormat == SCE_GXM_COLOR_FORMAT_A8B8G8R8);
+    v3k_assert(surfaceType == SCE_GXM_COLOR_SURFACE_LINEAR);
+    v3k_assert(scaleMode == SCE_GXM_COLOR_SURFACE_SCALE_NONE);
+    v3k_assert(outputRegisterSize == SCE_GXM_OUTPUT_REGISTER_SIZE_32BIT);
+    v3k_assert(width > 0);
+    v3k_assert(height > 0);
+    v3k_assert(strideInPixels > 0);
+    v3k_assert(data);
 
     memset(surface, 0, sizeof(*surface));
     surface->pbeEmitWords[0] = width;
@@ -189,8 +190,8 @@ EXPORT(int, sceGxmColorSurfaceSetScaleMode) {
 }
 
 EXPORT(int, sceGxmCreateContext, const emu::SceGxmContextParams *params, Ptr<SceGxmContext> *context) {
-    assert(params != nullptr);
-    assert(context != nullptr);
+    v3k_assert(params != nullptr);
+    v3k_assert(context != nullptr);
 
     *context = alloc<SceGxmContext>(host.mem, __FUNCTION__);
     if (!*context) {
@@ -200,9 +201,9 @@ EXPORT(int, sceGxmCreateContext, const emu::SceGxmContextParams *params, Ptr<Sce
     SceGxmContext *const ctx = context->get(host.mem);
     ctx->params = *params;
 
-    assert(SDL_GL_GetCurrentContext() == nullptr);
+    v3k_assert(SDL_GL_GetCurrentContext() == nullptr);
     ctx->gl = GLContextPtr(SDL_GL_CreateContext(host.window.get()), SDL_GL_DeleteContext);
-    assert(ctx->gl != nullptr);
+    v3k_assert(ctx->gl != nullptr);
 
     Binding::initialize(false);
     setCallbackMaskExcept(CallbackMask::Before | CallbackMask::After, { "glGetError" });
@@ -232,8 +233,8 @@ EXPORT(int, sceGxmCreateDeferredContext) {
 }
 
 EXPORT(int, sceGxmCreateRenderTarget, const SceGxmRenderTargetParams *params, Ptr<SceGxmRenderTarget> *renderTarget) {
-    assert(params != nullptr);
-    assert(renderTarget != nullptr);
+    v3k_assert(params != nullptr);
+    v3k_assert(renderTarget != nullptr);
 
     *renderTarget = alloc<SceGxmRenderTarget>(host.mem, __FUNCTION__);
     if (!*renderTarget) {
@@ -289,11 +290,11 @@ EXPORT(int, sceGxmDepthStencilSurfaceGetStrideInSamples) {
 }
 
 EXPORT(int, sceGxmDepthStencilSurfaceInit, emu::SceGxmDepthStencilSurface *surface, SceGxmDepthStencilFormat depthStencilFormat, SceGxmDepthStencilSurfaceType surfaceType, unsigned int strideInSamples, Ptr<void> depthData, Ptr<void> stencilData) {
-    assert(surface != nullptr);
-    assert(depthStencilFormat == SCE_GXM_DEPTH_STENCIL_FORMAT_S8D24);
-    assert(surfaceType == SCE_GXM_DEPTH_STENCIL_SURFACE_TILED);
-    assert(strideInSamples > 0);
-    assert(depthData);
+    v3k_assert(surface != nullptr);
+    v3k_assert(depthStencilFormat == SCE_GXM_DEPTH_STENCIL_FORMAT_S8D24);
+    v3k_assert(surfaceType == SCE_GXM_DEPTH_STENCIL_SURFACE_TILED);
+    v3k_assert(strideInSamples > 0);
+    v3k_assert(depthData);
 
     // TODO What to do here?
     memset(surface, 0, sizeof(*surface));
@@ -332,7 +333,7 @@ EXPORT(int, sceGxmDepthStencilSurfaceSetForceStoreMode) {
 }
 
 EXPORT(int, sceGxmDestroyContext, Ptr<SceGxmContext> context) {
-    assert(context);
+    v3k_assert(context);
 
     free(host.mem, context);
 
@@ -345,7 +346,7 @@ EXPORT(int, sceGxmDestroyDeferredContext) {
 
 EXPORT(int, sceGxmDestroyRenderTarget, Ptr<SceGxmRenderTarget> renderTarget) {
     MemState &mem = host.mem;
-    assert(renderTarget);
+    v3k_assert(renderTarget);
 
     free(mem, renderTarget);
 
@@ -353,9 +354,9 @@ EXPORT(int, sceGxmDestroyRenderTarget, Ptr<SceGxmRenderTarget> renderTarget) {
 }
 
 EXPORT(void, sceGxmDisplayQueueAddEntry, Ptr<SceGxmSyncObject> oldBuffer, Ptr<SceGxmSyncObject> newBuffer, Ptr<const void> callbackData) {
-    //assert(oldBuffer != nullptr);
-    //assert(newBuffer != nullptr);
-    assert(callbackData);
+    //v3k_assert(oldBuffer != nullptr);
+    //v3k_assert(newBuffer != nullptr);
+    v3k_assert(callbackData);
     DisplayCallback *display_callback = new DisplayCallback();
 
     const Address address = alloc(host.mem, host.gxm.params.displayQueueCallbackDataSize, __FUNCTION__);
@@ -376,8 +377,8 @@ EXPORT(int, sceGxmDisplayQueueFinish) {
 }
 
 EXPORT(int, sceGxmDraw, SceGxmContext *context, SceGxmPrimitiveType primType, SceGxmIndexFormat indexType, const void *indexData, unsigned int indexCount) {
-    assert(context != nullptr);
-    assert(indexData != nullptr);
+    v3k_assert(context != nullptr);
+    v3k_assert(indexData != nullptr);
 
     if (!host.gxm.isInScene) {
         return error(__func__, SCE_GXM_ERROR_NOT_WITHIN_SCENE);
@@ -414,9 +415,9 @@ EXPORT(int, sceGxmEndCommandList) {
 
 EXPORT(int, sceGxmEndScene, SceGxmContext *context, const emu::SceGxmNotification *vertexNotification, const emu::SceGxmNotification *fragmentNotification) {
     const MemState &mem = host.mem;
-    assert(context != nullptr);
-    assert(vertexNotification == nullptr);
-    assert(fragmentNotification == nullptr);
+    v3k_assert(context != nullptr);
+    v3k_assert(vertexNotification == nullptr);
+    v3k_assert(fragmentNotification == nullptr);
 
     if (!host.gxm.isInScene) {
         return error(__func__, SCE_GXM_ERROR_NOT_WITHIN_SCENE);
@@ -443,7 +444,7 @@ EXPORT(int, sceGxmExecuteCommandList) {
 }
 
 EXPORT(void, sceGxmFinish, SceGxmContext *context) {
-    assert(context != nullptr);
+    v3k_assert(context != nullptr);
     glFinish();
 }
 
@@ -529,7 +530,7 @@ static int SDLCALL thread_function(void *data) {
 }
 
 EXPORT(int, sceGxmInitialize, const emu::SceGxmInitializeParams *params) {
-    assert(params != nullptr);
+    v3k_assert(params != nullptr);
 
     host.gxm.params = *params;
     host.gxm.display_queue.displayQueueMaxPendingCount_ = params->displayQueueMaxPendingCount;
@@ -573,9 +574,9 @@ EXPORT(int, sceGxmIsDebugVersion) {
 }
 
 EXPORT(int, sceGxmMapFragmentUsseMemory, Ptr<void> base, SceSize size, unsigned int *offset) {
-    assert(base);
-    assert(size > 0);
-    assert(offset != nullptr);
+    v3k_assert(base);
+    v3k_assert(size > 0);
+    v3k_assert(offset != nullptr);
 
     // TODO What should this be?
     *offset = base.address();
@@ -584,17 +585,17 @@ EXPORT(int, sceGxmMapFragmentUsseMemory, Ptr<void> base, SceSize size, unsigned 
 }
 
 EXPORT(int, sceGxmMapMemory, void *base, SceSize size, SceGxmMemoryAttribFlags attr) {
-    assert(base != nullptr);
-    assert(size > 0);
-    assert((attr == SCE_GXM_MEMORY_ATTRIB_READ) || (attr == SCE_GXM_MEMORY_ATTRIB_RW));
+    v3k_assert(base != nullptr);
+    v3k_assert(size > 0);
+    v3k_assert((attr == SCE_GXM_MEMORY_ATTRIB_READ) || (attr == SCE_GXM_MEMORY_ATTRIB_RW));
 
     return 0;
 }
 
 EXPORT(int, sceGxmMapVertexUsseMemory, Ptr<void> base, SceSize size, unsigned int *offset) {
-    assert(base);
-    assert(size > 0);
-    assert(offset != nullptr);
+    v3k_assert(base);
+    v3k_assert(size > 0);
+    v3k_assert(offset != nullptr);
 
     // TODO What should this be?
     *offset = base.address();
@@ -611,8 +612,8 @@ EXPORT(int, sceGxmNotificationWait) {
 }
 
 EXPORT(int, sceGxmPadHeartbeat, const emu::SceGxmColorSurface *displaySurface, SceGxmSyncObject *displaySyncObject) {
-    assert(displaySurface != nullptr);
-    assert(displaySyncObject != nullptr);
+    v3k_assert(displaySurface != nullptr);
+    v3k_assert(displaySyncObject != nullptr);
 
     return 0;
 }
@@ -706,20 +707,20 @@ EXPORT(int, sceGxmPrecomputedVertexStateSetUniformBuffer) {
 }
 
 EXPORT(int, sceGxmProgramCheck, const SceGxmProgram *program) {
-    assert(program != nullptr);
+    v3k_assert(program != nullptr);
 
-    assert(memcmp(&program->magic, "GXP", 4) == 0);
-    assert(program->major_version == 1);
-    assert(program->minor_version == 4);
-    assert(program->unk6 == 0);
+    v3k_assert(memcmp(&program->magic, "GXP", 4) == 0);
+    v3k_assert(program->major_version == 1);
+    v3k_assert(program->minor_version == 4);
+    v3k_assert(program->unk6 == 0);
 
     return 0;
 }
 
 EXPORT(Ptr<SceGxmProgramParameter>, sceGxmProgramFindParameterByName, const SceGxmProgram *program, const char *name) {
     const MemState &mem = host.mem;
-    assert(program != nullptr);
-    assert(name != nullptr);
+    v3k_assert(program != nullptr);
+    v3k_assert(name != nullptr);
 
     const SceGxmProgramParameter *const parameters = reinterpret_cast<const SceGxmProgramParameter *>(reinterpret_cast<const uint8_t *>(&program->parameters_offset) + program->parameters_offset);
     for (uint32_t i = 0; i < program->parameter_count; ++i) {
@@ -820,7 +821,7 @@ EXPORT(int, sceGxmProgramParameterGetName) {
 }
 
 EXPORT(unsigned int, sceGxmProgramParameterGetResourceIndex, const SceGxmProgramParameter *parameter) {
-    assert(parameter != nullptr);
+    v3k_assert(parameter != nullptr);
 
     return parameter->resource_index;
 }
@@ -858,12 +859,12 @@ EXPORT(int, sceGxmRenderTargetGetDriverMemBlock) {
 }
 
 EXPORT(int, sceGxmReserveFragmentDefaultUniformBuffer, SceGxmContext *context, Ptr<void> *uniformBuffer) {
-    assert(context != nullptr);
-    assert(uniformBuffer != nullptr);
+    v3k_assert(context != nullptr);
+    v3k_assert(uniformBuffer != nullptr);
 
     const size_t size = 64; // TODO I guess this must be in the fragment program.
     const size_t next_used = context->fragment_ring_buffer_used + size;
-    assert(next_used <= context->params.fragmentRingBufferMemSize);
+    v3k_assert(next_used <= context->params.fragmentRingBufferMemSize);
     if (next_used > context->params.fragmentRingBufferMemSize) {
         return error(__func__, SCE_GXM_ERROR_OUT_OF_MEMORY);
     }
@@ -881,12 +882,12 @@ EXPORT(int, sceGxmRenderTargetGetHostMem) {
 }
 
 EXPORT(int, sceGxmReserveVertexDefaultUniformBuffer, SceGxmContext *context, Ptr<void> *uniformBuffer) {
-    assert(context != nullptr);
-    assert(uniformBuffer != nullptr);
+    v3k_assert(context != nullptr);
+    v3k_assert(uniformBuffer != nullptr);
 
     const size_t size = 64; // TODO I guess this must be in the vertex program.
     const size_t next_used = context->vertex_ring_buffer_used + size;
-    assert(next_used <= context->params.vertexRingBufferMemSize);
+    v3k_assert(next_used <= context->params.vertexRingBufferMemSize);
     if (next_used > context->params.vertexRingBufferMemSize) {
         return error(__func__, SCE_GXM_ERROR_OUT_OF_MEMORY);
     }
@@ -990,8 +991,8 @@ EXPORT(int, sceGxmSetFragmentDefaultUniformBuffer) {
 }
 
 EXPORT(void, sceGxmSetFragmentProgram, SceGxmContext *context, Ptr<const SceGxmFragmentProgram> fragmentProgram) {
-    assert(context != nullptr);
-    assert(fragmentProgram);
+    v3k_assert(context != nullptr);
+    v3k_assert(fragmentProgram);
 
     context->fragment_program = fragmentProgram;
 
@@ -1007,8 +1008,8 @@ EXPORT(void, sceGxmSetFragmentProgram, SceGxmContext *context, Ptr<const SceGxmF
 }
 
 EXPORT(int, sceGxmSetFragmentTexture, SceGxmContext *context, unsigned int textureIndex, const SceGxmTexture *texture) {
-    assert(context != nullptr);
-    assert(texture != nullptr);
+    v3k_assert(context != nullptr);
+    v3k_assert(texture != nullptr);
 
     glActiveTexture((GLenum)(GL_TEXTURE0 + textureIndex));
     glBindTexture(GL_TEXTURE_2D, context->texture[0]);
@@ -1161,13 +1162,13 @@ EXPORT(int, sceGxmSetTwoSidedEnable) {
 }
 
 EXPORT(int, sceGxmSetUniformDataF, void *uniformBuffer, const SceGxmProgramParameter *parameter, unsigned int componentOffset, unsigned int componentCount, const float *sourceData) {
-    assert(uniformBuffer != nullptr);
-    assert(parameter != nullptr);
-    assert(parameter->container_index == 14);
-    assert(parameter->resource_index == 0);
-    assert(componentOffset == 0);
-    assert(componentCount > 0);
-    assert(sourceData != nullptr);
+    v3k_assert(uniformBuffer != nullptr);
+    v3k_assert(parameter != nullptr);
+    v3k_assert(parameter->container_index == 14);
+    v3k_assert(parameter->resource_index == 0);
+    v3k_assert(componentOffset == 0);
+    v3k_assert(componentCount > 0);
+    v3k_assert(sourceData != nullptr);
 
     size_t size = componentCount * sizeof(float);
     size_t offset = componentOffset * sizeof(float);
@@ -1189,16 +1190,16 @@ EXPORT(int, sceGxmSetVertexDefaultUniformBuffer) {
 }
 
 EXPORT(void, sceGxmSetVertexProgram, SceGxmContext *context, Ptr<const SceGxmVertexProgram> vertexProgram) {
-    assert(context != nullptr);
-    assert(vertexProgram);
+    v3k_assert(context != nullptr);
+    v3k_assert(vertexProgram);
 
     context->vertex_program = vertexProgram;
 }
 
 EXPORT(int, sceGxmSetVertexStream, SceGxmContext *context, unsigned int streamIndex, const uint8_t *streamData) {
-    assert(context != nullptr);
-    assert(streamData != nullptr);
-    assert(context->vertex_program);
+    v3k_assert(context != nullptr);
+    v3k_assert(streamData != nullptr);
+    v3k_assert(context->vertex_program);
 
     const SceGxmVertexProgram &vertex_program = *context->vertex_program.get(host.mem);
     for (const emu::SceGxmVertexAttribute &attribute : vertex_program.attributes) {
@@ -1260,8 +1261,8 @@ EXPORT(int, sceGxmSetYuvProfile) {
 }
 
 EXPORT(int, sceGxmShaderPatcherAddRefFragmentProgram, SceGxmShaderPatcher *shaderPatcher, SceGxmFragmentProgram *fragmentProgram) {
-    assert(shaderPatcher != nullptr);
-    assert(fragmentProgram != nullptr);
+    v3k_assert(shaderPatcher != nullptr);
+    v3k_assert(fragmentProgram != nullptr);
 
     ++fragmentProgram->reference_count;
 
@@ -1269,8 +1270,8 @@ EXPORT(int, sceGxmShaderPatcherAddRefFragmentProgram, SceGxmShaderPatcher *shade
 }
 
 EXPORT(int, sceGxmShaderPatcherAddRefVertexProgram, SceGxmShaderPatcher *shaderPatcher, SceGxmVertexProgram *vertexProgram) {
-    assert(shaderPatcher != nullptr);
-    assert(vertexProgram != nullptr);
+    v3k_assert(shaderPatcher != nullptr);
+    v3k_assert(vertexProgram != nullptr);
 
     ++vertexProgram->reference_count;
 
@@ -1278,11 +1279,11 @@ EXPORT(int, sceGxmShaderPatcherAddRefVertexProgram, SceGxmShaderPatcher *shaderP
 }
 
 EXPORT(int, sceGxmShaderPatcherCreate, const emu::SceGxmShaderPatcherParams *params, Ptr<SceGxmShaderPatcher> *shaderPatcher) {
-    assert(params != nullptr);
-    assert(shaderPatcher != nullptr);
+    v3k_assert(params != nullptr);
+    v3k_assert(shaderPatcher != nullptr);
 
     *shaderPatcher = alloc<SceGxmShaderPatcher>(host.mem, __FUNCTION__);
-    assert(*shaderPatcher);
+    v3k_assert(*shaderPatcher);
     if (!*shaderPatcher) {
         return error(__func__, SCE_GXM_ERROR_OUT_OF_MEMORY);
     }
@@ -1292,12 +1293,12 @@ EXPORT(int, sceGxmShaderPatcherCreate, const emu::SceGxmShaderPatcherParams *par
 
 EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shaderPatcher, const SceGxmRegisteredProgram *programId, SceGxmOutputRegisterFormat outputFormat, SceGxmMultisampleMode multisampleMode, const emu::SceGxmBlendInfo *blendInfo, Ptr<const SceGxmProgram> vertexProgram, Ptr<SceGxmFragmentProgram> *fragmentProgram) {
     MemState &mem = host.mem;
-    assert(shaderPatcher != nullptr);
-    assert(programId != nullptr);
-    assert(outputFormat == SCE_GXM_OUTPUT_REGISTER_FORMAT_UCHAR4);
-    assert(multisampleMode == SCE_GXM_MULTISAMPLE_NONE);
-    assert(vertexProgram);
-    assert(fragmentProgram != nullptr);
+    v3k_assert(shaderPatcher != nullptr);
+    v3k_assert(programId != nullptr);
+    v3k_assert(outputFormat == SCE_GXM_OUTPUT_REGISTER_FORMAT_UCHAR4);
+    v3k_assert(multisampleMode == SCE_GXM_MULTISAMPLE_NONE);
+    v3k_assert(vertexProgram);
+    v3k_assert(fragmentProgram != nullptr);
 
     static const emu::SceGxmBlendInfo default_blend_info = {
         SCE_GXM_COLOR_MASK_ALL,
@@ -1320,7 +1321,7 @@ EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shade
     }
 
     *fragmentProgram = alloc<SceGxmFragmentProgram>(mem, __FUNCTION__);
-    assert(*fragmentProgram);
+    v3k_assert(*fragmentProgram);
     if (!*fragmentProgram) {
         return error(__func__, SCE_GXM_ERROR_OUT_OF_MEMORY);
     }
@@ -1355,16 +1356,16 @@ EXPORT(int, sceGxmShaderPatcherCreateMaskUpdateFragmentProgram) {
 
 EXPORT(int, sceGxmShaderPatcherCreateVertexProgram, SceGxmShaderPatcher *shaderPatcher, const SceGxmRegisteredProgram *programId, const emu::SceGxmVertexAttribute *attributes, unsigned int attributeCount, const SceGxmVertexStream *streams, unsigned int streamCount, Ptr<SceGxmVertexProgram> *vertexProgram) {
     MemState &mem = host.mem;
-    assert(shaderPatcher != nullptr);
-    assert(programId != nullptr);
-    assert(attributes != nullptr);
-    assert(attributeCount > 0);
-    assert(streams != nullptr);
-    assert(streamCount > 0);
-    assert(vertexProgram != nullptr);
+    v3k_assert(shaderPatcher != nullptr);
+    v3k_assert(programId != nullptr);
+    v3k_assert(attributes != nullptr);
+    v3k_assert(attributeCount > 0);
+    v3k_assert(streams != nullptr);
+    v3k_assert(streamCount > 0);
+    v3k_assert(vertexProgram != nullptr);
 
     *vertexProgram = alloc<SceGxmVertexProgram>(mem, __FUNCTION__);
-    assert(*vertexProgram);
+    v3k_assert(*vertexProgram);
     if (!*vertexProgram) {
         return error(__func__, SCE_GXM_ERROR_OUT_OF_MEMORY);
     }
@@ -1380,7 +1381,7 @@ EXPORT(int, sceGxmShaderPatcherCreateVertexProgram, SceGxmShaderPatcher *shaderP
 }
 
 EXPORT(int, sceGxmShaderPatcherDestroy, Ptr<SceGxmShaderPatcher> shaderPatcher) {
-    assert(shaderPatcher);
+    v3k_assert(shaderPatcher);
 
     free(host.mem, shaderPatcher);
 
@@ -1428,12 +1429,12 @@ EXPORT(int, sceGxmShaderPatcherGetVertexUsseMemAllocated) {
 }
 
 EXPORT(int, sceGxmShaderPatcherRegisterProgram, SceGxmShaderPatcher *shaderPatcher, Ptr<const SceGxmProgram> programHeader, emu::SceGxmShaderPatcherId *programId) {
-    assert(shaderPatcher != nullptr);
-    assert(programHeader);
-    assert(programId != nullptr);
+    v3k_assert(shaderPatcher != nullptr);
+    v3k_assert(programHeader);
+    v3k_assert(programId != nullptr);
 
     *programId = alloc<SceGxmRegisteredProgram>(host.mem, __FUNCTION__);
-    assert(*programId);
+    v3k_assert(*programId);
     if (!*programId) {
         return error(__func__, SCE_GXM_ERROR_OUT_OF_MEMORY);
     }
@@ -1445,8 +1446,8 @@ EXPORT(int, sceGxmShaderPatcherRegisterProgram, SceGxmShaderPatcher *shaderPatch
 }
 
 EXPORT(int, sceGxmShaderPatcherReleaseFragmentProgram, SceGxmShaderPatcher *shaderPatcher, Ptr<SceGxmFragmentProgram> fragmentProgram) {
-    assert(shaderPatcher != nullptr);
-    assert(fragmentProgram);
+    v3k_assert(shaderPatcher != nullptr);
+    v3k_assert(fragmentProgram);
 
     SceGxmFragmentProgram *const fp = fragmentProgram.get(host.mem);
     --fp->reference_count;
@@ -1464,8 +1465,8 @@ EXPORT(int, sceGxmShaderPatcherReleaseFragmentProgram, SceGxmShaderPatcher *shad
 }
 
 EXPORT(int, sceGxmShaderPatcherReleaseVertexProgram, SceGxmShaderPatcher *shaderPatcher, Ptr<SceGxmVertexProgram> vertexProgram) {
-    assert(shaderPatcher != nullptr);
-    assert(vertexProgram);
+    v3k_assert(shaderPatcher != nullptr);
+    v3k_assert(vertexProgram);
 
     SceGxmVertexProgram *const vp = vertexProgram.get(host.mem);
     --vp->reference_count;
@@ -1485,8 +1486,8 @@ EXPORT(int, sceGxmShaderPatcherSetUserData) {
 }
 
 EXPORT(int, sceGxmShaderPatcherUnregisterProgram, SceGxmShaderPatcher *shaderPatcher, emu::SceGxmShaderPatcherId programId) {
-    assert(shaderPatcher != nullptr);
-    assert(programId);
+    v3k_assert(shaderPatcher != nullptr);
+    v3k_assert(programId);
 
     SceGxmRegisteredProgram *const rp = programId.get(host.mem);
     rp->program.reset();
@@ -1497,7 +1498,7 @@ EXPORT(int, sceGxmShaderPatcherUnregisterProgram, SceGxmShaderPatcher *shaderPat
 }
 
 EXPORT(int, sceGxmSyncObjectCreate, Ptr<SceGxmSyncObject> *syncObject) {
-    assert(syncObject != nullptr);
+    v3k_assert(syncObject != nullptr);
 
     *syncObject = alloc<SceGxmSyncObject>(host.mem, __FUNCTION__);
     if (!*syncObject) {
@@ -1510,7 +1511,7 @@ EXPORT(int, sceGxmSyncObjectCreate, Ptr<SceGxmSyncObject> *syncObject) {
 }
 
 EXPORT(int, sceGxmSyncObjectDestroy, Ptr<SceGxmSyncObject> syncObject) {
-    assert(syncObject);
+    v3k_assert(syncObject);
 
     free(host.mem, syncObject);
 
@@ -1522,27 +1523,27 @@ EXPORT(int, sceGxmTerminate) {
 }
 
 EXPORT(Ptr<void>, sceGxmTextureGetData, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return Ptr<void>(texture->data_addr << 2);
 }
 
 EXPORT(int, sceGxmTextureGetFormat, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return texture::get_format(texture);
 }
 
 EXPORT(int, sceGxmTextureGetGammaMode, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return (texture->gamma_mode << 27);
 }
 
 EXPORT(unsigned int, sceGxmTextureGetHeight, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return texture::get_height(texture);
 }
 
 EXPORT(unsigned int, sceGxmTextureGetLodBias, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     if ((texture->type << 29) == SCE_GXM_TEXTURE_LINEAR_STRIDED){
         return 0;
     }
@@ -1550,7 +1551,7 @@ EXPORT(unsigned int, sceGxmTextureGetLodBias, const SceGxmTexture *texture) {
 }
 
 EXPORT(unsigned int, sceGxmTextureGetLodMin, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     if ((texture->type << 29) == SCE_GXM_TEXTURE_LINEAR_STRIDED){
         return 0;
     }
@@ -1558,12 +1559,12 @@ EXPORT(unsigned int, sceGxmTextureGetLodMin, const SceGxmTexture *texture) {
 }
 
 EXPORT(int, sceGxmTextureGetMagFilter, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return texture->mag_filter;
 }
 
 EXPORT(int, sceGxmTextureGetMinFilter, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     if ((texture->type << 29) == SCE_GXM_TEXTURE_LINEAR_STRIDED){
         return texture->mag_filter;
     }
@@ -1571,7 +1572,7 @@ EXPORT(int, sceGxmTextureGetMinFilter, const SceGxmTexture *texture) {
 }
 
 EXPORT(int, sceGxmTextureGetMipFilter, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     if ((texture->type << 29) == SCE_GXM_TEXTURE_LINEAR_STRIDED){
         return SCE_GXM_TEXTURE_MIP_FILTER_DISABLED;
     }
@@ -1579,7 +1580,7 @@ EXPORT(int, sceGxmTextureGetMipFilter, const SceGxmTexture *texture) {
 }
 
 EXPORT(unsigned int, sceGxmTextureGetMipmapCount, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     if ((texture->type << 29) == SCE_GXM_TEXTURE_LINEAR_STRIDED){
         return 0;
     }
@@ -1587,7 +1588,7 @@ EXPORT(unsigned int, sceGxmTextureGetMipmapCount, const SceGxmTexture *texture) 
 }
 
 EXPORT(unsigned int, sceGxmTextureGetMipmapCountUnsafe, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return texture->mip_count + 1;
 }
 
@@ -1596,8 +1597,8 @@ EXPORT(int, sceGxmTextureGetNormalizeMode, const SceGxmTexture *texture) {
 }
 
 EXPORT(Ptr<void>, sceGxmTextureGetPalette, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
-    assert(texture::is_paletted_format(texture::get_format(texture)));
+    v3k_assert(texture != nullptr);
+    v3k_assert(texture::is_paletted_format(texture::get_format(texture)));
     return Ptr<void>(texture->palette_addr << 6);
 }
 
@@ -1606,17 +1607,17 @@ EXPORT(int, sceGxmTextureGetStride) {
 }
 
 EXPORT(int, sceGxmTextureGetType, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return (texture->type << 29);
 }
 
 EXPORT(int, sceGxmTextureGetUAddrMode, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return texture->uaddr_mode;
 }
 
 EXPORT(int, sceGxmTextureGetUAddrModeSafe, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     if ((texture->type << 29) == SCE_GXM_TEXTURE_LINEAR_STRIDED){
         return SCE_GXM_TEXTURE_ADDR_CLAMP;
     }
@@ -1624,12 +1625,12 @@ EXPORT(int, sceGxmTextureGetUAddrModeSafe, const SceGxmTexture *texture) {
 }
 
 EXPORT(int, sceGxmTextureGetVAddrMode, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return texture->vaddr_mode;
 }
 
 EXPORT(int, sceGxmTextureGetVAddrModeSafe, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     if ((texture->type << 29) == SCE_GXM_TEXTURE_LINEAR_STRIDED){
         return SCE_GXM_TEXTURE_ADDR_CLAMP;
     }
@@ -1637,7 +1638,7 @@ EXPORT(int, sceGxmTextureGetVAddrModeSafe, const SceGxmTexture *texture) {
 }
 
 EXPORT(unsigned int, sceGxmTextureGetWidth, const SceGxmTexture *texture) {
-    assert(texture != nullptr);
+    v3k_assert(texture != nullptr);
     return texture::get_width(texture);
 }
 
@@ -1907,19 +1908,19 @@ EXPORT(int, sceGxmTransferFinish) {
 }
 
 EXPORT(int, sceGxmUnmapFragmentUsseMemory, void *base) {
-    assert(base != nullptr);
+    v3k_assert(base != nullptr);
 
     return 0;
 }
 
 EXPORT(int, sceGxmUnmapMemory, void *base) {
-    assert(base != nullptr);
+    v3k_assert(base != nullptr);
 
     return 0;
 }
 
 EXPORT(int, sceGxmUnmapVertexUsseMemory, void *base) {
-    assert(base != nullptr);
+    v3k_assert(base != nullptr);
 
     return 0;
 }

--- a/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
+++ b/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
@@ -22,6 +22,7 @@
 #include <io/functions.h>
 #include <kernel/functions.h>
 #include <kernel/thread_functions.h>
+#include <util/v3k_assert.h>
 
 #include <psp2/kernel/error.h>
 #include <psp2/kernel/threadmgr.h>
@@ -762,12 +763,12 @@ EXPORT(int, sceKernelCreateLwCond) {
 }
 
 EXPORT(int, sceKernelCreateLwMutex, SceKernelLwMutexWork *pWork, const char *pName, unsigned int attr, int initCount, const SceKernelLwMutexOptParam *pOptParam) {
-    assert(pWork != nullptr);
-    assert(pName != nullptr);
-    assert((attr == 0) || (attr == 2));
-    assert(initCount >= 0);
-    assert(initCount <= 1);
-    assert(pOptParam == nullptr);
+    v3k_assert(pWork != nullptr);
+    v3k_assert(pName != nullptr);
+    v3k_assert((attr == 0) || (attr == 2));
+    v3k_assert(initCount >= 0);
+    v3k_assert(initCount <= 1);
+    v3k_assert(pOptParam == nullptr);
 
     return unimplemented("sceKernelCreateLwMutex");
 }
@@ -991,9 +992,9 @@ EXPORT(int, sceKernelLoadStartModule) {
 }
 
 EXPORT(int, sceKernelLockLwMutex, SceKernelLwMutexWork *pWork, int lockCount, unsigned int *pTimeout) {
-    assert(pWork != nullptr);
-    assert(lockCount == 1);
-    assert(pTimeout == nullptr);
+    v3k_assert(pWork != nullptr);
+    v3k_assert(lockCount == 1);
+    v3k_assert(pTimeout == nullptr);
 
     return unimplemented("sceKernelLockLwMutex");
 }
@@ -1163,8 +1164,8 @@ EXPORT(int, sceKernelUnloadModule) {
 }
 
 EXPORT(int, sceKernelUnlockLwMutex, SceKernelLwMutexWork *pWork, int unlockCount) {
-    assert(pWork != nullptr);
-    assert(unlockCount == 1);
+    v3k_assert(pWork != nullptr);
+    v3k_assert(unlockCount == 1);
 
     return unimplemented("sceKernelUnlockLwMutex");
 }
@@ -1218,9 +1219,9 @@ EXPORT(int, sceKernelWaitMultipleEventsCB) {
 }
 
 EXPORT(int, sceKernelWaitSema, SceUID semaid, int signal, SceUInt *timeout) {
-    assert(semaid >= 0);
-    assert(signal == 1);
-    assert(timeout == nullptr);
+    v3k_assert(semaid >= 0);
+    v3k_assert(signal == 1);
+    v3k_assert(timeout == nullptr);
 
     // TODO Don't lock twice.
     const SemaphorePtr semaphore = lock_and_find(semaid, host.kernel.semaphores, host.kernel.mutex);
@@ -1232,7 +1233,7 @@ EXPORT(int, sceKernelWaitSema, SceUID semaid, int signal, SceUInt *timeout) {
 
     {
         const std::unique_lock<std::mutex> lock(thread->mutex);
-        assert(thread->to_do == ThreadToDo::run);
+        v3k_assert(thread->to_do == ThreadToDo::run);
         thread->to_do = ThreadToDo::wait;
     }
     stop(*thread->cpu);

--- a/src/emulator/modules/SceSysmem/SceSysmem.cpp
+++ b/src/emulator/modules/SceSysmem/SceSysmem.cpp
@@ -28,10 +28,10 @@ using namespace emu;
 
 EXPORT(SceUID, sceKernelAllocMemBlock, const char *name, SceKernelMemBlockType type, int size, emu::SceKernelAllocMemBlockOpt *optp) {
     MemState &mem = host.mem;
-    assert(name != nullptr);
-    assert(type != 0);
-    assert(size != 0);
-    assert(optp == nullptr);
+    v3k_assert(name != nullptr);
+    v3k_assert(type != 0);
+    v3k_assert(size != 0);
+    v3k_assert(optp == nullptr);
 
     const Ptr<void> address(alloc(mem, size, name));
     if (!address) {
@@ -70,11 +70,11 @@ EXPORT(int, sceKernelFindMemBlockByAddr) {
 }
 
 EXPORT(int, sceKernelFreeMemBlock, SceUID uid) {
-    assert(uid >= 0);
+    v3k_assert(uid >= 0);
 
     KernelState *const state = &host.kernel;
     const Blocks::const_iterator block = state->blocks.find(uid);
-    assert(block != state->blocks.end());
+    v3k_assert(block != state->blocks.end());
 
     free(host.mem, block->second.address());
     state->blocks.erase(block);
@@ -91,8 +91,8 @@ EXPORT(int, sceKernelGetFreeMemorySize) {
 }
 
 EXPORT(int, sceKernelGetMemBlockBase, SceUID uid, Ptr<void> *basep) {
-    assert(uid >= 0);
-    assert(basep != nullptr);
+    v3k_assert(uid >= 0);
+    v3k_assert(basep != nullptr);
 
     const KernelState *const state = &host.kernel;
     const Blocks::const_iterator block = state->blocks.find(uid);

--- a/src/emulator/modules/SceTouch/SceTouch.cpp
+++ b/src/emulator/modules/SceTouch/SceTouch.cpp
@@ -78,10 +78,10 @@ EXPORT(int, sceTouchGetSamplingStateExt) {
 }
 
 EXPORT(int, sceTouchPeek, SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs) {
-    assert(port >= 0);
-    assert(port <= 1);
-    assert(pData != nullptr);
-    assert(nBufs == 1);
+    v3k_assert(port >= 0);
+    v3k_assert(port <= 1);
+    v3k_assert(pData != nullptr);
+    v3k_assert(nBufs == 1);
 
     memset(pData, 0, sizeof(*pData));
     pData->timeStamp = timestamp++; // TODO Use the real time and units.

--- a/src/emulator/relocation.cpp
+++ b/src/emulator/relocation.cpp
@@ -17,8 +17,8 @@
 
 #include "relocation.h"
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
-#include <assert.h>
 #include <iostream>
 #include <cstring>
 
@@ -202,7 +202,7 @@ bool relocate(const void *entries, size_t size, const SegmentAddresses &segments
     const void *const end = static_cast<const uint8_t *>(entries) + size;
     const Entry *entry = static_cast<const Entry *>(entries);
     while (entry < end) {
-        assert(entry->is_short == 0);
+        v3k_assert(entry->is_short == 0);
 
         const Ptr<void> symbol_start = segments.find(entry->symbol_segment)->second;
         const Address s = (entry->symbol_segment == 0xf) ? 0 : symbol_start.address();
@@ -212,7 +212,7 @@ bool relocate(const void *entries, size_t size, const SegmentAddresses &segments
             entry = short_entry + 1;
         } else {
             const LongEntry *const long_entry = static_cast<const LongEntry *>(entry);
-            assert(long_entry->code2 == 0);
+            v3k_assert(long_entry->code2 == 0);
 
             const Ptr<void> segment_start = segments.find(long_entry->data_segment)->second;
             const Address p = segment_start.address() + long_entry->offset;

--- a/src/emulator/util/CMakeLists.txt
+++ b/src/emulator/util/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
 	util
 	STATIC
+	include/util/v3k_assert.h
 	include/util/find.h
 	include/util/lock_and_find.h
 	include/util/resource.h

--- a/src/emulator/util/include/util/log.h
+++ b/src/emulator/util/include/util/log.h
@@ -1,3 +1,20 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 #pragma once
 
 #include <spdlog/spdlog.h>
@@ -13,9 +30,9 @@ void init_logging();
 #define LOG_ERROR(fmt, ...) g_logger->error("|E| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
 #define LOG_CRITICAL(fmt, ...) g_logger->critical("|C| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
 
-#define LOG_TRACE_IF(flag, fmt, ...) g_logger->trace_if(flag, "|T| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
-#define LOG_DEBUG_IF(flag, fmt, ...) g_logger->debug_if(flag, "|D| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
-#define LOG_INFO_IF(flag, fmt, ...) g_logger->info_if(flag, "|I| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
-#define LOG_WARN_IF(flag, fmt, ...) g_logger->warn_if(flag, "|W| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
-#define LOG_ERROR_IF(flag, fmt, ...) g_logger->error_if(flag, "|E| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
-#define LOG_CRITICAL_IF(flag, fmt, ...) g_logger->critical_if(flag, "|C| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
+#define LOG_TRACE_IF(flag, fmt, ...) if (flag) g_logger->trace(flag, "|T| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
+#define LOG_DEBUG_IF(flag, fmt, ...) if (flag) g_logger->debug(flag, "|D| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
+#define LOG_INFO_IF(flag, fmt, ...) if (flag) g_logger->info(flag, "|I| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
+#define LOG_WARN_IF(flag, fmt, ...) if (flag) g_logger->warn(flag, "|W| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
+#define LOG_ERROR_IF(flag, fmt, ...) if (flag) g_logger->error(flag, "|E| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)
+#define LOG_CRITICAL_IF(flag, fmt, ...) if (flag) g_logger->critical(flag, "|C| [{:s}]:  " fmt, __FUNCTION__, ## __VA_ARGS__)

--- a/src/emulator/util/include/util/v3k_assert.h
+++ b/src/emulator/util/include/util/v3k_assert.h
@@ -1,0 +1,41 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <util/log.h>
+
+#include <cstdlib>
+
+#define STRINGIZE_DETAIL(x) #x ""
+#define STRINGIZE(x) STRINGIZE_DETAIL(x)
+#define HERE "(in file " __FILE__ ":" STRINGIZE(__LINE__) ")"
+
+static bool g_should_abort = false;
+inline void v3k_assert_set_abort(bool should_abort) {
+    g_should_abort = should_abort;
+}
+
+#define v3k_assert(flag, fmt, ...)                                                           \
+    do {                                                                                     \
+        if (!(flag)) {                                                                       \
+            LOG_CRITICAL("Assertion \"{}\" failed!\n{}\n" fmt, #flag, HERE, ##__VA_ARGS__); \
+            if (g_should_abort) {                                                           \
+                abort();                                                                     \
+            }                                                                                \
+        }                                                                                    \
+    } while (false)

--- a/src/emulator/vpk.cpp
+++ b/src/emulator/vpk.cpp
@@ -23,8 +23,8 @@
 #include <io/state.h>
 #include <util/string_convert.h>
 #include <util/log.h>
+#include <util/v3k_assert.h>
 
-#include <cassert>
 #include <cstring>
 #include <vector>
 
@@ -37,7 +37,7 @@ static void delete_zip(mz_zip_archive *zip) {
 
 static size_t write_to_buffer(void *pOpaque, mz_uint64 file_ofs, const void *pBuf, size_t n) {
     Buffer *const buffer = static_cast<Buffer *>(pOpaque);
-    assert(file_ofs == buffer->size());
+    v3k_assert(file_ofs == buffer->size());
     const uint8_t *const first = static_cast<const uint8_t *>(pBuf);
     const uint8_t *const last = &first[n];
     buffer->insert(buffer->end(), first, last);


### PR DESCRIPTION
Adds custom assert: `v3k_assert` which:
- Works on Release mode
- Reports assertion fails to logging system
- Optionally aborts like normal asserts, or not
- Above is decided at runtime. **The argument `-s` or `--strict` makes it exit on failed `assert`s**

Existing codebase is ported to use it.

So:
1) **It functions the same as it did by default, except now it logs failed asserts.**
2) If you want to enable exiting on failed assertions, pass the above arg before the `.vpk` path. Probably more useful for developers.