### PR TITLE
Μain refactoring & some random fixes

### DIFF
--- a/src/emulator/cpu/src/cpu.cpp
+++ b/src/emulator/cpu/src/cpu.cpp
@@ -66,12 +66,12 @@ static void code_hook(uc_engine *uc, uint64_t address, uint32_t size, void *user
     const size_t buffer_size = GB(4) - address;
     const bool thumb = is_thumb_mode(uc);
     const std::string disassembly = disassemble(state.disasm, code, buffer_size, address, thumb);
-    LOG_TRACE("0x{:08X} {}", address, disassembly);
+    LOG_TRACE("{} {}", log_hex(address), disassembly);
 }
 
 static void log_memory_access(const char *type, Address address, int size, int64_t value, const MemState &mem) {
     const char *const name = mem_name(address, mem);
-    LOG_TRACE("{} {} bytes, address 0x{:08X} ( {} ), value {:#x}", type, size, address, name, value);
+    LOG_TRACE("{} {} bytes, address {} ( {} ), value {:#x}", type, size, address, name, value);
 }
 
 static void read_hook(uc_engine *uc, uc_mem_type type, uint64_t address, int size, int64_t value, void *user_data) {
@@ -204,7 +204,7 @@ int run(CPUState &state, bool callback) {
     if (err != UC_ERR_OK) {
         std::uint32_t error_pc = read_pc(state);
         uint32_t lr = read_lr(state);
-        LOG_CRITICAL("Unicorn error 0x{:02X} at: start PC: 0x{:08X} error PC 0x{:08X} LR: 0x{:08X}", err, pc, error_pc, lr);
+        LOG_CRITICAL("Unicorn error {} at: start PC: {} error PC {} LR: {}", log_hex(err), log_hex(pc), log_hex(error_pc), log_hex(lr));
         return -1;
     }
     pc = read_pc(state);

--- a/src/emulator/gui/CMakeLists.txt
+++ b/src/emulator/gui/CMakeLists.txt
@@ -7,6 +7,7 @@ include/gui/state.h
 src/imgui_impl_sdl_gl3.cpp
 src/ui_common_dialog.cpp
 src/ui_condvars_dialog.cpp
+src/ui_eventflags_dialog.cpp
 src/ui_main.cpp
 src/ui_main_menubar.cpp
 src/ui_mutexes_dialog.cpp

--- a/src/emulator/gui/CMakeLists.txt
+++ b/src/emulator/gui/CMakeLists.txt
@@ -2,9 +2,11 @@ add_library(
 gui
 STATIC
 include/gui/imgui_impl_sdl_gl3.h
+include/gui/imgui_impl.h
 include/gui/functions.h
 include/gui/state.h
 src/imgui_impl_sdl_gl3.cpp
+src/imgui_impl.cpp
 src/ui_common_dialog.cpp
 src/ui_condvars_dialog.cpp
 src/ui_eventflags_dialog.cpp

--- a/src/emulator/gui/include/gui/imgui_impl.h
+++ b/src/emulator/gui/include/gui/imgui_impl.h
@@ -17,27 +17,20 @@
 
 #pragma once
 
-#include <cstdint>
+#include <host/state.h>
 
-static constexpr auto MENUBAR_HEIGHT = 19;
+// clang-format off
+#include <imgui.h>
+#include <gui/imgui_impl_sdl_gl3.h>
+// clang-format on
 
-enum GenericDialogState {
-    UNK_STATE,
-    CONFIRM_STATE,
-    CANCEL_STATE
-};
+#include <glutil/gl.h>
 
-struct HostState;
+namespace imgui {
 
-void DrawMainMenuBar(HostState &host);
-void DrawThreadsDialog(HostState &host);
-void DrawSemaphoresDialog(HostState &host);
-void DrawMutexesDialog(HostState &host);
-void DrawLwMutexesDialog(HostState &host);
-void DrawLwCondvarsDialog(HostState &host);
-void DrawCondvarsDialog(HostState &host);
-void DrawEventFlagsDialog(HostState &host);
-void DrawUI(HostState &host);
-void DrawCommonDialog(HostState &host);
-void DrawGameSelector(HostState &host, bool *is_vpk);
-void DrawReinstallDialog(HostState &host, GenericDialogState *status);
+    void init(WindowPtr window);
+    void draw_begin(WindowPtr window);
+    void draw_main(HostState &host, GLuint TextureID);
+    void draw_end(WindowPtr window);
+
+} // namespace imgui

--- a/src/emulator/gui/src/imgui_impl.cpp
+++ b/src/emulator/gui/src/imgui_impl.cpp
@@ -1,0 +1,67 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <gui/imgui_impl.h>
+
+#include <gui/functions.h>
+
+#include <SDL.h>
+
+void imgui::init(WindowPtr window) {
+    ImGui::CreateContext();
+    ImGui_ImplSdlGL3_Init(window.get());
+    ImGui::StyleColorsDark();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+}
+
+void imgui::draw_begin(WindowPtr window) {
+    ImGui_ImplSdlGL3_NewFrame(window.get());
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+}
+
+void imgui::draw_main(HostState& host, GLuint texture_id) {
+    const auto window_size = host.display.window_size;
+    const auto image_size = host.display.image_size;
+
+    // workaround for imgui-related crash
+    if (host.display.image_size.width == 0)
+        return;
+
+    glBindTexture(GL_TEXTURE_2D, texture_id);
+    void *const pixels = host.display.base.cast<void>().get(host.mem);
+
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, host.display.pitch);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, image_size.width, image_size.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiSetCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(window_size.width, window_size.height), ImGuiSetCond_Always);
+    ImGui::Begin("", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus);
+    host.gui.renderer_focused = ImGui::IsWindowFocused();
+    ImGui::Image(reinterpret_cast<void *>(texture_id), ImVec2(image_size.width, image_size.height));
+    ImGui::End();
+}
+
+void imgui::draw_end(WindowPtr window) {
+    glViewport(0, 0, static_cast<int>(ImGui::GetIO().DisplaySize.x), static_cast<int>(ImGui::GetIO().DisplaySize.y));
+    ImGui::Render();
+    ImGui_ImplSdlGL3_RenderDrawData(ImGui::GetDrawData());
+    SDL_GL_SwapWindow(window.get());
+}

--- a/src/emulator/gui/src/imgui_impl.cpp
+++ b/src/emulator/gui/src/imgui_impl.cpp
@@ -33,7 +33,7 @@ void imgui::draw_begin(WindowPtr window) {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
-void imgui::draw_main(HostState& host, GLuint texture_id) {
+void imgui::draw_main(HostState &host, GLuint texture_id) {
     const auto window_size = host.display.window_size;
     const auto image_size = host.display.image_size;
 

--- a/src/emulator/gui/src/ui_eventflags_dialog.cpp
+++ b/src/emulator/gui/src/ui_eventflags_dialog.cpp
@@ -1,0 +1,41 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <gui/functions.h>
+#include <imgui.h>
+
+#include <host/state.h>
+#include <kernel/thread/thread_functions.h>
+#include <kernel/thread/thread_state.h>
+#include <util/resource.h>
+
+void DrawEventFlagsDialog(HostState &host) {
+    ImGui::Begin("Event Flags", &host.gui.eventflags_dialog);
+    ImGui::TextColored(ImVec4(255, 255, 0, 255), "%-16s %-32s  %-7s   %-8s   %-16s", "ID", "EventFlag Name", "Flags", "Attributes", "Waiting Threads");
+
+    const std::lock_guard<std::mutex> lock(host.kernel.mutex);
+    for (auto event : host.kernel.eventflags) {
+        std::shared_ptr<EventFlag> event_state = event.second;
+        ImGui::Text("0x%08X       %-32s  %02d        %01d         %02u                 ",
+            event.first,
+            event_state->name,
+            event_state->flags,
+            event_state->attr,
+            event_state->waiting_threads.size());
+    }
+    ImGui::End();
+}

--- a/src/emulator/gui/src/ui_main.cpp
+++ b/src/emulator/gui/src/ui_main.cpp
@@ -19,15 +19,9 @@
 #include <host/state.h>
 #include <imgui.h>
 
-static constexpr auto DEFAULT_RES_WIDTH = 960;
-static constexpr auto DEFAULT_RES_HEIGHT = 544;
-static constexpr auto WINDOW_BORDER_WIDTH = 16;
-static constexpr auto WINDOW_BORDER_HEIGHT = 34;
-static constexpr auto MENUBAR_HEIGHT = 19;
-
 void DrawGameSelector(HostState &host, bool *is_vpk) {
     ImGui::SetNextWindowPos(ImVec2(0, 19), ImGuiSetCond_Always);
-    ImGui::SetNextWindowSize(ImVec2(DEFAULT_RES_WIDTH + WINDOW_BORDER_WIDTH, DEFAULT_RES_HEIGHT + WINDOW_BORDER_HEIGHT - MENUBAR_HEIGHT), ImGuiSetCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(host.display.window_size.width, host.display.window_size.height - MENUBAR_HEIGHT), ImGuiSetCond_Always);
     ImGui::Begin("", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus);
     switch (host.gui.game_selector.state) {
     case SELECT_APP:

--- a/src/emulator/gui/src/ui_mutexes_dialog.cpp
+++ b/src/emulator/gui/src/ui_mutexes_dialog.cpp
@@ -59,20 +59,3 @@ void DrawLwMutexesDialog(HostState &host) {
     }
     ImGui::End();
 }
-
-void DrawEventFlagsDialog(HostState &host) {
-    ImGui::Begin("Event Flags", &host.gui.eventflags_dialog);
-    ImGui::TextColored(ImVec4(255, 255, 0, 255), "%-16s %-32s   %-7s   %-8s  %-16s   %-16s", "ID", "EventFlag Name", "Flags", "Attributes", "Waiting Threads");
-
-    const std::lock_guard<std::mutex> lock(host.kernel.mutex);
-    for (auto event : host.kernel.eventflags) {
-        std::shared_ptr<EventFlag> event_state = event.second;
-        ImGui::Text("0x%08X       %-32s   %02d        %01d           %02u                 ",
-            event.first,
-            event_state->name,
-            event_state->flags,
-            event_state->attr,
-            event_state->waiting_threads.size());
-    }
-    ImGui::End();
-}

--- a/src/emulator/gxm/src/gxm.cpp
+++ b/src/emulator/gxm/src/gxm.cpp
@@ -88,8 +88,8 @@ static void log_parameter(const SceGxmProgramParameter &parameter) {
         type = "Other type";
         break;
     }
-    LOG_DEBUG("{}: name:{:s} type:{:d} component_count:{:x} container_index:{:x}",
-        type, parameter_name_raw(parameter), parameter.type, parameter.component_count, parameter.container_index);
+    LOG_DEBUG("{}: name:{:s} type:{:d} component_count:{} container_index:{}",
+        type, parameter_name_raw(parameter), parameter.type, log_hex(uint8_t(parameter.component_count)), log_hex(uint8_t(parameter.container_index)));
 }
 
 static const char *scalar_type(SceGxmParameterType type) {
@@ -106,7 +106,7 @@ static const char *scalar_type(SceGxmParameterType type) {
     case SCE_GXM_PARAMETER_TYPE_S32:
         return "int";
     default: {
-        LOG_ERROR("Unsupported parameter type {:#x} used in shader.", type);
+        LOG_ERROR("Unsupported parameter type {} used in shader.", log_hex(type));
     }
 
         return "?";
@@ -122,7 +122,7 @@ static const char *vector_prefix(SceGxmParameterType type) {
     case SCE_GXM_PARAMETER_TYPE_S32:
         return "i";
     default:
-        LOG_ERROR("Unsupported parameter type {:#x} used in shader.", type);
+        LOG_ERROR("Unsupported parameter type {} used in shader.", log_hex(type));
     }
     return "?";
 }
@@ -596,7 +596,7 @@ GLenum attribute_format_to_gl_type(SceGxmAttributeFormat format) {
         return GL_FLOAT;
 
     default: {
-        LOG_ERROR("Unsupported attribute format {:#x}", format);
+        LOG_ERROR("Unsupported attribute format {}", log_hex(format));
     }
         return GL_UNSIGNED_BYTE;
     }
@@ -620,7 +620,7 @@ size_t attribute_format_size(SceGxmAttributeFormat format) {
     case SCE_GXM_ATTRIBUTE_FORMAT_F32:
         return 4;
     default:
-        LOG_ERROR("Unsupported attribute format {:#x}", format);
+        LOG_ERROR("Unsupported attribute format {}", log_hex(format));
         return 4;
     }
 }
@@ -755,7 +755,7 @@ namespace texture {
         case SCE_GXM_TEXTURE_ADDR_CLAMP_HALF_BORDER:
             return GL_CLAMP_TO_BORDER; // FIXME: Is this correct?
         default:
-            LOG_WARN("Unsupported texture wrap mode translated: 0x{:08X}", src);
+            LOG_WARN("Unsupported texture wrap mode translated: {}", log_hex(src));
             return GL_CLAMP_TO_EDGE;
         }
     }
@@ -769,7 +769,7 @@ namespace texture {
         case SCE_GXM_TEXTURE_FILTER_LINEAR:
             return GL_LINEAR;
         default:
-            LOG_WARN("Unsupported texture min/mag filter translated: 0x{:08X}", src);
+            LOG_WARN("Unsupported texture min/mag filter translated: {}", log_hex(src));
             return GL_LINEAR;
         }
     }

--- a/src/emulator/host/include/host/app.h
+++ b/src/emulator/host/include/host/app.h
@@ -37,8 +37,8 @@ template <class T>
 class Ptr;
 
 typedef std::vector<uint8_t> Buffer;
-typedef std::unique_ptr<const void, void(*)(const void *)> SDLPtr;
-typedef std::unique_ptr<SDL_Surface, void(*)(SDL_Surface *)> SurfacePtr;
+typedef std::unique_ptr<const void, void (*)(const void *)> SDLPtr;
+typedef std::unique_ptr<SDL_Surface, void (*)(SDL_Surface *)> SurfacePtr;
 
 enum ExitCode {
     Success = 0,

--- a/src/emulator/host/include/host/app.h
+++ b/src/emulator/host/include/host/app.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <glbinding/gl/types.h>
+
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -28,8 +31,28 @@ static constexpr auto WINDOW_BORDER_HEIGHT = 34;
 typedef std::vector<uint8_t> Buffer;
 
 struct HostState;
+struct SDL_Window;
+struct SDL_Surface;
 template <class T>
 class Ptr;
 
-bool load_app(Ptr<const void> &entry_point, HostState &host, const std::wstring &path, bool is_vpk);
+typedef std::vector<uint8_t> Buffer;
+typedef std::unique_ptr<const void, void(*)(const void *)> SDLPtr;
+typedef std::unique_ptr<SDL_Surface, void(*)(SDL_Surface *)> SurfacePtr;
+
+enum ExitCode {
+    Success = 0,
+    IncorrectArgs,
+    SDLInitFailed,
+    HostInitFailed,
+    ModuleLoadFailed,
+    InitThreadFailed,
+    RunThreadFailed
+};
+
+void error_dialog(const std::string &message, SDL_Window *window = nullptr);
+ExitCode load_app(Ptr<const void> &entry_point, HostState &host, const std::wstring &path, bool is_vpk);
+ExitCode run_app(HostState &host, Ptr<const void> &entry_point);
 bool read_file_from_disk(Buffer &buf, const char *file, HostState &host);
+void set_window_title(HostState &host);
+void no_fb_fallback(HostState &host, gl::GLuint *fb_texture_id);

--- a/src/emulator/host/include/host/app.h
+++ b/src/emulator/host/include/host/app.h
@@ -20,6 +20,11 @@
 #include <string>
 #include <vector>
 
+static constexpr auto DEFAULT_RES_WIDTH = 960;
+static constexpr auto DEFAULT_RES_HEIGHT = 544;
+static constexpr auto WINDOW_BORDER_WIDTH = 16;
+static constexpr auto WINDOW_BORDER_HEIGHT = 34;
+
 typedef std::vector<uint8_t> Buffer;
 
 struct HostState;

--- a/src/emulator/host/include/host/functions.h
+++ b/src/emulator/host/include/host/functions.h
@@ -19,14 +19,8 @@
 
 #include <psp2/types.h>
 
-#include <kernel/thread/sync_primitives.h>
-#include <kernel/thread/thread_functions.h>
-#include <mem/ptr.h>
-
-#include <cstdint>
-
 struct HostState;
 
-bool init(HostState &state, std::uint32_t window_width, std::uint32_t border_width, std::uint32_t window_height, std::uint32_t border_height);
+bool init(HostState &state);
 bool handle_events(HostState &host);
 void call_import(HostState &host, uint32_t nid, SceUID thread_id);

--- a/src/emulator/host/include/host/state.h
+++ b/src/emulator/host/include/host/state.h
@@ -42,7 +42,9 @@ struct DisplayState {
         uint32_t height = 0;
 
         Size() = default;
-        Size(uint32_t w, uint32_t h) : width(w), height(h) {}
+        Size(uint32_t w, uint32_t h)
+            : width(w)
+            , height(h) {}
 
         Size &operator+(const Size &rhs) const {
             Size _size(this->width + rhs.width, this->height + rhs.height);

--- a/src/emulator/host/src/app.cpp
+++ b/src/emulator/host/src/app.cpp
@@ -23,10 +23,10 @@
 #include <host/sfo.h>
 #include <host/state.h>
 #include <host/version.h>
-#include <kernel/thread/thread_functions.h>
 #include <io/state.h>
-#include <util/fs.h>
+#include <kernel/thread/thread_functions.h>
 #include <util/find.h>
+#include <util/fs.h>
 #include <util/log.h>
 #include <util/string_convert.h>
 
@@ -36,10 +36,10 @@
 #include <cassert>
 #include <cstring>
 #include <fstream>
-#include <sstream>
 #include <iostream>
 #include <istream>
 #include <iterator>
+#include <sstream>
 
 // clang-format off
 #include <imgui.h>
@@ -261,7 +261,6 @@ ExitCode load_app(Ptr<const void> &entry_point, HostState &host, const std::wstr
     return Success;
 }
 
-
 ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
     const CallImport call_import = [&host](uint32_t nid, SceUID main_thread_id) {
         ::call_import(host, nid, main_thread_id);
@@ -293,16 +292,14 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
     return Success;
 }
 
-void no_fb_fallback(HostState &host, GLuint *fb_texture_id)
-{
+void no_fb_fallback(HostState &host, GLuint *fb_texture_id) {
     glGenTextures(1, fb_texture_id);
     glClearColor(1.0, 0.0, 0.5, 1.0);
     glClearDepth(1.0f);
     glViewport(0, 0, host.display.image_size.width, host.display.image_size.height);
 }
 
-void set_window_title(HostState& host)
-{
+void set_window_title(HostState &host) {
     const uint32_t sdl_ticks_now = SDL_GetTicks();
     const uint32_t ms = sdl_ticks_now - host.sdl_ticks;
     if (ms >= 1000 && host.frame_count > 0) {

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -220,7 +220,7 @@ void call_import(HostState &host, uint32_t nid, SceUID thread_id) {
 
         if (LOG_IMPORT_CALLS) {
             const char *const name = import_name(nid);
-            LOG_TRACE("THREAD_ID {} NID 0x{:08X} ({}) called", thread_id, nid, name);
+            LOG_TRACE("THREAD_ID {} NID {} ({}) called", thread_id, log_hex(nid), name);
         }
         const ImportFn fn = resolve_import(nid);
         if (fn) {
@@ -231,7 +231,7 @@ void call_import(HostState &host, uint32_t nid, SceUID thread_id) {
 
         if (LOG_IMPORT_CALLS) {
             const char *const name = import_name(nid);
-            LOG_TRACE("THREAD_ID {} EXPORTED NID 0x{:08X} at 0x{:08X} ({})) called", thread_id, nid, export_pc, name);
+            LOG_TRACE("THREAD_ID {} EXPORTED NID {} at {} ({})) called", thread_id, log_hex(nid), log_hex(export_pc), name);
         }
         const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
         const std::lock_guard<std::mutex> lock(thread->mutex);

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -98,7 +98,7 @@ void after_callback(const glbinding::FunctionCall &fn) {
     }
 }
 
-bool init(HostState &state, std::uint32_t window_width, std::uint32_t border_width, std::uint32_t window_height, std::uint32_t border_height) {
+bool init(HostState &state) {
     const std::unique_ptr<char, void (&)(void *)> base_path(SDL_GetBasePath(), SDL_free);
     const std::unique_ptr<char, void (&)(void *)> pref_path(SDL_GetPrefPath(org_name, app_name), SDL_free);
 
@@ -113,7 +113,8 @@ bool init(HostState &state, std::uint32_t window_width, std::uint32_t border_wid
 
     state.base_path = base_path.get();
     state.pref_path = pref_path.get();
-    state.window = WindowPtr(SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, window_width + border_width, window_height + border_height, SDL_WINDOW_OPENGL), SDL_DestroyWindow);
+    state.display.set_dims(DEFAULT_RES_WIDTH, DEFAULT_RES_HEIGHT, WINDOW_BORDER_WIDTH, WINDOW_BORDER_HEIGHT);
+    state.window = WindowPtr(SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, state.display.window_size.width, state.display.window_size.height, SDL_WINDOW_OPENGL), SDL_DestroyWindow);
     if (!state.window || !init(state.mem) || !init(state.audio, resume_thread) || !init(state.io, state.pref_path.c_str())) {
         return false;
     }
@@ -139,7 +140,6 @@ bool init(HostState &state, std::uint32_t window_width, std::uint32_t border_wid
     Binding::setAfterCallback(after_callback);
 
     state.kernel.base_tick = { rtc_base_ticks() };
-    state.display.set_window_dims(window_width, window_height);
 
     std::string dir_path = state.pref_path + "ux0/app";
 #ifdef WIN32

--- a/src/emulator/io/include/io/io.h
+++ b/src/emulator/io/include/io/io.h
@@ -27,3 +27,6 @@ enum class VitaIoDevice {
 };
 
 #undef DEVICE
+
+std::string normalize_path(const std::string &device, const std::string& path);
+std::pair<VitaIoDevice, std::string> translate_device(const std::string &path_);

--- a/src/emulator/io/include/io/io.h
+++ b/src/emulator/io/include/io/io.h
@@ -28,5 +28,5 @@ enum class VitaIoDevice {
 
 #undef DEVICE
 
-std::string normalize_path(const std::string &device, const std::string& path);
+std::string normalize_path(const std::string &device, const std::string &path);
 std::pair<VitaIoDevice, std::string> translate_device(const std::string &path_);

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -82,20 +82,27 @@ const char *translate_open_mode(int flags) {
     }
 }
 
-std::string translate_path(const std::string &part_name, const std::string &path, const std::string &pref_path) {
-    std::string res = pref_path;
-    res += part_name;
-    int i = part_name.length();
-    res += "/";
+std::string normalize_path(const std::string &device, const std::string& path) {
+    std::string normalized_path(device + "/");
+    uint32_t dev_length = device.length();
 
     if (path.empty())
-        return res;
-    if (path[i + 1] == '/')
-        i++;
-    res += &path[i + 1];
+        return normalized_path;
 
-    return res;
+    if (path[dev_length + 1] == '/') {
+        // Skip "/" since we already added one
+        normalized_path.erase(dev_length, 1);
+    }
+
+    normalized_path += path.substr(dev_length + 1);
+    return normalized_path;
 }
+
+std::string translate_path(const std::string &device, const std::string &path, const std::string &pref_path) {
+    std::string res = normalize_path(device, path);
+    return pref_path + res;
+}
+
 
 bool init(IOState &io, const char *pref_path) {
     std::string ux0 = pref_path;
@@ -121,7 +128,7 @@ bool init(IOState &io, const char *pref_path) {
     return true;
 }
 
-static std::pair<VitaIoDevice, std::string>
+std::pair<VitaIoDevice, std::string>
 translate_device(const std::string &path_) {
     std::string path(path_);
 

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -82,7 +82,7 @@ const char *translate_open_mode(int flags) {
     }
 }
 
-std::string normalize_path(const std::string &device, const std::string& path) {
+std::string normalize_path(const std::string &device, const std::string &path) {
     std::string normalized_path(device + "/");
     uint32_t dev_length = device.length();
 
@@ -102,7 +102,6 @@ std::string translate_path(const std::string &device, const std::string &path, c
     std::string res = normalize_path(device, path);
     return pref_path + res;
 }
-
 
 bool init(IOState &io, const char *pref_path) {
     std::string ux0 = pref_path;

--- a/src/emulator/kernel/src/load_self.cpp
+++ b/src/emulator/kernel/src/load_self.cpp
@@ -59,7 +59,7 @@ static bool load_var_imports(const uint32_t *nids, const Ptr<uint32_t> *entries,
 
         if (LOG_IMPORTS) {
             const char *const name = import_name(nid);
-            LOG_DEBUG("\tNID 0x{:08X} ({}) at {:#x}", nid, name, entry.address());
+            LOG_DEBUG("\tNID {} ({}) at {}", log_hex(nid), name, log_hex(entry.address()));
         }
 
         uint32_t *const stub = entry.get(mem);
@@ -72,7 +72,7 @@ static bool load_var_imports(const uint32_t *nids, const Ptr<uint32_t> *entries,
         const ExportNids::iterator export_address = kernel.export_nids.find(nid);
         if (export_address == kernel.export_nids.end()) {
             const char *const name = import_name(nid);
-            LOG_ERROR("\tNID NOT FOUND 0x{:08X} ({}) at {:#x}: 0x{:08X}", nid, name, entry.address(), stub[0]);
+            LOG_ERROR("\tNID NOT FOUND {} ({}) at {:#x}: {}", log_hex(nid), name, entry.address(), log_hex(stub[0]));
             continue;
         }
         uint32_t *const export_ptr = Ptr<uint32_t>(export_address->second).get(mem);
@@ -123,7 +123,7 @@ static bool load_func_imports(const uint32_t *nids, const Ptr<uint32_t> *entries
 
         if (LOG_IMPORTS) {
             const char *const name = import_name(nid);
-            LOG_DEBUG("\tNID 0x{:08X} ({}) at {:#x}", nid, name, entry.address());
+            LOG_DEBUG("\tNID {} ({}) at {}", log_hex(nid), name, log_hex(entry.address()));
         }
 
         const ExportNids::iterator export_address = kernel.export_nids.find(nid);
@@ -191,7 +191,7 @@ static bool load_func_exports(Ptr<const void> &entry_point, const uint32_t *nids
         if (LOG_EXPORTS) {
             const char *const name = import_name(nid);
 
-            LOG_DEBUG("\tNID 0x{:08X} ({}) at {:#x}", nid, name, entry.address());
+            LOG_DEBUG("\tNID {} ({}) at {}", log_hex(nid), name, entry.address());
         }
     }
 
@@ -205,24 +205,24 @@ static bool load_var_exports(Ptr<const void> &entry_point, const uint32_t *nids,
 
         if (nid == NID_PROCESS_PARAM) {
             kernel.process_param = entry;
-            LOG_DEBUG("\tNID 0x{:08X} (SCE_PROC_PARAMS) at {:#x}", nid, entry.address());
+            LOG_DEBUG("\tNID {} (SCE_PROC_PARAMS) at {}", log_hex(nid), log_hex(entry.address()));
             continue;
         }
 
         if (nid == NID_MODULE_INFO) {
-            LOG_DEBUG("\tNID 0x{:08X} (NID_MODULE_INFO) at {:#x}", nid, entry.address());
+            LOG_DEBUG("\tNID {} (NID_MODULE_INFO) at {}", log_hex(nid), log_hex(entry.address()));
             continue;
         }
 
         if (nid == 0x936c8a78) {
-            LOG_DEBUG("\tNID 0x{:08X} (SYSLYB) at {:#x}", nid, entry.address());
+            LOG_DEBUG("\tNID {} (SYSLYB) at {:#x}", log_hex(nid), log_hex(entry.address()));
             continue;
         }
 
         if (LOG_EXPORTS) {
             const char *const name = import_name(nid);
 
-            LOG_DEBUG("\tNID 0x{:08X} ({}) at {:#x}", nid, name, entry.address());
+            LOG_DEBUG("\tNID {} ({}) at {:#x}", log_hex(nid), name, log_hex(entry.address()));
         }
 
         kernel.export_nids.emplace(nid, entry.address());

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -69,11 +69,6 @@ static void term_sdl(const void *succeeded) {
     SDL_Quit();
 }
 
-static constexpr auto DEFAULT_RES_WIDTH = 960;
-static constexpr auto DEFAULT_RES_HEIGHT = 544;
-static constexpr auto WINDOW_BORDER_WIDTH = 16;
-static constexpr auto WINDOW_BORDER_HEIGHT = 34;
-
 int main(int argc, char *argv[]) {
     init_logging();
 
@@ -105,8 +100,8 @@ int main(int argc, char *argv[]) {
     }
 
     HostState host;
-    if (!init(host, DEFAULT_RES_WIDTH, WINDOW_BORDER_WIDTH, DEFAULT_RES_HEIGHT, WINDOW_BORDER_HEIGHT)) {
-        error("Host initialisation failed.", host.window.get());
+    if (!init(host)) {
+        error_dialog("Host initialisation failed.", host.window.get());
         return HostInitFailed;
     }
 

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
 
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-    // Filter out an argument that macOS Finder appends 
+    // Filter out an argument that macOS Finder appends
     const char *const *const path_arg = std::find_if_not(&argv[1], &argv[argc], [](const char *arg) {
         return strncmp(arg, "-psn_", 5) == 0;
     });

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -20,10 +20,7 @@
 #include <host/state.h>
 #include <host/version.h>
 #include <kernel/thread/thread_functions.h>
-#include <kernel/thread/thread_state.h>
-#include <util/find.h>
 #include <util/log.h>
-#include <util/resource.h>
 #include <util/string_convert.h>
 
 #include <SDL.h>
@@ -31,40 +28,9 @@
 
 #include <algorithm> // find_if_not
 #include <cassert>
-#include <iostream>
-#include <sstream>
 
 #include <gui/functions.h>
 #include <gui/imgui_impl.h>
-
-typedef std::unique_ptr<const void, void (*)(const void *)> SDLPtr;
-typedef std::unique_ptr<SDL_Surface, void (*)(SDL_Surface *)> SurfacePtr;
-
-enum ExitCode {
-    Success = 0,
-    IncorrectArgs,
-    SDLInitFailed,
-    HostInitFailed,
-    ModuleLoadFailed,
-    InitThreadFailed,
-    RunThreadFailed
-};
-
-static bool is_macos_process_arg(const char *arg) {
-    return strncmp(arg, "-psn_", 5) == 0;
-}
-
-static void error(const std::string &message, SDL_Window *window = nullptr) {
-    if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Error", message.c_str(), window) < 0) {
-        LOG_ERROR("SDL Error: {}", message);
-    }
-}
-
-static void term_sdl(const void *succeeded) {
-    assert(succeeded != nullptr);
-
-    SDL_Quit();
-}
 
 int main(int argc, char *argv[]) {
     init_logging();
@@ -73,15 +39,22 @@ int main(int argc, char *argv[]) {
 
     ProgramArgsWide argv_wide = process_args(argc, argv);
 
-    const SDLPtr sdl(reinterpret_cast<const void *>(SDL_Init(SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_VIDEO) >= 0), term_sdl);
+    const SDLPtr sdl(reinterpret_cast<const void *>(SDL_Init(SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_VIDEO) >= 0), [](const void *succeeded) {
+        assert(succeeded != nullptr);
+        SDL_Quit();
+    });
     if (!sdl) {
-        error("SDL initialisation failed.");
+        error_dialog("SDL initialisation failed.");
         return SDLInitFailed;
     }
 
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-    const char *const *const path_arg = std::find_if_not(&argv[1], &argv[argc], is_macos_process_arg);
+    // Filter out an argument that macOS Finder appends 
+    const char *const *const path_arg = std::find_if_not(&argv[1], &argv[argc], [](const char *arg) {
+        return strncmp(arg, "-psn_", 5) == 0;
+    });
+
     std::wstring path;
     if (path_arg != &argv[argc]) {
         path = utf_to_wide(*path_arg);
@@ -124,50 +97,17 @@ int main(int argc, char *argv[]) {
     }
 
     Ptr<const void> entry_point;
-    if (!load_app(entry_point, host, path, is_vpk)) {
-        std::string message = "Failed to load \"";
-        message += wide_to_utf(path);
-        message += "\"";
-        message += "\nSee console output for details.";
-        error(message.c_str(), host.window.get());
-        return ModuleLoadFailed;
-    }
+    if (auto err = load_app(entry_point, host, path, is_vpk) != Success)
+        return err;
 
-    const CallImport call_import = [&host](uint32_t nid, SceUID main_thread_id) {
-        ::call_import(host, nid, main_thread_id);
-    };
+    if (auto err = run_app(host, entry_point) != Success)
+        return err;
 
-    const SceUID main_thread_id = create_thread(entry_point, host.kernel, host.mem, host.io.title_id.c_str(), SCE_KERNEL_DEFAULT_PRIORITY_USER, SCE_KERNEL_STACK_SIZE_USER_MAIN, call_import, false);
-    if (main_thread_id < 0) {
-        error("Failed to init main thread.", host.window.get());
-        return InitThreadFailed;
-    }
-
-    const ThreadStatePtr main_thread = find(main_thread_id, host.kernel.threads);
-    Ptr<void> argp = Ptr<void>();
-    if (!strncmp(host.kernel.loaded_modules.begin()->second->module_name, "SceLibc", 7)) {
-        const SceUID libc_thread_id = create_thread(host.kernel.loaded_modules.begin()->second->module_start, host.kernel, host.mem, "libc", SCE_KERNEL_DEFAULT_PRIORITY_USER, SCE_KERNEL_STACK_SIZE_USER_DEFAULT, call_import, false);
-        const ThreadStatePtr libc_thread = find(libc_thread_id, host.kernel.threads);
-        run_on_current(*libc_thread, host.kernel.loaded_modules.begin()->second->module_start, 0, argp);
-        libc_thread->to_do = ThreadToDo::exit;
-        libc_thread->something_to_do.notify_all(); // TODO Should this be notify_one()?
-        host.kernel.running_threads.erase(libc_thread_id);
-        host.kernel.threads.erase(libc_thread_id);
-    }
-
-    if (start_thread(host.kernel, main_thread_id, 0, Ptr<void>()) < 0) {
-        error("Failed to run main thread.", host.window.get());
-        return RunThreadFailed;
-    }
-
-    GLuint TextureID = 0;
-    host.t1 = SDL_GetTicks();
+    GLuint fb_texture_id = 0;
+    host.sdl_ticks = SDL_GetTicks();
     while (handle_events(host)) {
-        if (!TextureID) {
-            glGenTextures(1, &TextureID);
-            glClearColor(1.0, 0.0, 0.5, 1.0);
-            glClearDepth(1.0f);
-            glViewport(0, 0, DEFAULT_RES_WIDTH, DEFAULT_RES_HEIGHT);
+        if (!fb_texture_id) {
+            no_fb_fallback(host, &fb_texture_id);
         }
 
         imgui::draw_begin(host.window);
@@ -181,17 +121,7 @@ int main(int argc, char *argv[]) {
 
         host.display.condvar.notify_all();
 
-        const uint32_t t2 = SDL_GetTicks();
-        const uint32_t ms = t2 - host.t1;
-        if (ms >= 1000 && host.frame_count > 0) {
-            const uint32_t fps = (host.frame_count * 1000) / ms;
-            const uint32_t ms_per_frame = ms / host.frame_count;
-            std::ostringstream title;
-            title << window_title << " | " << host.game_title << " (" << host.io.title_id << ") | " << ms_per_frame << " ms/frame (" << fps << " frames/sec)";
-            SDL_SetWindowTitle(host.window.get(), title.str().c_str());
-            host.t1 = t2;
-            host.frame_count = 0;
-        }
+        set_window_title(host);
     }
     return Success;
 }

--- a/src/emulator/mem/src/mem.cpp
+++ b/src/emulator/mem/src/mem.cpp
@@ -93,7 +93,7 @@ bool init(MemState &state) {
     DWORD old_protect = 0;
     const BOOL res = VirtualProtect(state.memory.get(), state.page_size, PAGE_NOACCESS, &old_protect);
     if (!res)
-        LOG_WARN("VirtualProtect failed: 0x{:08X}", res);
+        LOG_WARN("VirtualProtect failed: {}", log_hex(res));
 #else
     mprotect(state.memory.get(), state.page_size, PROT_NONE);
 #endif

--- a/src/emulator/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/src/emulator/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -282,11 +282,11 @@ EXPORT(int, sceMsgDialogInit, const Ptr<emu::SceMsgDialogParam> param) {
             break;
         case SCE_MSG_DIALOG_SYSMSG_TYPE_INVALID:
         default:
-            LOG_ERROR("Attempt to init message dialog with unknown system message mode: 0x{:08X}", p->sysMsgParam.get(host.mem)->sysMsgType);
+            LOG_ERROR("Attempt to init message dialog with unknown system message mode: {}", log_hex(p->sysMsgParam.get(host.mem)->sysMsgType));
         }
         break;
     case SCE_MSG_DIALOG_MODE_ERROR_CODE:
-        host.gui.common_dialog.msg.message = fmt::format("An error occurred. Errorcode: 0x{:08X}", p->errorCodeParam.get(host.mem)->errorCode);
+        host.gui.common_dialog.msg.message = fmt::format("An error occurred. Errorcode: {}", log_hex(p->errorCodeParam.get(host.mem)->errorCode));
         host.gui.common_dialog.msg.btn_num = 0;
         break;
     case SCE_MSG_DIALOG_MODE_PROGRESS_BAR:
@@ -298,7 +298,7 @@ EXPORT(int, sceMsgDialogInit, const Ptr<emu::SceMsgDialogParam> param) {
         break;
     case SCE_MSG_DIALOG_MODE_INVALID:
     default:
-        LOG_ERROR("Attempt to init message dialog with unknown mode: 0x{:08X}", p->mode);
+        LOG_ERROR("Attempt to init message dialog with unknown mode: {}", log_hex(p->mode));
         break;
     }
 

--- a/src/emulator/modules/SceDisplay/SceDisplayUser.cpp
+++ b/src/emulator/modules/SceDisplay/SceDisplayUser.cpp
@@ -73,10 +73,10 @@ EXPORT(int, sceDisplaySetFrameBuf, const emu::SceDisplayFrameBuf *pParam, SceDis
     }
 
     host.display.base = pParam->base;
-    host.display.height = pParam->height;
     host.display.pitch = pParam->pitch;
     host.display.pixelformat = pParam->pixelformat;
-    host.display.width = pParam->width;
+    host.display.image_size.width = pParam->width;
+    host.display.image_size.height = pParam->height;
     ++host.frame_count;
 
     MicroProfileFlip(nullptr);

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -93,12 +93,12 @@ EXPORT(int, sceGxmBeginScene, SceGxmContext *context, unsigned int flags, const 
     }
 
     glEnable(GL_SCISSOR_TEST);
-    glScissor(0, 0, host.display.window_width, host.display.window_height);
+    glScissor(0, 0, host.display.image_size.width, host.display.image_size.height);
 
     context->viewport.x = 0;
     context->viewport.y = 0;
-    context->viewport.w = host.display.window_width;
-    context->viewport.h = host.display.window_height;
+    context->viewport.w = host.display.image_size.width;
+    context->viewport.h = host.display.image_size.height;
     context->viewport.nearVal = 0.0f;
     context->viewport.farVal = 1.0f;
     glViewport(context->viewport.x, context->viewport.y, context->viewport.w, context->viewport.h);
@@ -223,7 +223,7 @@ EXPORT(int, sceGxmCreateContext, const emu::SceGxmContextParams *params, Ptr<Sce
     LOG_INFO("GL_VERSION = {}", glGetString(GL_VERSION));
     LOG_INFO("GL_SHADING_LANGUAGE_VERSION = {}", glGetString(GL_SHADING_LANGUAGE_VERSION));
 
-    glViewport(0, 0, host.display.window_width, host.display.window_height);
+    glViewport(0, 0, host.display.image_size.width, host.display.image_size.height);
 
     // TODO This is just for debugging.
     glClearColor(0.0625f, 0.125f, 0.25f, 0);
@@ -1282,13 +1282,13 @@ EXPORT(void, sceGxmSetRegionClip, SceGxmContext *context, SceGxmRegionClipMode m
     yMax += yMax % 32;
     switch (mode) {
     case SCE_GXM_REGION_CLIP_NONE:
-        glScissor(0, 0, host.display.window_width, host.display.window_height);
+        glScissor(0, 0, host.display.image_size.width, host.display.image_size.height);
         break;
     case SCE_GXM_REGION_CLIP_ALL:
         glScissor(0, 0, 0, 0);
         break;
     case SCE_GXM_REGION_CLIP_OUTSIDE:
-        glScissor(xMin, host.display.window_height - yMax, xMin + xMax, yMin + yMax);
+        glScissor(xMin, host.display.image_size.height - yMax, xMin + xMax, yMin + yMax);
         break;
     case SCE_GXM_REGION_CLIP_INSIDE:
         // TODO: Implement this
@@ -1369,7 +1369,7 @@ EXPORT(void, sceGxmSetViewportEnable, SceGxmContext *context, SceGxmViewportMode
         glViewport(context->viewport.x, context->viewport.y, context->viewport.w, context->viewport.h);
         glDepthRange(context->viewport.nearVal, context->viewport.farVal);
     } else {
-        glViewport(0, 0, host.display.window_width, host.display.window_height);
+        glViewport(0, 0, host.display.image_size.width, host.display.image_size.height);
         glDepthRange(0.0f, 1.0f);
     }
 }

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1819,10 +1819,10 @@ EXPORT(int, sceGxmTextureInitLinear, SceGxmTexture *texture, Ptr<const void> dat
             case SCE_GXM_TEXTURE_FORMAT_P8_1BGR:
                 break;
             default:
-                LOG_WARN("Initialized texture with untested paletted texture format: 0x{:08X}", texFormat);
+                LOG_WARN("Initialized texture with untested paletted texture format: {}", log_hex(texFormat));
             }
         } else
-            LOG_ERROR("Initialized texture with unsupported texture format: 0x{:08X}", texFormat);
+            LOG_ERROR("Initialized texture with unsupported texture format: {}", log_hex(texFormat));
     }
 
     texture->mip_count = mipCount - 1;

--- a/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
+++ b/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
@@ -1059,7 +1059,7 @@ EXPORT(int, sceKernelLoadStartModule, char *path, SceSize args, Ptr<void> argp, 
     uint32_t result = run_on_current(*thread, entry_point, args, argp);
     char *module_name = module->second.get()->module_name;
 
-    LOG_INFO("{} returned 0x{:08X}", module_name, result);
+    LOG_INFO("{} returned {}", module_name, log_hex(result));
 
     if (status)
         *status = result;

--- a/src/emulator/modules/SceLibc/SceLibc.cpp
+++ b/src/emulator/modules/SceLibc/SceLibc.cpp
@@ -432,6 +432,7 @@ EXPORT(int, fileno) {
 }
 
 EXPORT(int, fopen, const char *filename, const char *mode) {
+    LOG_WARN_IF(mode[0] != 'r', "fopen({}, {})", filename, *mode);
     return open_file(host.io, filename, SCE_O_RDONLY, host.pref_path.c_str());
 }
 

--- a/src/emulator/util/include/util/log.h
+++ b/src/emulator/util/include/util/log.h
@@ -19,6 +19,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include <type_traits>
+
 extern std::shared_ptr<spdlog::logger> g_logger;
 
 void init_logging();
@@ -48,3 +50,9 @@ void init_logging();
 #define LOG_CRITICAL_IF(flag, fmt, ...) \
     if (flag)                           \
     g_logger->critical(flag, "|C| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
+
+template<typename T>
+std::string log_hex(T val) {
+    using unsigned_type = typename std::make_unsigned<T>::type;
+    return fmt::format("0x{:0x}", static_cast<unsigned_type>(val));
+}

--- a/src/emulator/util/include/util/log.h
+++ b/src/emulator/util/include/util/log.h
@@ -34,22 +34,22 @@ void init_logging();
 
 #define LOG_TRACE_IF(flag, fmt, ...) \
     if (flag)                        \
-    g_logger->trace(flag, "|T| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
+    g_logger->trace("|T| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
 #define LOG_DEBUG_IF(flag, fmt, ...) \
     if (flag)                        \
-    g_logger->debug(flag, "|D| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
+    g_logger->debug("|D| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
 #define LOG_INFO_IF(flag, fmt, ...) \
     if (flag)                       \
-    g_logger->info(flag, "|I| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
+    g_logger->info("|I| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
 #define LOG_WARN_IF(flag, fmt, ...) \
     if (flag)                       \
-    g_logger->warn(flag, "|W| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
+    g_logger->warn("|W| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
 #define LOG_ERROR_IF(flag, fmt, ...) \
     if (flag)                        \
-    g_logger->error(flag, "|E| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
+    g_logger->error("|E| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
 #define LOG_CRITICAL_IF(flag, fmt, ...) \
     if (flag)                           \
-    g_logger->critical(flag, "|C| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
+    g_logger->critical("|C| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
 
 template<typename T>
 std::string log_hex(T val) {

--- a/src/emulator/util/include/util/log.h
+++ b/src/emulator/util/include/util/log.h
@@ -51,7 +51,7 @@ void init_logging();
     if (flag)                           \
     g_logger->critical("|C| [{:s}]:  " fmt, __FUNCTION__, ##__VA_ARGS__)
 
-template<typename T>
+template <typename T>
 std::string log_hex(T val) {
     using unsigned_type = typename std::make_unsigned<T>::type;
     return fmt::format("0x{:0x}", static_cast<unsigned_type>(val));


### PR DESCRIPTION
Some needed `main()`, `host` and `imgui` impl. refactoring and a few minor fixes.
Resolves #255.

### Note to devs
Please use `log_hex()` to format hex strings from now on, with `{}` as the format string. It outputs unsigned hex strings in the format of `0xD34DB33F`, with `0` padding according to size of input type.
This is so that we finally have a standardized way to print them.