### PR TITLE
log: Restore spdlog flush on debug log level

### DIFF
--- a/src/emulator/util/src/util.cpp
+++ b/src/emulator/util/src/util.cpp
@@ -72,6 +72,7 @@ void init() {
     });
 
     spdlog::set_pattern("%^[%H:%M:%S.%e] |%L| [%!]: %v%$");
+    spdlog::flush_on(spdlog::level::debug);
 }
 
 void set_level(spdlog::level::level_enum log_level) {


### PR DESCRIPTION
The change was removed in PR #383 but it seems to be necessary for Windows users.