### PR TITLE
gui/host: Replace EOL characters in game titles by spaces

### DIFF
--- a/src/emulator/host/src/app.cpp
+++ b/src/emulator/host/src/app.cpp
@@ -211,6 +211,7 @@ bool load_app_impl(Ptr<const void> &entry_point, HostState &host, const std::wst
     load_sfo(host.sfo_handle, params);
 
     find_data(host.game_title, host.sfo_handle, "TITLE");
+    std::replace(host.game_title.begin(), host.game_title.end(), '\n', ' ');
     find_data(host.io.title_id, host.sfo_handle, "TITLE_ID");
     std::string category;
     find_data(category, host.sfo_handle, "CATEGORY");

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -228,6 +228,7 @@ bool init(HostState &state, Config cfg) {
                     SfoFile sfo_handle;
                     load_sfo(sfo_handle, params);
                     find_data(state.game_title, sfo_handle, "TITLE");
+                    std::replace(state.game_title.begin(), state.game_title.end(), '\n', ' ');
                     state.gui.game_selector.games.push_back({ state.game_title, state.io.title_id });
                 }
             }


### PR DESCRIPTION
Fix #360 and display the title in one line in the log