### PR TITLE
Fixes and miscs

### DIFF
--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -297,6 +297,13 @@ public:
     std::uint32_t unk_78;
     std::uint32_t maybe_parameters_offset2; //not sure
 
+    std::uint32_t unk_80;
+    std::uint32_t unk_84;
+    std::uint32_t unk_88;
+    std::uint32_t unk_8C;
+    std::uint32_t container_count;
+    std::uint32_t container_offset;
+
     emu::SceGxmProgramType get_type() const {
         return static_cast<emu::SceGxmProgramType>(type & 1);
     }
@@ -334,6 +341,14 @@ struct SceGxmProgramParameter {
 };
 
 static_assert(sizeof(SceGxmProgramParameter) == 16, "Incorrect structure layout.");
+
+struct SceGxmProgramParameterContainer
+{
+  uint16_t container_index;
+  uint16_t unk02;
+  uint16_t base_sa_offset;
+  uint16_t max_resource_index;
+};
 
 struct SceGxmRegisteredProgram {
     // TODO This is an opaque type.

--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -411,6 +411,7 @@ namespace gxp {
 enum class GenericParameterType {
     Scalar,
     Vector,
-    Matrix
+    Matrix,
+    Array
 };
 } // namespace gxp

--- a/src/emulator/gxm/src/gxp.cpp
+++ b/src/emulator/gxm/src/gxp.cpp
@@ -87,7 +87,8 @@ GenericParameterType parameter_generic_type(const SceGxmProgramParameter &parame
         if (parameter.array_size > 1) {
             // matrix emission disabled
             // return GenericParameterType::Matrix;
-            return GenericParameterType::Vector;
+            //return GenericParameterType::Vector;
+            return GenericParameterType::Array;
         } else {
             return GenericParameterType::Vector;
         }

--- a/src/emulator/renderer/src/uniforms.cpp
+++ b/src/emulator/renderer/src/uniforms.cpp
@@ -77,12 +77,9 @@ static void set_uniform(GLint location, size_t component_count, GLsizei array_si
             break;
         }
         break;
+
     case 4:
-        if (array_size % 4 == 0) {
-            uniform_matrix_4<T>(location, array_size / 4, GL_FALSE, value);
-        } else {
-            uniform_4<T>(location, array_size, value);
-        }
+        uniform_4<T>(location, array_size, value);
         break;
 
     default:
@@ -145,21 +142,7 @@ static void set_uniforms(GLuint gl_program, ShaderProgram &shader_program, const
             return true;
         };
 
-        // An array only
-        if (parameter.array_size == 1) {
-            do_supply(name, 1, parameter.resource_index);
-        } else {
-            // There are two types: a matrix listed as a bunch of vector
-            //                      Or simply a matrix
-            if (glGetUniformLocation(gl_program, name.c_str()) < 0) {
-                // Do loop
-                for (std::uint32_t i = 0; i < parameter.array_size; i++) {
-                    do_supply(name + "_" + std::to_string(i), 1, parameter.resource_index + i * parameter.component_count);
-                }
-            } else {
-                do_supply(name, parameter.array_size, parameter.resource_index);
-            }
-        }
+        do_supply(name, parameter.array_size, parameter.resource_index);
     }
 }
 

--- a/src/emulator/renderer/src/uniforms.cpp
+++ b/src/emulator/renderer/src/uniforms.cpp
@@ -50,7 +50,7 @@ void uniform_matrix_4<GLint>(GLint location, GLsizei count, GLboolean transpose,
 }
 
 template <class T>
