### PR TITLE
gui: add lle modules in setting dialog

### DIFF
--- a/src/emulator/gui/include/gui/state.h
+++ b/src/emulator/gui/include/gui/state.h
@@ -93,6 +93,9 @@ struct State {
     char disassembly_count[5] = "100";
     std::vector<std::string> disassembly;
 
+    ImGuiTextFilter module_search_bar;
+
+    ImGuiTextFilter game_search_bar;
     GLuint current_background = 0;
     std::map<std::string, GLObject> game_backgrounds;
     std::map<std::string, GLObject> user_backgrounds;

--- a/src/emulator/gui/src/game_selector.cpp
+++ b/src/emulator/gui/src/game_selector.cpp
@@ -16,6 +16,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <gui/functions.h>
+#include <gui/state.h>
 
 #include "private.h"
 
@@ -36,8 +37,6 @@ void draw_game_selector(HostState &host) {
     if (host.gui.current_background)
         ImGui::SetNextWindowBgAlpha(host.cfg.background_alpha);
     ImGui::Begin("Game Selector", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
-
-    static ImGuiTextFilter search_bar;
 
     if (host.gui.current_background) {
         ImGui::GetBackgroundDrawList()->AddImage(reinterpret_cast<void *>(host.gui.current_background),
@@ -155,10 +154,10 @@ void draw_game_selector(HostState &host) {
         }
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_SEARCH_BAR_TEXT);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, GUI_COLOR_SEARCH_BAR_BG);
-        ImGui::SameLine(ImGui::GetColumnWidth() - (ImGui::CalcTextSize("Search").x + ImGui::GetStyle().DisplayWindowPadding.x + 300));
-        ImGui::TextColored(GUI_COLOR_TEXT, "Search");
+        ImGui::SameLine(ImGui::GetColumnWidth() - (ImGui::CalcTextSize("Game Search").x + ImGui::GetStyle().DisplayWindowPadding.x + 300));
+        ImGui::TextColored(GUI_COLOR_TEXT, "Game Search");
         ImGui::SameLine();
-        search_bar.Draw("", 300);
+        host.gui.game_search_bar.Draw("##game_search_bar", 300);
 
         ImGui::NextColumn();
         ImGui::Separator();
@@ -166,7 +165,7 @@ void draw_game_selector(HostState &host) {
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
         for (const auto &game : host.gui.game_selector.games) {
             bool selected[4] = { false, false, false, false };
-            if (!search_bar.PassFilter(game.title.c_str()) && !search_bar.PassFilter(game.title_id.c_str()))
+            if (!host.gui.game_search_bar.PassFilter(game.title.c_str()))
                 continue;
             if (host.gui.game_selector.icons[game.title_id]) {
                 GLuint texture = host.gui.game_selector.icons[game.title_id].get();


### PR DESCRIPTION
- Add in settings dialog Core tab with lle module for select what you want in liste.
- Add reset button for reset all modules selected.
- Add button for apply log level change without reboot.
- Add search bar for search particular module wanted on list.
- Add check for show lle list only if found one llle file.
- Fix size list language for not set item outiside setting box
# For Exemple:
![image](https://user-images.githubusercontent.com/5261759/58592654-32fb0780-8269-11e9-9dd4-dcf5878f603f.png)
