### PR TITLE
kernel/load_self: Fix a crash when there's a non-PT_LOAD segment present

### DIFF
--- a/src/emulator/kernel/src/load_self.cpp
+++ b/src/emulator/kernel/src/load_self.cpp
@@ -458,9 +458,16 @@ SceUID load_self(Ptr<const void> &entry_point, KernelState &kernel, MemState &me
     strncpy(sceKernelModuleInfo->path, self_path.c_str(), 255);
 
     for (Elf_Half segment_index = 0; segment_index < elf.e_phnum; ++segment_index) {
-        sceKernelModuleInfo->segments[segment_index].size = sizeof(sceKernelModuleInfo->segments[segment_index]);
-        sceKernelModuleInfo->segments[segment_index].vaddr = segment_reloc_info[segment_index].addr;
-        sceKernelModuleInfo->segments[segment_index].memsz = segments[segment_index].p_memsz;
+        emu::SceKernelSegmentInfo &segment = sceKernelModuleInfo->segments[segment_index];
+        segment.size = sizeof(segment);
+
+        auto it = segment_reloc_info.find(segment_index);
+        if (it != segment_reloc_info.end())
+            segment.vaddr = it->second.addr;
+        else
+            segment.vaddr = 0;
+
+        segment.memsz = segments[segment_index].p_memsz;
     }
 
     sceKernelModuleInfo->type = module_info->type;


### PR DESCRIPTION
When there's a segment of non-PT_LOAD type (for example, `PT_SCE_COMMENT`), load_self would crash when it attempts to read a non-existent value from the std::map.

I've also taken the liberty to clean up the nearby code a little reducing the copypasta.

Repro: OrangeSunflower.vpk homebrew (or possibly any Unity homebrew). But it still crashes later, seemingly for a different reason.