### PR TITLE
Properly implementing multiple controllers support.

### DIFF
--- a/src/emulator/ctrl/include/ctrl/state.h
+++ b/src/emulator/ctrl/include/ctrl/state.h
@@ -9,12 +9,18 @@
 struct _SDL_GameController;
 
 typedef std::shared_ptr<_SDL_GameController> GameControllerPtr;
-typedef std::map<SDL_JoystickGUID, GameControllerPtr> GameControllerList;
-
 typedef std::shared_ptr<_SDL_Haptic> HapticPtr;
-typedef std::map<SDL_JoystickGUID, HapticPtr> HapticList;
+
+struct Controller {
+    GameControllerPtr controller;
+    HapticPtr haptic;
+    int port;
+};
+
+typedef std::map<SDL_JoystickGUID, Controller> ControllerList;
 
 struct CtrlState {
-    GameControllerList controllers;
-    HapticList haptics;
+    ControllerList controllers;
+    int controllers_num;
+    bool free_ports[4] = { true, true, true, true };
 };

--- a/src/emulator/modules/SceCtrl/SceCtrl.cpp
+++ b/src/emulator/modules/SceCtrl/SceCtrl.cpp
@@ -147,15 +147,12 @@ static uint8_t float_to_byte(float f) {
 }
 
 static int reserve_port(CtrlState &state) {
-    int res = -1;
     for (int i = 0; i < 4; i++) {
         if (state.free_ports[i]) {
             state.free_ports[i] = false;
-            res = i + 1;
-            break;
+            return i + 1;
         }
     }
-    return res;
 }
 
 static void remove_disconnected_controllers(CtrlState &state) {
@@ -275,8 +272,12 @@ EXPORT(int, sceCtrlGetButtonIntercept) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceCtrlGetControllerPortInfo) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceCtrlGetControllerPortInfo, SceCtrlPortInfo *info) {
+    info->port[0] = SCE_CTRL_TYPE_PHY;
+    for (int i = 0; i < 4; i++) {
+        info->port[i + 1] = host.ctrl.free_ports[i] ? SCE_CTRL_TYPE_UNPAIRED : SCE_CTRL_TYPE_DS3;
+    }
+    return 0;
 }
 
 EXPORT(int, sceCtrlGetProcessStatus) {


### PR DESCRIPTION
Before this PR, controllers where not paired to a sceCtrl port resulting in weird behaviours when multiple joysticks where plugged in (or if an application using multiple controllers were used).

Now Vita3K will bind only max 4 controllers and pair them to a sceCtrl port so that a single controller will give input for a single port like it works on retail PSTV.