### PR TITLE
sceKernelAllocMemBlock: remove assert for SceKernelAllocMemBlockOpt

### DIFF
--- a/src/emulator/modules/SceSysmem/SceSysmem.cpp
+++ b/src/emulator/modules/SceSysmem/SceSysmem.cpp
@@ -31,7 +31,6 @@ EXPORT(SceUID, sceKernelAllocMemBlock, const char *name, SceKernelMemBlockType t
     assert(name != nullptr);
     assert(type != 0);
     assert(size != 0);
-    assert(optp == nullptr);
 
     const Ptr<void> address(alloc(mem, size, name));
     if (!address) {


### PR DESCRIPTION
The parameter `SceKernelAllocMemBlockOpt` can be not null when used in `sceKernelAllocMemBlock`, see https://github.com/joshaxey/textquest/blob/3891bcb1cc13c27d599efe18aa34ba49ad62f000/src/graphics.c#L53-L61

This change allows the homebrew TextQuest to go further.

**Before**
```
SceUID export_sceKernelAllocMemBlock(HostState&, SceUID, const char*, const char*, SceKernelMemBlockType, int, emu::SceKernelAllocMemBlockOpt*): Assertion `optp == nullptr' failed.
```
**After**
![screenshot from 2018-08-08 19-26-19](https://user-images.githubusercontent.com/25406440/43853623-fbdb8b68-9b40-11e8-87d7-5c2ab68e14d0.png)
