### PR TITLE
gen-linux.sh: Add ignore-site-config for boost

### DIFF
--- a/gen-linux.sh
+++ b/gen-linux.sh
@@ -12,7 +12,7 @@ if [[ -z "${CI}" ]]; then
 	sh bootstrap.sh
 
 	# Build our Boost subset
-	./b2 -j5 --build-dir=../boost-build --stagedir=../boost-build stage
+	./b2 --ignore-site-config -j5 --build-dir=../boost-build --stagedir=../boost-build stage
 	cd ../../..
 fi
 


### PR DESCRIPTION
This fixes the build on gentoo and specifically this issue https://github.com/Vita3K/Vita3K/issues/321#issuecomment-450370966

Since the idea is to build an independent copy of boost there's no reason to include the OS site-config