### PR TITLE
[threads] Refactoring "display" threads.

### DIFF
--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -140,21 +140,12 @@ int main(int argc, char *argv[]) {
         return InitThreadFailed;
     }
 
-    const SceUID display_thread_id = create_thread(entry_point, host.kernel, host.mem, "display", stack_size, call_import, false);
-
-    if (display_thread_id < 0) {
-        error("Failed to init display thread.", host.window.get());
-        return InitThreadFailed;
-    }
-
     const ThreadStatePtr main_thread = find(main_thread_id, host.kernel.threads);
 
     if (start_thread(host.kernel, main_thread_id, 0, Ptr<void>()) < 0) {
         error("Failed to run main thread.", host.window.get());
         return RunThreadFailed;
     }
-
-    const ThreadStatePtr display_thread = find(display_thread_id, host.kernel.threads);
     
     GLuint TextureID = 0;
     host.t1 = SDL_GetTicks();

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -542,7 +542,7 @@ EXPORT(int, sceGxmInitialize, const emu::SceGxmInitializeParams *params) {
         ::call_import(host, nid, thread_id);
     };
 
-    const SceUID display_thread_id = create_thread(Ptr<void>(read_pc(*main_thread->cpu)), host.kernel, host.mem, "display", MB(1), call_import, false);
+    const SceUID display_thread_id = create_thread(Ptr<void>(read_pc(*main_thread->cpu)), host.kernel, host.mem, "SceGxmDisplayQueue", MB(1), call_import, false);
 
     if (display_thread_id < 0) {
         return error(__func__, SCE_GXM_ERROR_DRIVER);


### PR DESCRIPTION
This removes the (apparently) useless display thread spawned on main.cpp and properly renames the one created via sceGxmInitialize to sceGxmDisplayQueue like it would be on real hw.