-static void set_uniform(GLint location, size_t component_count, GLsizei array_size, const T *value, const std::string &name, bool log_uniforms) {
+static void set_uniform(GLint location, size_t component_count, GLsizei array_size, const T *value, const std::string &name, bool is_matrix, bool log_uniforms) {
     if (log_uniforms) {
         // warning: shit code
         std::string values = "{ ";
@@ -79,6 +79,11 @@ static void set_uniform(GLint location, size_t component_count, GLsizei array_si
         break;
 
     case 4:
+        if (is_matrix) {
+            uniform_matrix_4<T>(location, array_size / 4, GL_FALSE, value);
+            break;
+        }
+
         uniform_4<T>(location, array_size, value);
         break;
 
@@ -114,6 +119,20 @@ static void set_uniforms(GLuint gl_program, ShaderProgram &shader_program, const
                 return false;
             }
 
+            // This was added for compability with hand-written shaders. GXP shaders don't use matrix, but rather flatten them as array.
+            // Hand-written shaders usually convet them to matrix if possible. Until we get rid of hand-written shaders, this will stay here.
+            bool is_matrix = false;
+
+            gl::GLint usize = 0;
+            gl::GLenum utype {};
+
+            glGetActiveUniform(gl_program, location, 0, nullptr, &usize, &utype, nullptr);
+
+            // TODO: Add more types
+            if (utype == GL_FLOAT_MAT2 || utype == GL_FLOAT_MAT3 || utype == GL_FLOAT_MAT4) {
+                is_matrix = true;
+            }
+
             const SceGxmParameterType type = static_cast<SceGxmParameterType>(static_cast<uint16_t>(parameter.type));
             const Ptr<const void> uniform_buffer = uniform_buffers[parameter.container_index];
             if (!uniform_buffer) {
@@ -128,11 +147,11 @@ static void set_uniforms(GLuint gl_program, ShaderProgram &shader_program, const
             switch (type) {
             case SCE_GXM_PARAMETER_TYPE_S32:
                 src_s32 = reinterpret_cast<const GLint *>(base + idx * 4); // TODO What offset?
-                set_uniform<GLint>(location, parameter.component_count, arr_size, src_s32, name, log_uniforms);
+                set_uniform<GLint>(location, parameter.component_count, arr_size, src_s32, name, is_matrix, log_uniforms);
                 break;
             case SCE_GXM_PARAMETER_TYPE_F32:
                 src_f32 = reinterpret_cast<const GLfloat *>(base + idx * 4); // TODO What offset?
-                set_uniform<GLfloat>(location, parameter.component_count, arr_size, src_f32, name, log_uniforms);
+                set_uniform<GLfloat>(location, parameter.component_count, arr_size, src_f32, name, is_matrix, log_uniforms);
                 break;
             default:
                 LOG_WARN("Type {} not handled for uniform parameter {}.", type, name);

--- a/src/emulator/shader/include/shader/usse_translator.h
+++ b/src/emulator/shader/include/shader/usse_translator.h
@@ -24,6 +24,7 @@
 #include <SPIRV/SpvBuilder.h>
 #include <boost/optional/optional.hpp>
 
+#include <array>
 #include <map>
 
 using boost::optional;
@@ -32,6 +33,7 @@ namespace shader::usse {
 
 // For debugging SPIR-V output
 static uint32_t instr_idx = 0;
+constexpr std::size_t max_sa_registers = 128;
 
 class USSETranslatorVisitor final {
 public:
@@ -48,6 +50,9 @@ public:
     // TODO: Figure out actual PA count limit
     std::unordered_map<uint16_t, SpirvReg> pa_writeable;
 
+    // Each SPIR-V reg will contains 4 SA
+    std::array<SpirvReg, max_sa_registers / 4> sa_supplies;
+
     USSETranslatorVisitor() = delete;
     explicit USSETranslatorVisitor(spv::Builder &_b, const uint64_t &_instr, const SpirvShaderParameters &spirv_params, const SceGxmProgram &program)
         : m_b(_b)
@@ -56,7 +61,7 @@ public:
         , m_program(program) {
         // Import GLSL.std.450
         std_builtins = m_b.import("GLSL.std.450");
-        
+
         // Build common type here, so builder won't have to look it up later
         type_f32 = m_b.makeFloatType(32);
 

--- a/src/emulator/shader/include/shader/usse_translator.h
+++ b/src/emulator/shader/include/shader/usse_translator.h
@@ -37,6 +37,8 @@ class USSETranslatorVisitor final {
 public:
     using instruction_return_type = bool;
 
+    spv::Id std_builtins;
+
     spv::Id type_f32;
     spv::Id type_f32_v[5]; // Starts from 1 ([1] is vec 1)
     spv::Id const_f32[4];
@@ -52,6 +54,9 @@ public:
         , m_instr(_instr)
         , m_spirv_params(spirv_params)
         , m_program(program) {
+        // Import GLSL.std.450
+        std_builtins = m_b.import("GLSL.std.450");
+        
         // Build common type here, so builder won't have to look it up later
         type_f32 = m_b.makeFloatType(32);
 

--- a/src/emulator/shader/include/shader/usse_translator_types.h
+++ b/src/emulator/shader/include/shader/usse_translator_types.h
@@ -48,6 +48,14 @@ struct SpirvVarRegBank {
         return vars;
     }
 
+    void set_next_offset(const std::uint32_t new_next_offset) {
+        next_offset = new_next_offset;
+    }
+
+    std::uint32_t get_next_offset() {
+        return next_offset;
+    }
+
     void push(const SpirvVar &var, uint32_t size) {
         const auto offset = next_offset;
 

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -233,7 +233,8 @@ spv::StorageClass reg_type_to_spv_storage_class(usse::RegisterBank reg_type) {
     return spv::StorageClassMax;
 }
 
-static spv::Id create_spirv_var_reg(spv::Builder &b, SpirvShaderParameters &parameters, std::string &name, usse::RegisterBank reg_type, uint32_t size, spv::Id type, optional<spv::StorageClass> force_storage = boost::none) {
+static spv::Id create_spirv_var_reg(spv::Builder &b, SpirvShaderParameters &parameters, std::string &name, usse::RegisterBank reg_type, uint32_t size, spv::Id type, optional<spv::StorageClass> force_storage = boost::none
+    , boost::optional<std::uint32_t> force_offset = boost::none) {
     sanitize_variable_name(name);
 
     const auto storage_class = force_storage ? *force_storage : reg_type_to_spv_storage_class(reg_type);
@@ -260,6 +261,10 @@ static spv::Id create_spirv_var_reg(spv::Builder &b, SpirvShaderParameters &para
     default:
         LOG_WARN("Unsupported reg_type {}", static_cast<uint32_t>(reg_type));
         return spv::NoResult;
+    }
+
+    if (force_offset) {
+        var_group->set_next_offset(force_offset.value());
     }
 
     var_group->push({ type, var_id }, size);
@@ -538,6 +543,74 @@ static void create_fragment_output(spv::Builder &b, SpirvShaderParameters &param
     parameters.outs.push({ frag_color_type, frag_color_var }, 4);
 }
 
+static const SceGxmProgramParameterContainer *get_containers(const SceGxmProgram &program) {
+    const SceGxmProgramParameterContainer *containers = reinterpret_cast<const SceGxmProgramParameterContainer*>
+        (reinterpret_cast<const std::uint8_t*>(&program.container_offset) + program.container_offset);
+
+    return containers;
+}
+
+static const SceGxmProgramParameterContainer *get_container_by_index(const SceGxmProgram &program, const std::uint16_t idx) {
+    const SceGxmProgramParameterContainer *container = get_containers(program);
+
+    for (std::uint32_t i = 0; i < program.container_count; i++) {
+        if (container[i].container_index == idx) {
+            return &container[i];
+        }
+    }
+
+    return nullptr;
+}
+
+static const char *get_container_name(const std::uint16_t idx) {
+    switch (idx) {
+    case 0:
+        return "BUFFER0 ";
+    case 1:
+        return "BUFFER1 ";
+    case 2:
+        return "BUFFER2 ";
+    case 3:
+        return "BUFFER3 ";
+    case 4:
+        return "BUFFER4 ";
+    case 5:
+        return "BUFFER5 ";
+    case 6:
+        return "BUFFER6 ";
+    case 7:
+        return "BUFFER7 ";
+    case 8:
+        return "BUFFER8 ";
+    case 9:
+        return "BUFFER9 ";
+    case 10:
+        return "BUFFER10";
+    case 11:
+        return "BUFFER11";
+    case 12:
+        return "BUFFER12";
+    case 13:
+        return "BUFFER13";
+    case 14:
+        return "DEFAULT ";
+    case 15:
+        return "TEXTURE ";
+    case 16:
+        return "LITERAL ";
+    case 17:
+        return "SCRATCH ";
+    case 18:
+        return "THREAD  ";
+    case 19:
+        return "DATA    ";
+    default:
+        break;
+    }
+
+    return "INVALID ";
+}
+
 static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProgram &program, emu::SceGxmProgramType program_type, NonDependentTextureQueryCallInfos &texture_queries) {
     SpirvShaderParameters spv_params = {};
     const SceGxmProgramParameter *const gxp_parameters = gxp::program_parameters(program);
@@ -548,13 +621,13 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     for (size_t i = 0; i < program.parameter_count; ++i) {
         const SceGxmProgramParameter &parameter = gxp_parameters[i];
 
-        gxp::log_parameter(parameter);
-
         usse::RegisterBank param_reg_type = usse::RegisterBank::PRIMATTR;
 
         switch (parameter.category) {
         case SCE_GXM_PARAMETER_CATEGORY_UNIFORM:
             param_reg_type = usse::RegisterBank::SECATTR;
+            [[fallthrough]];
+
         // fallthrough
         case SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE: {
             const std::string struct_name = gxp::parameter_struct_name(parameter);
@@ -607,13 +680,33 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                         std::replace(var_name.begin(), var_name.end(), '.', '_');
                 }
 
+                auto container = get_container_by_index(program, parameter.container_index);
+                std::uint32_t offset = parameter.resource_index;
+
+                if (parameter.resource_index < container->max_resource_index) {
+                    offset = container->base_sa_offset + parameter.resource_index;
+                }
+
+                // If no container, we use the absolute offset
                 for (auto p = 0; p < parameter.array_size; ++p) {
                     std::string var_elem_name;
                     if (parameter.array_size == 1)
                         var_elem_name = var_name;
                     else
                         var_elem_name = fmt::format("{}_{}", var_name, p);
-                    create_spirv_var_reg(b, spv_params, var_elem_name, param_reg_type, parameter.component_count, param_type);
+                        
+                    std::string param_log = fmt::format("[{} + {}] {}a{} = {}",
+                        get_container_name(parameter.container_index), parameter.resource_index,
+                        is_uniform ? "s" : "p", offset, var_name);
+
+                    if (parameter.array_size > 1) {
+                        param_log += fmt::format("[{}]", parameter.array_size);
+                    }
+
+                    LOG_DEBUG(param_log);
+
+                    create_spirv_var_reg(b, spv_params, var_elem_name, param_reg_type, parameter.component_count, param_type
+                        , boost::none, offset);
                 }
             }
             break;

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -675,28 +675,6 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                     offset = container->base_sa_offset + parameter.resource_index;
                 }
 
-                // If no container, we use the absolute offset
-                /*
-                for (auto p = 0; p < parameter.array_size; ++p) {
-                    std::string var_elem_name;
-                    if (parameter.array_size == 1)
-                        var_elem_name = var_name;
-                    else
-                        var_elem_name = fmt::format("{}_{}", var_name, p);
-                        
-                    std::string param_log = fmt::format("[{} + {}] {}a{} = {}",
-                        get_container_name(parameter.container_index), parameter.resource_index,
-                        is_uniform ? "s" : "p", offset, var_name);
-
-                    if (parameter.array_size > 1) {
-                        param_log += fmt::format("[{}]", parameter.array_size);
-                    }
-
-                    LOG_DEBUG(param_log);
-
-                    create_spirv_var_reg(b, spv_params, var_elem_name, param_reg_type, parameter.component_count, param_type
-                        , boost::none, (p == 0) ? offset : boost::none);
-                }*/
                 // Make the type
                 std::string param_log = fmt::format("[{} + {}] {}a{} = {}",
                     get_container_name(parameter.container_index), parameter.resource_index,
@@ -772,9 +750,9 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         if (missing_primary_attrs > 2) {
             LOG_ERROR("missing primary attributes: {}", missing_primary_attrs);
         } else if (missing_primary_attrs > 0) {
-            const auto pa_type = b.makeVectorType(b.makeFloatType(32), missing_primary_attrs * 2);
+            const auto pa_type = b.makeVectorType(b.makeFloatType(32), static_cast<int>(missing_primary_attrs * 2));
             std::string pa_name = "pa0_blend";
-            create_spirv_var_reg(b, spv_params, pa_name, usse::RegisterBank::PRIMATTR, missing_primary_attrs * 2, pa_type); // TODO: * 2 is a hack because we don't yet support f16
+            create_spirv_var_reg(b, spv_params, pa_name, usse::RegisterBank::PRIMATTR, static_cast<std::uint32_t>(missing_primary_attrs * 2), pa_type); // TODO: * 2 is a hack because we don't yet support f16
         }
     }
 

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -683,7 +683,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                 auto container = get_container_by_index(program, parameter.container_index);
                 std::uint32_t offset = parameter.resource_index;
 
-                if (parameter.resource_index < container->max_resource_index) {
+                if (container && parameter.resource_index < container->max_resource_index) {
                     offset = container->base_sa_offset + parameter.resource_index;
                 }
 

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -707,6 +707,9 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
 
                     create_spirv_var_reg(b, spv_params, var_elem_name, param_reg_type, parameter.component_count, param_type
                         , boost::none, offset);
+
+                    // TODO: This may varys with component size.
+                    offset += parameter.component_count;
                 }
             }
             break;

--- a/src/emulator/shader/src/usse_translator.cpp
+++ b/src/emulator/shader/src/usse_translator.cpp
@@ -210,7 +210,7 @@ spv::Id USSETranslatorVisitor::load(Operand &op, const Imm4 dest_mask, const std
         const uint32_t reg_left_comp_count = m_b.getNumTypeComponents(reg_left.type_id) - reg_left_comp_offset;
         const uint32_t reg_right_comp_count = m_b.getNumTypeComponents(reg_right.type_id) - reg_right_comp_offset;
 
-        const bool is_equal_comp_count = (reg_left_comp_count == reg_right_comp_count);
+        const bool is_equal_comp_count = (reg_left_comp_count == reg_right_comp_count) && (reg_left_comp_count == dest_comp_count);
 
         if (is_equal_comp_count) {
             const bool is_reg_left_comp_offset = (reg_left_comp_offset == 0);

--- a/src/emulator/shader/src/usse_translator.cpp
+++ b/src/emulator/shader/src/usse_translator.cpp
@@ -66,8 +66,12 @@ bool shader::usse::USSETranslatorVisitor::get_spirv_reg(usse::RegisterBank bank,
 
     if (bank == usse::RegisterBank::PRIMATTR && get_for_store) {
         if (pa_writeable.count(pa_writeable_idx) == 0) {
-            const std::string new_pa_writeable_name = fmt::format("pa{}_temp", std::to_string(reg_offset));
-            const spv::Id new_pa_writeable = m_b.createVariable(spv::StorageClassPrivate, reg.type_id, new_pa_writeable_name.c_str());
+            const std::string new_pa_writeable_name = fmt::format("pa{}_temp", 
+                std::to_string(((reg_offset + shift_offset) / 4) * 4));
+
+            const spv::Id v4t = m_b.makeVectorType(type_f32, 4);
+
+            const spv::Id new_pa_writeable = m_b.createVariable(spv::StorageClassPrivate, v4t, new_pa_writeable_name.c_str());
             m_b.createStore(m_b.createLoad(reg.var_id), new_pa_writeable);
 
             reg.var_id = new_pa_writeable;


### PR DESCRIPTION
- Fix Flood It compile error: error C7011: implicit cast from "vec4" to "vec2", and some bugs in optimization and hacks
- A part of TODO: Correct secondary attribute (SECATTR) generation
- Add support for generating and access array types
- Implement VMIN, VMAX instructions
- Remove unroll

The reason for i say a part is: this doesn't not correct sampler SA offset. I don't know how they are generated yet.