### PR TITLE
renderer/io: Dump shaders to separate game specific directory

### DIFF
--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -170,7 +170,7 @@ bool init(HostState &state, Config cfg) {
     state.base_path = base_path.get();
     state.pref_path = pref_path.get();
     state.window = WindowPtr(SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, DEFAULT_RES_WIDTH, DEFAULT_RES_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE), SDL_DestroyWindow);
-    if (!state.window || !init(state.mem) || !init(state.audio, resume_thread) || !init(state.io, state.pref_path.c_str())) {
+    if (!state.window || !init(state.mem) || !init(state.audio, resume_thread) || !init(state.io, state.pref_path.c_str(), state.base_path.c_str())) {
         return false;
     }
 

--- a/src/emulator/io/include/io/functions.h
+++ b/src/emulator/io/include/io/functions.h
@@ -30,7 +30,7 @@ struct SceIoDirent;
 
 void init_device_paths(IOState &io);
 
-bool init(IOState &io, const char *pref_path);
+bool init(IOState &io, const char *pref_path, const char *base_path);
 SceUID open_file(IOState &io, const std::string &path_, int flags, const char *pref_path, const char *export_name);
 int read_file(void *data, IOState &io, SceUID fd, SceSize size, const char *export_name);
 int write_file(SceUID fd, const void *data, SceSize size, const IOState &io, const char *export_name);

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -199,7 +199,7 @@ bool read_app_file(FileBuffer &buf, const std::string &pref_path, const std::str
 
 } // namespace vfs
 
-bool init(IOState &io, const char *pref_path) {
+bool init(IOState &io, const char *pref_path, const char *base_path) {
     std::string ux0 = pref_path;
     std::string uma0 = pref_path;
     ux0 += "ux0";
@@ -219,6 +219,8 @@ bool init(IOState &io, const char *pref_path) {
     fs::create_directory(ux0_savedata);
     fs::create_directory(uma0);
     fs::create_directory(uma0_data);
+
+    fs::create_directory(std::string(base_path) + "/shaderlog");
 
     return true;
 }

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1281,7 +1281,7 @@ EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shade
     fp->program = programId->program;
     fp->renderer_data = std::make_unique<renderer::FragmentProgram>();
 
-    if (!renderer::create(*fp->renderer_data.get(), host.renderer, *programId->program.get(mem), blendInfo, host.base_path.c_str())) {
+    if (!renderer::create(*fp->renderer_data.get(), host.renderer, *programId->program.get(mem), blendInfo, host.base_path.c_str(), host.io.title_id.c_str())) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 
@@ -1306,7 +1306,7 @@ EXPORT(int, sceGxmShaderPatcherCreateMaskUpdateFragmentProgram, SceGxmShaderPatc
     memcpy(const_cast<SceGxmProgram *>(fp->program.get(mem)), mask_gxp, size_mask_gxp);
     fp->renderer_data = std::make_unique<renderer::FragmentProgram>();
 
-    if (!renderer::create(*fp->renderer_data, host.renderer, *fp->program.get(mem), nullptr, host.base_path.c_str())) {
+    if (!renderer::create(*fp->renderer_data, host.renderer, *fp->program.get(mem), nullptr, host.base_path.c_str(), host.io.title_id.c_str())) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 
@@ -1335,7 +1335,7 @@ EXPORT(int, sceGxmShaderPatcherCreateVertexProgram, SceGxmShaderPatcher *shaderP
     vp->attributes.insert(vp->attributes.end(), &attributes[0], &attributes[attributeCount]);
     vp->renderer_data = std::make_unique<renderer::VertexProgram>();
 
-    if (!renderer::create(*vp->renderer_data.get(), host.renderer, *programId->program.get(mem), host.base_path.c_str())) {
+    if (!renderer::create(*vp->renderer_data.get(), host.renderer, *programId->program.get(mem), host.base_path.c_str(), host.io.title_id.c_str())) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 

--- a/src/emulator/renderer/include/renderer/functions.h
+++ b/src/emulator/renderer/include/renderer/functions.h
@@ -19,8 +19,8 @@ struct VertexProgram;
 
 bool create(Context &context, SDL_Window *window);
 bool create(RenderTarget &rt, const SceGxmRenderTargetParams &params);
-bool create(FragmentProgram &fp, State &state, const SceGxmProgram &program, const emu::SceGxmBlendInfo *blend, const char *base_path);
-bool create(VertexProgram &vp, State &state, const SceGxmProgram &program, const char *base_path);
+bool create(FragmentProgram &fp, State &state, const SceGxmProgram &program, const emu::SceGxmBlendInfo *blend, const char *base_path, const char *title_id);
+bool create(VertexProgram &vp, State &state, const SceGxmProgram &program, const char *base_path, const char *title_id);
 void begin_scene(const RenderTarget &rt);
 void end_scene(Context &context, SceGxmSyncObject *sync_object, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels);
 bool sync_state(Context &context, const GxmContextState &state, const MemState &mem, bool enable_texture_cache, bool log_active_shaders, bool log_uniforms);

--- a/src/emulator/renderer/src/functions.h
+++ b/src/emulator/renderer/src/functions.h
@@ -28,8 +28,8 @@ GLboolean attribute_format_normalised(SceGxmAttributeFormat format);
 SharedGLObject compile_program(ProgramCache &cache, const GxmContextState &state, const MemState &mem);
 
 // Shaders.
-std::string load_fragment_shader(GLSLCache &cache, const SceGxmProgram &fragment_program, const char *base_path);
-std::string load_vertex_shader(GLSLCache &cache, const SceGxmProgram &vertex_program, const char *base_path);
+std::string load_fragment_shader(GLSLCache &cache, const SceGxmProgram &fragment_program, const char *base_path, const char *title_id);
+std::string load_vertex_shader(GLSLCache &cache, const SceGxmProgram &vertex_program, const char *base_path, const char *title_id);
 
 namespace texture {
 

--- a/src/emulator/renderer/src/renderer.cpp
+++ b/src/emulator/renderer/src/renderer.cpp
@@ -154,10 +154,10 @@ bool create(RenderTarget &rt, const SceGxmRenderTargetParams &params) {
     return true;
 }
 
-bool create(FragmentProgram &fp, State &state, const SceGxmProgram &program, const emu::SceGxmBlendInfo *blend, const char *base_path) {
+bool create(FragmentProgram &fp, State &state, const SceGxmProgram &program, const emu::SceGxmBlendInfo *blend, const char *base_path, const char *title_id) {
     R_PROFILE(__func__);
 
-    fp.glsl = load_fragment_shader(state.fragment_glsl_cache, program, base_path);
+    fp.glsl = load_fragment_shader(state.fragment_glsl_cache, program, base_path, title_id);
 
     // Translate blending.
     if (blend != nullptr) {
@@ -177,10 +177,10 @@ bool create(FragmentProgram &fp, State &state, const SceGxmProgram &program, con
     return true;
 }
 
-bool create(VertexProgram &vp, State &state, const SceGxmProgram &program, const char *base_path) {
+bool create(VertexProgram &vp, State &state, const SceGxmProgram &program, const char *base_path, const char *title_id) {
     R_PROFILE(__func__);
 
-    vp.glsl = load_vertex_shader(state.vertex_glsl_cache, program, base_path);
+    vp.glsl = load_vertex_shader(state.vertex_glsl_cache, program, base_path, title_id);
     vp.attribute_locations = attribute_locations(program);
 
     return true;


### PR DESCRIPTION
Shaders are now dumped in the main executable's directory, in `/shaderlog/<titleID>`.
Fixes #228.

Edit: Also, a reminder, these shaders are **not** read, just dumped, so don't modify them in-place. If you want to do that, move the ones you need to `/shaders` first.