### PR TITLE
io: Handle error cases when calling create_dir

### DIFF
--- a/src/emulator/io/include/io/io.h
+++ b/src/emulator/io/include/io/io.h
@@ -17,9 +17,10 @@
 
 #pragma once
 
-#define SCE_ERROR_ERRNO_ENOENT 0x80010002 // File doesn't exist
-#define SCE_ERROR_ERRNO_EMFILE 0x80010018 // File doesn't exist
-#define SCE_ERROR_ERRNO_EBADF 0x80010051 // Invalid descriptor
+#define SCE_ERROR_ERRNO_ENOENT 0x80010002 // Associated file or directory does not exist
+#define SCE_ERROR_ERRNO_EEXIST 0x80010011 // File exists
+#define SCE_ERROR_ERRNO_EMFILE 0x80010018 // Too many files are open
+#define SCE_ERROR_ERRNO_EBADFD 0x80010051 // File descriptor is invalid for this operation
 
 #define JOIN_DEVICE(p) VitaIoDevice::p
 #define DEVICE(path, name) name,


### PR DESCRIPTION
For example, the homebrew [pfba](http://vitadb.rinnegatamante.it/#/info/20) tries to create the directory `ux0:/data/pfba/roms` but failed because the directory `ux0:/data/pfba` does not exist.

```
[21:32:43.040] |T| [create_dir]:  sceIoMkdir: Removing dir ux0:/data/pfba/roms (ux0:/data/pfba/roms)
terminate called after throwing an instance of 'std::experimental::filesystem::v1::__cxx11::filesystem_error'
  what():  filesystem error: cannot create directory: No such file or directory [/home/scribam/.local/share/Vita3K/Vita3K/ux0/data/pfba/roms]
```