### PR TITLE
kernel/load_self: Add another check for when the segment shouldn't be loaded

### DIFF
--- a/src/emulator/kernel/include/kernel/types.h
+++ b/src/emulator/kernel/include/kernel/types.h
@@ -26,6 +26,8 @@
 
 #define SCE_ERROR_ERRNO_EINVAL 0x80010016
 
+constexpr size_t MODULE_INFO_NUM_SEGMENTS = 4;
+
 namespace emu {
 struct SceKernelSegmentInfo {
     SceUInt size; //!< sizeof(SceKernelSegmentInfo)
@@ -53,7 +55,7 @@ struct SceKernelModuleInfo {
     SceSize tlsInitSize;
     SceSize tlsAreaSize;
     char path[256];
-    SceKernelSegmentInfo segments[4];
+    SceKernelSegmentInfo segments[MODULE_INFO_NUM_SEGMENTS];
     SceUInt type; //!< 6 = user-mode PRX?
 };
 

--- a/src/emulator/kernel/src/load_self.cpp
+++ b/src/emulator/kernel/src/load_self.cpp
@@ -463,7 +463,7 @@ SceUID load_self(Ptr<const void> &entry_point, KernelState &kernel, MemState &me
         if (it == segment_reloc_info.end())
             continue;
 
-        if (segment_index >= 4) {
+        if (segment_index >= MODULE_INFO_NUM_SEGMENTS) {
             LOG_ERROR("Segment {} should not be loadable", segment_index);
             continue;
         }


### PR DESCRIPTION
As we only have up to 4 segments in the structure, don't attempt to place any more than that.