### PR TITLE
Eliminate lock per import call

### DIFF
--- a/src/emulator/cpu/include/cpu/functions.h
+++ b/src/emulator/cpu/include/cpu/functions.h
@@ -25,7 +25,7 @@
 struct CPUState;
 struct MemState;
 
-typedef std::function<void(uint32_t, Address)> CallSVC;
+typedef std::function<void(CPUState &cpu, uint32_t, Address)> CallSVC;
 typedef std::unique_ptr<CPUState, std::function<void(CPUState *)>> CPUStatePtr;
 
 CPUStatePtr init_cpu(Address pc, Address sp, bool log_code, CallSVC call_svc, MemState &mem);

--- a/src/emulator/cpu/src/cpu.cpp
+++ b/src/emulator/cpu/src/cpu.cpp
@@ -104,14 +104,14 @@ static void intr_hook(uc_engine *uc, uint32_t intno, void *user_data) {
         err = uc_mem_read(uc, svc_address, &svc_instruction, sizeof(svc_instruction));
         assert(err == UC_ERR_OK);
         const uint8_t imm = svc_instruction & 0xff;
-        state.call_svc(imm, pc);
+        state.call_svc(state, imm, pc);
     } else {
         const Address svc_address = pc - 4;
         uint32_t svc_instruction = 0;
         err = uc_mem_read(uc, svc_address, &svc_instruction, sizeof(svc_instruction));
         assert(err == UC_ERR_OK);
         const uint32_t imm = svc_instruction & 0xffffff;
-        state.call_svc(imm, pc);
+        state.call_svc(state, imm, pc);
     }
 }
 

--- a/src/emulator/host/include/host/functions.h
+++ b/src/emulator/host/include/host/functions.h
@@ -19,8 +19,9 @@
 
 #include <psp2/types.h>
 
+struct CPUState;
 struct HostState;
 
 bool init(HostState &state);
 bool handle_events(HostState &host);
-void call_import(HostState &host, uint32_t nid, SceUID thread_id);
+void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id);

--- a/src/emulator/host/include/host/import_fn.h
+++ b/src/emulator/host/include/host/import_fn.h
@@ -21,6 +21,7 @@
 
 #include <functional>
 
+struct CPUState;
 struct HostState;
 
-typedef std::function<void(HostState &host, SceUID thread_id)> ImportFn;
+typedef std::function<void(HostState &host, CPUState &cpu, SceUID thread_id)> ImportFn;

--- a/src/emulator/host/src/app.cpp
+++ b/src/emulator/host/src/app.cpp
@@ -263,8 +263,8 @@ ExitCode load_app(Ptr<const void> &entry_point, HostState &host, const std::wstr
 }
 
 ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
