### PR TITLE
Add support Visual Studio 2019 and improve time compile build.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 [submodule "src/external/glbinding"]
 	path = src/external/glbinding
 	url = https://github.com/cginternals/glbinding.git
-	branch = v3.0
+	branch = v3.1
 [submodule "src/external/yaml-cpp"]
 	path = src/external/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp

--- a/gen-windows.bat
+++ b/gen-windows.bat
@@ -1,7 +1,12 @@
 @echo off
 
+echo Please choose your preferred Visual Studio version.
+choice /c 79 /n /t 3 /d 7 /m "Press '7' for VS 2017 or '9' for VS 2019: "
+if errorlevel 1 set vs_version=Visual Studio 15 2017 Win64
+if errorlevel 2 set vs_version=Visual Studio 16 2019
+
 REM CI uses pre-built Boost
-IF "%CI%"=="" (
+IF "%CI%"=="" IF "%vs_version%"=="Visual Studio 15 2017 Win64" (
 	REM Create build dir
 	mkdir src\external\boost-build
 	cd src\external\boost
@@ -11,13 +16,14 @@ IF "%CI%"=="" (
 	cd ../../..
 )
 
-REM Generate project files
+REM Create build folder
 mkdir build-windows
 pushd build-windows
 
+REM Generate project files
 IF "%CI%"=="" (
-	cmake -G "Visual Studio 15 2017 Win64" ..
+	cmake -G "%vs_version%" ..
 ) ELSE (
-	cmake -G "Visual Studio 15 2017 Win64" -DCI:BOOL=ON -DCMAKE_CONFIGURATION_TYPES=%CONFIGURATION% ..
+	cmake -G "%vs_version%" -DCI:BOOL=ON -DCMAKE_CONFIGURATION_TYPES=%CONFIGURATION% ..
 )
 popd

--- a/src/emulator/init.cpp
+++ b/src/emulator/init.cpp
@@ -62,10 +62,14 @@ static void before_callback(const glbinding::FunctionCall &fn) {
 static void after_callback(const glbinding::FunctionCall &fn) {
     MICROPROFILE_LEAVE();
     for (GLenum error = glGetError(); error != GL_NO_ERROR; error = glGetError()) {
+#ifdef _DEBUG
         std::stringstream gl_error;
         gl_error << error;
         LOG_ERROR("OpenGL: {} set error {}.", fn.function->name(), gl_error.str());
         assert(false);
+#else
+        LOG_ERROR("OpenGL error: {}", log_hex(static_cast<std::uint32_t>(error)));
+#endif
     }
 }
 


### PR DESCRIPTION
- Add compatibility project on Visual studio 2019 and with fix compilation issue with link glbinding-aux on release build.

- Improve time on compilation appveyor and on VS, generate exe file take now only ~10 sec.
- Add choice script for user choice if wanted use 2017 or 2019 and using timmer for default value using
VS2017
For now, Visual studio 2019 require external install boost already build, 1.70 with msvc 14.2 version, but is exactly same with Dynarmic, also request external version for have all file needed, so need update it in future.
# Ressult for appveyor time build
- Before :
![image](https://user-images.githubusercontent.com/5261759/57912685-3e265e80-788b-11e9-834a-8af0bc37e45d.png)
- After :
![image](https://user-images.githubusercontent.com/5261759/57912678-3666ba00-788b-11e9-848a-d12605d57505.png)

