### PR TITLE
Fix buid for yaml-cpp on cmake

### DIFF
--- a/src/emulator/CMakeLists.txt
+++ b/src/emulator/CMakeLists.txt
@@ -85,7 +85,8 @@ else()
 	target_link_libraries(emulator PRIVATE ${Boost_LIBRARIES} cpu dialog elfio glutil gui host imgui modules nids vita-toolchain util)
 endif()
 set_target_properties(emulator PROPERTIES OUTPUT_NAME Vita3K
-	ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+	ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+	LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
 	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 if(APPLE)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -11,6 +11,16 @@ function(check_submodules_present)
 endfunction()
 check_submodules_present()
 
+# Fix a glslang hack
+# See https://github.com/KhronosGroup/glslang/issues/1015 and https://github.com/Vita3K/Vita3K/pull/369 for details
+if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	if(WIN32)
+		set(CMAKE_INSTALL_PREFIX "C:/Program Files/${PROJECT_NAME}" CACHE STRING "Default install prefix is: C:/Program Files" FORCE)
+	elseif(UNIX)
+		set(CMAKE_INSTALL_PREFIX /usr/local CACHE STRING "Default install prefix is: /usr/local" FORCE)
+	endif()
+endif()
+
 option(CAPSTONE_BUILD_SHARED "Build shared library" OFF)
 option(CAPSTONE_BUILD_TESTS "Build tests" OFF)
 option(CAPSTONE_ARM_SUPPORT "ARM support" ON)
@@ -105,6 +115,7 @@ target_include_directories(vita-toolchain INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}
 option(YAML_CPP_BUILD_TESTS "Enable testing" OFF)
 option(YAML_CPP_BUILD_TOOLS "Enable parse tools" OFF)
 option(YAML_CPP_BUILD_CONTRIB "Enable contrib stuff in library" OFF)
+option(YAML_CPP_INSTALL "Enable generation of install target" OFF)
 add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
 add_library(yaml INTERFACE)
 target_include_directories(yaml INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp/include")


### PR DESCRIPTION
Fix build issue on yaml-cpp after re generate cmake build, caused by issue on gslang with it change variable "CMAKE_INSTALL_PREFIX" with set force "install", causing broken yaml-cpp.
More info on gslang issue here https://github.com/KhronosGroup/glslang/issues/1015

For more understund how it works now with my fix, on first generate gslang set "install" value on "CMAKE_INSTALL_PREFIX" and after my code look if value is by default, and if not re set it with default value forced for can works after all time.

Separate .lib and .exp on lib folder bin folder show only .exe and bin file.

Update yaml-cpp submodule on last master