### PR TITLE
shader: implement bitwise-test

### DIFF
--- a/src/emulator/shader/src/translator/alu.cpp
+++ b/src/emulator/shader/src/translator/alu.cpp
@@ -373,6 +373,36 @@ spv::Id USSETranslatorVisitor::do_alu_op(Instruction &inst, const Imm4 dest_mask
     spv::Id source_type = m_b.getTypeId(vsrc1);
 
     switch (inst.opcode) {
+    case Opcode::AND: {
+        result = m_b.createBinOp(spv::OpBitwiseAnd, source_type, vsrc1, vsrc2);
+        break;
+    }
+
+    case Opcode::OR: {
+        result = m_b.createBinOp(spv::OpBitwiseOr, source_type, vsrc1, vsrc2);
+        break;
+    }
+
+    case Opcode::XOR: {
+        result = m_b.createBinOp(spv::OpBitwiseXor, source_type, vsrc1, vsrc2);
+        break;
+    }
+
+    case Opcode::SHL: {
+        result = m_b.createBinOp(spv::OpShiftLeftLogical, source_type, vsrc1, vsrc2);
+        break;
+    }
+
+    case Opcode::SHR: {
+        result = m_b.createBinOp(spv::OpShiftRightLogical, source_type, vsrc1, vsrc2);
+        break;
+    }
+
+    case Opcode::ASR: {
+        result = m_b.createBinOp(spv::OpShiftRightArithmetic, source_type, vsrc1, vsrc2);
+        break;
+    }
+
     case Opcode::VDSX:
     case Opcode::VF16DSX:
         result = m_b.createOp(spv::OpDPdx, source_type, ids);
@@ -608,9 +638,9 @@ bool USSETranslatorVisitor::vbw(
     default: return false;
     }
 
-    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_ext, false, 8, m_second_program);
-    inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank, src2_ext, false, 8, m_second_program);
-    inst.opr.dest = decode_dest(inst.opr.dest, dest_n, dest_bank, dest_ext, false, 8, m_second_program);
+    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_ext, false, 7, m_second_program);
+    inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank, src2_ext, false, 7, m_second_program);
+    inst.opr.dest = decode_dest(inst.opr.dest, dest_n, dest_bank, dest_ext, false, 7, m_second_program);
 
     spv::Id src1 = load(inst.opr.src1, 0b0001);
     spv::Id src2 = 0;

--- a/src/emulator/shader/src/translator/branch_cond.cpp
+++ b/src/emulator/shader/src/translator/branch_cond.cpp
@@ -148,6 +148,10 @@ static Opcode decode_test_inst(const Imm2 alu_sel, const Imm4 alu_op, const Imm1
         }
     }
 
+    if (alu_sel == 3) {
+        filled_dt = DataType::F32;
+    }
+
     return test_ops[alu_sel][alu_op];
 }
 

--- a/src/emulator/shader/src/translator/utils.cpp
+++ b/src/emulator/shader/src/translator/utils.cpp
@@ -566,12 +566,12 @@ spv::Id USSETranslatorVisitor::load(Operand &op, const Imm4 dest_mask, const int
     // TODO: Properly handle
     if (op.bank == RegisterBank::IMMEDIATE) {
         auto t = m_b.makeVectorType(type_f32, static_cast<int>(dest_comp_count_to_get));
-        auto one = m_b.makeFpConstant(type_f32, 1.0);
+        auto value = m_b.makeFpConstant(type_f32, static_cast<float>(op.num));
 
         std::vector<spv::Id> ops;
         ops.resize(dest_comp_count_to_get);
 
-        std::fill(ops.begin(), ops.end(), one);
+        std::fill(ops.begin(), ops.end(), value);
 
         return m_b.makeCompositeConstant(t, ops);
     }

--- a/src/emulator/shader/src/usse_disasm.cpp
+++ b/src/emulator/shader/src/usse_disasm.cpp
@@ -94,6 +94,10 @@ std::string reg_to_str(RegisterBank bank, uint32_t reg_num) {
         break;
     }
 
+    case RegisterBank::IMMEDIATE: {
+        break;
+    }
+
     default: {
         opstr += "INVALID";
         break;
@@ -111,7 +115,7 @@ std::string operand_to_str(Operand op, Imm4 write_mask, std::uint32_t shift) {
 
     std::string opstr = reg_to_str(op.bank, op.num + shift);
 
-    if (write_mask != 0) {
+    if (write_mask != 0 && op.bank != RegisterBank::IMMEDIATE) {
         opstr += "." + swizzle_to_str<4>(op.swizzle, write_mask, shift);
     }
 


### PR DESCRIPTION
Some small changes that fix test instructions.

It also adds support for bitwise operations for test instructions, so that's nice.