### PR TITLE
[net] Fixed a regression in vitaQuake

### DIFF
--- a/src/emulator/modules/SceNet/SceNet.cpp
+++ b/src/emulator/modules/SceNet/SceNet.cpp
@@ -29,14 +29,15 @@
 #include <errno.h>
 #endif
 
+// NOTE: This should be SCE_NET_##errname but it causes vitaQuake to softlock in online games
 #ifdef WIN32
 #define ERROR_CASE(errname) \
     case (WSA##errname):    \
-        return SCE_NET_##errname;
+        return SCE_NET_ERROR_##errname;
 #else
 #define ERROR_CASE(errname) \
     case (errname):         \
-        return SCE_NET_##errname;
+        return SCE_NET_ERROR_##errname;
 #endif
 
 static int translate_errorcode() {


### PR DESCRIPTION
Can't say why but using the correct values (SCE_NET_* errors) causes vitaQuake to softlock.
PSVita returns on real hardware SCE_NET_* errors and not SCE_NET_ERROR_* errors with those functions, source: https://github.com/Rinnegatamante/vitaQuakeIII/commit/f5db2245386513888a0bb1700c6dd4ed4daed2ce

Further investigations are required, for the moment i reverted errors to SCE_NET_ERROR_* and left a NOTE.