### PR TITLE
Cmake tweaks

### DIFF
--- a/gen-windows.bat
+++ b/gen-windows.bat
@@ -18,6 +18,6 @@ pushd build-windows
 IF "%CI%"=="" (
 	cmake -G "Visual Studio 15 2017 Win64" ..
 ) ELSE (
-	cmake -G "Visual Studio 15 2017 Win64" -DCI:BOOL=ON ..
+	cmake -G "Visual Studio 15 2017 Win64" -DCI:BOOL=ON -DCMAKE_CONFIGURATION_TYPES=%CONFIGURATION% ..
 )
 popd

--- a/src/emulator/mem/CMakeLists.txt
+++ b/src/emulator/mem/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library(
 )
 
 target_include_directories(mem PUBLIC include)
-target_link_libraries(mem PUBLIC util spdlog)
+target_link_libraries(mem PUBLIC util)

--- a/src/emulator/net/CMakeLists.txt
+++ b/src/emulator/net/CMakeLists.txt
@@ -7,7 +7,7 @@ src/net.cpp
 )
 
 target_include_directories(net PUBLIC include)
-target_link_libraries(net PUBLIC mem sdl2 vita-headers)
+target_link_libraries(net PUBLIC mem vita-headers)
 if (WIN32)
     target_link_libraries(net PRIVATE winsock)
 endif()

--- a/src/emulator/nids/CMakeLists.txt
+++ b/src/emulator/nids/CMakeLists.txt
@@ -8,4 +8,3 @@ add_library(
 )
 
 target_include_directories(nids PUBLIC include)
-target_link_libraries(cpu INTERFACE util spdlog)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -126,6 +126,7 @@ target_link_libraries(yaml INTERFACE yaml-cpp)
 add_library(rpcs3 INTERFACE)
 target_include_directories(rpcs3 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/rpcs3/include")
 
+option(ENABLE_SPVREMAPPER "Enables building of SPVRemapper" OFF)
 option(ENABLE_GLSLANG_BINARIES "Builds glslangValidator and spirv-remap" OFF)
 option(ENABLE_AMD_EXTENSIONS "Enables support of AMD-specific extensions" OFF)
 option(ENABLE_NV_EXTENSIONS "Enables support of Nvidia-specific extensions" OFF)


### PR DESCRIPTION
- **Commit "cmake: Cleanup link libraries"**
Fix the warning below (was it a typo in `src/emulator/nids/CMakeLists.txt`?) and remove unnecessary libraries link.
![image](https://user-images.githubusercontent.com/25406440/51204267-7597f500-1903-11e9-8bfc-65b3b58b1bf0.png)

- **Commit "cmake: Do not build SPVRemapper"**
We don't use it so no reason to build it :slightly_smiling_face: 

- **Commit "cmake/ci: Generate "Release" Visual Studio solution only"**
Currently, on AppVeyor, we generate a solution file for the following four configurations but we only use "Release".
![image](https://user-images.githubusercontent.com/25406440/51204389-cf98ba80-1903-11e9-9fc6-a2ac6fbee65b.png)
With this commit, one configuration will be used, the one defined in the configuration node of the `appveyor.yml`.
