### PR TITLE
 [gxm] Attrib location and set_uniform fixes. 

### DIFF
--- a/src/emulator/gxm/src/gxm.cpp
+++ b/src/emulator/gxm/src/gxm.cpp
@@ -287,15 +287,15 @@ void uniform_matrix_4<GLfloat>(GLint location, GLsizei count, GLboolean transpos
 template <class T>
 void set_uniform(GLint location, size_t component_count, GLsizei array_size, const T *value) {
     switch (component_count) {
-		case 1:
-			switch (array_size) {
-				case 1:
-					uniform_1<T>(location, array_size, value);
-					break;
+        case 1:
+            switch (array_size) {
+                case 1:
+                    uniform_1<T>(location, array_size, value);
+                    break;
                 case 4:
                     uniform_4<T>(location, array_size, value);
-					break;
-			}
+                    break;
+            }
         case 4:
             switch (array_size) {
                 case 1:

--- a/src/emulator/gxm/src/gxm.cpp
+++ b/src/emulator/gxm/src/gxm.cpp
@@ -254,9 +254,9 @@ static SharedGLObject compile_glsl(GLenum type, const std::string& source) {
 
 static void bind_attribute_locations(GLuint gl_program, const SceGxmVertexProgram &program) {
     GXM_PROFILE(__FUNCTION__);
-
+    
     for (const AttributeLocations::value_type &binding : program.attribute_locations) {
-        glBindAttribLocation(gl_program, binding.first, binding.second.c_str());
+        glBindAttribLocation(gl_program, binding.first / 4, binding.second.c_str());
     }
 }
 
@@ -266,6 +266,14 @@ void uniform_4(GLint location, GLsizei count, const T *value);
 template <>
 void uniform_4<GLfloat>(GLint location, GLsizei count, const GLfloat *value) {
     glUniform4fv(location, count, value);
+}
+
+template <class T>
+void uniform_1(GLint location, GLsizei count, const T *value);
+
+template <>
+void uniform_1<GLfloat>(GLint location, GLsizei count, const GLfloat *value) {
+    glUniform1fv(location, count, value);
 }
 
 template <class T>
@@ -279,8 +287,20 @@ void uniform_matrix_4<GLfloat>(GLint location, GLsizei count, GLboolean transpos
 template <class T>
 void set_uniform(GLint location, size_t component_count, GLsizei array_size, const T *value) {
     switch (component_count) {
+		case 1:
+			switch (array_size) {
+				case 1:
+					uniform_1<T>(location, array_size, value);
+					break;
+                case 4:
+                    uniform_4<T>(location, array_size, value);
+					break;
+			}
         case 4:
             switch (array_size) {
+                case 1:
+                    uniform_1<T>(location, array_size, value);
+                    break;
                 case 4:
                     uniform_matrix_4<T>(location, 1, GL_FALSE, value);
                     break;

--- a/src/emulator/gxm/src/gxm.cpp
+++ b/src/emulator/gxm/src/gxm.cpp
@@ -256,7 +256,7 @@ static void bind_attribute_locations(GLuint gl_program, const SceGxmVertexProgra
     GXM_PROFILE(__FUNCTION__);
     
     for (const AttributeLocations::value_type &binding : program.attribute_locations) {
-        glBindAttribLocation(gl_program, binding.first / 4, binding.second.c_str());
+        glBindAttribLocation(gl_program, binding.first / sizeof(uint32_t), binding.second.c_str());
     }
 }
 

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1215,7 +1215,7 @@ EXPORT(int, sceGxmSetVertexStream, SceGxmContext *context, unsigned int streamIn
         const GLenum type = attribute_format_to_gl_type(static_cast<SceGxmAttributeFormat>(attribute.format));
         const GLboolean normalised = attribute_format_normalised(static_cast<SceGxmAttributeFormat>(attribute.format)) ? GL_TRUE : GL_FALSE;
         const GLvoid *const pointer = streamData + attribute.offset;
-        int attrib_location = attribute.regIndex / 4;
+        int attrib_location = attribute.regIndex / sizeof(uint32_t);
         glVertexAttribPointer(attrib_location, attribute.componentCount, type, normalised, stream.stride, pointer);
 
         glEnableVertexAttribArray(attrib_location); // TODO Disable.

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1215,9 +1215,10 @@ EXPORT(int, sceGxmSetVertexStream, SceGxmContext *context, unsigned int streamIn
         const GLenum type = attribute_format_to_gl_type(static_cast<SceGxmAttributeFormat>(attribute.format));
         const GLboolean normalised = attribute_format_normalised(static_cast<SceGxmAttributeFormat>(attribute.format)) ? GL_TRUE : GL_FALSE;
         const GLvoid *const pointer = streamData + attribute.offset;
-        glVertexAttribPointer(attribute.regIndex, attribute.componentCount, type, normalised, stream.stride, pointer);
+        int attrib_location = attribute.regIndex / 4;
+        glVertexAttribPointer(attrib_location, attribute.componentCount, type, normalised, stream.stride, pointer);
 
-        glEnableVertexAttribArray(attribute.regIndex); // TODO Disable.
+        glEnableVertexAttribArray(attrib_location); // TODO Disable.
     }
 
     return 0;


### PR DESCRIPTION
With this Flood It! works correctly.
What this PR does:

- Fixes some bad behaviours in set_uniform adding support for "float" uniforms.
- Fixes attrib location leak. Before we were using only glVertexAttribPointer with index 0,4,8,12,...; now we use 0,1,2,3,4... allowing us to use up to 16 vertex attributes like it should be.

This allows Flood It! to correctly work:
![immagine](https://user-images.githubusercontent.com/9152710/38809240-37a88348-4183-11e8-804c-2ffffa8d304c.png)
![immagine](https://user-images.githubusercontent.com/9152710/38809248-3ba0d9f0-4183-11e8-9aa5-ee28f78cfa4d.png)
