### PR TITLE
gui: Option To Add a Background Image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,6 +27,9 @@
 	path = src/external/spdlog
 	url = https://github.com/gabime/spdlog.git
 	branch = v1.x
+[submodule "src/external/stb"]
+	path = src/external/stb
+	url = https://github.com/nothings/stb
 [submodule "src/external/dirent"]
 	path = src/external/dirent
 	url = https://github.com/tronkko/dirent

--- a/src/emulator/config.cpp
+++ b/src/emulator/config.cpp
@@ -100,6 +100,8 @@ bool serialize(Config &cfg) {
     config_file_emit_optional_single(emitter, "log-level", cfg.log_level);
     config_file_emit_optional_single(emitter, "pref-path", cfg.pref_path);
     config_file_emit_optional_single(emitter, "wait-for-debugger", cfg.wait_for_debugger);
+    config_file_emit_optional_single(emitter, "background-image", cfg.background_image);
+    config_file_emit_optional_single(emitter, "background-alpha", cfg.background_alpha);
 
     emitter << YAML::EndMap;
 
@@ -118,7 +120,7 @@ static bool deserialize(Config &cfg) {
     try {
         config_node = YAML::LoadFile("config.yml");
     } catch (YAML::Exception &exception) {
-        std::cerr << "Config file can't be load: Error: " << exception.what() << "\n";
+        std::cerr << "Config file can't be loaded: Error: " << exception.what() << "\n";
         return false;
     }
 
@@ -132,6 +134,8 @@ static bool deserialize(Config &cfg) {
     get_yaml_value_optional(config_node, "log-level", &cfg.log_level, static_cast<int>(spdlog::level::trace));
     get_yaml_value_optional(config_node, "pref-path", &cfg.pref_path);
     get_yaml_value_optional(config_node, "wait-for-debugger", &cfg.wait_for_debugger);
+    get_yaml_value_optional(config_node, "background-image", &cfg.background_image);
+    get_yaml_value_optional(config_node, "background-alpha", &cfg.background_alpha);
 
     // lle-modules
     try {

--- a/src/emulator/glutil/include/glutil/object.h
+++ b/src/emulator/glutil/include/glutil/object.h
@@ -24,20 +24,25 @@
 
 class GLObject {
 public:
-    using Deleter = std::function<void(GLuint)>;
+    using SingularDeleter = std::function<void(GLuint)>;
+    using AggregateDeleter = std::function<void(int, const GLuint *)>;
 
     GLObject() = default;
     ~GLObject();
 
-    bool init(GLuint name, Deleter deleter);
+    bool init(GLuint name, AggregateDeleter aggregate_deleter);
+    bool init(GLuint name, SingularDeleter singular_deleter);
     GLuint get() const;
     operator GLuint() const;
+    operator bool() const;
 
 private:
+    bool init(GLuint name);
     const GLObject &operator=(const GLObject &) = delete;
 
     GLuint name = 0;
-    Deleter deleter = nullptr;
+    AggregateDeleter aggregate_deleter = nullptr;
+    SingularDeleter singular_deleter = nullptr;
 };
 
 using SharedGLObject = std::shared_ptr<GLObject>;

--- a/src/emulator/glutil/src/object.cpp
+++ b/src/emulator/glutil/src/object.cpp
@@ -20,20 +20,35 @@
 #include <cassert>
 
 GLObject::~GLObject() {
-    if (deleter != nullptr) {
-        deleter(name);
+    if (aggregate_deleter != nullptr) {
+        aggregate_deleter(1, &name);
+    }
+    if (singular_deleter != nullptr) {
+        singular_deleter(name);
     }
     name = 0;
 }
 
-bool GLObject::init(GLuint name, Deleter deleter) {
+bool GLObject::init(GLuint name) {
     assert(name != 0);
     assert(this->name == 0);
     this->name = name;
-    if (deleter)
-        this->deleter = deleter;
 
     return name != 0;
+}
+
+bool GLObject::init(GLuint name, AggregateDeleter aggregate_deleter) {
+    if (aggregate_deleter)
+        this->aggregate_deleter = aggregate_deleter;
+
+    return init(name);
+}
+
+bool GLObject::init(GLuint name, SingularDeleter singular_deleter) {
+    if (singular_deleter)
+        this->singular_deleter = singular_deleter;
+
+    return init(name);
 }
 
 GLuint GLObject::get() const {
@@ -43,5 +58,9 @@ GLuint GLObject::get() const {
 
 GLObject::operator GLuint() const {
     assert(name != 0);
+    return name;
+}
+
+GLObject::operator bool() const {
     return name;
 }

--- a/src/emulator/gui/CMakeLists.txt
+++ b/src/emulator/gui/CMakeLists.txt
@@ -23,4 +23,4 @@ src/about_dialog.cpp
 )
 
 target_include_directories(gui PUBLIC include)
-target_link_libraries(gui PUBLIC sdl2 imgui glutil host kernel cpu util dialog)
+target_link_libraries(gui PUBLIC sdl2 stb imgui glutil host kernel cpu util dialog)

--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -90,6 +90,8 @@ struct State {
     char disassembly_count[5] = "100";
     std::vector<std::string> disassembly;
 
+    uint32_t background_texture = 0;
+
     SceUID thread_watch_index = -1;
 
     // imgui

--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -22,6 +22,8 @@
 #include <imgui.h>
 #include <imgui_memory_editor.h>
 
+#include <glutil/object.h>
+
 namespace gui {
 
 enum SelectorState {
@@ -90,7 +92,7 @@ struct State {
     char disassembly_count[5] = "100";
     std::vector<std::string> disassembly;
 
-    uint32_t background_texture = 0;
+    GLObject background_texture;
 
     SceUID thread_watch_index = -1;
 

--- a/src/emulator/gui/src/game_selector.cpp
+++ b/src/emulator/gui/src/game_selector.cpp
@@ -41,7 +41,7 @@ void draw_game_selector(HostState &host) {
     search_bar.Draw("Search", 300);
 
     if (host.gui.background_texture) {
-        ImGui::GetBackgroundDrawList()->AddImage(reinterpret_cast<void *>(host.gui.background_texture),
+        ImGui::GetBackgroundDrawList()->AddImage(reinterpret_cast<void *>(host.gui.background_texture.get()),
             ImVec2(0, 0), display_size);
     }
 

--- a/src/emulator/gui/src/game_selector.cpp
+++ b/src/emulator/gui/src/game_selector.cpp
@@ -33,10 +33,17 @@ void draw_game_selector(HostState &host) {
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiSetCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - MENUBAR_HEIGHT), ImGuiSetCond_Always);
+    if (host.cfg.background_alpha)
+        ImGui::SetNextWindowBgAlpha(host.cfg.background_alpha.value());
     ImGui::Begin("Game Selector", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
     static ImGuiTextFilter search_bar;
     search_bar.Draw("Search", 300);
+
+    if (host.gui.background_texture) {
+        ImGui::GetBackgroundDrawList()->AddImage(reinterpret_cast<void *>(host.gui.background_texture),
+            ImVec2(0, 0), display_size);
+    }
 
     switch (host.gui.game_selector.state) {
     case SELECT_APP:

--- a/src/emulator/gui/src/gui.cpp
+++ b/src/emulator/gui/src/gui.cpp
@@ -138,8 +138,11 @@ static void init_background(State &gui, const std::string &image_path) {
         return;
     }
 
-    glGenTextures(1, &gui.background_texture);
-    glBindTexture(GL_TEXTURE_2D, gui.background_texture);
+    GLuint texture;
+    glGenTextures(1, &texture);
+    gui.background_texture.init(texture, glDeleteTextures);
+
+    glBindTexture(GL_TEXTURE_2D, gui.background_texture.get());
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);

--- a/src/emulator/gui/src/gui.cpp
+++ b/src/emulator/gui/src/gui.cpp
@@ -29,6 +29,9 @@
 
 #include <SDL_video.h>
 
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+
 #include <fstream>
 #include <string>
 
@@ -120,12 +123,40 @@ static void init_font(State &gui) {
     gui.normal_font = io.Fonts->AddFontFromMemoryTTF(gui.font_data.data(), font_file_size, 16, &font_config, io.Fonts->GetGlyphRangesJapanese());
 }
 
+static void init_background(State &gui, const std::string &image_path) {
+    if (!std::ifstream(image_path).good()) {
+        LOG_INFO("Invalid background file path {}.", image_path);
+        return;
+    }
+
+    int32_t width = 0;
+    int32_t height = 0;
+    stbi_uc *data = stbi_load(image_path.c_str(), &width, &height, nullptr, 3);
+
+    if (!data) {
+        LOG_INFO("Could not load background from {}.", image_path);
+        return;
+    }
+
+    glGenTextures(1, &gui.background_texture);
+    glBindTexture(GL_TEXTURE_2D, gui.background_texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+}
+
 void init(HostState &host) {
     ImGui::CreateContext();
     ImGui_ImplSdlGL3_Init(host.window.get());
 
     init_style();
     init_font(host.gui);
+    if (host.cfg.background_image) {
+        init_background(host.gui, host.cfg.background_image.value());
+    }
 }
 
 void draw_begin(HostState &host) {

--- a/src/emulator/gui/src/gui.cpp
+++ b/src/emulator/gui/src/gui.cpp
@@ -131,7 +131,7 @@ static void init_background(State &gui, const std::string &image_path) {
 
     int32_t width = 0;
     int32_t height = 0;
-    stbi_uc *data = stbi_load(image_path.c_str(), &width, &height, nullptr, 3);
+    stbi_uc *data = stbi_load(image_path.c_str(), &width, &height, nullptr, STBI_rgb_alpha);
 
     if (!data) {
         LOG_INFO("Could not load background from {}.", image_path);
@@ -140,7 +140,7 @@ static void init_background(State &gui, const std::string &image_path) {
 
     glGenTextures(1, &gui.background_texture);
     glBindTexture(GL_TEXTURE_2D, gui.background_texture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_REPEAT);

--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -40,4 +40,6 @@ struct Config {
     optional<std::string> pref_path;
     bool archive_log = false;
     optional<bool> wait_for_debugger;
+    optional<std::string> background_image;
+    optional<float> background_alpha;
 };

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -54,6 +54,9 @@ target_include_directories(elfio INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/elfio")
 add_subdirectory(spdlog EXCLUDE_FROM_ALL)
 target_compile_definitions(spdlog INTERFACE SPDLOG_WCHAR_FILENAMES=1 SPDLOG_NO_THREAD_ID=1 SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
+add_library(stb INTERFACE)
+target_include_directories(stb INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/stb")
+
 option(BUILD_SHARED_LIBS "Build shared instead of static libraries." OFF)
 option(OPTION_BUILD_TOOLS "Build tools." OFF)
 option(OPTION_BUILD_EXAMPLES "Build examples." OFF)


### PR DESCRIPTION
As per request, config.yml accepts the `background-image` and `background-alpha` options.

`background-image` is an optional path to some picture on your hardrive. It changes your launch page's background for some nice tasty customization. It should stretch to fit your screen, just pretend that it is in the next screenshot.
<img width="1072" alt="Screen Shot 2019-04-21 at 12 05 34 PM" src="https://user-images.githubusercontent.com/32211852/56472994-67420380-6433-11e9-990e-88bb15bb52c5.png">

`background-alpha` is an optional decimal that lets you see the image more or less. The higher the value, the harder it is to see. Kinda confusing imo but at least it works.