### PR TITLE
Attempt to fix main audio underflow bug

### DIFF
--- a/src/emulator/audio/include/audio/state.h
+++ b/src/emulator/audio/include/audio/state.h
@@ -21,7 +21,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <vector>
 
 #include <psp2/types.h>
@@ -31,28 +30,18 @@
 typedef std::shared_ptr<SDL_AudioStream> AudioStreamPtr;
 typedef std::function<void(SceUID)> ResumeAudioThread;
 
-struct AudioOutput {
-    const uint8_t *buf = nullptr;
-    int len_bytes = 0;
-    SceUID thread = -1;
-};
-
 struct ReadOnlyAudioOutPortState {
     int len_bytes = 0;
 };
 
-struct AudioCallbackOutPortState {
-    AudioStreamPtr stream;
-};
-
 struct SharedAudioOutPortState {
     std::mutex mutex;
-    std::queue<AudioOutput> outputs;
+    AudioStreamPtr stream;
+    SceUID thread = -1;
 };
 
 struct AudioOutPort {
     ReadOnlyAudioOutPortState ro;
-    AudioCallbackOutPortState callback;
     SharedAudioOutPortState shared;
 };
 

--- a/src/emulator/audio/src/audio.cpp
+++ b/src/emulator/audio/src/audio.cpp
@@ -92,7 +92,7 @@ bool init(AudioState &state, ResumeAudioThread resume_thread) {
     desired.freq = 48000;
     desired.format = AUDIO_S16LSB;
     desired.channels = 2;
-    desired.samples = 512;
+    desired.samples = 1024;
     desired.callback = &audio_callback;
     desired.userdata = &state;
 

--- a/src/emulator/audio/src/audio.cpp
+++ b/src/emulator/audio/src/audio.cpp
@@ -27,42 +27,31 @@
 
 #define AUDIO_PROFILE(name) MICROPROFILE_SCOPEI("Audio", name, MP_THISTLE)
 
-static const int stream_put_granularity = 512;
-
 static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOutPort &port, const ResumeAudioThread &resume_thread) {
     AUDIO_PROFILE(__func__);
 
-    int available_to_get = SDL_AudioStreamAvailable(port.callback.stream.get());
-    assert(available_to_get >= 0);
+    // How much data is available?
+    std::unique_lock<std::mutex> lock(port.shared.mutex);
+    const int bytes_available = SDL_AudioStreamAvailable(port.shared.stream.get());
+    assert(bytes_available >= 0);
 
-    while (available_to_get < len) {
-        std::unique_lock<std::mutex> lock(port.shared.mutex);
-        if (port.shared.outputs.empty()) {
-            lock.unlock();
-            SDL_AudioStreamFlush(port.callback.stream.get());
-            break;
-        } else {
-            AudioOutput &output = port.shared.outputs.front();
-            const int bytes_to_put = std::min(stream_put_granularity, output.len_bytes);
-            const int ret = SDL_AudioStreamPut(port.callback.stream.get(), output.buf, bytes_to_put);
-            assert(ret == 0);
-            output.buf += bytes_to_put;
-            output.len_bytes -= bytes_to_put;
-            if (output.len_bytes <= 0) {
-                const SceUID thread = output.thread;
-                port.shared.outputs.pop();
-                resume_thread(thread);
-            }
+    // Running out of data?
+    // The (len * 2) is just a guess that seems to work.
+    if (bytes_available < (len * 2)) {
+        // Is there a thread waiting for playback to finish?
+        if (port.shared.thread >= 0) {
+            // Wake the thread up.
+            resume_thread(port.shared.thread);
+            port.shared.thread = -1;
         }
-
-        available_to_get = SDL_AudioStreamAvailable(port.callback.stream.get());
-        assert(available_to_get >= 0);
     }
 
-    const int bytes_to_get = std::min(len, available_to_get);
-    const int get_result = SDL_AudioStreamGet(port.callback.stream.get(), temp_buffer, bytes_to_get);
-    if (get_result > 0) {
-        SDL_MixAudio(stream, temp_buffer, bytes_to_get, SDL_MIX_MAXVOLUME);
+    // Mix as much as we need.
+    const int bytes_to_get = std::min(len, bytes_available);
+    const int bytes_got = SDL_AudioStreamGet(port.shared.stream.get(), temp_buffer, bytes_to_get);
+    lock.unlock();
+    if (bytes_got > 0) {
+        SDL_MixAudio(stream, temp_buffer, bytes_got, SDL_MIX_MAXVOLUME);
     }
 }
 


### PR DESCRIPTION
When a game attempts to output audio, I put it to the port's stream immediately rather than deferring that to the audio callback.

This avoids underflow when the game's thread doesn't wake up fast enough to output more audio.

Additionally, I only put the thread to sleep if the audio isn't going to finish playing in the next audio callback. This means the calling thread generally won't stop if submitting audio in small chunks.

I then increased the SDL chunk size, as it was popping a bit on my Mac.