### PR TITLE
System: Add choice console language in config.

### DIFF
--- a/src/emulator/config.cpp
+++ b/src/emulator/config.cpp
@@ -19,6 +19,7 @@
 
 #include <gui/state.h>
 #include <host/version.h>
+#include <psp2/system_param.h>
 #include <util/log.h>
 #include <util/string_utils.h>
 
@@ -98,6 +99,7 @@ bool serialize(Config &cfg) {
     config_file_emit_single(emitter, "show-gui", cfg.show_gui);
     config_file_emit_single(emitter, "icon-size", cfg.icon_size);
     config_file_emit_single(emitter, "archive-log", cfg.archive_log);
+    config_file_emit_single(emitter, "sys-lang", cfg.sys_lang);
     config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
     config_file_emit_optional_single(emitter, "log-level", cfg.log_level);
     config_file_emit_optional_single(emitter, "pref-path", cfg.pref_path);
@@ -134,6 +136,7 @@ static bool deserialize(Config &cfg) {
     get_yaml_value(config_node, "show-gui", &cfg.show_gui, false);
     get_yaml_value(config_node, "icon-size", &cfg.icon_size, static_cast<int>(gui::ICON_SIZE_DEFAULT));
     get_yaml_value(config_node, "archive-log", &cfg.archive_log, false);
+    get_yaml_value(config_node, "sys-lang", &cfg.sys_lang, static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US));
     get_yaml_value_optional(config_node, "log-level", &cfg.log_level, static_cast<int>(spdlog::level::trace));
     get_yaml_value_optional(config_node, "pref-path", &cfg.pref_path);
     get_yaml_value_optional(config_node, "wait-for-debugger", &cfg.wait_for_debugger);

--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -30,6 +30,7 @@ struct Config {
     optional<std::string> run_title_id;
     optional<std::string> recompile_shader_path;
     optional<int> log_level;
+    int sys_lang;
     bool log_imports = false;
     bool log_exports = false;
     bool log_active_shaders = false;

--- a/src/emulator/modules/SceAppUtil/SceAppUtil.cpp
+++ b/src/emulator/modules/SceAppUtil/SceAppUtil.cpp
@@ -273,9 +273,13 @@ EXPORT(int, sceAppUtilStoreBrowse) {
 }
 
 EXPORT(int, sceAppUtilSystemParamGetInt, unsigned int paramId, int *value) {
+    auto sys_lang = static_cast<SceSystemParamLang>(host.cfg.sys_lang);
+    if (sys_lang > SCE_SYSTEM_PARAM_LANG_TURKISH)
+        sys_lang = SCE_SYSTEM_PARAM_LANG_ENGLISH_US;
+
     switch (paramId) {
     case SCE_SYSTEM_PARAM_ID_LANG:
-        *value = SCE_SYSTEM_PARAM_LANG_ENGLISH_US;
+        *value = sys_lang;
         return 0;
     case SCE_SYSTEM_PARAM_ID_ENTER_BUTTON:
         *value = SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS;


### PR DESCRIPTION
- Add choice language inside config file.
Tested with few langue full working, here in french
![image](https://user-images.githubusercontent.com/5261759/57053010-77f04600-6c8b-11e9-8da0-06efa2bec350.png)
Ingame here in spanich
![image](https://user-images.githubusercontent.com/5261759/57053099-2f855800-6c8c-11e9-8114-31c2ffc21593.png)
List of Language available, first is 0 and last is 19
>	Japanese = 0
	American English = 2 // Default value 
	French = 2
	Spanish = 3
	German = 4
	Italian = 5
	Dutch = 6
	Portugal Portuguese = 7
	Russian = 8
	Korean = 9
	Traditional Chinese = 10
	Simplified Chinese = 11
	Finnish = 12
	Swedish = 13
	Danish = 14
	Norwegian  = 15
	Polish = 16
	Brazil Portuguese = 17
	British English = 18
	Turkish = 19

so set in config 0 to 19 like you want used
- Important for user: All PSVita game not have all language, very lot gamer have only English.
