### PR TITLE
Initial sceCtrlSetActuator implementation.

### DIFF
--- a/src/emulator/ctrl/include/ctrl/state.h
+++ b/src/emulator/ctrl/include/ctrl/state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <SDL_haptic.h>
 #include <SDL_joystick.h>
 
 #include <map>
@@ -10,6 +11,10 @@ struct _SDL_GameController;
 typedef std::shared_ptr<_SDL_GameController> GameControllerPtr;
 typedef std::map<SDL_JoystickGUID, GameControllerPtr> GameControllerList;
 
+typedef std::shared_ptr<_SDL_Haptic> HapticPtr;
+typedef std::map<SDL_JoystickGUID, HapticPtr> HapticList;
+
 struct CtrlState {
     GameControllerList controllers;
+    HapticList haptics;
 };

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
     LOG_INFO("{}", window_title);
 
     std::atexit(SDL_Quit);
-    if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_VIDEO) < 0) {
+    if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC | SDL_INIT_VIDEO) < 0) {
         error_dialog("SDL initialisation failed.");
         return SDLInitFailed;
     }

--- a/src/emulator/modules/SceCtrl/SceCtrl.cpp
+++ b/src/emulator/modules/SceCtrl/SceCtrl.cpp
@@ -167,8 +167,8 @@ static void add_new_controllers(CtrlState &state) {
                 SDL_Haptic *haptic = SDL_HapticOpenFromJoystick(SDL_GameControllerGetJoystick(controller.get()));
                 SDL_HapticRumbleInit(haptic);
                 const HapticPtr handle(haptic, SDL_HapticClose);
-                state.controllers.insert(GameControllerList::value_type(guid, controller));
-                state.haptics.insert(HapticList::value_type(guid, handle));
+                state.controllers.emplace(guid, controller);
+                state.haptics.emplace(guid, handle);
             }
         }
     }
@@ -185,7 +185,7 @@ static int peek_buffer_positive(HostState &host, SceCtrlData *&pad_data) {
     std::array<float, 4> axes;
     axes.fill(0);
     apply_keyboard(&pad_data->buttons, axes.data());
-    for (const GameControllerList::value_type &controller : state.controllers) {
+    for (const auto& controller : state.controllers) {
         apply_controller(&pad_data->buttons, axes.data(), controller.second.get());
     }
 
@@ -209,7 +209,7 @@ static int rumble(HostState &host, const SceCtrlActuator *&pState) {
     remove_disconnected_controllers(state);
     add_new_controllers(state);
 
-    for (const HapticList::value_type &haptic : state.haptics) {
+    for (const auto& haptic : state.haptics) {
         SDL_Haptic *handle = haptic.second.get();
         if (pState->small == 0 && pState->large == 0) {
             SDL_HapticRumbleStop(handle);


### PR DESCRIPTION
Added joystick rumbling support.
Tested with an XInput joystick with vitaQuake (to test it, you just have to wait till player gets damaged on demo playback).

Probably more testing is required with different kind of joysticks to see if the behaviour is correct.

Handles https://github.com/Vita3K/Vita3K/issues/33