### PR TITLE
Allocation viewer crash fix

### DIFF
--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -58,7 +58,7 @@ struct GuiState {
 
     DialogState common_dialog;
     GamesSelector game_selector;
-    MemoryEditor *memory_editor;
+    MemoryEditor *memory_editor = nullptr;
     size_t memory_editor_start, memory_editor_count;
 
     // imgui


### PR DESCRIPTION
This merge prevents a crash when opening the memory allocation viewer. The code that draws the viewer relies on `memory_editor` being null when it should not be drawn, but it was not explicitly set to null.
![unknown](https://user-images.githubusercontent.com/32211852/51069068-f26e5a80-15f5-11e9-869d-4274e567c8c1.png)
This fix ensures that the memory editor is only drawn when it has been opened which prevents the crash.

Thanks to waterflame for pointing this out.