### PR TITLE
LLE support for dumped modules

### DIFF
--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -17,11 +17,14 @@
 
 #pragma once
 
+#include <host/app.h>
+
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
 #include <boost/optional/optional_io.hpp>
 
 #include <string>
+#include <vector>
 
 using boost::optional;
 
@@ -30,6 +33,7 @@ struct Config {
     optional<std::string> vpk_path;
     optional<std::string> run_title_id;
     optional<int> log_level;
+    std::vector<std::string> lle_modules;
 };
 
 namespace config {
@@ -40,6 +44,6 @@ namespace config {
   * \param cfg Config options are returend via this parameter.
   * \return True on success, false on error.
   */
-bool init(Config &cfg, int argc, char **argv);
+ExitCode init(Config &cfg, int argc, char **argv);
 
 } // namespace config

--- a/src/emulator/kernel/include/kernel/state.h
+++ b/src/emulator/kernel/include/kernel/state.h
@@ -22,6 +22,7 @@
 #include <mem/ptr.h>
 
 #include <psp2/rtc.h>
+#include <psp2/sysmodule.h>
 #include <psp2/types.h>
 
 #include <atomic>
@@ -179,6 +180,8 @@ struct WaitingThreadState {
 
 typedef std::map<SceUID, WaitingThreadState> KernelWaitingThreadStates;
 
+using LoadedSysmodules = std::vector<SceSysmoduleModuleId>;
+
 struct KernelState {
     std::mutex mutex;
     Blocks blocks;
@@ -193,6 +196,7 @@ struct KernelState {
     ThreadPtrs running_threads;
     KernelWaitingThreadStates waiting_threads;
     SceKernelModuleInfoPtrs loaded_modules;
+    LoadedSysmodules loaded_sysmodules;
     ExportNids export_nids;
     SceRtcTick base_tick;
     Ptr<uint32_t> process_param;

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -37,8 +37,8 @@ int main(int argc, char *argv[]) {
     logging::init();
 
     Config cfg{};
-    if (!config::init(cfg, argc, argv))
-        return IncorrectArgs;
+    if (const bool ret = config::init(cfg, argc, argv))
+        return ret;
 
     LOG_INFO("{}", window_title);
 

--- a/src/emulator/modules/SceSysmodule/SceSysmodule.cpp
+++ b/src/emulator/modules/SceSysmodule/SceSysmodule.cpp
@@ -17,18 +17,194 @@
 
 #include "SceSysmodule.h"
 
+#include <host/app.h>
+#include <host/functions.h>
+#include <io/io.h>
+#include <kernel/load_self.h>
+#include <kernel/thread/thread_functions.h>
+#include <util/find.h>
+#include <util/log.h>
+
 #include <psp2/sysmodule.h>
 
-EXPORT(int, sceSysmoduleIsLoaded, SceSysmoduleModuleId id) {
-    return SCE_SYSMODULE_LOADED;
+#include <vector>
+
+static constexpr auto SYSMODULE_COUNT = 0x56;
+
+using SysmodulePaths = std::array<std::vector<const char *>, SYSMODULE_COUNT>;
+
+static SysmodulePaths init_sysmodule_paths() {
+    SysmodulePaths p;
+
+    // Below dependencies are roughly derived from strings order in sysmodule.skprx
+    // Not guaranteed to be correct
+
+    p[SCE_SYSMODULE_NET] = { "libnet", "libnetctl" };
+    p[SCE_SYSMODULE_HTTP] = { "libhttp" };
+    p[SCE_SYSMODULE_SSL] = { "libssl" };
+    p[SCE_SYSMODULE_HTTPS] = { "libssl" }; // no https module, I'm assuming it also uses libssl
+    p[SCE_SYSMODULE_PERF] = { "libperf" };
+    p[SCE_SYSMODULE_FIBER] = { "libfiber" };
+    p[SCE_SYSMODULE_ULT] = { "libult" };
+    p[SCE_SYSMODULE_DBG] = { "librazorcapture_es4", "librazorhud_es4" };
+    p[SCE_SYSMODULE_RAZOR_CAPTURE] = { "librazorcapture_es4" };
+    p[SCE_SYSMODULE_RAZOR_HUD] = { "librazorhud_es4" };
+    p[SCE_SYSMODULE_NGS] = { "libngs" };
+    p[SCE_SYSMODULE_SULPHA] = { "libsulpha" };
+    p[SCE_SYSMODULE_SAS] = { "libsas" };
+    p[SCE_SYSMODULE_PGF] = { "libpgf" };
+    p[SCE_SYSMODULE_APPUTIL] = { "libapputil" };
+    p[SCE_SYSMODULE_FIOS2] = { "libfios2" };
+    p[SCE_SYSMODULE_IME] = { "libime" };
+    p[SCE_SYSMODULE_NP_BASIC] = { "np_basic" };
+    p[SCE_SYSMODULE_SYSTEM_GESTURE] = { "libsystemgesture" };
+    p[SCE_SYSMODULE_LOCATION] = { "liblocation" };
+    p[SCE_SYSMODULE_NP] = { "np_common", "np_manager", "np_basic" };
+    p[SCE_SYSMODULE_PHOTO_EXPORT] = { "libScePhotoExport" };
+    p[SCE_SYSMODULE_XML] = { "libSceXml" };
+    p[SCE_SYSMODULE_NP_COMMERCE2] = { "np_commerce2" };
+    p[SCE_SYSMODULE_NP_UTILITY] = { "np_utility" };
+    p[SCE_SYSMODULE_VOICE] = { "libvoice" };
+    p[SCE_SYSMODULE_VOICEQOS] = { "libvoiceqos" };
+    p[SCE_SYSMODULE_NP_MATCHING2] = { "np_matching2" };
+    p[SCE_SYSMODULE_SCREEN_SHOT] = { "libSceScreenShot" };
+    p[SCE_SYSMODULE_NP_SCORE_RANKING] = { "np_ranking" };
+    p[SCE_SYSMODULE_SQLITE] = { "libSceSqlite" };
+    p[SCE_SYSMODULE_TRIGGER_UTIL] = { "trigger_util" };
+    p[SCE_SYSMODULE_RUDP] = { "librudp" };
+    p[SCE_SYSMODULE_CODECENGINE_PERF] = { "libcodecengine_perf" };
+    p[SCE_SYSMODULE_LIVEAREA] = { "livearea_util" };
+    p[SCE_SYSMODULE_NP_ACTIVITY] = { "np_activity_sdk" };
+    p[SCE_SYSMODULE_NP_TROPHY] = { "np_trophy" };
+    p[SCE_SYSMODULE_NP_MESSAGE] = { "np_message_padding", "np_message" };
+    p[SCE_SYSMODULE_SHUTTER_SOUND] = { "libSceShutterSound" };
+    p[SCE_SYSMODULE_CLIPBOARD] = { "libclipboard" };
+    p[SCE_SYSMODULE_NP_PARTY] = { "np_party" };
+    p[SCE_SYSMODULE_NET_ADHOC_MATCHING] = { "adhoc_matching" };
+    p[SCE_SYSMODULE_NEAR_UTIL] = { "libScenNearUtil" };
+    p[SCE_SYSMODULE_NP_TUS] = { "np_tus" };
+    p[SCE_SYSMODULE_MP4] = { "libscemp4" };
+    p[SCE_SYSMODULE_AACENC] = { "libnaac" };
+    p[SCE_SYSMODULE_HANDWRITING] = { "libhandwriting" };
+    p[SCE_SYSMODULE_ATRAC] = { "libatrac" };
+    p[SCE_SYSMODULE_NP_SNS_FACEBOOK] = { "np_sns_facebook" };
+    p[SCE_SYSMODULE_VIDEO_EXPORT] = { "libSceVideoExport" };
+    p[SCE_SYSMODULE_NOTIFICATION_UTIL] = { "notification_util" };
+    p[SCE_SYSMODULE_BG_APP_UTIL] = { "bgapputil" };
+    p[SCE_SYSMODULE_INCOMING_DIALOG] = { "incoming_dialog" };
+    p[SCE_SYSMODULE_IPMI] = { "libipmi_nongame" };
+    p[SCE_SYSMODULE_AUDIOCODEC] = { "libaudiocodec" };
+    p[SCE_SYSMODULE_FACE] = { "libface" };
+    p[SCE_SYSMODULE_SMART] = { "libsmart" };
+    p[SCE_SYSMODULE_MARLIN] = { "libmln" };
+    p[SCE_SYSMODULE_MARLIN_DOWNLOADER] = { "libmlndownloader" };
+    p[SCE_SYSMODULE_MARLIN_APP_LIB] = { "libmlnapplib" };
+    p[SCE_SYSMODULE_TELEPHONY_UTIL] = { "libSceTelephonyUtil" };
+    p[SCE_SYSMODULE_PSPNET_ADHOC] = { "pspnet_adhoc" };
+    p[SCE_SYSMODULE_DTCP_IP] = { "libSceDtcpIp" };
+    p[SCE_SYSMODULE_VIDEO_SEARCH_EMPR] = { "libSceVideoSearchEmpr" };
+    p[SCE_SYSMODULE_NP_SIGNALING] = { "np_signaling" };
+    p[SCE_SYSMODULE_BEISOBMF] = { "libSceBeisobmf" };
+    p[SCE_SYSMODULE_BEMP2SYS] = { "libSceBemp2sys" };
+    p[SCE_SYSMODULE_MUSIC_EXPORT] = { "libSceMusicExport" };
+    p[SCE_SYSMODULE_NEAR_DIALOG_UTIL] = { "libSceNearDialogUtil" };
+    p[SCE_SYSMODULE_LOCATION_EXTENSION] = { "liblocation_extension" };
+    p[SCE_SYSMODULE_AVPLAYER] = { "libsceavplayer" };
+    p[SCE_SYSMODULE_MAIL_API] = { "mail_api_for_local_libc" };
+    p[SCE_SYSMODULE_TELEPORT_CLIENT] = { "libSceTeleportClient" };
+    p[SCE_SYSMODULE_TELEPORT_SERVER] = { "libSceTeleportServer" };
+    p[SCE_SYSMODULE_MP4_RECORDER] = { "libSceMp4Rec" };
+    p[SCE_SYSMODULE_APPUTIL_EXT] = { "apputil_ext" };
+    p[SCE_SYSMODULE_NP_WEBAPI] = { "np_webapi" };
+    p[SCE_SYSMODULE_AVCDEC] = { "avcdec_for_player" };
+    p[SCE_SYSMODULE_JSON] = { "libSceJson" };
+
+    return p;
+}
+
+static const SysmodulePaths sysmodule_paths = init_sysmodule_paths();
+
+bool is_lle_module(SceSysmoduleModuleId module_id) {
+    const auto paths = sysmodule_paths[module_id];
+    // Do we know the module and its dependencies' paths?
+    const bool have_paths = !paths.empty();
+
+    return have_paths;
+}
+
+bool is_module_loaded(KernelState &kernel, SceSysmoduleModuleId module_id) {
+    return std::find(kernel.loaded_sysmodules.begin(), kernel.loaded_sysmodules.end(), module_id) != kernel.loaded_sysmodules.end();
+}
+
+/**
+ * \return False on failure, true on success
+ */
+bool load_module(HostState &host, SceSysmoduleModuleId module_id) {
+    const CallImport call_import = [&host](CPUState &cpu, uint32_t nid, SceUID main_thread_id) {
+        ::call_import(host, cpu, nid, main_thread_id);
+    };
+
+    LOG_INFO("Loading module ID: {}", log_hex(module_id));
+
+    const auto module_paths = sysmodule_paths[module_id];
+
+    for (std::string module_path : module_paths) {
+        module_path = "sys/external/" + module_path + ".suprx";
+
+        vfs::FileBuffer module_buffer;
+        Ptr<const void> lib_entry_point;
+
+        if (vfs::read_file(VitaIoDevice::VS0, module_buffer, host.pref_path, module_path)) {
+            SceUID loaded_module_uid = load_self(lib_entry_point, host.kernel, host.mem, module_buffer.data(), module_path);
+            const auto module = host.kernel.loaded_modules[loaded_module_uid];
+            const auto module_name = module->module_name;
+
+            if (loaded_module_uid >= 0) {
+                LOG_INFO("Module {} (at \"{}\") loaded", module_name, module_path);
+            } else {
+                LOG_ERROR("Error when loading module at \"{}\"", module_path);
+                return false;
+            }
+
+            // TODO: Run entry point of loaded modules. Was having issues with it.
+        } else {
+            LOG_ERROR("Module at \"{}\" not present", module_path);
+            // ignore and assume it was loaded
+        }
+    }
+
+    host.kernel.loaded_sysmodules.push_back(module_id);
+    return true;
+}
+
+EXPORT(int, sceSysmoduleIsLoaded, SceSysmoduleModuleId module_id) {
+    if (module_id < 0 || module_id > SYSMODULE_COUNT)
+        return SCE_SYSMODULE_ERROR_INVALID_VALUE;
+    
+    if (is_lle_module(module_id))
+        if (is_module_loaded(host.kernel, module_id))
+            return SCE_SYSMODULE_LOADED;
+        else
+            return SCE_SYSMODULE_ERROR_UNLOADED;
+    else
+        return SCE_SYSMODULE_LOADED;
 }
 
 EXPORT(int, sceSysmoduleIsLoadedInternal) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceSysmoduleLoadModule, SceSysmoduleModuleId id) {
-    return SCE_SYSMODULE_LOADED;
+EXPORT(int, sceSysmoduleLoadModule, SceSysmoduleModuleId module_id) {
+    if (module_id < 0 || module_id > SYSMODULE_COUNT)
+        return SCE_SYSMODULE_ERROR_INVALID_VALUE;
+    
+    if (is_lle_module(module_id))
+        if (load_module(host, module_id))
+            return SCE_SYSMODULE_LOADED;
+        else
+            return SCE_SYSMODULE_ERROR_UNLOADED;
+    else
+        return SCE_SYSMODULE_LOADED;
 }
 
 EXPORT(int, sceSysmoduleLoadModuleInternal) {


### PR DESCRIPTION
Help message shows the following for the option:

```
  -m [ --lle-modules ] arg         Load given (decrypted) OS modules from disk.
                                   Separate by commas to specify multiple
                                   modules (no spaces). Full path and extension
                                   should not be included, the following are
                                   assumed: vs0:sys/external/<name>.suprx
                                   Example: --lle-modules libscemp4,libngs
```

See commits for the rest of the fixes.