### PR TITLE
gui: Fix Threading Information

### DIFF
--- a/src/emulator/gui/src/allocations_dialog.cpp
+++ b/src/emulator/gui/src/allocations_dialog.cpp
@@ -1,3 +1,20 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 #include <gui/functions.h>
 
 #include "private.h"

--- a/src/emulator/gui/src/disassembly_dialog.cpp
+++ b/src/emulator/gui/src/disassembly_dialog.cpp
@@ -1,3 +1,20 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 #include <gui/functions.h>
 
 #include "private.h"

--- a/src/emulator/gui/src/threads_dialog.cpp
+++ b/src/emulator/gui/src/threads_dialog.cpp
@@ -51,9 +51,10 @@ void draw_thread_details_dialog(HostState &host) {
     ImGui::Text("LR: %08x", lr);
     ImGui::Text("Executing: %s", disassemble(cpu, pc).c_str());
     ImGui::Separator();
-    for (int a = 0; a < 8; a++) {
-        ImGui::Text("r%02i: %08x   r%02i: %08x", a, registers[a], a + 8, registers[a + 8]);
+    for (int a = 0; a < 6; a++) {
+        ImGui::Text("r%02i: %08x   r%02i: %08x", a, registers[a], a + 6, registers[a + 6]);
     }
+    ImGui::Text("r12: %08x", registers[12]);
 
     ImGui::End();
 }
@@ -79,7 +80,7 @@ void draw_threads_dialog(HostState &host) {
             run_state = "Exiting";
             break;
         }
-        if (ImGui::Selectable(fmt::format("{:0>8X}         {:<32}   {:<16}   {:0<8X}",
+        if (ImGui::Selectable(fmt::format("{:0>8X}         {:<32}   {:<16}   {:0>8X}",
                 thread.first, th_state->name, run_state, th_state->stack.get()->get())
                                   .c_str())) {
             host.gui.thread_watch_index = thread.first;

--- a/src/emulator/gui/src/threads_dialog.cpp
+++ b/src/emulator/gui/src/threads_dialog.cpp
@@ -38,8 +38,8 @@ void draw_thread_details_dialog(HostState &host) {
     uint32_t pc = read_pc(cpu);
     uint32_t sp = read_sp(cpu);
     uint32_t lr = read_lr(cpu);
-    uint32_t registers[16];
-    for (size_t a = 0; a < 16; a++)
+    uint32_t registers[13];
+    for (size_t a = 0; a < 13; a++)
         registers[a] = read_reg(cpu, a);
 
     // TODO: Add THUMB/ARM mode viewer. What arch is the cpu currently using?


### PR DESCRIPTION
I found some gui issues while debugging. This PR fixes the following bugs:

- The alignment for the stack pointer value on the thread screen was fixed.

Before:
<img width="636" alt="Screen Shot 2019-03-22 at 11 46 08 PM" src="https://user-images.githubusercontent.com/32211852/54861324-8b5bd900-4cfd-11e9-96d6-5e14c8023da4.png">
After:
<img width="639" alt="Screen Shot 2019-03-22 at 11 46 44 PM" src="https://user-images.githubusercontent.com/32211852/54861328-a7f81100-4cfd-11e9-94a2-cefa77b1eb60.png">

- Registers r13-r15 were hidden from the thread viewer screen. They're aliases for pc, lr and sp which are already shown anyway.
<img width="235" alt="Screen Shot 2019-03-22 at 11 47 21 PM" src="https://user-images.githubusercontent.com/32211852/54861378-6a47b800-4cfe-11e9-88c6-97121bf4abb2.png">

- Headers were added to certain files that were missing them.