### PR TITLE
Settings/Gui: Add news settings dialog and misc things

### DIFF
--- a/src/emulator/config.cpp
+++ b/src/emulator/config.cpp
@@ -99,6 +99,7 @@ bool serialize(Config &cfg) {
     config_file_emit_single(emitter, "show-gui", cfg.show_gui);
     config_file_emit_single(emitter, "icon-size", cfg.icon_size);
     config_file_emit_single(emitter, "archive-log", cfg.archive_log);
+    config_file_emit_single(emitter, "sys-button", cfg.sys_button);
     config_file_emit_single(emitter, "sys-lang", cfg.sys_lang);
     config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
     config_file_emit_optional_single(emitter, "log-level", cfg.log_level);
@@ -136,6 +137,7 @@ static bool deserialize(Config &cfg) {
     get_yaml_value(config_node, "show-gui", &cfg.show_gui, false);
     get_yaml_value(config_node, "icon-size", &cfg.icon_size, static_cast<int>(gui::ICON_SIZE_DEFAULT));
     get_yaml_value(config_node, "archive-log", &cfg.archive_log, false);
+    get_yaml_value(config_node, "sys-button", &cfg.sys_button, static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS));
     get_yaml_value(config_node, "sys-lang", &cfg.sys_lang, static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US));
     get_yaml_value_optional(config_node, "log-level", &cfg.log_level, static_cast<int>(spdlog::level::trace));
     get_yaml_value_optional(config_node, "pref-path", &cfg.pref_path);

--- a/src/emulator/config.cpp
+++ b/src/emulator/config.cpp
@@ -17,7 +17,6 @@
 
 #include "config.h"
 
-#include <gui/state.h>
 #include <host/version.h>
 #include <psp2/system_param.h>
 #include <util/log.h>
@@ -99,14 +98,15 @@ bool serialize(Config &cfg) {
     config_file_emit_single(emitter, "show-gui", cfg.show_gui);
     config_file_emit_single(emitter, "icon-size", cfg.icon_size);
     config_file_emit_single(emitter, "archive-log", cfg.archive_log);
+    config_file_emit_single(emitter, "texture-cache", cfg.texture_cache);
     config_file_emit_single(emitter, "sys-button", cfg.sys_button);
     config_file_emit_single(emitter, "sys-lang", cfg.sys_lang);
+    config_file_emit_single(emitter, "background-alpha", cfg.background_alpha);
     config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
     config_file_emit_optional_single(emitter, "log-level", cfg.log_level);
     config_file_emit_optional_single(emitter, "pref-path", cfg.pref_path);
     config_file_emit_optional_single(emitter, "wait-for-debugger", cfg.wait_for_debugger);
     config_file_emit_optional_single(emitter, "background-image", cfg.background_image);
-    config_file_emit_optional_single(emitter, "background-alpha", cfg.background_alpha);
 
     emitter << YAML::EndMap;
 
@@ -135,15 +135,16 @@ static bool deserialize(Config &cfg) {
     get_yaml_value(config_node, "log-uniforms", &cfg.log_uniforms, false);
     get_yaml_value(config_node, "pstv-mode", &cfg.pstv_mode, false);
     get_yaml_value(config_node, "show-gui", &cfg.show_gui, false);
-    get_yaml_value(config_node, "icon-size", &cfg.icon_size, static_cast<int>(gui::ICON_SIZE_DEFAULT));
+    get_yaml_value(config_node, "icon-size", &cfg.icon_size, static_cast<int>(64));
     get_yaml_value(config_node, "archive-log", &cfg.archive_log, false);
+    get_yaml_value(config_node, "texture-cache", &cfg.texture_cache, true);
     get_yaml_value(config_node, "sys-button", &cfg.sys_button, static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS));
     get_yaml_value(config_node, "sys-lang", &cfg.sys_lang, static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US));
+    get_yaml_value(config_node, "background-alpha", &cfg.background_alpha, 0.000f);
     get_yaml_value_optional(config_node, "log-level", &cfg.log_level, static_cast<int>(spdlog::level::trace));
     get_yaml_value_optional(config_node, "pref-path", &cfg.pref_path);
     get_yaml_value_optional(config_node, "wait-for-debugger", &cfg.wait_for_debugger);
     get_yaml_value_optional(config_node, "background-image", &cfg.background_image);
