### PR TITLE
gui: Provide controls information to the user

### DIFF
--- a/src/emulator/gui/CMakeLists.txt
+++ b/src/emulator/gui/CMakeLists.txt
@@ -16,6 +16,7 @@ src/ui_main_menubar.cpp
 src/ui_mutexes_dialog.cpp
 src/ui_semaphores_dialog.cpp
 src/ui_threads_dialog.cpp
+src/ui_controls_dialog.cpp
 )
 
 target_include_directories(gui PUBLIC include)

--- a/src/emulator/gui/include/gui/functions.h
+++ b/src/emulator/gui/include/gui/functions.h
@@ -43,3 +43,4 @@ void DrawUI(HostState &host);
 void DrawCommonDialog(HostState &host);
 void DrawGameSelector(HostState &host, AppRunType *run_type);
 void DrawReinstallDialog(HostState &host, GenericDialogState *status);
+void DrawControlsDialog(HostState &host);

--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -51,6 +51,9 @@ struct GuiState {
     // Optimisation menu
     bool texture_cache = true;
 
+    // Help menu
+    bool controls_dialog = false;
+
     DialogState common_dialog;
     GamesSelector game_selector;
 

--- a/src/emulator/gui/src/ui_controls_dialog.cpp
+++ b/src/emulator/gui/src/ui_controls_dialog.cpp
@@ -1,0 +1,48 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <gui/functions.h>
+#include <imgui.h>
+
+#include <gui/gui_constants.h>
+#include <host/state.h>
+
+void DrawControlsDialog(HostState &host) {
+    float width = ImGui::GetWindowWidth() / 1.35;
+    float height = ImGui::GetWindowHeight() / 1.35;
+    ImGui::SetNextWindowSize(ImVec2(width, height));
+    ImGui::SetNextWindowPosCenter();
+    ImGui::Begin("Controls", &host.gui.controls_dialog);
+
+    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%-16s    %-16s", "Button", "Mapped button");
+    ImGui::Text("%-16s    %-16s", "Left stick", "WASD");
+    ImGui::Text("%-16s    %-16s", "Right stick", "IJKL");
+    ImGui::Text("%-16s    %-16s", "D-pad", "Arrow keys");
+    ImGui::Text("%-16s    %-16s", "L button", "Q");
+    ImGui::Text("%-16s    %-16s", "R button", "R");
+    ImGui::Text("%-16s    %-16s", "Square button", "Z");
+    ImGui::Text("%-16s    %-16s", "X button", "X");
+    ImGui::Text("%-16s    %-16s", "Circle button", "C");
+    ImGui::Text("%-16s    %-16s", "Triangle button", "V");
+    ImGui::Text("%-16s    %-16s", "Start button", "Enter");
+    ImGui::Text("%-16s    %-16s", "Select button", "Right shift");
+
+    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%-16s", "GUI");
+    ImGui::Text("%-16s    %-16s", "Toggle GUI visibility", "G");
+
+    ImGui::End();
+}

--- a/src/emulator/gui/src/ui_main.cpp
+++ b/src/emulator/gui/src/ui_main.cpp
@@ -113,5 +113,8 @@ void DrawUI(HostState &host) {
     if (host.gui.eventflags_dialog) {
         DrawEventFlagsDialog(host);
     }
+    if (host.gui.controls_dialog) {
+        DrawControlsDialog(host);
+    }
     ImGui::PopFont();
 }

--- a/src/emulator/gui/src/ui_main_menubar.cpp
+++ b/src/emulator/gui/src/ui_main_menubar.cpp
@@ -44,6 +44,14 @@ void DrawMainMenuBar(HostState &host) {
             ImGui::PopStyleColor();
             ImGui::EndMenu();
         }
+
+        if (ImGui::BeginMenu("Help")) {
+            ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+            ImGui::MenuItem("Controls", nullptr, &host.gui.controls_dialog);
+            ImGui::PopStyleColor();
+            ImGui::EndMenu();
+        }
+
         ImGui::PopStyleColor();
         ImGui::EndMainMenuBar();
     }


### PR DESCRIPTION
Added an entry to MainMenuBar called "Help" with one entry "Controls", which simply displays the default key mappings.
![vitacontrols](https://user-images.githubusercontent.com/23663355/48007052-15bceb00-e117-11e8-925f-4500b83a2fda.png)
