### PR TITLE
Shader gen, kernel, io and renderer improvements

### DIFF
--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -10,6 +10,8 @@
 #include <memory>
 #include <mutex>
 
+#define SCE_GXM_DEFAULT_UNIFORM_BUFFER_CONTAINER_INDEX 0xE
+
 namespace renderer {
 struct FragmentProgram;
 struct VertexProgram;

--- a/src/emulator/io/include/io/state.h
+++ b/src/emulator/io/include/io/state.h
@@ -42,9 +42,10 @@ typedef std::shared_ptr<_WDIR> DirPtr;
 typedef std::shared_ptr<DIR> DirPtr;
 #endif
 
-enum TtyType {
-    TTY_IN,
-    TTY_OUT
+enum TtyType : std::uint8_t {
+    TTY_IN = 0b01,
+    TTY_OUT = 0b10,
+    TTY_INOUT = TTY_IN | TTY_OUT
 };
 
 struct IoComponent {

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -322,13 +322,6 @@ int write_file(SceUID fd, const void *data, SceSize size, const IOState &io, con
         return IO_ERROR(SCE_ERROR_ERRNO_EBADF);
     }
 
-    LOG_TRACE("{}: Writing file: fd: {}, size: {}", export_name, log_hex(fd), size);
-
-    const StdFiles::const_iterator file = io.std_files.find(fd);
-    if (file != io.std_files.end()) {
-        return fwrite(data, 1, size, file->second.file_handle.get());
-    }
-
     const TtyFiles::const_iterator tty_file = io.tty_files.find(fd);
     if (tty_file != io.tty_files.end()) {
         if (tty_file->second & TTY_OUT) {
@@ -343,6 +336,13 @@ int write_file(SceUID fd, const void *data, SceSize size, const IOState &io, con
         }
 
         return IO_ERROR_UNK();
+    }
+
+    LOG_TRACE("{}: Writing file: fd: {}, size: {}", export_name, log_hex(fd), size);
+
+    const StdFiles::const_iterator file = io.std_files.find(fd);
+    if (file != io.std_files.end()) {
+        return fwrite(data, 1, size, file->second.file_handle.get());
     }
 
     return IO_ERROR(SCE_ERROR_ERRNO_EBADF);

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -335,9 +335,9 @@ int write_file(SceUID fd, const void *data, SceSize size, const IOState &io, con
             std::string s(reinterpret_cast<char const *>(data), size);
 
             // trim newline
-            if (s.back() == '\n') {
-                s.back() = '\0';
-            }
+            if (s.back() == '\n')
+                s.pop_back();
+
             LOG_INFO("*** TTY: {}", s);
             return size;
         }

--- a/src/emulator/kernel/src/thread/sync_primitives.cpp
+++ b/src/emulator/kernel/src/thread/sync_primitives.cpp
@@ -634,7 +634,7 @@ int delete_eventflag(KernelState &kernel, const char *export_name, SceUID thread
     }
 
     if (event->waiting_threads.empty()) {
-        const std::lock_guard<std::mutex> lock(event->mutex);
+        const std::lock_guard<std::mutex> lock2(event->mutex);
         kernel.eventflags.erase(event_id);
     } else {
         // TODO:

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -907,7 +907,7 @@ EXPORT(int, sceGxmReserveFragmentDefaultUniformBuffer, SceGxmContext *context, P
     *uniformBuffer = context->state.params.fragmentRingBufferMem.cast<uint8_t>() + static_cast<int32_t>(context->state.fragment_ring_buffer_used);
     context->state.fragment_ring_buffer_used = next_used;
 
-    context->state.fragment_uniform_buffers[14] = *uniformBuffer;
+    context->state.fragment_uniform_buffers[SCE_GXM_DEFAULT_UNIFORM_BUFFER_CONTAINER_INDEX] = *uniformBuffer;
 
     return 0;
 }
@@ -933,7 +933,7 @@ EXPORT(int, sceGxmReserveVertexDefaultUniformBuffer, SceGxmContext *context, Ptr
     *uniformBuffer = context->state.params.vertexRingBufferMem.cast<uint8_t>() + static_cast<int32_t>(context->state.vertex_ring_buffer_used);
     context->state.vertex_ring_buffer_used = next_used;
 
-    context->state.vertex_uniform_buffers[14] = *uniformBuffer;
+    context->state.vertex_uniform_buffers[SCE_GXM_DEFAULT_UNIFORM_BUFFER_CONTAINER_INDEX] = *uniformBuffer;
 
     return 0;
 }
@@ -1116,7 +1116,7 @@ EXPORT(void, sceGxmSetTwoSidedEnable, SceGxmContext *context, SceGxmTwoSidedMode
 EXPORT(int, sceGxmSetUniformDataF, void *uniformBuffer, const SceGxmProgramParameter *parameter, unsigned int componentOffset, unsigned int componentCount, const float *sourceData) {
     assert(uniformBuffer != nullptr);
     assert(parameter != nullptr);
-    assert(parameter->container_index == 14);
+    assert(parameter->container_index == SCE_GXM_DEFAULT_UNIFORM_BUFFER_CONTAINER_INDEX);
     assert(componentCount > 0);
     assert(sourceData != nullptr);
 

--- a/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -104,7 +104,7 @@ EXPORT(int, sceKernelCreateThreadForUser) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelDelayThread, SceUInt delay) {
+int delay_thread(SceUInt delay) {
 #ifdef _WIN32
     Sleep(delay / 1000);
 #else
@@ -113,16 +113,24 @@ EXPORT(int, sceKernelDelayThread, SceUInt delay) {
     return SCE_KERNEL_OK;
 }
 
-EXPORT(int, sceKernelDelayThread200) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelDelayThread, SceUInt delay) {
+    STUBBED("bad accuracy");
+    return delay_thread(delay);
 }
 
-EXPORT(int, sceKernelDelayThreadCB) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelDelayThread200, SceUInt delay) {
+    STUBBED("bad accuracy, untested");
+    return delay_thread(delay);
 }
 
-EXPORT(int, sceKernelDelayThreadCB200) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelDelayThreadCB, SceUInt delay) {
+    STUBBED("no CB, bad accuracy");
+    return delay_thread(delay);
+}
+
+EXPORT(int, sceKernelDelayThreadCB200, SceUInt delay) {
+    STUBBED("no CB, bad accuracy, untested");
+    return delay_thread(delay);
 }
 
 EXPORT(int, sceKernelDeleteCallback) {

--- a/src/emulator/renderer/src/sync_state.cpp
+++ b/src/emulator/renderer/src/sync_state.cpp
@@ -9,6 +9,8 @@
 #include <gxm/types.h>
 #include <util/log.h>
 
+#include <cmath>
+
 namespace renderer {
 static GLenum translate_depth_func(SceGxmDepthFunc depth_func) {
     R_PROFILE(__func__);
@@ -109,8 +111,8 @@ bool sync_state(Context &context, const GxmContextState &state, const MemState &
     const GLsizei display_h = state.color_surface.pbeEmitWords[1];
     const GxmViewport &viewport = state.viewport;
     if (viewport.enable == SCE_GXM_VIEWPORT_ENABLED) {
-        const GLfloat w = viewport.scale.x * 2;
-        const GLfloat h = viewport.scale.y * -2;
+        const GLfloat w = std::abs(viewport.scale.x * 2);
+        const GLfloat h = std::abs(viewport.scale.y * 2);
         const GLfloat x = viewport.offset.x - viewport.scale.x;
         const GLfloat y = display_h - (viewport.offset.y - viewport.scale.y);
         glViewportIndexedf(0, x, y, w, h);

--- a/src/emulator/shadergen/src/shadergen_spirv.cpp
+++ b/src/emulator/shadergen/src/shadergen_spirv.cpp
@@ -377,6 +377,26 @@ SpirvShaderParameters create_parameters(spv::Builder &spv_builder, const SceGxmP
     return out_parameters;
 }
 
+void generate_shader_body(spv::Builder &spv_builder, SpirvShaderParameters parameters, emu::SceGxmProgramType program_type) {
+    if (program_type == emu::SceGxmProgramType::Fragment) {
+        const auto frag_color_output = parameters.fragment_outputs[0];
+        const auto frag_color_type = frag_color_output.type_id;
+        const auto frag_color_var = frag_color_output.var_id;
+
+        // STUB: Write arbitrary color (blue) for now
+        const spv::Id float_0_const = spv_builder.makeFloatConstant(0.f);
+        const spv::Id float_1_const = spv_builder.makeFloatConstant(1.f);
+
+        const spv::Id vec4_blue_const = spv_builder.makeCompositeConstant(frag_color_type,
+            { float_0_const, float_0_const, float_1_const, float_1_const });
+
+        spv_builder.createStore(vec4_blue_const, frag_color_var);
+    }
+    else if (program_type == emu::SceGxmProgramType::Vertex) {
+        // TODO: vertex shader body
+    }
+}
+
 SpirvCode generate_shader(const SceGxmProgram &program, emu::SceGxmProgramType program_type) {
     SpirvCode spirv;
 
@@ -412,7 +432,9 @@ SpirvCode generate_shader(const SceGxmProgram &program, emu::SceGxmProgramType p
 
     // entry point
     spv::Function *spv_func_main = spv_builder.makeEntryPoint(entry_point_name.c_str());
-    // TODO: vertex/fragment shader body
+
+    generate_shader_body(spv_builder, parameters, program_type);
+
     spv_builder.leaveFunction();
 
     // VS Execution Modes


### PR DESCRIPTION
- shadergen: Emit fragment output
  - With hardcoded type and size (vec4)
  - Add some structural comments
  - Rename param_struct_t -> StructDeclContext

- shadergen: Write static color to fragment shader color output
  - Like the GLSL transpiler used to, for debugging

- renderer: Ensure viewport dimensions are non-negative


- kernel/threadmgr: Stub 'callback check' functions


- io: Fix TTY for for read/write file descriptors 
  - TTY fd's can be both read and write, previous code assumed either
  one or the other.
  - Persona 4's TTY output is visible with this.


- io: Don't print null terminator in TTY output

- io: Don't log twice if printing to TTY

- gxm: Don't hardcode uniform buffer container index