-    const CallImport call_import = [&host](uint32_t nid, SceUID main_thread_id) {
-        ::call_import(host, nid, main_thread_id);
+    const CallImport call_import = [&host](CPUState &cpu, uint32_t nid, SceUID main_thread_id) {
+        ::call_import(host, cpu, nid, main_thread_id);
     };
 
     const SceUID main_thread_id = create_thread(entry_point, host.kernel, host.mem, host.io.title_id.c_str(), SCE_KERNEL_DEFAULT_PRIORITY_USER, SCE_KERNEL_STACK_SIZE_USER_MAIN, call_import, false);

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -218,7 +218,7 @@ Address resolve_export(KernelState &kernel, uint32_t nid) {
     return export_address->second;
 }
 
-void call_import(HostState &host, uint32_t nid, SceUID thread_id) {
+void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id) {
     Address export_pc = resolve_export(host.kernel, nid);
 
     if (!export_pc) {
@@ -230,7 +230,7 @@ void call_import(HostState &host, uint32_t nid, SceUID thread_id) {
         }
         const ImportFn fn = resolve_import(nid);
         if (fn) {
-            fn(host, thread_id);
+            fn(host, cpu, thread_id);
         }
     } else {
         // LLE - directly run ARM code imported from some loaded module

--- a/src/emulator/kernel/include/kernel/thread/thread_functions.h
+++ b/src/emulator/kernel/include/kernel/thread/thread_functions.h
@@ -27,7 +27,7 @@
 struct CPUState;
 struct ThreadState;
 
-typedef std::function<void(uint32_t, SceUID)> CallImport;
+typedef std::function<void(CPUState &, uint32_t, SceUID)> CallImport;
 typedef std::shared_ptr<ThreadState> ThreadStatePtr;
 
 SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stackSize, CallImport call_import, bool log_code);

--- a/src/emulator/kernel/src/thread/thread.cpp
+++ b/src/emulator/kernel/src/thread/thread.cpp
@@ -73,10 +73,10 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
     const Address stack_top = thread->stack->get() + stack_size;
     memset(Ptr<void>(thread->stack->get()).get(mem), 0xcc, stack_size);
 
-    const CallSVC call_svc = [call_import, thid, &mem](uint32_t imm, Address pc) {
+    const CallSVC call_svc = [call_import, thid, &mem](CPUState &cpu, uint32_t imm, Address pc) {
         assert(imm == 0);
         const uint32_t nid = *Ptr<uint32_t>(pc + 4).get(mem);
-        call_import(nid, thid);
+        call_import(cpu, nid, thid);
     };
 
     thread->cpu = init_cpu(entry_point.address(), stack_top, log_code, call_svc, mem);

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -19,13 +19,13 @@
 
 #include <gxm/functions.h>
 #include <gxm/types.h>
-#include <util/log.h>
-
-#include <glbinding/Binding.h>
 
 #include <cpu/functions.h>
 #include <host/functions.h>
 #include <kernel/thread/thread_functions.h>
+#include <util/log.h>
+
+#include <glbinding/Binding.h>
 #include <psp2/kernel/error.h>
 
 #include <algorithm>

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -23,6 +23,7 @@
 #include <cpu/functions.h>
 #include <host/functions.h>
 #include <kernel/thread/thread_functions.h>
+#include <util/lock_and_find.h>
 #include <util/log.h>
 
 #include <glbinding/Binding.h>

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -629,8 +629,8 @@ EXPORT(int, sceGxmInitialize, const emu::SceGxmInitializeParams *params) {
 
     const ThreadStatePtr main_thread = find(thread_id, host.kernel.threads);
 
-    const CallImport call_import = [&host](uint32_t nid, SceUID thread_id) {
-        ::call_import(host, nid, thread_id);
+    const CallImport call_import = [&host](CPUState &cpu, uint32_t nid, SceUID thread_id) {
+        ::call_import(host, cpu, nid, thread_id);
     };
 
     const auto stack_size = SCE_KERNEL_STACK_SIZE_USER_DEFAULT; // TODO: Verify this is the correct stack size

--- a/src/emulator/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
+++ b/src/emulator/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
@@ -17,6 +17,8 @@
 
 #include "SceThreadmgrCoredumpTime.h"
 
+#include <util/lock_and_find.h>
+
 EXPORT(int, sceKernelExitThread, int status) {
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
     const std::lock_guard<std::mutex> lock(thread->mutex);

--- a/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
+++ b/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
@@ -842,8 +842,8 @@ EXPORT(SceUID, sceKernelCreateThread, const char *name, emu::SceKernelThreadEntr
     if (cpu_affinity_mask > 0x70000) {
         return RET_ERROR(SCE_KERNEL_ERROR_INVALID_CPU_AFFINITY);
     }
-    const CallImport call_import = [&host](uint32_t nid, SceUID thread_id) {
-        ::call_import(host, nid, thread_id);
+    const CallImport call_import = [&host](CPUState &cpu, uint32_t nid, SceUID thread_id) {
+        ::call_import(host, cpu, nid, thread_id);
     };
 
     const SceUID thid = create_thread(entry.cast<const void>(), host.kernel, host.mem, name, init_priority, stack_size, call_import, false);
@@ -1056,8 +1056,8 @@ EXPORT(int, sceKernelLoadStartModule, char *path, SceSize args, Ptr<void> argp, 
     const SceKernelModuleInfoPtrs::const_iterator module = host.kernel.loaded_modules.find(modId);
     assert(module != host.kernel.loaded_modules.end());
 
-    const CallImport call_import = [&host](uint32_t nid, SceUID thread_id) {
-        ::call_import(host, nid, thread_id);
+    const CallImport call_import = [&host](CPUState &cpu, uint32_t nid, SceUID thread_id) {
+        ::call_import(host, cpu, nid, thread_id);
     };
 
     const SceUID thid = create_thread(entry_point.cast<const void>(), host.kernel, host.mem, module->second.get()->module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, SCE_KERNEL_STACK_SIZE_USER_DEFAULT, call_import, false);

--- a/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
+++ b/src/emulator/modules/SceLibKernel/SceLibKernel.cpp
@@ -26,6 +26,7 @@
 #include <kernel/thread/thread_functions.h>
 #include <kernel/types.h>
 #include <rtc/rtc.h>
+#include <util/lock_and_find.h>
 #include <util/log.h>
 
 #include <kernel/load_self.h>

--- a/src/emulator/modules/SceNetCtl/SceNetCtl.cpp
+++ b/src/emulator/modules/SceNetCtl/SceNetCtl.cpp
@@ -22,6 +22,8 @@
 #define s_addr s_addr
 #endif
 #include <kernel/thread/thread_functions.h>
+#include <util/lock_and_find.h>
+
 #include <psp2/net/netctl.h>
 
 EXPORT(int, sceNetCtlAdhocDisconnect) {


### PR DESCRIPTION
Pass `CPUState` through via `call_svc`, `call_import` rather than lock a mutex to look it up.