### PR TITLE
host/config: Log config settings during init

### DIFF
--- a/src/emulator/host/src/config.cpp
+++ b/src/emulator/host/src/config.cpp
@@ -100,6 +100,22 @@ ExitCode init(Config &cfg, int argc, char **argv) {
 
         logging::set_level(static_cast<spdlog::level::level_enum>(*cfg.log_level));
 
+        LOG_INFO_IF(cfg.vpk_path, "input-vpk-path: {}", *cfg.vpk_path);
+        LOG_INFO_IF(cfg.run_title_id, "input-installed-id: {}", *cfg.run_title_id);
+        if (!cfg.lle_modules.empty()) {
+            auto modules = std::string();
+            for (const auto &mod : cfg.lle_modules) {
+                modules += mod + ",";
+            }
+            modules.pop_back();
+            LOG_INFO("lle-modules: {}", modules);
+        }
+        LOG_INFO_IF(cfg.log_level, "log-level: {}", *cfg.log_level);
+        LOG_INFO("log-imports: {}", cfg.log_imports);
+        LOG_INFO("log-exports: {}", cfg.log_exports);
+        LOG_INFO("log-active-shaders: {}", cfg.log_active_shaders);
+        LOG_INFO("log-uniforms: {}", cfg.log_uniforms);
+
     } catch (std::exception &e) {
         std::cerr << "error: " << e.what() << "\n";
         return IncorrectArgs;

--- a/src/emulator/host/src/config.cpp
+++ b/src/emulator/host/src/config.cpp
@@ -103,7 +103,7 @@ ExitCode init(Config &cfg, int argc, char **argv) {
         LOG_INFO_IF(cfg.vpk_path, "input-vpk-path: {}", *cfg.vpk_path);
         LOG_INFO_IF(cfg.run_title_id, "input-installed-id: {}", *cfg.run_title_id);
         if (!cfg.lle_modules.empty()) {
-            auto modules = std::string();
+            std::string modules;
             for (const auto &mod : cfg.lle_modules) {
                 modules += mod + ",";
             }


### PR DESCRIPTION
Addresses #342 by logging all current config settings during `config::init`.

Not sure if there's a better way to work with the lle_modules vector, I may have missed an existing utility somewhere to combine them into a comma-separated string.

Also not totally sure if INFO is the right logging level, I could see DEBUG being a good fit as well.

Thanks in advance for the review!

Sample log:

```
[20:30:46.738] |I| [config::init]:  input-installed-id: CRFT00001
[20:30:46.740] |I| [config::init]:  lle-modules: test,test,test,test
[20:30:46.741] |I| [config::init]:  log-level: 2
[20:30:46.741] |I| [config::init]:  log-imports: true
[20:30:46.742] |I| [config::init]:  log-exports: true
[20:30:46.742] |I| [config::init]:  log-active-shaders: true
[20:30:46.742] |I| [config::init]:  log-uniforms: false
```