### PR TITLE
Shader generation, GXM and renderer improvements

### DIFF
--- a/src/emulator/gxm/include/gxm/functions.h
+++ b/src/emulator/gxm/include/gxm/functions.h
@@ -35,4 +35,8 @@ std::string parameter_struct_name(const SceGxmProgramParameter &parameter);
 const SceGxmProgramParameter *program_parameters(const SceGxmProgram &program);
 SceGxmParameterType parameter_type(const SceGxmProgramParameter &parameter);
 GenericParameterType parameter_generic_type(const SceGxmProgramParameter &parameter);
+/**
+ * \return SceGxmVertexProgramOutput (bitfield)
+ */
+SceGxmVertexProgramOutputs get_vertex_outputs(const SceGxmProgram &program);
 } // namespace gxp

--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -137,6 +137,44 @@ enum SceGxmProgramType : std::uint8_t {
 };
 } // namespace emu
 
+enum SceGxmVertexProgramOutputs : int {
+    _SCE_GXM_VERTEX_PROGRAM_OUTPUT_INVALID = 0,
+
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_POSITION = 1 << 0,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_FOG = 1 << 1,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_COLOR0 = 1 << 2,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_COLOR1 = 1 << 3,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD0 = 1 << 4,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD1 = 1 << 5,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD2 = 1 << 6,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD3 = 1 << 7,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD4 = 1 << 8,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD5 = 1 << 9,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD6 = 1 << 10,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD7 = 1 << 11,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD8 = 1 << 12,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD9 = 1 << 13,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_PSIZE = 1 << 14,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP0 = 1 << 15,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP1 = 1 << 16,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP2 = 1 << 17,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP3 = 1 << 18,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP4 = 1 << 19,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP5 = 1 << 20,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP6 = 1 << 21,
+    SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP7 = 1 << 22,
+
+    _SCE_GXM_VERTEX_PROGRAM_OUTPUT_LAST = 1 << 23
+};
+
+struct SceGxmProgramVertexOutput {
+    std::uint8_t unk[16];
+
+    std::uint32_t vertex_outputs1; // includes everything except texcoord outputs
+    std::uint32_t vertex_outputs2; // includes texcoord outputs
+};
+static_assert(sizeof(SceGxmProgramVertexOutput) == 24);
+
 struct SceGxmProgram {
     std::uint32_t magic; // should be "GXP\0"
 
@@ -162,7 +200,7 @@ struct SceGxmProgram {
     std::uint32_t unk20;
     std::uint32_t parameter_count;
     std::uint32_t parameters_offset; // Number of bytes from the start of this field to the first parameter.
-    std::uint32_t unk2C;
+    std::uint32_t vertex_outputs_offset; // offset to vertex outputs, relative to this field
 
     std::uint16_t primary_reg_count; // (PAs)
     std::uint16_t secondary_reg_count; // (SAs)

--- a/src/emulator/gxm/src/gxp.cpp
+++ b/src/emulator/gxm/src/gxp.cpp
@@ -67,7 +67,7 @@ SceGxmParameterType parameter_type(const SceGxmProgramParameter &parameter) {
 
 GenericParameterType parameter_generic_type(const SceGxmProgramParameter &parameter) {
     if (parameter.component_count > 1) {
-        if (parameter.array_size > 1 && parameter.array_size <= 4) {
+        if (parameter.array_size > 1) {
             return GenericParameterType::Matrix;
         } else {
             return GenericParameterType::Vector;

--- a/src/emulator/gxm/src/gxp.cpp
+++ b/src/emulator/gxm/src/gxp.cpp
@@ -103,4 +103,70 @@ std::string parameter_struct_name(const SceGxmProgramParameter &parameter) {
         return "";
 }
 
+SceGxmVertexProgramOutputs get_vertex_outputs(const SceGxmProgram &program) {
+    if (!program.is_vertex())
+        return _SCE_GXM_VERTEX_PROGRAM_OUTPUT_INVALID;
+
+    auto vertex_outputs_ptr = reinterpret_cast<const SceGxmProgramVertexOutput *>(reinterpret_cast<const std::uint8_t *>(&program.vertex_outputs_offset) + program.vertex_outputs_offset);
+    const std::uint32_t vo1 = vertex_outputs_ptr->vertex_outputs1;
+    const std::uint32_t vo2 = vertex_outputs_ptr->vertex_outputs2;
+
+    const bool has_fog = vo1 & 0x200;
+    const bool has_color = vo1 & 0x800;
+
+    int res = SCE_GXM_VERTEX_PROGRAM_OUTPUT_COLOR0 | SCE_GXM_VERTEX_PROGRAM_OUTPUT_POSITION;
+    int res_nocolor = SCE_GXM_VERTEX_PROGRAM_OUTPUT_POSITION;
+
+    if (has_fog) {
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_FOG;
+        res_nocolor |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_FOG;
+    }
+
+    if (!has_color)
+        res = res_nocolor;
+
+    if (vo1 & 0x400)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_COLOR1;
+    if (vo2 & 7)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD0;
+    if (vo2 & 0x38)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD1;
+    if (vo2 & 0x1C0)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD2;
+    if (vo2 & 0xE00)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD3;
+    if (vo2 & 0x7000)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD4;
+    if (vo2 & 0x38000)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD5;
+    if (vo2 & 0x1C0000)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD6;
+    if (vo2 & 0xE00000)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD7;
+    if (vo2 & 0x7000000)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD8;
+    if (vo2 & 0x38000000)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD9;
+    if (vo1 & 0x100)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_PSIZE;
+    if (vo1 & 1)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP0;
+    if (vo1 & 2)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP1;
+    if (vo1 & 4)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP2;
+    if (vo1 & 8)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP3;
+    if (vo1 & 0x10)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP4;
+    if (vo1 & 0x20)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP5;
+    if (vo1 & 0x40)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP6;
+    if (vo1 & 0x80)
+        res |= SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP7;
+
+    return static_cast<SceGxmVertexProgramOutputs>(res);
+}
+
 } // namespace gxp

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -58,6 +58,19 @@
 #include <unistd.h>
 #endif
 
+#ifdef _WIN32
+// Use discrete GPU by default
+
+extern "C" {
+// NVIDIA Optimus (Driver: 302+)
+//     See: http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
+__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+// AMD (Driver: 13.35+)
+//     See: https://gpuopen.com/amdpowerxpressrequesthighperformance/
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
+
 using namespace glbinding;
 
 static constexpr bool LOG_IMPORT_CALLS = false;

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -796,11 +796,10 @@ EXPORT(int, sceGxmProgramGetType, const SceGxmProgram *program) {
     return program->type & 1;
 }
 
-EXPORT(int, sceGxmProgramGetVertexProgramOutputs, const SceGxmProgram *program) {
-    if (program->type != emu::SceGxmProgramType::Vertex)
-        return 0;
-    else
-        return UNIMPLEMENTED();
+EXPORT(int, sceGxmProgramGetVertexProgramOutputs, Ptr<const SceGxmProgram> program_) {
+    const auto program = program_.get(host.mem);
+
+    return gxp::get_vertex_outputs(*program);
 }
 
 EXPORT(int, sceGxmProgramIsDepthReplaceUsed) {

--- a/src/emulator/renderer/include/renderer/types.h
+++ b/src/emulator/renderer/include/renderer/types.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <memory>
 #include <tuple>
+#include <vector>
 
 typedef void *SDL_GLContext;
 
@@ -18,6 +19,7 @@ typedef std::map<GLuint, std::string> AttributeLocations;
 typedef std::unique_ptr<void, std::function<void(SDL_GLContext)>> GLContextPtr;
 typedef std::tuple<std::string, std::string> ProgramGLSLs;
 typedef std::map<ProgramGLSLs, SharedGLObject> ProgramCache;
+typedef std::vector<std::string> ExcludedUniforms; // vector instead of unordered_set since it's much faster for few elements
 
 struct Context {
     GLContextPtr gl;
@@ -28,8 +30,12 @@ struct Context {
     GLObjectArray<SCE_GXM_MAX_VERTEX_STREAMS> stream_vertex_buffers;
 };
 
-struct FragmentProgram {
+struct ShaderProgram {
     std::string glsl;
+    ExcludedUniforms excluded_uniforms;
+};
+
+struct FragmentProgram : ShaderProgram {
     GLboolean color_mask_red = GL_TRUE;
     GLboolean color_mask_green = GL_TRUE;
     GLboolean color_mask_blue = GL_TRUE;
@@ -43,13 +49,12 @@ struct FragmentProgram {
     GLenum alpha_dst = GL_ZERO;
 };
 
+struct VertexProgram : ShaderProgram {
+    AttributeLocations attribute_locations;
+};
+
 struct RenderTarget {
     GLObjectArray<2> renderbuffers;
     GLObjectArray<1> framebuffer;
-};
-
-struct VertexProgram {
-    std::string glsl;
-    AttributeLocations attribute_locations;
 };
 } // namespace renderer

--- a/src/emulator/renderer/src/compile_program.cpp
+++ b/src/emulator/renderer/src/compile_program.cpp
@@ -59,8 +59,8 @@ SharedGLObject compile_program(ProgramCache &cache, const GxmContextState &state
     assert(state.fragment_program);
     assert(state.vertex_program);
 
-    const FragmentProgram &fragment_program = *state.fragment_program.get(mem)->renderer.get();
-    const VertexProgram &vertex_program = *state.vertex_program.get(mem)->renderer.get();
+    const FragmentProgram &fragment_program = *state.fragment_program.get(mem)->renderer_data.get();
+    const VertexProgram &vertex_program = *state.vertex_program.get(mem)->renderer_data.get();
     const ProgramGLSLs glsls(fragment_program.glsl, vertex_program.glsl);
     const ProgramCache::const_iterator cached = cache.find(glsls);
     if (cached != cache.end()) {

--- a/src/emulator/renderer/src/sync_state.cpp
+++ b/src/emulator/renderer/src/sync_state.cpp
@@ -180,7 +180,7 @@ bool sync_state(Context &context, const GxmContextState &state, const MemState &
 
     // Blending.
     const SceGxmFragmentProgram &gxm_fragment_program = *state.fragment_program.get(mem);
-    const FragmentProgram &fragment_program = *gxm_fragment_program.renderer.get();
+    const FragmentProgram &fragment_program = *gxm_fragment_program.renderer_data.get();
     glColorMask(fragment_program.color_mask_red, fragment_program.color_mask_green, fragment_program.color_mask_blue, fragment_program.color_mask_alpha);
     if (fragment_program.blend_enabled) {
         glEnable(GL_BLEND);


### PR DESCRIPTION
Most notable are the SPIR-V/shader generation improvements.

As an example, a shader from the game "Alone With You" is generated like so (irrelevant stuff omitted):
```glsl
uniform mat4 gm_Matrices[5];

in vec4 input_aPosition;
in vec4 input_aColour;
in vec4 input_aTexCoord;
out vec4 spv_oPosition;
out vec4 spv_oColor0;
out vec2 spv_oTexcoord0;
out vec2 spv_oTexcoord1;
out vec2 spv_oPsize;
```
whereas previously, like so:
```glsl
struct input
{
    vec4 aPosition;
    vec4 aColour;
    vec4 aTexCoord;
};

uniform vec4 gm_Matrices[20];

in input _input;
```

So you can see 3 improvements there:
1) **Vertex outputs** (all `spv_o*` declarations that were not previously there)
2) **Flattening of vertex input structs**
    This needs to happen, previous method was wrong, the shader didn't compile. I didn't previously know 
    because Nvidia's shader compiler ignored the error for some reason.
3) **Better matrix detection heuristics** (you can see how `gm_Matrices`'s type is corrected)