### PR TITLE
util/config: config option to duplicate log with title id/game name as log name

### DIFF
--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -40,6 +40,7 @@ struct Config {
     std::vector<std::string> lle_modules;
     bool pstv_mode = false;
     optional<std::string> pref_path;
+    bool duplicate_log = false;
 };
 
 namespace config {

--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -40,7 +40,7 @@ struct Config {
     std::vector<std::string> lle_modules;
     bool pstv_mode = false;
     optional<std::string> pref_path;
-    bool duplicate_log = false;
+    bool archive_log = false;
 };
 
 namespace config {

--- a/src/emulator/host/src/app.cpp
+++ b/src/emulator/host/src/app.cpp
@@ -213,6 +213,13 @@ bool load_app_impl(Ptr<const void> &entry_point, HostState &host, const std::wst
     find_data(host.game_title, host.sfo_handle, "TITLE");
     std::replace(host.game_title.begin(), host.game_title.end(), '\n', ' ');
     find_data(host.io.title_id, host.sfo_handle, "TITLE_ID");
+
+    if (host.cfg.duplicate_log) {
+        if (!fs::exists(host.base_path + "/logs"))
+            fs::create_directory(std::string(host.base_path) + "/logs");
+        logging::add_sink(host.io.title_id, host.game_title);
+    }
+
     std::string category;
     find_data(category, host.sfo_handle, "CATEGORY");
 

--- a/src/emulator/host/src/app.cpp
+++ b/src/emulator/host/src/app.cpp
@@ -232,7 +232,7 @@ bool load_app_impl(Ptr<const void> &entry_point, HostState &host, const std::wst
                 std::cerr << "failed to get working directory" << std::endl;
             }
 #else
-            logging::add_sink(log_name);
+            logging::add_sink(string_utils::utf_to_wide(log_name));
 #endif
         } catch (const spdlog::spdlog_ex &ex) {
             std::cerr << "File log initialization failed: " << ex.what() << std::endl;

--- a/src/emulator/host/src/app.cpp
+++ b/src/emulator/host/src/app.cpp
@@ -214,10 +214,29 @@ bool load_app_impl(Ptr<const void> &entry_point, HostState &host, const std::wst
     std::replace(host.game_title.begin(), host.game_title.end(), '\n', ' ');
     find_data(host.io.title_id, host.sfo_handle, "TITLE_ID");
 
-    if (host.cfg.duplicate_log) {
-        if (!fs::exists(host.base_path + "/logs"))
-            fs::create_directory(std::string(host.base_path) + "/logs");
-        logging::add_sink(host.io.title_id, host.game_title);
+    if (host.cfg.archive_log) {
+        fs::create_directory(std::string(host.base_path) + "/logs");
+        try {
+            std::string game_title = string_utils::remove_special_chars(host.game_title);
+            const auto log_name = fmt::format("{} - [{}].log", game_title, host.io.title_id);
+#ifdef WIN32
+            wchar_t buffer[MAX_PATH];
+            GetModuleFileNameW(NULL, buffer, MAX_PATH);
+            std::string::size_type pos = std::wstring(buffer).find_last_of(L"\\\\");
+            std::wstring path = std::wstring(buffer).substr(0, pos);
+
+            if (!path.empty()) {
+                const auto full_log_path = path + L"\\" + L"\\logs\\" + string_utils::utf_to_wide(log_name);
+                logging::add_sink(full_log_path);
+            } else {
+                std::cerr << "failed to get working directory" << std::endl;
+            }
+#else
+            logging::add_sink(log_name);
+#endif
+        } catch (const spdlog::spdlog_ex &ex) {
+            std::cerr << "File log initialization failed: " << ex.what() << std::endl;
+        }
     }
 
     std::string category;

--- a/src/emulator/host/src/config.cpp
+++ b/src/emulator/host/src/config.cpp
@@ -95,7 +95,7 @@ ExitCode serialize(Config &cfg) {
     config_file_emit_single(emitter, "log-active-shaders", cfg.log_active_shaders);
     config_file_emit_single(emitter, "log-uniforms", cfg.log_uniforms);
     config_file_emit_single(emitter, "pstv-mode", cfg.pstv_mode);
-    config_file_emit_single(emitter, "duplicate-log", cfg.duplicate_log);
+    config_file_emit_single(emitter, "archive-log", cfg.archive_log);
     config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
     config_file_emit_optional_single(emitter, "log-level", cfg.log_level);
     config_file_emit_optional_single(emitter, "pref-path", cfg.pref_path);
@@ -126,8 +126,7 @@ ExitCode deserialize(Config &cfg) {
     get_yaml_value(config_node, "log-active-shaders", &cfg.log_active_shaders, false);
     get_yaml_value(config_node, "log-uniforms", &cfg.log_uniforms, false);
     get_yaml_value(config_node, "pstv-mode", &cfg.pstv_mode, false);
-    get_yaml_value(config_node, "duplicate-log", &cfg.duplicate_log, false);
-
+    get_yaml_value(config_node, "archive-log", &cfg.archive_log, false);
     get_yaml_value_optional(config_node, "log-level", &cfg.log_level, static_cast<int>(spdlog::level::trace));
     get_yaml_value_optional(config_node, "pref-path", &cfg.pref_path);
 
@@ -163,13 +162,13 @@ ExitCode init(Config &cfg, int argc, char **argv) {
 
         po::options_description config_desc("Configuration");
         config_desc.add_options()
+            ("archive-log,A", po::bool_switch(&cfg.archive_log), "Makes a duplicate of the log file with TITLE_ID and Game ID as title")
             ("lle-modules,m", po::value<std::string>(), "Load given (decrypted) OS modules from disk. Separate by commas to specify multiple modules (no spaces). Full path and extension should not be included, the following are assumed: vs0:sys/external/<name>.suprx\nExample: --lle-modules libscemp4,libngs")
             ("log-level,l", po::value(&cfg.log_level)->default_value(spdlog::level::trace), "logging level:\nTRACE = 0\nDEBUG = 1\nINFO = 2\nWARN = 3\nERROR = 4\nCRITICAL = 5\nOFF = 6")
             ("log-imports,I", po::bool_switch(&cfg.log_imports), "Log Imports")
             ("log-exports,E", po::bool_switch(&cfg.log_exports), "Log Exports")
             ("log-active-shaders,S", po::bool_switch(&cfg.log_active_shaders), "Log Active Shaders")
-            ("log-uniforms,U", po::bool_switch(&cfg.log_uniforms), "Log Uniforms")
-            ("duplicate-log,D", po::bool_switch(&cfg.duplicate_log), "Makes a duplicate of the log file with TITLE_ID and Game ID as title");
+            ("log-uniforms,U", po::bool_switch(&cfg.log_uniforms), "Log Uniforms");
         // clang-format on
 
         // Positional args

--- a/src/emulator/host/src/config.cpp
+++ b/src/emulator/host/src/config.cpp
@@ -76,10 +76,10 @@ void config_file_emit_optional_single(YAML::Emitter &emitter, const char *name, 
 }
 
 template <typename T>
-void config_file_emit_vector(YAML::Emitter &emitter, const char *name, std::vector<T> &values)  {
+void config_file_emit_vector(YAML::Emitter &emitter, const char *name, std::vector<T> &values) {
     emitter << YAML::Key << name << YAML::BeginSeq;
 
-    for (const T &value: values) {
+    for (const T &value : values) {
         emitter << value;
     }
 
@@ -95,6 +95,7 @@ ExitCode serialize(Config &cfg) {
     config_file_emit_single(emitter, "log-active-shaders", cfg.log_active_shaders);
     config_file_emit_single(emitter, "log-uniforms", cfg.log_uniforms);
     config_file_emit_single(emitter, "pstv-mode", cfg.pstv_mode);
+    config_file_emit_single(emitter, "duplicate-log", cfg.duplicate_log);
     config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
     config_file_emit_optional_single(emitter, "log-level", cfg.log_level);
     config_file_emit_optional_single(emitter, "pref-path", cfg.pref_path);
@@ -111,7 +112,7 @@ ExitCode serialize(Config &cfg) {
 }
 
 ExitCode deserialize(Config &cfg) {
-    YAML::Node config_node {};
+    YAML::Node config_node{};
 
     try {
         config_node = YAML::LoadFile("config.yml");
@@ -125,7 +126,8 @@ ExitCode deserialize(Config &cfg) {
     get_yaml_value(config_node, "log-active-shaders", &cfg.log_active_shaders, false);
     get_yaml_value(config_node, "log-uniforms", &cfg.log_uniforms, false);
     get_yaml_value(config_node, "pstv-mode", &cfg.pstv_mode, false);
-    
+    get_yaml_value(config_node, "duplicate-log", &cfg.duplicate_log, false);
+
     get_yaml_value_optional(config_node, "log-level", &cfg.log_level, static_cast<int>(spdlog::level::trace));
     get_yaml_value_optional(config_node, "pref-path", &cfg.pref_path);
 
@@ -133,7 +135,7 @@ ExitCode deserialize(Config &cfg) {
     try {
         YAML::Node lle_modules_node = config_node["lle-modules"];
 
-        for (auto lle_module_node: lle_modules_node) {
+        for (auto lle_module_node : lle_modules_node) {
             cfg.lle_modules.push_back(lle_module_node.as<std::string>());
         }
     } catch (YAML::Exception &exception) {
@@ -166,7 +168,8 @@ ExitCode init(Config &cfg, int argc, char **argv) {
             ("log-imports,I", po::bool_switch(&cfg.log_imports), "Log Imports")
             ("log-exports,E", po::bool_switch(&cfg.log_exports), "Log Exports")
             ("log-active-shaders,S", po::bool_switch(&cfg.log_active_shaders), "Log Active Shaders")
-            ("log-uniforms,U", po::bool_switch(&cfg.log_uniforms), "Log Uniforms");
+            ("log-uniforms,U", po::bool_switch(&cfg.log_uniforms), "Log Uniforms")
+            ("duplicate-log,D", po::bool_switch(&cfg.duplicate_log), "Makes a duplicate of the log file with TITLE_ID and Game ID as title");
         // clang-format on
 
         // Positional args

--- a/src/emulator/util/include/util/log.h
+++ b/src/emulator/util/include/util/log.h
@@ -25,7 +25,7 @@ namespace logging {
 
 void init();
 void set_level(spdlog::level::level_enum log_level);
-void add_sink(std::string title_id, std::string game_id);
+void add_sink(std::wstring log_path);
 
 #define LOG_TRACE SPDLOG_TRACE
 #define LOG_DEBUG SPDLOG_DEBUG

--- a/src/emulator/util/include/util/log.h
+++ b/src/emulator/util/include/util/log.h
@@ -25,6 +25,7 @@ namespace logging {
 
 void init();
 void set_level(spdlog::level::level_enum log_level);
+void add_sink(std::string title_id, std::string game_id);
 
 #define LOG_TRACE SPDLOG_TRACE
 #define LOG_DEBUG SPDLOG_DEBUG

--- a/src/emulator/util/include/util/string_utils.h
+++ b/src/emulator/util/include/util/string_utils.h
@@ -13,6 +13,7 @@ std::wstring utf_to_wide(const std::string &str);
 std::string wide_to_utf(const std::wstring &str);
 std::string utf16_to_utf8(const std::u16string &str);
 std::u16string utf8_to_utf16(const std::string &str);
+std::string remove_special_chars(std::string str);
 
 } // namespace string_utils
 

--- a/src/emulator/util/src/util.cpp
+++ b/src/emulator/util/src/util.cpp
@@ -81,8 +81,11 @@ void set_level(spdlog::level::level_enum log_level) {
 }
 
 void add_sink(std::wstring log_path) {
+#ifdef _WIN32
     sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path, true));
-
+#else
+    sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(string_utils::wide_to_utf(log_path), true));
+#endif
     spdlog::set_default_logger(std::make_shared<spdlog::logger>("vita3k logger", begin(sinks), end(sinks)));
     spdlog::set_pattern(LOG_PATTERN);
 }

--- a/src/emulator/util/src/util.cpp
+++ b/src/emulator/util/src/util.cpp
@@ -31,6 +31,7 @@ static const
     = "vita3k.log";
 #endif
 
+static const char *LOG_PATTERN = "%^[%H:%M:%S.%e] |%L| [%!]: %v%$";
 std::vector<spdlog::sink_ptr> sinks;
 
 void init() {
@@ -71,7 +72,7 @@ void init() {
         std::cerr << "spdlog error: " << msg << std::endl;
     });
 
-    spdlog::set_pattern("%^[%H:%M:%S.%e] |%L| [%!]: %v%$");
+    spdlog::set_pattern(LOG_PATTERN);
     spdlog::flush_on(spdlog::level::debug);
 }
 
@@ -79,37 +80,11 @@ void set_level(spdlog::level::level_enum log_level) {
     spdlog::set_level(log_level);
 }
 
-void add_sink(std::string title_id, std::string game_id) {
-    try {
-        game_id = string_utils::remove_special_chars(game_id);
-        const auto log_name = fmt::format("{} - [{}].log", game_id, title_id);
-#ifdef WIN32
-        wchar_t buffer[MAX_PATH];
-        GetModuleFileNameW(NULL, buffer, MAX_PATH);
-        std::string::size_type pos = std::wstring(buffer).find_last_of(L"\\\\");
-        std::wstring path = std::wstring(buffer).substr(0, pos);
-
-        if (!path.empty()) {
-            const auto full_log_path = path + L"\\" + L"\\logs\\" + string_utils::utf_to_wide(log_name);
-            sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(full_log_path, true));
-        } else {
-            std::cerr << "failed to get working directory" << std::endl;
-        }
-#else
-        sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_name, true));
-#endif
-    } catch (const spdlog::spdlog_ex &ex) {
-        std::cerr << "File log initialization failed: " << ex.what() << std::endl;
-    }
+void add_sink(std::wstring log_path) {
+    sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path, true));
 
     spdlog::set_default_logger(std::make_shared<spdlog::logger>("vita3k logger", begin(sinks), end(sinks)));
-
-    spdlog::set_error_handler([](const std::string &msg) {
-        std::cerr << "spdlog error: " << msg << std::endl;
-    });
-
-    spdlog::set_pattern("%^[%H:%M:%S.%e] |%L| [%!]: %v%$");
-    spdlog::flush_on(spdlog::level::debug);
+    spdlog::set_pattern(LOG_PATTERN);
 }
 
 } // namespace logging
@@ -157,6 +132,9 @@ std::string remove_special_chars(std::string str) {
         case '|':
         case '*':
             c = ' ';
+            break;
+        default:
+            continue;
         }
     }
     return str;


### PR DESCRIPTION
This PR fixes #402 

- it creates a copy of the log file with the game's name and title id as the file's name.
- the second log file sink is only added after the game has launched which omits the first few config system lines from logging
- it outputs to a new directory called `logs`
- added a config option to enable this from the command line using -A or --archive-log