### PR TITLE
Use unicorn as submodule in Unix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "src/external/imgui_club"]
 	path = src/external/imgui_club
 	url = https://github.com/ocornut/imgui_club.git
+[submodule "src/external/unicorn-src"]
+	path = src/external/unicorn-src
+	url = https://github.com/unicorn-engine/unicorn.git

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+
 function(check_submodules_present)
     file(READ "${CMAKE_SOURCE_DIR}/.gitmodules" gitmodules)
     string(REGEX MATCHALL "path *= *[^ \t\r\n]*" gitmodules ${gitmodules})
@@ -107,8 +109,16 @@ elseif(WIN32)
 	target_include_directories(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn/windows/include")
 	target_link_libraries(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn/windows/unicorn.lib")
 elseif(UNIX)
-	target_include_directories(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn/unix/include")
-	target_link_libraries(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn/unix/lib/libunicorn.a")
+	target_include_directories(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn-src/include")
+	externalproject_add(
+		unicorn_build
+		SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/unicorn-src"
+		BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/unicorn-src"
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/unicorn-build.sh"
+		INSTALL_COMMAND "")
+	add_dependencies(unicorn unicorn_build)
+	target_link_libraries(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn-src/libunicorn.a")
 else()
 	find_package(PkgConfig)
 	pkg_check_modules(UNICORN REQUIRED unicorn)

--- a/src/external/unicorn-build.sh
+++ b/src/external/unicorn-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+UNICORN_ARCHS=arm UNICORN_DEBUG=no UNICORN_SHARED=no ./make.sh


### PR DESCRIPTION
Spiritual successor of #277 by @muemart which was reverted in #278 because Windows builds were broken.
As no proper fix for the Windows build problems has been found, this interim solution of using a submodule on the platforms in which it works seemed better in my opinion.

As I only have access to Linux, building has not been tested in neither Windows nor macOS. Those ought to be unaffected by these changes though.