### PR TITLE
ci: Fix broken upload for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,7 @@ matrix:
       before_deploy:
       - git config --global user.email "builds@travis-ci.com"
       - git config --global user.name "Travis CI"
-      - cd ${TRAVIS_BUILD_DIR}/build/bin
-      - ls
-      - chmod -R 755 .
+      - cd "$HOME/linux-build/bin/"
       - zip -r Vita3K-linux-nightly.zip .
       deploy:
         provider: script

--- a/.travis/linux/build.sh
+++ b/.travis/linux/build.sh
@@ -2,3 +2,6 @@
 
 docker pull ubuntu:18.04
 docker run -v $(pwd):/Vita3K -v "$HOME/.ccache":/root/.ccache ubuntu:18.04 /bin/bash -ex /Vita3K/.travis/linux/docker.sh
+
+mkdir "$HOME/linux-build"
+cp -r $(pwd)/build/bin "$HOME/linux-build"

--- a/.travis/linux/deploy.sh
+++ b/.travis/linux/deploy.sh
@@ -2,7 +2,7 @@
 set -e
 
 git clone https://github.com/Vita3K/Vita3K-builds.git
-cp $TRAVIS_BUILD_DIR/build/bin/Vita3K-linux-nightly.zip Vita3K-builds/
+cp $HOME/linux-build/bin/Vita3K-linux-nightly.zip Vita3K-builds/
 cd Vita3K-builds
 
 git config user.name "Travis CI"


### PR DESCRIPTION
Fixing the upload for linux again. This time it should work (method was borrowed from citra, copying the binary instead of try to change the permissions of the binary folder)