### PR TITLE
[gxm] Using no filter as default for textures.

### DIFF
--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1710,8 +1710,8 @@ EXPORT(int, sceGxmTextureInitLinear, SceGxmTexture *texture, Ptr<const void> dat
     texture->data_addr = data.address() >> 2;
     texture->swizzle_format = (texFormat & 0x7000) >> 12;
     texture->normalize_mode = 1;
-    texture->min_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
-    texture->mag_filter = SCE_GXM_TEXTURE_FILTER_LINEAR;
+    texture->min_filter = SCE_GXM_TEXTURE_FILTER_POINT;
+    texture->mag_filter = SCE_GXM_TEXTURE_FILTER_POINT;
 
     return 0;
 }


### PR DESCRIPTION
This fixes ugly borders in some homebrews like Happy Land and HCL for textures and fixes Flood It! main menu background being "blurred".