### PR TITLE
util: filesystem fix for macOS

### DIFF
--- a/src/emulator/gui/src/imgui_impl.cpp
+++ b/src/emulator/gui/src/imgui_impl.cpp
@@ -21,6 +21,7 @@
 
 #include <glutil/gl.h>
 #include <host/state.h>
+#include <util/fs.h>
 #include <util/log.h>
 #include <util/string_utils.h>
 
@@ -30,8 +31,6 @@
 
 #include <fstream>
 #include <string>
-
-namespace fs = boost::filesystem;
 
 namespace imgui {
 

--- a/src/emulator/gui/src/imgui_impl.cpp
+++ b/src/emulator/gui/src/imgui_impl.cpp
@@ -26,7 +26,6 @@
 #include <util/string_utils.h>
 
 #include <SDL_video.h>
-#include <boost/filesystem.hpp>
 #include <imgui.h>
 
 #include <fstream>

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -485,7 +485,7 @@ int create_dir(IOState &io, const char *dir, int mode, const char *pref_path, co
     case VitaIoDevice::UX0:
     case VitaIoDevice::UMA0: {
         std::string dir_path = to_host_path(translated_path, pref_path, device);
-        std::error_code error_code;
+        boost::system::error_code error_code;
 
         fs::create_directory(dir_path, error_code);
 

--- a/src/emulator/kernel/src/load_self.cpp
+++ b/src/emulator/kernel/src/load_self.cpp
@@ -24,8 +24,8 @@
 
 #include <nids/functions.h>
 #include <util/log.h>
+#include <util/fs.h>
 
-#include <boost/filesystem.hpp>
 #include <elfio/elf_types.hpp>
 #include <spdlog/fmt/fmt.h>
 // clang-format off
@@ -52,7 +52,6 @@
 #define NID_PROCESS_PARAM 0x70FBA1E7
 
 using namespace ELFIO;
-namespace fs = boost::filesystem;
 
 static constexpr bool LOG_MODULE_LOADING = false;
 static constexpr bool DUMP_SEGMENTS = false;

--- a/src/emulator/util/include/util/fs.h
+++ b/src/emulator/util/include/util/fs.h
@@ -1,13 +1,5 @@
 #pragma once
 
-#ifndef __APPLE__
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-void rmkdir(const char *dir);
-namespace fs {
-bool create_directory(std::string path);
-bool create_directories(std::string path);
-int remove(std::string path);
-} // namespace fs
-#endif
+#include <boost/filesystem.hpp>
+
+namespace fs = boost::filesystem;


### PR DESCRIPTION
On macOS, util/fs.h doesn't have a definition of `fs::create_directory()` with two parameters. This causes a build error in io.cpp:
<img width="940" alt="screen shot 2019-01-19 at 11 18 01 pm" src="https://user-images.githubusercontent.com/32211852/51442775-2c9ec280-1cae-11e9-95e5-0e19b3d4f6c9.png">
This pull request fixes this by changing util/fs.h to use boost/filesystem.hpp (which has both parameters available).