### PR TITLE
display/queue: Remove [m]lock.release() for all OS

### DIFF
--- a/src/emulator/modules/SceDisplay/SceDisplay.cpp
+++ b/src/emulator/modules/SceDisplay/SceDisplay.cpp
@@ -80,9 +80,6 @@ EXPORT(int, sceDisplayWaitSetFrameBuf) {
     if (!host.display.sync_rendering) {
         std::unique_lock<std::mutex> lock(host.display.mutex);
         host.display.condvar.wait(lock);
-#ifndef WIN32
-        lock.release();
-#endif
     } else
         host.display.condvar.notify_all();
 
@@ -109,9 +106,6 @@ EXPORT(int, sceDisplayWaitVblankStart) {
     if (!host.display.sync_rendering) {
         std::unique_lock<std::mutex> lock(host.display.mutex);
         host.display.condvar.wait(lock);
-#ifndef WIN32
-        lock.release();
-#endif
     } else
         host.display.condvar.notify_all();
 

--- a/src/emulator/threads/include/threads/queue.h
+++ b/src/emulator/threads/include/threads/queue.h
@@ -20,11 +20,6 @@ public:
                 condempty_.wait(mlock);
             }
             if (aborted) {
-// releasing the mutex on Windows results in it not
-// being unlocked by the destructor
-#ifndef WIN32
-                mlock.release();
-#endif
                 return {};
             }
 
@@ -42,11 +37,6 @@ public:
                 cond_.wait(mlock);
             }
             if (aborted) {
-// releasing the mutex on Windows results in it not
-// being unlocked by the destructor
-#ifndef WIN32
-                mlock.release();
-#endif
                 return;
             }
             queue_.push(item);


### PR DESCRIPTION
Should fix #362 (with the changes at lines 112-114)

@VelocityRa Do you remember why the preprocessors were added in commit https://github.com/Vita3K/Vita3K/pull/146/commits/44ce9e2e98d819e64c70f024c698d75cee7adae0 (instead of deleting the lines)? Was it because you didn't want to change the behavior on other OS and/or you were only able to test on Windows?