### PR TITLE
Speed up Windows build & build hotfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ if(NOT CI)
 	pre_configure_boost()
 endif()
 
+if(WIN32)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+	add_definitions (/D "_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS")
+endif()
+
 add_subdirectory(src/external)
 add_subdirectory(src/emulator)
 add_subdirectory(src/gen-modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ enable_testing()
 
 macro(pre_configure_boost)
 	message("Setting up ext-boost environment variables")
-	set(BOOST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/boost")
+	set(BOOST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/src/external/boost")
 	set(BOOST_INCLUDEDIR "${BOOST_ROOT}/boost")
-	set(BOOST_LIBRARYDIR "${CMAKE_CURRENT_SOURCE_DIR}/boost-build/lib")
+	set(BOOST_LIBRARYDIR "${CMAKE_CURRENT_SOURCE_DIR}/src/external/boost-build/lib")
 
 	message("Using Boost_VERSION: ${BOOST_ROOT}")
 	message("Using Boost_INCLUDE_DIRS: ${BOOST_INCLUDEDIR}")

--- a/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -174,6 +174,8 @@ EXPORT(int, sceKernelDeleteSimpleEvent) {
 
 EXPORT(int, sceKernelDeleteThread, SceUID thid) {
     const ThreadStatePtr thread = lock_and_find(thid, host.kernel.threads, host.kernel.mutex);
+
+    const std::lock_guard<std::mutex> lock2(host.kernel.mutex);
     host.kernel.running_threads.erase(thid);
     host.kernel.waiting_threads.erase(thid);
     host.kernel.threads.erase(thid);
@@ -201,6 +203,7 @@ EXPORT(int, sceKernelExitDeleteThread, int status) {
 
     thread->waiting_threads.clear();
 
+    const std::lock_guard<std::mutex> lock2(host.kernel.mutex);
     host.kernel.running_threads.erase(thread_id);
     host.kernel.waiting_threads.erase(thread_id);
     host.kernel.threads.erase(thread_id);


### PR DESCRIPTION
- Windows build:
  - Use multiple cores
  - Disable C++17 deprecation warnings that are slowing down AppVeyor
  - Builds 3-4 times faster on my quad-core CPU.

- Update ext-boost to include Boost.Optional

- A threadmgr race condition fix