### PR TITLE
Fix status on loading modules

### DIFF
--- a/src/emulator/kernel/include/kernel/thread_functions.h
+++ b/src/emulator/kernel/include/kernel/thread_functions.h
@@ -35,4 +35,4 @@ int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const 
 Ptr<void> copy_stack(SceUID thid, SceUID thread_id, const Ptr<void> &argp, KernelState &kernel, MemState &mem);
 bool run_thread(ThreadState &thread, bool callback);
 bool run_callback(ThreadState &thread, Address &pc, Address &data);
-bool run_on_current(ThreadState &thread, const Ptr<const void> entry_point, SceSize arglen, Ptr<void> &argp);
+uint32_t run_on_current(ThreadState &thread, const Ptr<const void> entry_point, SceSize arglen, Ptr<void> &argp);

--- a/src/emulator/kernel/src/thread.cpp
+++ b/src/emulator/kernel/src/thread.cpp
@@ -190,12 +190,13 @@ bool run_callback(ThreadState &thread, Address &pc, Address &data) {
     return run_thread(thread, true);
 }
 
-bool run_on_current(ThreadState &thread, const Ptr<const void> entry_point, SceSize arglen, Ptr<void> &argp) {
+uint32_t run_on_current(ThreadState &thread, const Ptr<const void> entry_point, SceSize arglen, Ptr<void> &argp) {
     std::unique_lock<std::mutex> lock(thread.mutex);
     stop(*thread.cpu);
     write_reg(*thread.cpu, 0, arglen);
     write_reg(*thread.cpu, 1, argp.address());
     write_pc(*thread.cpu, entry_point.address());
     lock.unlock();
-    return run_thread(thread, false);
+    run_thread(thread, false);
+    return read_reg(*thread.cpu, 0);
 }


### PR DESCRIPTION
Some games use status value as a way to call functions from the module