### PR TITLE
Added an allocation viewer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "src/external/dlmalloc"]
 	path = src/external/dlmalloc
 	url = https://github.com/Vita3K/dlmalloc
+[submodule "src/external/imgui_club"]
+	path = src/external/imgui_club
+	url = https://github.com/ocornut/imgui_club.git

--- a/src/emulator/cpu/src/cpu.cpp
+++ b/src/emulator/cpu/src/cpu.cpp
@@ -64,7 +64,7 @@ static bool is_thumb_mode(uc_engine *uc) {
 
 static void code_hook(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
     CPUState &state = *static_cast<CPUState *>(user_data);
-    const MemState &mem = *state.mem;
+    MemState &mem = *state.mem;
     const uint8_t *const code = Ptr<const uint8_t>(static_cast<Address>(address)).get(mem);
     const size_t buffer_size = GB(4) - address;
     const bool thumb = is_thumb_mode(uc);
@@ -72,7 +72,7 @@ static void code_hook(uc_engine *uc, uint64_t address, uint32_t size, void *user
     LOG_TRACE("{}: {} {}", log_hex((uint64_t)uc), log_hex(address), disassembly);
 }
 
-static void log_memory_access(uc_engine *uc, const char *type, Address address, int size, int64_t value, const MemState &mem) {
+static void log_memory_access(uc_engine *uc, const char *type, Address address, int size, int64_t value, MemState &mem) {
     const char *const name = mem_name(address, mem);
     LOG_TRACE("{}: {} {} bytes, address {} ( {} ), value {}", log_hex((uint64_t)uc), type, size, log_hex(address), name, log_hex(value));
 }
@@ -80,15 +80,15 @@ static void log_memory_access(uc_engine *uc, const char *type, Address address, 
 static void read_hook(uc_engine *uc, uc_mem_type type, uint64_t address, int size, int64_t value, void *user_data) {
     assert(value == 0);
 
-    const CPUState &state = *static_cast<const CPUState *>(user_data);
-    const MemState &mem = *state.mem;
+    CPUState &state = *static_cast<CPUState *>(user_data);
+    MemState &mem = *state.mem;
     memcpy(&value, Ptr<const void>(static_cast<Address>(address)).get(mem), size);
     log_memory_access(uc, "Read", static_cast<Address>(address), size, value, mem);
 }
 
 static void write_hook(uc_engine *uc, uc_mem_type type, uint64_t address, int size, int64_t value, void *user_data) {
-    const CPUState &state = *static_cast<const CPUState *>(user_data);
-    const MemState &mem = *state.mem;
+    CPUState &state = *static_cast<CPUState *>(user_data);
+    MemState &mem = *state.mem;
     log_memory_access(uc, "Write", static_cast<Address>(address), size, value, mem);
 }
 

--- a/src/emulator/gui/CMakeLists.txt
+++ b/src/emulator/gui/CMakeLists.txt
@@ -17,6 +17,7 @@ src/ui_mutexes_dialog.cpp
 src/ui_semaphores_dialog.cpp
 src/ui_threads_dialog.cpp
 src/ui_controls_dialog.cpp
+src/ui_allocations_dialog.cpp
 )
 
 target_include_directories(gui PUBLIC include)

--- a/src/emulator/gui/include/gui/functions.h
+++ b/src/emulator/gui/include/gui/functions.h
@@ -39,6 +39,7 @@ void DrawLwMutexesDialog(HostState &host);
 void DrawLwCondvarsDialog(HostState &host);
 void DrawCondvarsDialog(HostState &host);
 void DrawEventFlagsDialog(HostState &host);
+void DrawAllocationsDialog(HostState &host);
 void DrawUI(HostState &host);
 void DrawCommonDialog(HostState &host);
 void DrawGameSelector(HostState &host, AppRunType *run_type);

--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -20,6 +20,7 @@
 #include <dialog/state.h>
 
 struct ImFont;
+struct MemoryEditor;
 
 enum SelectorState {
     SELECT_APP
@@ -47,6 +48,7 @@ struct GuiState {
     bool mutexes_dialog = false;
     bool lwmutexes_dialog = false;
     bool eventflags_dialog = false;
+    bool allocations_dialog = false;
 
     // Optimisation menu
     bool texture_cache = true;
@@ -56,6 +58,8 @@ struct GuiState {
 
     DialogState common_dialog;
     GamesSelector game_selector;
+    MemoryEditor* memory_editor;
+    long memory_editor_start, memory_editor_count;
 
     // imgui
     ImFont *normal_font{};

--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -58,8 +58,8 @@ struct GuiState {
 
     DialogState common_dialog;
     GamesSelector game_selector;
-    MemoryEditor* memory_editor;
-    long memory_editor_start, memory_editor_count;
+    MemoryEditor *memory_editor;
+    size_t memory_editor_start, memory_editor_count;
 
     // imgui
     ImFont *normal_font{};

--- a/src/emulator/gui/src/ui_allocations_dialog.cpp
+++ b/src/emulator/gui/src/ui_allocations_dialog.cpp
@@ -6,18 +6,14 @@
 
 #include <host/state.h>
 
-#include <string.h>
+#include <spdlog/fmt/fmt.h>
 
 void DrawAllocationsDialog(HostState &host) {
-    ImGui::Begin("Allocations", &host.gui.allocations_dialog);
+    ImGui::Begin("Memory Allocations", &host.gui.allocations_dialog);
 
     const std::lock_guard<std::mutex> lock(host.mem.generation_mutex);
     for (const auto &pair : host.mem.generation_names) {
-        int length = snprintf(nullptr, 0, "%i: %s", (int)pair.first, pair.second.c_str());
-        std::vector<char> buffer((unsigned long)length);
-        sprintf(&buffer[0], "%i: %s", (int)pair.first, pair.second.c_str());
-
-        if (ImGui::TreeNode(&buffer[0])) {
+        if (ImGui::TreeNode(fmt::format("{}: {}", pair.first, pair.second).c_str())) {
             long index = -1, count = 1;
             for (long a = 0; a < host.mem.allocated_pages.size(); a++) {
                 if (index != -1) {
@@ -32,12 +28,11 @@ void DrawAllocationsDialog(HostState &host) {
             if (index == -1) {
                 ImGui::Text("Generation no longer exists.");
             } else {
-                long start = index * KB(4);
-                ImGui::Text("Range %08lx - %08lx.", start, (index + count) * KB(4));
+                ImGui::Text("Range %08lx - %08lx.", index * KB(4), (index + count) * KB(4));
                 ImGui::Text("Size: %li KB (%li page[s])", count * 4l, count);
                 if (index != 0) {
                     if (ImGui::Selectable("View/Edit")) {
-                        host.gui.memory_editor_start = start;
+                        host.gui.memory_editor_start = index * KB(4);
                         host.gui.memory_editor_count = count * KB(4);
                         if (!host.gui.memory_editor) host.gui.memory_editor = new MemoryEditor;
                     }
@@ -50,7 +45,7 @@ void DrawAllocationsDialog(HostState &host) {
     if (host.gui.memory_editor) {
         if (host.gui.memory_editor->Open) {
             host.gui.memory_editor->DrawWindow("Editor", host.mem.memory.get() + host.gui.memory_editor_start,
-                    (size_t) host.gui.memory_editor_count, (size_t) host.gui.memory_editor_start);
+                    host.gui.memory_editor_count, host.gui.memory_editor_start);
         } else {
             delete host.gui.memory_editor;
             host.gui.memory_editor = nullptr;

--- a/src/emulator/gui/src/ui_allocations_dialog.cpp
+++ b/src/emulator/gui/src/ui_allocations_dialog.cpp
@@ -15,6 +15,7 @@ void DrawAllocationsDialog(HostState &host) {
     for (const auto &pair : host.mem.generation_names) {
         if (ImGui::TreeNode(fmt::format("{}: {}", pair.first, pair.second).c_str())) {
             long index = -1, count = 1;
+            
             for (long a = 0; a < host.mem.allocated_pages.size(); a++) {
                 if (index != -1) {
                     if (host.mem.allocated_pages[a] != pair.first) break;
@@ -25,6 +26,7 @@ void DrawAllocationsDialog(HostState &host) {
                     index = a;
                 }
             }
+
             if (index == -1) {
                 ImGui::Text("Generation no longer exists.");
             } else {

--- a/src/emulator/gui/src/ui_allocations_dialog.cpp
+++ b/src/emulator/gui/src/ui_allocations_dialog.cpp
@@ -1,0 +1,65 @@
+//
+// Created by Taylor Whatley on 2019-01-10.
+//
+
+#include <gui/functions.h>
+#include <gui/gui_constants.h>
+
+#include <imgui.h>
+#include <imgui_memory_editor.h>
+
+#include <host/state.h>
+
+#include <string.h>
+
+void DrawAllocationsDialog(HostState &host) {
+    ImGui::Begin("Allocations", &host.gui.allocations_dialog);
+
+    const std::lock_guard<std::mutex> lock(host.mem.generation_mutex);
+    for (const auto &pair : host.mem.generation_names) {
+        int length = snprintf(nullptr, 0, "%i: %s", (int)pair.first, pair.second.c_str());
+        std::vector<char> buffer((unsigned long)length);
+        sprintf(&buffer[0], "%i: %s", (int)pair.first, pair.second.c_str());
+
+        if (ImGui::TreeNode(&buffer[0])) {
+            long index = -1, count = 1;
+            for (long a = 0; a < host.mem.allocated_pages.size(); a++) {
+                if (index != -1) {
+                    if (host.mem.allocated_pages[a] != pair.first) break;
+                    count++;
+                }
+
+                if (index == -1 && host.mem.allocated_pages[a] == pair.first) {
+                    index = a;
+                }
+            }
+            if (index == -1) {
+                ImGui::Text("Generation no longer exists.");
+            } else {
+                long start = index * KB(4);
+                ImGui::Text("Range %08lx - %08lx.", start, (index + count) * KB(4));
+                ImGui::Text("Size: %li KB (%li page[s])", count * 4l, count);
+                if (index != 0) {
+                    if (ImGui::Selectable("View/Edit")) {
+                        host.gui.memory_editor_start = start;
+                        host.gui.memory_editor_count = count * KB(4);
+                        if (!host.gui.memory_editor) host.gui.memory_editor = new MemoryEditor;
+                    }
+                }
+            }
+            ImGui::TreePop();
+        }
+    }
+
+    if (host.gui.memory_editor) {
+        if (host.gui.memory_editor->Open) {
+            host.gui.memory_editor->DrawWindow("Editor", host.mem.memory.get() + host.gui.memory_editor_start,
+                    (size_t) host.gui.memory_editor_count, (size_t) host.gui.memory_editor_start);
+        } else {
+            delete host.gui.memory_editor;
+            host.gui.memory_editor = nullptr;
+        }
+    }
+
+    ImGui::End();
+}

--- a/src/emulator/gui/src/ui_allocations_dialog.cpp
+++ b/src/emulator/gui/src/ui_allocations_dialog.cpp
@@ -1,7 +1,3 @@
-//
-// Created by Taylor Whatley on 2019-01-10.
-//
-
 #include <gui/functions.h>
 #include <gui/gui_constants.h>
 

--- a/src/emulator/gui/src/ui_main.cpp
+++ b/src/emulator/gui/src/ui_main.cpp
@@ -116,5 +116,8 @@ void DrawUI(HostState &host) {
     if (host.gui.controls_dialog) {
         DrawControlsDialog(host);
     }
+    if (host.gui.allocations_dialog) {
+        DrawAllocationsDialog(host);
+    }
     ImGui::PopFont();
 }

--- a/src/emulator/gui/src/ui_main_menubar.cpp
+++ b/src/emulator/gui/src/ui_main_menubar.cpp
@@ -34,6 +34,7 @@ void DrawMainMenuBar(HostState &host) {
             ImGui::MenuItem("Condition Variables", nullptr, &host.gui.condvars_dialog);
             ImGui::MenuItem("Lightweight Condition Variables", nullptr, &host.gui.lwcondvars_dialog);
             ImGui::MenuItem("Event Flags", nullptr, &host.gui.eventflags_dialog);
+            ImGui::MenuItem("Allocations", nullptr, &host.gui.allocations_dialog);
             ImGui::PopStyleColor();
             ImGui::EndMenu();
         }

--- a/src/emulator/gui/src/ui_main_menubar.cpp
+++ b/src/emulator/gui/src/ui_main_menubar.cpp
@@ -34,7 +34,7 @@ void DrawMainMenuBar(HostState &host) {
             ImGui::MenuItem("Condition Variables", nullptr, &host.gui.condvars_dialog);
             ImGui::MenuItem("Lightweight Condition Variables", nullptr, &host.gui.lwcondvars_dialog);
             ImGui::MenuItem("Event Flags", nullptr, &host.gui.eventflags_dialog);
-            ImGui::MenuItem("Allocations", nullptr, &host.gui.allocations_dialog);
+            ImGui::MenuItem("Memory Allocations", nullptr, &host.gui.allocations_dialog);
             ImGui::PopStyleColor();
             ImGui::EndMenu();
         }

--- a/src/emulator/mem/include/mem/mem.h
+++ b/src/emulator/mem/include/mem/mem.h
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <map>
+#include <mutex>
 #include <memory>
 #include <string>
 #include <vector>
@@ -34,6 +35,7 @@ struct MemState {
     Generation generation = 0;
     Memory memory;
     Allocated allocated_pages;
+    std::mutex generation_mutex;
     GenerationNames generation_names;
 };
 
@@ -54,4 +56,4 @@ Address alloc(MemState &state, size_t size, const char *name);
 Address alloc_at(MemState &state, Address address, size_t size, const char *name);
 void free(MemState &state, Address address);
 uint32_t mem_available(MemState &state);
-const char *mem_name(Address address, const MemState &state);
+const char *mem_name(Address address, MemState &state);

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -64,8 +64,10 @@ target_include_directories(microprofile PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/micr
 set_property(TARGET microprofile PROPERTY CXX_STANDARD 11)
 target_compile_definitions(microprofile PUBLIC MICROPROFILE_ENABLED=0 MICROPROFILE_GPU_TIMERS=0)
 
+# The imgui target is including both imgui and imgui_club.
 add_library(imgui STATIC imgui/imgui.cpp imgui/imgui_draw.cpp imgui/imgui_widgets.cpp)
-target_include_directories(imgui PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/imgui")
+target_include_directories(imgui PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/imgui"
+		"${CMAKE_CURRENT_SOURCE_DIR}/imgui_club/imgui_memory_editor/")
 
 add_library(miniz STATIC miniz/miniz.c miniz/miniz.h)
 target_include_directories(miniz PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/miniz")


### PR DESCRIPTION
This pull request adds an allocation viewer to the debug menu of Vita3K. The allocation viewer allows a debugger to do a few things:

- View the allocation's generation and name.
- Tell the size of the allocation in pages and kilobytes.
- View where allocation starts and ends (as a hexadecimal address).
- View and edit the contents of the allocation using imgui_club's memory editor.
<img width="1072" alt="screen shot 2019-01-10 at 10 24 41 pm" src="https://user-images.githubusercontent.com/32211852/51011930-9984c080-1528-11e9-9df2-abfe7be44931.png">
<img width="1072" alt="screen shot 2019-01-10 at 10 25 24 pm 2" src="https://user-images.githubusercontent.com/32211852/51011932-9c7fb100-1528-11e9-9601-907c0e7dc761.png">

