### PR TITLE
kernel: (Lightweight) Condition Variables

### DIFF
--- a/src/emulator/gui/CMakeLists.txt
+++ b/src/emulator/gui/CMakeLists.txt
@@ -6,6 +6,7 @@ include/gui/functions.h
 include/gui/state.h
 src/imgui_impl_sdl_gl2.cpp
 src/ui_common_dialog.cpp
+src/ui_condvars_dialog.cpp
 src/ui_main.cpp
 src/ui_main_menubar.cpp
 src/ui_mutexes_dialog.cpp

--- a/src/emulator/gui/include/gui/functions.h
+++ b/src/emulator/gui/include/gui/functions.h
@@ -24,6 +24,8 @@ void DrawThreadsDialog(HostState &host);
 void DrawSemaphoresDialog(HostState &host);
 void DrawMutexesDialog(HostState &host);
 void DrawLwMutexesDialog(HostState &host);
+void DrawLwCondvarsDialog(HostState &host);
+void DrawCondvarsDialog(HostState &host);
 void DrawUI(HostState &host);
 void DrawCommonDialog(HostState &host);
 void DrawGameSelector(HostState &host, bool *is_vpk);

--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -34,6 +34,8 @@ struct GuiState {
     bool renderer_focused = true;
     bool threads_dialog = false;
     bool semaphores_dialog = false;
+    bool condvars_dialog = false;
+    bool lwcondvars_dialog = false;
     bool mutexes_dialog = false;
     bool lwmutexes_dialog = false;
 

--- a/src/emulator/gui/src/ui_common_dialog.cpp
+++ b/src/emulator/gui/src/ui_common_dialog.cpp
@@ -83,7 +83,7 @@ void DrawTrophySetupDialog(HostState &host) {
         std::string closeup_text = "This dialog will close automatically in ";
         closeup_text += std::to_string(timer);
         closeup_text += " seconds.";
-        ImGui::Text(closeup_text.c_str());
+        ImGui::Text("%s", closeup_text.c_str());
         ImGui::End();
     } else {
         host.gui.common_dialog.status = SCE_COMMON_DIALOG_STATUS_FINISHED;

--- a/src/emulator/gui/src/ui_condvars_dialog.cpp
+++ b/src/emulator/gui/src/ui_condvars_dialog.cpp
@@ -1,0 +1,58 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <gui/functions.h>
+#include <imgui.h>
+
+#include <host/state.h>
+#include <kernel/thread/thread_functions.h>
+#include <kernel/thread/thread_state.h>
+#include <util/resource.h>
+
+void DrawCondvarsDialog(HostState &host) {
+    ImGui::Begin("Condition Variables", &host.gui.condvars_dialog);
+    ImGui::TextColored(ImVec4(255, 255, 0, 255), "%-16s %-32s   %-16s %-16s", "ID", "Name", "Attributes", "Waiting Threads");
+
+    const std::lock_guard<std::mutex> lock(host.kernel.mutex);
+
+    for (auto condvar : host.kernel.condvars) {
+        std::shared_ptr<Condvar> sema_state = condvar.second;
+        ImGui::Text("0x%08X       %-32s   %02d             %02u",
+            condvar.first,
+            sema_state->name,
+            sema_state->attr,
+            sema_state->waiting_threads.size());
+    }
+    ImGui::End();
+}
+
+void DrawLwCondvarsDialog(HostState &host) {
+    ImGui::Begin("Lightweight Condition Variables", &host.gui.lwcondvars_dialog);
+    ImGui::TextColored(ImVec4(255, 255, 0, 255), "%-16s %-32s   %-16s %-16s", "ID", "Name", "Attributes", "Waiting Threads");
+
+    const std::lock_guard<std::mutex> lock(host.kernel.mutex);
+
+    for (auto condvar : host.kernel.lwcondvars) {
+        std::shared_ptr<Condvar> sema_state = condvar.second;
+        ImGui::Text("0x%08X       %-32s   %02d             %02u",
+            condvar.first,
+            sema_state->name,
+            sema_state->attr,
+            sema_state->waiting_threads.size());
+    }
+    ImGui::End();
+}

--- a/src/emulator/gui/src/ui_main.cpp
+++ b/src/emulator/gui/src/ui_main.cpp
@@ -62,4 +62,10 @@ void DrawUI(HostState &host) {
     if (host.gui.lwmutexes_dialog) {
         DrawLwMutexesDialog(host);
     }
+    if (host.gui.condvars_dialog) {
+        DrawCondvarsDialog(host);
+    }
+    if (host.gui.lwcondvars_dialog) {
+        DrawLwCondvarsDialog(host);
+    }
 }

--- a/src/emulator/gui/src/ui_main_menubar.cpp
+++ b/src/emulator/gui/src/ui_main_menubar.cpp
@@ -34,6 +34,12 @@ void DrawMainMenuBar(HostState &host) {
             if (ImGui::MenuItem("Lightweight Mutexes", nullptr, host.gui.lwmutexes_dialog)) {
                 host.gui.lwmutexes_dialog = !host.gui.lwmutexes_dialog;
             }
+            if (ImGui::MenuItem("Condition Variables", nullptr, host.gui.condvars_dialog)) {
+                host.gui.condvars_dialog = !host.gui.condvars_dialog;
+            }
+            if (ImGui::MenuItem("Lightweight Condition Variables", nullptr, host.gui.lwcondvars_dialog)) {
+                host.gui.lwcondvars_dialog = !host.gui.lwcondvars_dialog;
+            }
             ImGui::EndMenu();
         }
         ImGui::EndMainMenuBar();

--- a/src/emulator/gxm/src/gxm.cpp
+++ b/src/emulator/gxm/src/gxm.cpp
@@ -127,9 +127,8 @@ static const char *vector_prefix(SceGxmParameterType type) {
     return "?";
 }
 
-static void output_uniform_decl(std::ostream &glsl, const SceGxmProgramParameter &parameter) {
-    assert(parameter.component_count == 4);
-    glsl << " sampler2D " << parameter_name_raw(parameter);
+static void output_sampler_decl(std::ostream &glsl, const SceGxmProgramParameter &parameter) {
+    glsl << "sampler2D " << parameter_name_raw(parameter);
 }
 
 static void output_scalar_decl(std::ostream &glsl, const SceGxmProgramParameter &parameter) {
@@ -202,7 +201,8 @@ static void output_glsl_decl(std::ostream &glsl, std::string &cur_struct_decl, c
 
     // TODO: Should be using param type here
     if (is_sampler) {
-        output_uniform_decl(glsl, parameter);
+        // samplers are special because they can't be inside structs
+        output_sampler_decl(glsl, parameter);
     } else if (parameter.component_count > 1) {
         if (parameter.array_size > 1 && parameter.array_size <= 4) {
             output_matrix_decl(glsl, parameter);
@@ -246,7 +246,7 @@ static void output_glsl_parameters(std::ostream &glsl, const SceGxmProgram &prog
             break;
         }
         case SCE_GXM_PARAMETER_CATEGORY_SAMPLER: {
-            output_glsl_decl(glsl, cur_struct_decl, parameter, "uniform ", true);
+            output_glsl_decl(glsl, cur_struct_decl, parameter, "uniform", true);
             break;
         }
         case SCE_GXM_PARAMETER_CATEGORY_AUXILIARY_SURFACE: {
@@ -525,7 +525,7 @@ AttributeLocations attribute_locations(const SceGxmProgram &vertex_program) {
             const auto struct_idx = name.find('.');
             const bool is_struct_field = struct_idx != std::string::npos;
             if (is_struct_field)
-                name.replace(struct_idx, 1, "");  //Workaround for input.field on glsl version 120
+                name.replace(struct_idx, 1, ""); //Workaround for input.field on glsl version 120
             locations.emplace(parameter.resource_index, name);
         }
     }

--- a/src/emulator/host/include/host/functions.h
+++ b/src/emulator/host/include/host/functions.h
@@ -19,8 +19,8 @@
 
 #include <psp2/types.h>
 
-#include <kernel/thread/thread_functions.h>
 #include <kernel/thread/sync_primitives.h>
+#include <kernel/thread/thread_functions.h>
 #include <mem/ptr.h>
 
 #include <cstdint>

--- a/src/emulator/host/src/app.cpp
+++ b/src/emulator/host/src/app.cpp
@@ -118,7 +118,7 @@ bool install_vpk(Ptr<const void> &entry_point, HostState &host, const std::wstri
     if (!read_file_from_zip(params, vpk_fp, sfo_path.c_str(), zip)) {
         return false;
     }
-    
+
     SfoFile sfo_handle;
     load_sfo(sfo_handle, params);
     find_data(host.io.title_id, sfo_handle, "TITLE_ID");
@@ -152,7 +152,7 @@ bool install_vpk(Ptr<const void> &entry_point, HostState &host, const std::wstri
                 std::string directory = output_path.substr(0, slash);
                 fs::create_directories(directory);
             }
-            
+
             LOG_INFO("Extracting {}", output_path);
             mz_zip_reader_extract_to_file(zip.get(), i, output_path.c_str(), 0);
         }
@@ -189,7 +189,7 @@ bool load_app(Ptr<const void> &entry_point, HostState &host, const std::wstring 
     LOG_INFO("Title: {}", host.game_title);
     LOG_INFO("Serial: {}", host.io.title_id);
     LOG_INFO("Category: {}", category);
-    
+
     host.io.savedata0_path = "ux0:/user/00/savedata/" + host.io.title_id + "/";
 
     Buffer eboot;

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -102,7 +102,7 @@ bool init(HostState &state, std::uint32_t window_width, std::uint32_t border_wid
     Binding::initialize(false);
     state.kernel.base_tick = { rtc_base_ticks() };
     state.display.set_window_dims(window_width, window_height);
-    
+
     std::string dir_path = state.pref_path + "ux0/app";
 #ifdef WIN32
     _WDIR *d = _wopendir((utf_to_wide(dir_path)).c_str());
@@ -134,12 +134,12 @@ bool init(HostState &state, std::uint32_t window_width, std::uint32_t border_wid
         }
     } while (dp);
 
-#ifdef WIN32    
+#ifdef WIN32
     _wclosedir(d);
 #else
     closedir(d);
 #endif
-    
+
     return true;
 }
 

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -179,7 +179,7 @@ SceUID open_file(IOState &io, const std::string &path_, int flags, const char *p
         device = VitaIoDevice::UX0;
         std::tie(device, device_name) = translate_device(path);
     }
-    
+
     switch (device) {
     case VitaIoDevice::TTY0:
     case VitaIoDevice::TTY1: {
@@ -336,7 +336,7 @@ int remove_file(IOState &io, const char *file, const char *pref_path) {
     std::string device_name;
     std::tie(device, device_name) = translate_device(file);
     std::string path = file;
-    
+
     // Redirect savedata0:/ to ux0:/user/00/savedata/<title_id>
     if (device == VitaIoDevice::SAVEDATA0) {
         std::string fixed_path = path.substr(10);
@@ -350,7 +350,7 @@ int remove_file(IOState &io, const char *file, const char *pref_path) {
             std::tie(device, device_name) = translate_device(path);
         }
     }
-    
+
     switch (device) {
     case VitaIoDevice::UX0:
     case VitaIoDevice::UMA0: {
@@ -370,7 +370,7 @@ int create_dir(IOState &io, const char *dir, int mode, const char *pref_path) {
     std::string device_name;
     std::tie(device, device_name) = translate_device(dir);
     std::string path = dir;
-    
+
     // Redirect savedata0:/ to ux0:/user/00/savedata/<title_id>
     if (device == VitaIoDevice::SAVEDATA0) {
         std::string fixed_path = path.substr(10);
@@ -405,7 +405,7 @@ int remove_dir(IOState &io, const char *dir, const char *pref_path) {
     std::string device_name;
     std::tie(device, device_name) = translate_device(dir);
     std::string path = dir;
-    
+
     // Redirect savedata0:/ to ux0:/user/00/savedata/<title_id>
     if (device == VitaIoDevice::SAVEDATA0) {
         std::string fixed_path = path.substr(10);
@@ -443,7 +443,7 @@ int stat_file(IOState &io, const char *file, SceIoStat *statp, const char *pref_
     std::string device_name;
     std::tie(device, device_name) = translate_device(file);
     std::string path = file;
-    
+
     // read and execute access rights
     statp->st_mode = SCE_S_IRUSR | SCE_S_IRGRP | SCE_S_IROTH | SCE_S_IXUSR | SCE_S_IXGRP | SCE_S_IXOTH;
 
@@ -462,7 +462,7 @@ int stat_file(IOState &io, const char *file, SceIoStat *statp, const char *pref_
         device = VitaIoDevice::UX0;
         std::tie(device, device_name) = translate_device(path);
     }
-    
+
     // Redirect savedata0:/ to ux0:/user/00/savedata/<title_id>
     if (device == VitaIoDevice::SAVEDATA0) {
         std::string fixed_path = path.substr(10);
@@ -540,7 +540,7 @@ int open_dir(IOState &io, const char *path, const char *pref_path) {
     std::string device_name;
     std::string spath = path;
     std::tie(device, device_name) = translate_device(spath);
-    
+
     // Redirect app0:/ to ux0:/app/<title_id>
     if (device == VitaIoDevice::APP0) {
         int i = 5;
@@ -552,7 +552,7 @@ int open_dir(IOState &io, const char *path, const char *pref_path) {
         device = VitaIoDevice::UX0;
         std::tie(device, device_name) = translate_device(spath);
     }
-    
+
     // Redirect savedata0:/ to ux0:/user/00/savedata/<title_id>
     if (device == VitaIoDevice::SAVEDATA0) {
         std::string fixed_path = spath.substr(10);
@@ -565,7 +565,7 @@ int open_dir(IOState &io, const char *path, const char *pref_path) {
             std::tie(device, device_name) = translate_device(spath);
         }
     }
-    
+
     std::string dir_path;
     switch (device) {
     case VitaIoDevice::UX0:

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -87,6 +87,8 @@ std::string translate_path(const std::string &part_name, const std::string &path
     int i = part_name.length();
     res += "/";
 
+    if (path.empty())
+        return res;
     if (path[i + 1] == '/')
         i++;
     res += &path[i + 1];

--- a/src/emulator/kernel/include/kernel/state.h
+++ b/src/emulator/kernel/include/kernel/state.h
@@ -46,13 +46,23 @@ typedef std::map<uint32_t, Address> ExportNids;
 
 struct WaitingThreadData {
     ThreadStatePtr thread;
-    std::int32_t lock_count;
-    std::int32_t priority;
+    int32_t priority;
 
-    WaitingThreadData(ThreadStatePtr thread, std::int32_t lock_count, std::int32_t priority)
-        : thread(thread)
-        , lock_count(lock_count)
-        , priority(priority) {}
+    // additional fields for each primitive
+    union {
+        struct { // mutex
+            int32_t lock_count;
+        };
+        struct { // semaphore
+            int32_t signal;
+        };
+        struct { // event flags
+            int32_t wait;
+            int32_t flags;
+        };
+        struct { // condvar
+        };
+    };
 
     bool operator>(const WaitingThreadData &rhs) const {
         return priority > rhs.priority;

--- a/src/emulator/kernel/include/kernel/state.h
+++ b/src/emulator/kernel/include/kernel/state.h
@@ -61,7 +61,11 @@ struct WaitingThreadData {
 
 using WaitingThreadQueue = std::priority_queue<WaitingThreadData, std::vector<WaitingThreadData>, std::greater<WaitingThreadData>>;
 
+// NOTE: uid is copied to sync primitives here for debugging,
+//       not really needed since they are put in std::map's
+
 struct Semaphore {
+    SceUID uid;
     int val;
     int max;
     uint32_t attr;
@@ -69,8 +73,11 @@ struct Semaphore {
     WaitingThreadQueue waiting_threads;
     char name[KERNELOBJECT_MAX_NAME_LENGTH + 1];
 };
+typedef std::shared_ptr<Semaphore> SemaphorePtr;
+typedef std::map<SceUID, SemaphorePtr> SemaphorePtrs;
 
 struct Mutex {
+    SceUID uid;
     int lock_count;
     uint32_t attr;
     std::mutex mutex;
@@ -78,9 +85,6 @@ struct Mutex {
     ThreadStatePtr owner;
     char name[KERNELOBJECT_MAX_NAME_LENGTH + 1];
 };
-
-typedef std::shared_ptr<Semaphore> SemaphorePtr;
-typedef std::map<SceUID, SemaphorePtr> SemaphorePtrs;
 typedef std::shared_ptr<Mutex> MutexPtr;
 typedef std::map<SceUID, MutexPtr> MutexPtrs;
 

--- a/src/emulator/kernel/include/kernel/state.h
+++ b/src/emulator/kernel/include/kernel/state.h
@@ -97,7 +97,6 @@ typedef std::map<SceUID, WaitingThreadState> KernelWaitingThreadStates;
 struct KernelState {
     std::mutex mutex;
     Blocks blocks;
-    SceUID next_uid = 0;
     ThreadToSlotToAddress tls;
     SemaphorePtrs semaphores;
     MutexPtrs mutexes;
@@ -109,4 +108,11 @@ struct KernelState {
     ExportNids export_nids;
     SceRtcTick base_tick;
     Ptr<uint32_t> process_param;
+
+    SceUID get_next_uid() {
+        return next_uid++;
+    }
+
+private:
+    std::atomic<SceUID> next_uid{ 0 };
 };

--- a/src/emulator/kernel/include/kernel/thread/sync_primitives.h
+++ b/src/emulator/kernel/include/kernel/thread/sync_primitives.h
@@ -37,5 +37,7 @@ SceUID semaphore_create(KernelState &kernel, const char *export_name, const char
 int semaphore_wait(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID semaid, int signal, SceUInt *timeout);
 int semaphore_signal(KernelState &kernel, const char *export_name, SceUID semaid, int signal);
 
-int wait_semaphore(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID semaid, int signal, SceUInt *timeout);
-int signal_sema(KernelState &kernel, const char *export_name, SceUID semaid, int signal);
+// Condition Variable
+SceUID condvar_create(SceUID *uid_out, KernelState &kernel, const char *export_name, const char *name, SceUInt attr, SceUID assoc_mutexid, SyncWeight weight);
+int condvar_wait(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID semaid, SceUInt *timeout, SyncWeight weight);
+int condvar_signal(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID condid, Condvar::SignalTarget signal_target, SyncWeight weight);

--- a/src/emulator/kernel/include/kernel/thread/sync_primitives.h
+++ b/src/emulator/kernel/include/kernel/thread/sync_primitives.h
@@ -19,17 +19,23 @@
 
 #include <psp2/types.h>
 
+#include <kernel/state.h>
+
 enum class SyncWeight {
     Light, // lightweight
     Heavy // 'heavy'weight
 };
 
-struct KernelState;
-SceUID create_mutex(SceUID *uid_out, KernelState &kernel, const char *export_name, SceUID thread_id, const char *name, SceUInt attr, int init_count, SyncWeight weight);
-int lock_mutex(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID mutexid, int lock_count, unsigned int *timeout, SyncWeight weight);
-int unlock_mutex(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID mutexid, int unlock_count, SyncWeight weight);
-int delete_mutex(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID mutexid, SyncWeight weight);
+// Mutex
+SceUID mutex_create(SceUID *uid_out, KernelState &kernel, const char *export_name, SceUID thread_id, const char *name, SceUInt attr, int init_count, SyncWeight weight);
+int mutex_lock(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID mutexid, int lock_count, unsigned int *timeout, SyncWeight weight);
+int mutex_unlock(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID mutexid, int unlock_count, SyncWeight weight);
+int mutex_delete(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID mutexid, SyncWeight weight);
 
-SceUID create_semaphore(KernelState &kernel, const char *export_name, const char *name, SceUInt attr, int initVal, int maxVal);
+// Semaphore
+SceUID semaphore_create(KernelState &kernel, const char *export_name, const char *name, SceUInt attr, int initVal, int maxVal);
+int semaphore_wait(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID semaid, int signal, SceUInt *timeout);
+int semaphore_signal(KernelState &kernel, const char *export_name, SceUID semaid, int signal);
+
 int wait_semaphore(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID semaid, int signal, SceUInt *timeout);
 int signal_sema(KernelState &kernel, const char *export_name, SceUID semaid, int signal);

--- a/src/emulator/kernel/include/kernel/types.h
+++ b/src/emulator/kernel/include/kernel/types.h
@@ -62,5 +62,12 @@ namespace emu {
         std::uint8_t padding[28];
     };
 
+    // We only use workarea for uid
+    struct SceKernelLwCondWork {
+        SceUID uid;
+
+        std::uint8_t padding[28];
+    };
+
     static_assert(sizeof(SceKernelLwMutexWork) == 32, "Incorrect size");
 }

--- a/src/emulator/kernel/src/load_self.cpp
+++ b/src/emulator/kernel/src/load_self.cpp
@@ -373,7 +373,7 @@ SceUID load_self(Ptr<const void> &entry_point, KernelState &kernel, MemState &me
     sceKernelModuleInfo->module_start = entry_point;
 
     const std::lock_guard<std::mutex> lock(kernel.mutex);
-    const SceUID uid = kernel.next_uid++;
+    const SceUID uid = kernel.get_next_uid();
     sceKernelModuleInfo->handle = uid;
     kernel.loaded_modules.emplace(uid, sceKernelModuleInfo);
 

--- a/src/emulator/kernel/src/thread/sync_primitives.cpp
+++ b/src/emulator/kernel/src/thread/sync_primitives.cpp
@@ -50,6 +50,8 @@ SceUID create_mutex(SceUID *uid_out, KernelState &kernel, const char *export_nam
     }
 
     const MutexPtr mutex = std::make_shared<Mutex>();
+    const SceUID uid = kernel.get_next_uid();
+    mutex->uid = uid;
     mutex->lock_count = init_count;
     std::copy(mutex_name, mutex_name + KERNELOBJECT_MAX_NAME_LENGTH, mutex->name);
     mutex->attr = attr;
@@ -201,6 +203,8 @@ SceUID create_semaphore(KernelState &kernel, const char *export_name, const char
     }
 
     const SemaphorePtr semaphore = std::make_shared<Semaphore>();
+    const SceUID uid = kernel.get_next_uid();
+    semaphore->uid = uid;
     semaphore->val = initVal;
     semaphore->max = maxVal;
     semaphore->attr = attr;

--- a/src/emulator/kernel/src/thread/sync_primitives.cpp
+++ b/src/emulator/kernel/src/thread/sync_primitives.cpp
@@ -60,8 +60,8 @@ SceUID create_mutex(SceUID *uid_out, KernelState &kernel, const char *export_nam
         const ThreadStatePtr thread = lock_and_find(thread_id, kernel.threads, kernel.mutex);
         mutex->owner = thread;
     }
+
     const std::lock_guard<std::mutex> lock(kernel.mutex);
-    const SceUID uid = kernel.next_uid++;
     auto &mutexes = get_mutexes(kernel, weight);
     mutexes.emplace(uid, mutex);
 
@@ -209,8 +209,8 @@ SceUID create_semaphore(KernelState &kernel, const char *export_name, const char
     semaphore->max = maxVal;
     semaphore->attr = attr;
     std::copy(name, name + KERNELOBJECT_MAX_NAME_LENGTH, semaphore->name);
+
     const std::lock_guard<std::mutex> lock(kernel.mutex);
-    const SceUID uid = kernel.next_uid++;
     kernel.semaphores.emplace(uid, semaphore);
 
     return uid;

--- a/src/emulator/kernel/src/thread/thread.cpp
+++ b/src/emulator/kernel/src/thread/thread.cpp
@@ -54,7 +54,7 @@ static int SDLCALL thread_function(void *data) {
 }
 
 SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stack_size, CallImport call_import, bool log_code) {
-    SceUID thid = kernel.next_uid++;
+    SceUID thid = kernel.get_next_uid();
 
     const ThreadStack::Deleter stack_deleter = [&mem](Address stack) {
         free(mem, stack);

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -103,20 +103,20 @@ int main(int argc, char *argv[]) {
             }
         }
     }
-    
+
     HostState host;
     if (!init(host, DEFAULT_RES_WIDTH, WINDOW_BORDER_WIDTH, DEFAULT_RES_HEIGHT, WINDOW_BORDER_HEIGHT)) {
         error("Host initialisation failed.", host.window.get());
         return HostInitFailed;
     }
-    
+
     ImGui::CreateContext();
     ImGui_ImplSdlGL2_Init(host.window.get());
     ImGui::StyleColorsDark();
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
-    
+
     bool is_vpk = true;
-    
+
     while (path.empty() && handle_events(host) && is_vpk) {
         ImGui_ImplSdlGL2_NewFrame(host.window.get());
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -127,11 +127,11 @@ int main(int argc, char *argv[]) {
         ImGui_ImplSdlGL2_RenderDrawData(ImGui::GetDrawData());
         SDL_GL_SwapWindow(host.window.get());
     }
-    
+
     if (!is_vpk) {
         path = utf_to_wide(host.gui.game_selector.title_id);
     }
-    
+
     if (path.empty()) {
         return Success;
     }

--- a/src/emulator/module/tests/arg_layout_tests.cpp
+++ b/src/emulator/module/tests/arg_layout_tests.cpp
@@ -25,51 +25,51 @@ static bool operator==(const ArgLayout &a, const ArgLayout &b) {
 
 static std::ostream &operator<<(std::ostream &out, const ArgLayout &layout) {
     switch (layout.location) {
-        case ArgLocation::gpr:
-            out << "r" << layout.offset;
-            break;
-        case ArgLocation::stack:
-            out << "stack + " << layout.offset;
-            break;
-        case ArgLocation::fp:
-            out << "s" << layout.offset;
-            break;
+    case ArgLocation::gpr:
+        out << "r" << layout.offset;
+        break;
+    case ArgLocation::stack:
+        out << "stack + " << layout.offset;
+        break;
+    case ArgLocation::fp:
+        out << "s" << layout.offset;
+        break;
     }
-    
+
     return out;
 }
 
 TEST(lay_out, gpr_overflows_to_stack) {
     const auto actual = lay_out<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t>();
-    const std::array<ArgLayout, 6> expected = {{
+    const std::array<ArgLayout, 6> expected = { {
         { ArgLocation::gpr, 0 },
         { ArgLocation::gpr, 1 },
         { ArgLocation::gpr, 2 },
         { ArgLocation::gpr, 3 },
         { ArgLocation::stack, 0 },
         { ArgLocation::stack, 4 },
-    }};
-    
+    } };
+
     ASSERT_EQ(actual, expected);
 }
 
 TEST(lay_out, dword_uses_two_gpr) {
     const auto actual = lay_out<int64_t, int32_t>();
-    const std::array<ArgLayout, 2> expected = {{
+    const std::array<ArgLayout, 2> expected = { {
         { ArgLocation::gpr, 0 },
         { ArgLocation::gpr, 2 },
-    }};
-    
+    } };
+
     ASSERT_EQ(actual, expected);
 }
 
 TEST(lay_out, dword_aligned_to_two_gpr) {
     const auto actual = lay_out<int32_t, int64_t>();
-    const std::array<ArgLayout, 2> expected = {{
+    const std::array<ArgLayout, 2> expected = { {
         { ArgLocation::gpr, 0 },
         { ArgLocation::gpr, 2 },
-    }};
-    
+    } };
+
     ASSERT_EQ(actual, expected);
 }
 
@@ -77,11 +77,11 @@ TEST(lay_out, dword_alignment_can_waste_gprs) {
     // Arg 3 could fit in r1, but alignment of arg 2 skipped it.
     // I've not observed this, but this is the current behaviour.
     const auto actual = lay_out<int32_t, int64_t, int32_t>();
-    const std::array<ArgLayout, 3> expected = {{
+    const std::array<ArgLayout, 3> expected = { {
         { ArgLocation::gpr, 0 },
         { ArgLocation::gpr, 2 },
         { ArgLocation::stack, 0 },
-    }};
-    
+    } };
+
     ASSERT_EQ(actual, expected);
 }

--- a/src/emulator/modules/SceAppUtil/SceAppUtil.cpp
+++ b/src/emulator/modules/SceAppUtil/SceAppUtil.cpp
@@ -153,7 +153,7 @@ EXPORT(int, sceAppUtilSaveDataDataRemove, emu::SceAppUtilSaveDataFileSlot *slot,
         file_path += files[i].dataPath.get(host.mem);
         remove_file(host.io, file_path.c_str(), host.pref_path.c_str());
     }
-    
+
     if (files[0].mode == SCE_APPUTIL_SAVEDATA_DATA_REMOVE_MODE_DEFAULT) {
         std::string slot_path = "savedata0:/SlotParam_";
         slot_path += std::to_string(slot->id);

--- a/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -142,7 +142,7 @@ EXPORT(int, sceKernelDeleteMsgPipe) {
 }
 
 EXPORT(int, sceKernelDeleteMutex, SceInt32 mutexid) {
-    return delete_mutex(host.kernel, export_name, thread_id, mutexid, SyncWeight::Heavy);
+    return mutex_delete(host.kernel, export_name, thread_id, mutexid, SyncWeight::Heavy);
 }
 
 EXPORT(int, sceKernelDeleteRWLock) {
@@ -283,7 +283,7 @@ EXPORT(int, sceKernelSignalCondTo) {
 }
 
 EXPORT(int, sceKernelSignalSema, SceUID semaid, int signal) {
-    return signal_sema(host.kernel, export_name, semaid, signal);
+    return semaphore_signal(host.kernel, export_name, semaid, signal);
 }
 
 EXPORT(int, sceKernelStartTimer) {
@@ -307,7 +307,7 @@ EXPORT(int, sceKernelTryLockWriteRWLock) {
 }
 
 EXPORT(int, sceKernelUnlockMutex, SceUID mutexid, int unlock_count) {
-    return unlock_mutex(host.kernel, export_name, thread_id, mutexid, unlock_count, SyncWeight::Heavy);
+    return mutex_unlock(host.kernel, export_name, thread_id, mutexid, unlock_count, SyncWeight::Heavy);
 }
 
 EXPORT(int, sceKernelUnlockReadRWLock) {

--- a/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -270,16 +270,19 @@ EXPORT(int, sceKernelSetTimerTimeWide) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelSignalCond) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSignalCond, SceUID condid) {
+    return condvar_signal(host.kernel, export_name, thread_id, condid,
+        Condvar::SignalTarget(Condvar::SignalTarget::Type::Any), SyncWeight::Heavy);
 }
 
-EXPORT(int, sceKernelSignalCondAll) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSignalCondAll, SceUID condid) {
+    return condvar_signal(host.kernel, export_name, thread_id, condid,
+        Condvar::SignalTarget(Condvar::SignalTarget::Type::All), SyncWeight::Heavy);
 }
 
-EXPORT(int, sceKernelSignalCondTo) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSignalCondTo, SceUID condid, SceUID thread_target) {
+    return condvar_signal(host.kernel, export_name, thread_id, condid,
+        Condvar::SignalTarget(Condvar::SignalTarget::Type::Specific, thread_target), SyncWeight::Heavy);
 }
 
 EXPORT(int, sceKernelSignalSema, SceUID semaid, int signal) {

--- a/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
+++ b/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
@@ -1177,16 +1177,22 @@ EXPORT(int, sceKernelSetTimerTime) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelSignalLwCond) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSignalLwCond, Ptr<emu::SceKernelLwCondWork> workarea) {
+    SceUID condid = workarea.get(host.mem)->uid;
+    return condvar_signal(host.kernel, export_name, thread_id, condid,
+        Condvar::SignalTarget(Condvar::SignalTarget::Type::Any), SyncWeight::Light);
 }
 
-EXPORT(int, sceKernelSignalLwCondAll) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSignalLwCondAll, Ptr<emu::SceKernelLwCondWork> workarea) {
+    SceUID condid = workarea.get(host.mem)->uid;
+    return condvar_signal(host.kernel, export_name, thread_id, condid,
+        Condvar::SignalTarget(Condvar::SignalTarget::Type::All), SyncWeight::Light);
 }
 
-EXPORT(int, sceKernelSignalLwCondTo) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSignalLwCondTo, Ptr<emu::SceKernelLwCondWork> workarea, SceUID thread_target) {
+    SceUID condid = workarea.get(host.mem)->uid;
+    return condvar_signal(host.kernel, export_name, thread_id, condid,
+        Condvar::SignalTarget(Condvar::SignalTarget::Type::Specific, thread_target), SyncWeight::Light);
 }
 
 EXPORT(int, sceKernelStackChkFail) {

--- a/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
+++ b/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
@@ -21,8 +21,8 @@
 #include <host/functions.h>
 #include <io/functions.h>
 #include <kernel/functions.h>
-#include <kernel/thread/thread_functions.h>
 #include <kernel/thread/sync_primitives.h>
+#include <kernel/thread/thread_functions.h>
 #include <rtc/rtc.h>
 #include <util/log.h>
 

--- a/src/emulator/modules/SceNetCtl/SceNetCtl.cpp
+++ b/src/emulator/modules/SceNetCtl/SceNetCtl.cpp
@@ -109,7 +109,7 @@ EXPORT(int, sceNetCtlInetGetState, uint32_t *state) {
 
 EXPORT(int, sceNetCtlInetRegisterCallback, Ptr<void> callback, Ptr<void> data, uint32_t *cid) {
     const std::lock_guard<std::mutex> lock(host.kernel.mutex);
-    *cid = host.kernel.next_uid++;
+    *cid = host.kernel.get_next_uid();
     emu::SceNetCtlCallback sceNetCtlCallback;
     sceNetCtlCallback.pc = callback.address();
     sceNetCtlCallback.data = data.address();

--- a/src/emulator/modules/SceSysmem/SceSysmem.cpp
+++ b/src/emulator/modules/SceSysmem/SceSysmem.cpp
@@ -39,7 +39,7 @@ EXPORT(SceUID, sceKernelAllocMemBlock, const char *name, SceKernelMemBlockType t
     }
 
     KernelState *const state = &host.kernel;
-    const SceUID uid = state->next_uid++;
+    const SceUID uid = state->get_next_uid();
     state->blocks.insert(Blocks::value_type(uid, address));
 
     return uid;


### PR DESCRIPTION
Also refactoring of mutex/semaphore code:
- Split some mutex functions to _impl functions because we need to run them from condvar code
- Change naming to have sync object name in the front
- Helper functions to reduce code duplication.
- Correct some returned erorrs
- Change `WaitingThreadData` to accomodate all current sync objects (and couple of future ones)
- Sync logging improvements

and a few other random fixes.