### PR TITLE
shader: Fixes

### DIFF
--- a/src/emulator/shader/include/shader/usse_translator.h
+++ b/src/emulator/shader/include/shader/usse_translator.h
@@ -59,12 +59,14 @@ public:
     // Contains repeat increasement offset
     int repeat_increase[4][4];
 
+    using RegisterCacheMap = std::unordered_map<uint16_t, SpirvReg>;
+
     // SPIR-V inputs are read-only, so we need to write to these temporaries instead
     // TODO: Figure out actual PA count limit
-    std::unordered_map<uint16_t, SpirvReg> pa_writeable;
+    RegisterCacheMap pa_writeable;
+    RegisterCacheMap r_supplies;
+    RegisterCacheMap sa_supplies;
 
-    // Each SPIR-V reg will contains 4 SA
-    std::array<SpirvReg, max_sa_registers / 4> sa_supplies;
     std::array<spv::Id, 4> predicates;
 
     void make_f16_unpack_func();

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -807,15 +807,6 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         create_fragment_output(b, spv_params, program);
     }
 
-    // Create temp reg vars
-    const std::size_t total_temp_reg_v4 = (program.temp_reg_count1 / 4) + ((program.temp_reg_count1 % 4) ? 1 : 0);
-
-    for (auto i = 0; i < total_temp_reg_v4; i++) {
-        auto name = fmt::format("r{}", i * 4);
-        auto type = b.makeVectorType(b.makeFloatType(32), 4); // TODO: Figure out correct type
-        create_spirv_var_reg(b, spv_params, name, usse::RegisterBank::TEMP, 4, type);
-    }
-
     // Create internal reg vars
     for (auto i = 0; i < 3; i++) {
         auto name = fmt::format("i{}", i);

--- a/src/emulator/shader/src/usse_translator_entry.cpp
+++ b/src/emulator/shader/src/usse_translator_entry.cpp
@@ -225,36 +225,6 @@ boost::optional<const USSEMatcher<V> &> DecodeUSSE(uint64_t instruction) {
     */
     INST(&V::vpck, "VPCK ()", "01000pppsnrydecb-aaaffftttmmmmkkll--gggggggoohiijjqqqqqqu--vvvvw"),
     
-    
-    // Bitwise Instructions
-    /*
-                             01 = op1_cnst
-                               ooo = op1 (3 bits)
-                                  ppp = pred (3 bits)
-                                     s = skipinv (1 bit)
-                                      n = nosched (1 bit)
-                                       r = repeat_count (1 bit)
-                                        y = sync_start (1 bit)
-                                         d = dest_ext (1 bit)
-                                          e = end (1 bit)
-                                           c = src1_ext (1 bit)
-                                            x = src2_ext (1 bit)
-                                             mmmm = mask_count (4 bits)
-                                                 i = src2_invert (1 bit)
-                                                  ttttt = src2_rot (5 bits)
-                                                       hh = src2_exth (2 bits)
-                                                         a = op2 (1 bit)
-                                                          b = bitwise_partial (1 bit)
-                                                           kk = dest_bank (2 bits)
-                                                             ff = src1_bank (2 bits)
-                                                               gg = src2_bank (2 bits)
-                                                                 jjjjjjj = dest_n (7 bits)
-                                                                        lllllll = src2_sel (7 bits)
-                                                                               qqqqqqq = src1_n (7 bits)
-                                                                                    uuuuuuu = src2_n (7 bits)
-    */
-    INST(&V::vbw, "VBW ()", "01ooopppsnrydecxmmmmittttthhabkkffggjjjjjjjlllllllqqqqqqquuuuuuu"),
-
     // Test Instructions
     /*
                               01001 = op1
@@ -319,6 +289,35 @@ boost::optional<const USSEMatcher<V> &> DecodeUSSE(uint64_t instruction) {
                                                                                               jjjjjjj = src2_n (7 bits)
     */
     INST(&V::vtstmsk, "VTSTMSK ()", "01111ppps-oydtrce-uuiizzm-aa--bbnnkkfffffffwllgggghhhhhhhjjjjjjj"),
+
+    // Bitwise Instructions
+    /*
+                             01 = op1_cnst
+                               ooo = op1 (3 bits)
+                                  ppp = pred (3 bits)
+                                     s = skipinv (1 bit)
+                                      n = nosched (1 bit)
+                                       r = repeat_count (1 bit)
+                                        y = sync_start (1 bit)
+                                         d = dest_ext (1 bit)
+                                          e = end (1 bit)
+                                           c = src1_ext (1 bit)
+                                            x = src2_ext (1 bit)
+                                             mmmm = mask_count (4 bits)
+                                                 i = src2_invert (1 bit)
+                                                  ttttt = src2_rot (5 bits)
+                                                       hh = src2_exth (2 bits)
+                                                         a = op2 (1 bit)
+                                                          b = bitwise_partial (1 bit)
+                                                           kk = dest_bank (2 bits)
+                                                             ff = src1_bank (2 bits)
+                                                               gg = src2_bank (2 bits)
+                                                                 jjjjjjj = dest_n (7 bits)
+                                                                        lllllll = src2_sel (7 bits)
+                                                                               qqqqqqq = src1_n (7 bits)
+                                                                                    uuuuuuu = src2_n (7 bits)
+    */
+    INST(&V::vbw, "VBW ()", "01ooopppsnrydecxmmmmittttthhabkkffggjjjjjjjlllllllqqqqqqquuuuuuu"),
 
     // Phase
     /*


### PR DESCRIPTION
- Refactoring register cache: Move common, duplicated code to lambda, also added TEMP register cache.
- Remove static temp register creation in recompiler code. It's just wrong.
- Reorder VBW. The match string only requires 01 at the beginning, really vague, so put it at the end