### PR TITLE
host: Add config file support and custom VFS directory

### DIFF
--- a/src/emulator/host/CMakeLists.txt
+++ b/src/emulator/host/CMakeLists.txt
@@ -22,4 +22,4 @@ configure_file(src/version.cpp.in version.cpp)
 
 target_include_directories(host PUBLIC include)
 target_link_libraries(host PUBLIC audio cpu ctrl gxm io kernel mem net nids np renderer rtc util gui)
-target_link_libraries(host PRIVATE ${Boost_LIBRARIES} glbinding-aux glutil microprofile sdl2)
+target_link_libraries(host PRIVATE ${Boost_LIBRARIES} glbinding-aux glutil microprofile sdl2 yaml-cpp)

--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -39,14 +39,30 @@ struct Config {
     bool log_uniforms = false;
     std::vector<std::string> lle_modules;
     bool pstv_mode = false;
+    optional<std::string> pref_path;
 };
 
 namespace config {
 
+/*
+ * \brief Initializes config system from a YML file.
+ * 
+ * \param cfg Config options are returned via this parameter.
+ * \return True on loading success.
+*/
+ExitCode init_from_config_file(Config &cfg, const char *config_file_name);
+
+/*
+ * \brief Save emulator config to a YML file.
+ *
+ * \return True on saving success.
+*/
+ExitCode save_config_to_file(Config &cfg, const char *config_file_name);
+
 /**
   * \brief Initializes config system, parsing command-line args and handling some basic ones:
   *        --help, --version, --log-level
-  * \param cfg Config options are returend via this parameter.
+  * \param cfg Config options are returned via this parameter.
   * \return True on success, false on error.
   */
 ExitCode init(Config &cfg, int argc, char **argv);

--- a/src/emulator/host/src/config.cpp
+++ b/src/emulator/host/src/config.cpp
@@ -27,14 +27,126 @@
 #include <boost/program_options.hpp>
 #include <spdlog/spdlog.h>
 
+#include <yaml-cpp/yaml.h>
+
 #include <exception>
+#include <fstream>
 #include <iostream>
 
 namespace po = boost::program_options;
 
 namespace config {
 
+template <typename T, typename Q = T>
+void get_yaml_value(YAML::Node &config_node, const char *key, T *target_val, Q default_val) {
+    try {
+        *target_val = config_node[key].as<Q>();
+    } catch (YAML::Exception &exception) {
+        *target_val = std::move(default_val);
+    }
+}
+
+template <typename T>
+void get_yaml_value_optional(YAML::Node &config_node, const char *key, boost::optional<T> *target_val, T default_val) {
+    try {
+        *target_val = config_node[key].as<T>();
+    } catch (YAML::Exception &exception) {
+        *target_val = std::move(default_val);
+    }
+}
+
+template <typename T>
+void get_yaml_value_optional(YAML::Node &config_node, const char *key, boost::optional<T> *target_val) {
+    try {
+        *target_val = config_node[key].as<T>();
+    } catch (YAML::Exception &exception) {
+        *target_val = boost::none;
+    }
+}
+
+template <typename T>
+void config_file_emit_single(YAML::Emitter &emitter, const char *name, T &val) {
+    emitter << YAML::Key << name << YAML::Value << val;
+}
+
+template <typename T>
+void config_file_emit_optional_single(YAML::Emitter &emitter, const char *name, boost::optional<T> &val) {
+    if (val) {
+        emitter << YAML::Key << name << YAML::Value << val.value();
+    }
+}
+
+template <typename T>
+void config_file_emit_vector(YAML::Emitter &emitter, const char *name, std::vector<T> &values)  {
+    emitter << YAML::Key << name << YAML::BeginSeq;
+
+    for (const T &value: values) {
+        emitter << value;
+    }
+
+    emitter << YAML::EndSeq;
+}
+
+ExitCode save_config_to_file(Config &cfg, const char *config_file_name) {
+    YAML::Emitter emitter;
+    emitter << YAML::BeginMap;
+
+    config_file_emit_single(emitter, "log-imports", cfg.log_imports);
+    config_file_emit_single(emitter, "log-exports", cfg.log_exports);
+    config_file_emit_single(emitter, "log-active-shaders", cfg.log_active_shaders);
+    config_file_emit_single(emitter, "log-uniforms", cfg.log_uniforms);
+    config_file_emit_single(emitter, "pstv-mode", cfg.pstv_mode);
+    config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
+    config_file_emit_optional_single(emitter, "log-level", cfg.log_level);
+    config_file_emit_optional_single(emitter, "pref-path", cfg.pref_path);
+
+    emitter << YAML::EndMap;
+
+    std::ofstream fo(config_file_name);
+    if (!fo) {
+        return IncorrectArgs;
+    }
+
+    fo << emitter.c_str();
+    return Success;
+}
+
+ExitCode init_from_config_file(Config &cfg, const char *config_file_name) {
+    YAML::Node config_node {};
+
+    try {
+        config_node = YAML::LoadFile(config_file_name);
+    } catch (YAML::Exception &exception) {
+        std::cerr << "Config file can't be load: Error: " << exception.what() << "\n";
+        return IncorrectArgs;
+    }
+
+    get_yaml_value(config_node, "log-imports", &cfg.log_imports, false);
+    get_yaml_value(config_node, "log-exports", &cfg.log_exports, false);
+    get_yaml_value(config_node, "log-active-shaders", &cfg.log_active_shaders, false);
+    get_yaml_value(config_node, "log-uniforms", &cfg.log_uniforms, false);
+    get_yaml_value(config_node, "pstv-mode", &cfg.pstv_mode, false);
+    
+    get_yaml_value_optional(config_node, "log-level", &cfg.log_level, static_cast<int>(spdlog::level::trace));
+    get_yaml_value_optional(config_node, "pref-path", &cfg.pref_path);
+
+    // lle-modules
+    try {
+        YAML::Node lle_modules_node = config_node["lle-modules"];
+
+        for (auto lle_module_node: lle_modules_node) {
+            cfg.lle_modules.push_back(lle_module_node.as<std::string>());
+        }
+    } catch (YAML::Exception &exception) {
+        std::cerr << "LLE modules node listed in config file has invalid syntax, please check again!\n";
+    }
+
+    return Success;
+}
+
 ExitCode init(Config &cfg, int argc, char **argv) {
+    init_from_config_file(cfg, "config.yml");
+
     try {
         // Declare all options
         // clang-format off
@@ -123,6 +235,9 @@ ExitCode init(Config &cfg, int argc, char **argv) {
         std::cerr << "Exception of unknown type!\n";
         return IncorrectArgs;
     }
+
+    // Save any changes made in command-line arguments
+    save_config_to_file(cfg, "config.yml");
     return Success;
 }
 

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -168,7 +168,15 @@ bool init(HostState &state, Config cfg) {
 
     state.cfg = std::move(cfg);
     state.base_path = base_path.get();
-    state.pref_path = pref_path.get();
+
+    // If configuration already provides preference path
+    if (!state.cfg.pref_path) {
+        state.pref_path = pref_path.get();
+        state.cfg.pref_path = state.pref_path;
+    } else {
+        state.pref_path = state.cfg.pref_path.value();
+    }
+
     state.window = WindowPtr(SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, DEFAULT_RES_WIDTH, DEFAULT_RES_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE), SDL_DestroyWindow);
     if (!state.window || !init(state.mem) || !init(state.audio, resume_thread) || !init(state.io, state.pref_path.c_str())) {
         return false;

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -138,6 +138,9 @@ int main(int argc, char *argv[]) {
 
     // De-initializations
     imgui::destroy(host);
+    
+    // There may be changes that made in the GUI, so we should save, again
+    config::save_config_to_file(host.cfg, "config.yml");
 
     return Success;
 }


### PR DESCRIPTION
- Add a config system. Config file is "config.yml", in base directory (most of the time where you run the executable)
- Add ability to specify the virtual filesystem directory. To edit this, follow the instruction:
    * ![exampl01](https://user-images.githubusercontent.com/25717050/52165207-41f50180-2730-11e9-9083-eebd12059a69.png)
   * Edit *pref-path* to where you want your virtual filesystem should reside.
   * After installing and running with the *pref-path* variables given, it should look like this: 
   * ![example1](https://user-images.githubusercontent.com/25717050/52165228-681aa180-2730-11e9-8566-4b2fdbeef799.png)
   
**Note:** This won't move the old game data to the new directory for you. Do it yourself
    