### PR TITLE
Reverting changes to set_uniform.

### DIFF
--- a/src/emulator/gxm/src/gxm.cpp
+++ b/src/emulator/gxm/src/gxm.cpp
@@ -292,15 +292,10 @@ void set_uniform(GLint location, size_t component_count, GLsizei array_size, con
                 case 1:
                     uniform_1<T>(location, array_size, value);
                     break;
-                case 4:
-                    uniform_4<T>(location, array_size, value);
-                    break;
             }
+            break;
         case 4:
             switch (array_size) {
-                case 1:
-                    uniform_1<T>(location, array_size, value);
-                    break;
                 case 4:
                     uniform_matrix_4<T>(location, 1, GL_FALSE, value);
                     break;

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1181,7 +1181,6 @@ EXPORT(int, sceGxmSetUniformDataF, void *uniformBuffer, const SceGxmProgramParam
     assert(uniformBuffer != nullptr);
     assert(parameter != nullptr);
     assert(parameter->container_index == 14);
-    assert(parameter->resource_index == 0);
     assert(componentOffset == 0);
     assert(componentCount > 0);
     assert(sourceData != nullptr);

--- a/src/emulator/shaders/7ab03ae7c55b085887bf61bc7dcc7bd403f36fd1be9b8d74783363a761a52aa9.vert
+++ b/src/emulator/shaders/7ab03ae7c55b085887bf61bc7dcc7bd403f36fd1be9b8d74783363a761a52aa9.vert
@@ -1,11 +1,11 @@
 // Vertex shader.
 #version 120
 
-in vec2 aPosition;
-in vec2 aTexcoord;
-in vec4 aColor;
-in float aAngle;
-in vec2 aTranslation;
+attribute vec2 aPosition;
+attribute vec2 aTexcoord;
+attribute vec4 aColor;
+attribute float aAngle;
+attribute vec2 aTranslation;
 uniform mat4 pm;
 uniform float trsEnable;
 


### PR DESCRIPTION
Change was actually fixing Flood It! but breaking more homebrews.
We should probably refactor the whole way uniforms work btw.
I left the added glUniform1fv code.