### PR TITLE
Support syncing of host/guest rendering (for RenderDoc)

### DIFF
--- a/src/emulator/host/include/host/state.h
+++ b/src/emulator/host/include/host/state.h
@@ -50,6 +50,10 @@ struct DisplayState {
     std::condition_variable condvar;
     std::atomic<bool> abort{ false };
     std::atomic<bool> imgui_render{ true };
+
+    // Synchronize host rendering to guest (GXM) rendering
+    // Used for debugging (so that graphics debuggers pick up GXM OpenGL calls)
+    static constexpr bool sync_rendering{ false };
 };
 
 struct HostState {

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -126,7 +126,12 @@ int main(int argc, char *argv[]) {
         }
         imgui::draw_end(host.window.get());
 
-        host.display.condvar.notify_all();
+        if (!host.display.sync_rendering)
+            host.display.condvar.notify_all();
+        else {
+            std::unique_lock<std::mutex> lock(host.display.mutex);
+            host.display.condvar.wait(lock);
+        }
 
         set_window_title(host);
     }


### PR DESCRIPTION
Allows graphics debuggers like RenderDoc to pick up OpenGL calls from GXM emulation.

Graphics debugger support is still not perfect, since with this approach they also pick up OpenGL calls from the host (main) thread, which messes up captures.
For this to work perfectly we'd need to do all rendering from a single thread, which is not trivial to do.