### PR TITLE
audio: Fix use after free in mix_out_port

### DIFF
--- a/src/emulator/audio/src/audio.cpp
+++ b/src/emulator/audio/src/audio.cpp
@@ -49,8 +49,9 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
             output.buf += bytes_to_put;
             output.len_bytes -= bytes_to_put;
             if (output.len_bytes <= 0) {
+                const SceUID thread = output.thread;
                 port.shared.outputs.pop();
-                resume_thread(output.thread);
+                resume_thread(thread);
             }
         }
 


### PR DESCRIPTION
`output` becomes invalidated after calling `pop()`