-    get_yaml_value_optional(config_node, "background-alpha", &cfg.background_alpha);
 
     // lle-modules
     try {

--- a/src/emulator/gui/CMakeLists.txt
+++ b/src/emulator/gui/CMakeLists.txt
@@ -15,6 +15,7 @@ src/mutexes_dialog.cpp
 src/private.h
 src/reinstall.cpp
 src/semaphores_dialog.cpp
+src/settings_dialog.cpp
 src/threads_dialog.cpp
 src/controls_dialog.cpp
 src/allocations_dialog.cpp
@@ -22,5 +23,5 @@ src/disassembly_dialog.cpp
 src/about_dialog.cpp
 )
 
-target_include_directories(gui PUBLIC include)
+target_include_directories(gui PUBLIC ${PROJECT_SOURCE_DIR}/src/emulator include)
 target_link_libraries(gui PUBLIC sdl2 stb imgui glutil host kernel cpu util dialog)

--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -67,8 +67,8 @@ struct DebugMenuState {
     bool disassembly_dialog = false;
 };
 
-struct OptimisationMenuState {
-    bool texture_cache = true;
+struct ConfigurationMenuState {
+    bool settings_dialog = false;
 };
 
 struct HelpMenuState {
@@ -79,7 +79,7 @@ struct HelpMenuState {
 struct State {
     bool renderer_focused = true;
     DebugMenuState debug_menu;
-    OptimisationMenuState optimisation_menu;
+    ConfigurationMenuState configuration_menu;
     HelpMenuState help_menu;
     DialogState common_dialog;
     GamesSelector game_selector;
@@ -101,14 +101,6 @@ struct State {
     ImFont *normal_font{};
     ImFont *monospaced_font{};
     std::vector<char> font_data;
-};
-
-enum IconSize {
-    ICON_SIZE_SMALL,
-    ICON_SIZE_DEFAULT,
-    ICON_SIZE_MEDIUM,
-    ICON_SIZE_LARGE,
-    ICON_SIZE_ORIGINAL,
 };
 
 } // namespace gui

--- a/src/emulator/gui/src/game_selector.cpp
+++ b/src/emulator/gui/src/game_selector.cpp
@@ -33,8 +33,7 @@ void draw_game_selector(HostState &host) {
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiSetCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - MENUBAR_HEIGHT), ImGuiSetCond_Always);
-    if (host.cfg.background_alpha)
-        ImGui::SetNextWindowBgAlpha(host.cfg.background_alpha.value());
+    ImGui::SetNextWindowBgAlpha(host.cfg.background_alpha);
     ImGui::Begin("Game Selector", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
     static ImGuiTextFilter search_bar;
@@ -44,18 +43,7 @@ void draw_game_selector(HostState &host) {
             ImVec2(0, 0), display_size);
     }
 
-    constexpr float default_icon_scale = 64.0f;
-    float icon_scale = default_icon_scale;
-
-    const auto icon_size = static_cast<gui::IconSize>(host.cfg.icon_size);
-    switch (icon_size) {
-    case ICON_SIZE_SMALL: icon_scale = icon_scale / 2; break;
-    case ICON_SIZE_DEFAULT: break;
-    case ICON_SIZE_MEDIUM: icon_scale = icon_scale + 16; break;
-    case ICON_SIZE_LARGE: icon_scale = icon_scale + 32; break;
-    case ICON_SIZE_ORIGINAL: icon_scale = icon_scale * 2; break;
-    default: break;
-    }
+    static int &icon_size = host.cfg.icon_size;
 
     switch (host.gui.game_selector.state) {
     case SELECT_APP:
@@ -63,7 +51,7 @@ void draw_game_selector(HostState &host) {
         ImGui::SetWindowFontScale(1.1f);
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
         ImGui::Button("Icon"); // Button to fit style, does nothing.
-        ImGui::SetColumnWidth(0, icon_scale + /* padding */ 20);
+        ImGui::SetColumnWidth(0, icon_size + /* padding */ 20);
         ImGui::NextColumn();
         std::string title_id_label = "TitleID";
         switch (host.gui.game_selector.title_id_sort_state) {
@@ -181,16 +169,16 @@ void draw_game_selector(HostState &host) {
                 continue;
             if (host.gui.game_selector.icons[game.title_id]) {
                 GLuint texture = host.gui.game_selector.icons[game.title_id].get();
-                if (ImGui::ImageButton(reinterpret_cast<void *>(texture), ImVec2(icon_scale, icon_scale))) {
+                if (ImGui::ImageButton(reinterpret_cast<void *>(texture), ImVec2(icon_size, icon_size))) {
                     selected[0] = true;
                 }
             }
             ImGui::NextColumn();
-            ImGui::Selectable(game.title_id.c_str(), &selected[1], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_scale));
+            ImGui::Selectable(game.title_id.c_str(), &selected[1], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
             ImGui::NextColumn();
-            ImGui::Selectable(game.app_ver.c_str(), &selected[2], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_scale));
+            ImGui::Selectable(game.app_ver.c_str(), &selected[2], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
             ImGui::NextColumn();
-            ImGui::Selectable(game.title.c_str(), &selected[3], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_scale));
+            ImGui::Selectable(game.title.c_str(), &selected[3], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
             ImGui::NextColumn();
             if (std::find(std::begin(selected), std::end(selected), true) != std::end(selected)) {
                 host.gui.game_selector.selected_title_id = game.title_id;

--- a/src/emulator/gui/src/gui.cpp
+++ b/src/emulator/gui/src/gui.cpp
@@ -73,8 +73,8 @@ static void init_style() {
     style->Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
     style->Colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.46f, 0.56f, 0.58f, 1.00f);
     style->Colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
-    style->Colors[ImGuiCol_CheckMark] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
-    style->Colors[ImGuiCol_SliderGrab] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
+    style->Colors[ImGuiCol_CheckMark] = ImVec4(1.00f, 0.55f, 0.00f, 1.00f);
+    style->Colors[ImGuiCol_SliderGrab] = ImVec4(1.00f, 0.55f, 0.00f, 1.00f);
     style->Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
     style->Colors[ImGuiCol_Button] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
     style->Colors[ImGuiCol_ButtonHovered] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
@@ -88,6 +88,9 @@ static void init_style() {
     style->Colors[ImGuiCol_ResizeGrip] = ImVec4(0.18f, 0.18f, 0.18f, 0.20f);
     style->Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.22f, 0.22f, 0.22f, 1.00f);
     style->Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.32f, 0.32f, 0.32f, 1.00f);
+    style->Colors[ImGuiCol_Tab] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
+    style->Colors[ImGuiCol_TabHovered] = ImVec4(0.32f, 0.30f, 0.23f, 1.00f);
+    style->Colors[ImGuiCol_TabActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
     style->Colors[ImGuiCol_PlotLines] = ImVec4(0.40f, 0.39f, 0.38f, 0.63f);
     style->Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.25f, 1.00f, 0.00f, 1.00f);
     style->Colors[ImGuiCol_PlotHistogram] = ImVec4(0.40f, 0.39f, 0.38f, 0.63f);
@@ -240,6 +243,9 @@ void draw_ui(HostState &host) {
     }
     if (host.gui.debug_menu.disassembly_dialog) {
         draw_disassembly_dialog(host);
+    }
+    if (host.gui.configuration_menu.settings_dialog) {
+        draw_settings_dialog(host);
     }
     if (host.gui.help_menu.controls_dialog) {
         draw_controls_dialog(host);

--- a/src/emulator/gui/src/main_menubar.cpp
+++ b/src/emulator/gui/src/main_menubar.cpp
@@ -40,31 +40,10 @@ static void draw_debug_menu(DebugMenuState &state) {
     }
 }
 
-static void draw_config_menu(HostState &host) {
+static void draw_config_menu(ConfigurationMenuState &state) {
     if (ImGui::BeginMenu("Configuration")) {
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
-        if (ImGui::BeginMenu("Emulated Console")) {
-            if (ImGui::MenuItem("PS Vita", nullptr, !host.cfg.pstv_mode)) {
-                host.cfg.pstv_mode = false;
-            }
-            if (ImGui::MenuItem("PS TV", nullptr, host.cfg.pstv_mode)) {
-                host.cfg.pstv_mode = true;
-            }
-            ImGui::EndMenu();
-        }
-        if (ImGui::BeginMenu("GUI")) {
-            ImGui::MenuItem("Enable", nullptr, &host.cfg.show_gui);
-            ImGui::EndMenu();
-        }
-        ImGui::PopStyleColor();
-        ImGui::EndMenu();
-    }
-}
-
-static void draw_optimisation_menu(OptimisationMenuState &state) {
-    if (ImGui::BeginMenu("Optimisation")) {
-        ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
-        ImGui::MenuItem("Texture Cache", nullptr, &state.texture_cache);
+        ImGui::MenuItem("Settings", nullptr, &state.settings_dialog);
         ImGui::PopStyleColor();
         ImGui::EndMenu();
     }
@@ -85,8 +64,7 @@ void draw_main_menu_bar(HostState &host) {
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
 
         draw_debug_menu(host.gui.debug_menu);
-        draw_config_menu(host);
-        draw_optimisation_menu(host.gui.optimisation_menu);
+        draw_config_menu(host.gui.configuration_menu);
         draw_help_menu(host.gui.help_menu);
 
         ImGui::PopStyleColor();

--- a/src/emulator/gui/src/private.h
+++ b/src/emulator/gui/src/private.h
@@ -45,6 +45,7 @@ void draw_condvars_dialog(HostState &host);
 void draw_event_flags_dialog(HostState &host);
 void draw_allocations_dialog(HostState &host);
 void draw_disassembly_dialog(HostState &host);
+void draw_settings_dialog(HostState &host);
 void draw_controls_dialog(HostState &host);
 void draw_about_dialog(HostState &host);
 

--- a/src/emulator/gui/src/settings_dialog.cpp
+++ b/src/emulator/gui/src/settings_dialog.cpp
@@ -1,0 +1,118 @@
+// Vita3K emulator project
+// Copyright (C) 2019 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "private.h"
+#include <config.h>
+#include <host/state.h>
+
+namespace gui {
+
+void draw_settings_dialog(HostState &host) {
+    ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+    ImGui::Begin("Settings", &host.gui.configuration_menu.settings_dialog, ImGuiWindowFlags_AlwaysAutoResize);
+    ImGuiTabBarFlags settings_tab_flags = ImGuiTabBarFlags_None;
+    ImGui::BeginTabBar("SettingsTabBar", settings_tab_flags);
+
+    // System
+    if (ImGui::BeginTabItem("System")) {
+        ImGui::PopStyleColor();
+        static const char *list_sys_lang[] = {
+            "Japanese", "American English", "French", "Spanish", "German", "Italian", "Dutch", "Portugal Portuguese", "Russian", "Korean",
+            "Traditional Chinese", "Simplified Chinese", "Finnish", "Swedish", "Danish", "Norwegian", "Polish", "Brazil Portuguese", "British English", "Turkish"
+        };
+        ImGui::Combo("Console Languague \nSelect your Languague.", &host.cfg.sys_lang, list_sys_lang, IM_ARRAYSIZE(list_sys_lang), 10);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Some games might not have your language.");
+        ImGui::Spacing();
+        ImGui::Text("Enter Button Assignement \nSelect your 'Enter' Button.");
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("This is the button that is used as 'Confirm' in game dialogs. \nSome games don't use this and get default confirmation button.");
+        ImGui::RadioButton("Circle", &host.cfg.sys_button, 0);
+        ImGui::RadioButton("Cross", &host.cfg.sys_button, 1);
+        ImGui::Spacing();
+        ImGui::Checkbox("Emulated Console \nSelect your Console mode.", &host.cfg.pstv_mode);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Check the box to enable PS TV mode.");
+        ImGui::EndTabItem();
+    } else {
+        ImGui::PopStyleColor();
+    }
+
+    // Emulator
+    ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+    if (ImGui::BeginTabItem("Emulator")) {
+        ImGui::PopStyleColor();
+        ImGui::Checkbox("Archive Log", &host.cfg.archive_log);
+        ImGui::SameLine();
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Check the box to enable Archiving Log.");
+        ImGui::Checkbox("Texture Cache", &host.cfg.texture_cache);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Uncheck the box to disable texture cache.");
+        ImGui::EndTabItem();
+    } else {
+        ImGui::PopStyleColor();
+    }
+
+    // GUI
+    ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+    if (ImGui::BeginTabItem("GUI")) {
+        ImGui::PopStyleColor();
+        ImGui::Checkbox("GUI Visible", &host.cfg.show_gui);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Check the box to show GUI after booting a game.");
+        ImGui::Spacing();
+        ImGui::SliderInt("Game Icon Size \nSelect your preferred icon size.", &host.cfg.icon_size, 16, 128);
+        ImGui::Spacing();
+        ImGui::SliderFloat("Background Alpha \nSelect your preferred transparent background effect.", &host.cfg.background_alpha, 0.999f, 0.000f);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Minimum slider is opaque and maximum is transparent.");
+        ImGui::EndTabItem();
+    } else {
+        ImGui::PopStyleColor();
+    }
+
+    // Debug
+    ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+    if (ImGui::BeginTabItem("Debug")) {
+        ImGui::PopStyleColor();
+        ImGui::Checkbox("Log Imports", &host.cfg.log_imports);
+        ImGui::SameLine();
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Log module import symbols.");
+        ImGui::Checkbox("Log Exports", &host.cfg.log_exports);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Log module export symbols.");
+        ImGui::Spacing();
+        ImGui::Checkbox("Log Shaders", &host.cfg.log_active_shaders);
+        ImGui::SameLine();
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Log shaders being used on each draw call.");
+        ImGui::Checkbox("Log Uniforms", &host.cfg.log_uniforms);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Log shader uniform names and values.");
+        ImGui::EndTabItem();
+    } else {
+        ImGui::PopStyleColor();
+    }
+
+    config::serialize(host.cfg);
+    ImGui::EndTabBar();
+    ImGui::End();
+}
+
+} // namespace gui

--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -41,8 +41,9 @@ struct Config {
     bool show_gui = false;
     optional<std::string> pref_path;
     bool archive_log = false;
+    bool texture_cache = true;
     optional<bool> wait_for_debugger;
     optional<std::string> background_image;
-    optional<float> background_alpha;
+    float background_alpha;
     int icon_size;
 };

--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -30,6 +30,7 @@ struct Config {
     optional<std::string> run_title_id;
     optional<std::string> recompile_shader_path;
     optional<int> log_level;
+    int sys_button;
     int sys_lang;
     bool log_imports = false;
     bool log_exports = false;

--- a/src/emulator/modules/SceAppUtil/SceAppUtil.cpp
+++ b/src/emulator/modules/SceAppUtil/SceAppUtil.cpp
@@ -273,16 +273,15 @@ EXPORT(int, sceAppUtilStoreBrowse) {
 }
 
 EXPORT(int, sceAppUtilSystemParamGetInt, unsigned int paramId, int *value) {
-    auto sys_lang = static_cast<SceSystemParamLang>(host.cfg.sys_lang);
-    if (sys_lang > SCE_SYSTEM_PARAM_LANG_TURKISH)
-        sys_lang = SCE_SYSTEM_PARAM_LANG_ENGLISH_US;
+    const SceSystemParamLang sys_lang = static_cast<SceSystemParamLang>(host.cfg.sys_lang);
+    const SceSystemParamEnterButtonAssign sys_button = static_cast<SceSystemParamEnterButtonAssign>(host.cfg.sys_button);
 
     switch (paramId) {
     case SCE_SYSTEM_PARAM_ID_LANG:
         *value = sys_lang;
         return 0;
     case SCE_SYSTEM_PARAM_ID_ENTER_BUTTON:
-        *value = SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS;
+        *value = sys_button;
         return 0;
     default:
         return RET_ERROR(SCE_APPUTIL_ERROR_PARAMETER);

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -416,7 +416,7 @@ EXPORT(int, sceGxmDraw, SceGxmContext *context, SceGxmPrimitiveType primType, Sc
         context->state.fragment_last_reserve_status = SceGxmLastReserveStatus::Available;
     }
 
-    if (!renderer::sync_state(context->renderer, context->state, host.mem, host.gui.optimisation_menu.texture_cache, host.cfg.log_active_shaders, host.cfg.log_uniforms)) {
+    if (!renderer::sync_state(context->renderer, context->state, host.mem, host.cfg.texture_cache, host.cfg.log_active_shaders, host.cfg.log_uniforms)) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 


### PR DESCRIPTION
Thx @VelocityRa for have help me for found how save value inside config and for helping first with PopStyleColor and some other thing found.
Thx also @1whatleytay for have help me on get better description.
Thx too @pent0 for fix my color issue on Tab title.

- Add news Settings dialog with tabs category (System, Emulator , GUI, and Debug) for configure GUI hiden, Icon Size with news Slider, Background Alpha with slider, Console Language, Button Assign, Archive Log, texture Cache and Console mode and all Diferent Log in Debug . 
- Gui/system: Add Assign enter button selection.
- Setting: change color for checkbox and slider for better view.
- Setting: Add 3 tab color for get different color active/no active and hovered.
- Remove Optimizations Bar Menu for set Texture Cache option inside Settings Dialog.
- Update imgui_club submodule, fix few warning and fix VS2019 compile.

# Result: 
- System tab
![image](https://user-images.githubusercontent.com/5261759/57178476-dc202f00-6e70-11e9-9e4b-bddb8d8a06ba.png)

- Emulator tab
![image](https://user-images.githubusercontent.com/5261759/57179907-738e7d80-6e83-11e9-947d-d7a3754f3e6e.png)

- GUI tab
![image](https://user-images.githubusercontent.com/5261759/57178478-e8a48780-6e70-11e9-8188-80188f30c43a.png)
 
- Debug tab 
![image](https://user-images.githubusercontent.com/5261759/57178482-fce88480-6e70-11e9-95c2-c4c1c87309fb.png)



