### PR TITLE
emulator: Add missing include `tuple`

### DIFF
--- a/src/emulator/module/include/module/lay_out_args.h
+++ b/src/emulator/module/include/module/lay_out_args.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <tuple>
 #include "args_layout.h"
 
 struct LayoutArgsState {


### PR DESCRIPTION
fix build error in linux