### PR TITLE
Golden

### DIFF
--- a/src/emulator/gxm/include/gxm/functions.h
+++ b/src/emulator/gxm/include/gxm/functions.h
@@ -40,4 +40,8 @@ GenericParameterType parameter_generic_type(const SceGxmProgramParameter &parame
  */
 SceGxmVertexProgramOutputs get_vertex_outputs(const SceGxmProgram &program, SceGxmVertexOutputTexCoordInfos *coord_infos = nullptr);
 SceGxmFragmentProgramInputs get_fragment_inputs(const SceGxmProgram &program);
+
+const int get_parameter_type_size(const SceGxmParameterType type);
+const int get_num_32_bit_components(const SceGxmParameterType type, const uint16_t num_comp);
+
 } // namespace gxp

--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -203,7 +203,7 @@ enum SceGxmVertexProgramOutputs : int {
 
 union SceGxmVertexOutputTexCoordInfo {
     bf_t<uint8_t, 0, 2> comp_count;
-    bf_t<uint8_t, 2, 1> unk0;
+    bf_t<uint8_t, 2, 1> type;
 };
 
 using SceGxmVertexOutputTexCoordInfos = std::array<SceGxmVertexOutputTexCoordInfo, 10>;

--- a/src/emulator/gxm/src/gxp.cpp
+++ b/src/emulator/gxm/src/gxp.cpp
@@ -73,6 +73,34 @@ void log_parameter(const SceGxmProgramParameter &parameter) {
         category, parameter_name_raw(parameter), log_parameter_semantic(parameter), parameter.type, uint8_t(parameter.component_count), log_hex(uint8_t(parameter.container_index)));
 }
 
+const int get_parameter_type_size(const SceGxmParameterType type) {
+    switch (type) {
+    case SCE_GXM_PARAMETER_TYPE_F32:
+    case SCE_GXM_PARAMETER_TYPE_U32:
+    case SCE_GXM_PARAMETER_TYPE_S32:
+        return 4;
+    
+    case SCE_GXM_PARAMETER_TYPE_F16:
+    case SCE_GXM_PARAMETER_TYPE_U16:
+    case SCE_GXM_PARAMETER_TYPE_S16:
+        return 2;
+
+    case SCE_GXM_PARAMETER_TYPE_U8:
+    case SCE_GXM_PARAMETER_TYPE_S8:
+        return 1;
+
+    default:
+        break;
+    }
+
+    return 4;
+}
+
+const int get_num_32_bit_components(const SceGxmParameterType type, const uint16_t num_comp) {
+    const int param_size = get_parameter_type_size(type);
+    return static_cast<int>(num_comp + (4 / param_size - 1)) * param_size / 4;
+}
+
 const SceGxmProgramParameter *program_parameters(const SceGxmProgram &program) {
     return reinterpret_cast<const SceGxmProgramParameter *>(reinterpret_cast<const uint8_t *>(&program.parameters_offset) + program.parameters_offset);
 }
@@ -83,15 +111,10 @@ SceGxmParameterType parameter_type(const SceGxmProgramParameter &parameter) {
 }
 
 GenericParameterType parameter_generic_type(const SceGxmProgramParameter &parameter) {
-    if (parameter.component_count > 1) {
-        if (parameter.array_size > 1) {
-            // matrix emission disabled
-            // return GenericParameterType::Matrix;
-            //return GenericParameterType::Vector;
-            return GenericParameterType::Array;
-        } else {
-            return GenericParameterType::Vector;
-        }
+    if (parameter.array_size > 1) {
+        return GenericParameterType::Array;
+    } else if (parameter.component_count > 1) {
+        return GenericParameterType::Vector;
     } else {
         return GenericParameterType::Scalar;
     }

--- a/src/emulator/gxm/src/gxp.cpp
+++ b/src/emulator/gxm/src/gxp.cpp
@@ -79,7 +79,7 @@ const int get_parameter_type_size(const SceGxmParameterType type) {
     case SCE_GXM_PARAMETER_TYPE_U32:
     case SCE_GXM_PARAMETER_TYPE_S32:
         return 4;
-    
+
     case SCE_GXM_PARAMETER_TYPE_F16:
     case SCE_GXM_PARAMETER_TYPE_U16:
     case SCE_GXM_PARAMETER_TYPE_S16:

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -1324,10 +1324,6 @@ EXPORT(int, sceGxmShaderPatcherCreateVertexProgram, SceGxmShaderPatcher *shaderP
     MemState &mem = host.mem;
     assert(shaderPatcher != nullptr);
     assert(programId != nullptr);
-    assert(attributes != nullptr);
-    assert(attributeCount > 0);
-    assert(streams != nullptr);
-    assert(streamCount > 0);
     assert(vertexProgram != nullptr);
 
     *vertexProgram = alloc<SceGxmVertexProgram>(mem, __FUNCTION__);
@@ -1338,8 +1334,15 @@ EXPORT(int, sceGxmShaderPatcherCreateVertexProgram, SceGxmShaderPatcher *shaderP
 
     SceGxmVertexProgram *const vp = vertexProgram->get(mem);
     vp->program = programId->program;
-    vp->streams.insert(vp->streams.end(), &streams[0], &streams[streamCount]);
-    vp->attributes.insert(vp->attributes.end(), &attributes[0], &attributes[attributeCount]);
+
+    if (streams && streamCount > 0) {
+        vp->streams.insert(vp->streams.end(), &streams[0], &streams[streamCount]);
+    }
+
+    if (attributes && attributeCount > 0) {
+        vp->attributes.insert(vp->attributes.end(), &attributes[0], &attributes[attributeCount]);
+    }
+
     vp->renderer_data = std::make_unique<renderer::VertexProgram>();
 
     if (!renderer::create(*vp->renderer_data.get(), host.renderer, *programId->program.get(mem), host.renderer.gxp_ptr_map, host.base_path.c_str(), host.io.title_id.c_str())) {

--- a/src/emulator/renderer/src/uniforms.cpp
+++ b/src/emulator/renderer/src/uniforms.cpp
@@ -260,7 +260,7 @@ static void set_uniforms(GLuint gl_program, ShaderProgram &shader_program, const
                 src_f32 = reinterpret_cast<const GLfloat *>(base + idx * 4);
                 set_uniform<GLfloat>(location, parameter.component_count, arr_size, src_f32, name, is_matrix, log_uniforms);
                 break;
-            
+
             default:
                 LOG_WARN("Type {} not handled for uniform parameter {}.", type, name);
                 break;

--- a/src/emulator/renderer/src/uniforms.cpp
+++ b/src/emulator/renderer/src/uniforms.cpp
@@ -23,6 +23,11 @@ void uniform_4<GLint>(GLint location, GLsizei count, const GLint *value) {
     glUniform4iv(location, count, value);
 }
 
+template <>
+void uniform_4<GLuint>(GLint location, GLsizei count, const GLuint *value) {
+    glUniform4uiv(location, count, value);
+}
+
 template <class T>
 static void uniform_2(GLint location, GLsizei count, const T *value);
 
@@ -34,6 +39,11 @@ void uniform_2<GLfloat>(GLint location, GLsizei count, const GLfloat *value) {
 template <>
 void uniform_2<GLint>(GLint location, GLsizei count, const GLint *value) {
     glUniform2iv(location, count, value);
+}
+
+template <>
+void uniform_2<GLuint>(GLint location, GLsizei count, const GLuint *value) {
+    glUniform2uiv(location, count, value);
 }
 
 template <class T>
@@ -49,6 +59,11 @@ void uniform_1<GLint>(GLint location, GLsizei count, const GLint *value) {
     glUniform1iv(location, count, value);
 }
 
+template <>
+void uniform_1<GLuint>(GLint location, GLsizei count, const GLuint *value) {
+    glUniform1uiv(location, count, value);
+}
+
 template <class T>
 static void uniform_matrix_4(GLint location, GLsizei count, GLboolean, const T *value);
 
@@ -60,6 +75,11 @@ void uniform_matrix_4<GLfloat>(GLint location, GLsizei count, GLboolean transpos
 template <>
 void uniform_matrix_4<GLint>(GLint location, GLsizei count, GLboolean transpose, const GLint *value) {
     glUniform4iv(location, count, (GLint *)value);
+}
+
+template <>
+void uniform_matrix_4<GLuint>(GLint location, GLsizei count, GLboolean transpose, const GLuint *value) {
+    glUniform4uiv(location, count, (GLuint *)value);
 }
 
 template <class T>
@@ -186,16 +206,36 @@ static void set_uniforms(GLuint gl_program, ShaderProgram &shader_program, const
 
             const GLint *src_s32;
             const GLfloat *src_f32;
+            const GLuint *src_u32;
 
             const uint8_t *const base = static_cast<const uint8_t *>(uniform_buffer.get(mem));
+            int type_size = gxp::get_parameter_type_size(type);
+            int num_comp = gxp::get_num_32_bit_components(type, parameter.component_count);
+
+            // The resource index points to SA bank. Each SA register is 4 bytes. Therefore, multiple the index with 4
+            // and adding with the base, to get the data.
             switch (type) {
             case SCE_GXM_PARAMETER_TYPE_S32:
-                src_s32 = reinterpret_cast<const GLint *>(base + idx * 4); // TODO What offset?
-                set_uniform<GLint>(location, parameter.component_count, arr_size, src_s32, name, is_matrix, log_uniforms);
+            case SCE_GXM_PARAMETER_TYPE_S16:
+            case SCE_GXM_PARAMETER_TYPE_S8:
+                src_s32 = reinterpret_cast<const GLint *>(base + idx * 4);
+                set_uniform<GLint>(location, num_comp, arr_size, src_s32, name,
+                    is_matrix, log_uniforms);
                 break;
+
+            case SCE_GXM_PARAMETER_TYPE_U32:
+            case SCE_GXM_PARAMETER_TYPE_U16:
+            case SCE_GXM_PARAMETER_TYPE_U8:
+                src_u32 = reinterpret_cast<const GLuint *>(base + idx * 4);
+                set_uniform<GLuint>(location, num_comp, arr_size, src_u32, name, 
+                    is_matrix, log_uniforms);
+                break;
+
             case SCE_GXM_PARAMETER_TYPE_F32:
-                src_f32 = reinterpret_cast<const GLfloat *>(base + idx * 4); // TODO What offset?
-                set_uniform<GLfloat>(location, parameter.component_count, arr_size, src_f32, name, is_matrix, log_uniforms);
+            case SCE_GXM_PARAMETER_TYPE_F16:
+                src_f32 = reinterpret_cast<const GLfloat *>(base + idx * 4);
+                set_uniform<GLfloat>(location, num_comp, arr_size, src_f32, name,
+                    is_matrix, log_uniforms);
                 break;
             default:
                 LOG_WARN("Type {} not handled for uniform parameter {}.", type, name);

--- a/src/emulator/shader/include/shader/spirv_recompiler.h
+++ b/src/emulator/shader/include/shader/spirv_recompiler.h
@@ -6,6 +6,7 @@
 #include <shader/usse_types.h>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace spv {

--- a/src/emulator/shader/include/shader/usse_translator.h
+++ b/src/emulator/shader/include/shader/usse_translator.h
@@ -61,7 +61,7 @@ public:
     int repeat_increase[4][4];
 
     void do_texture_queries(const NonDependentTextureQueryCallInfos &texture_queries);
-    spv::Id do_fetch_texture(const spv::Id tex, const spv::Id coord, const DataType dest_type);
+    spv::Id do_fetch_texture(const spv::Id tex, const Coord &coord, const DataType dest_type);
 
     USSETranslatorVisitor() = delete;
     explicit USSETranslatorVisitor(spv::Builder &_b, USSERecompiler &_recompiler, const SceGxmProgram &program,

--- a/src/emulator/shader/include/shader/usse_translator_types.h
+++ b/src/emulator/shader/include/shader/usse_translator_types.h
@@ -46,9 +46,12 @@ struct SpirvShaderParameters {
     std::unordered_map<std::uint32_t, spv::Id> samplers;
 };
 
+using Coord = std::pair<spv::Id, int>;
+
 struct NonDependentTextureQueryCallInfo {
     spv::Id sampler;
-    spv::Id coord;
+    Coord coord;
+    int coord_index;
 
     std::uint32_t dest_offset;
     int store_type; ///< For sampling method later

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -352,7 +352,7 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             const auto pa_iter_type = b.makeVectorType(b.makeFloatType(32), 4);
             const auto pa_iter_size = ((descriptor->size >> 4) & 3) + 1;
             const auto pa_iter_var = create_input_variable(b, parameters, utils, pa_name.c_str(), RegisterBank::PRIMATTR,
-                pa_offset, pa_iter_type, pa_iter_size * 4);
+                pa_offset, pa_iter_type, num_comp * 4, spv::NoResult, pa_dtype);
 
             LOG_DEBUG("Iterator: pa{} = ({}{}) {}", pa_offset, pa_type, num_comp, pa_name);
 

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -753,22 +753,27 @@ static spv::Function *make_vert_finalize_function(spv::Builder &b, const SpirvSh
         return std::make_pair(vo, VertexProgramOutputProperties(name, component_count));
     };
 
+    auto calculate_copy_comp_count = [](const SceGxmVertexOutputTexCoordInfo &info) {
+        const bool is_f16 = (info.type == 1);
+        return (info.comp_count + 1) >> (is_f16 ? 1 : 0);
+    };
+
     // TODO: Verify component counts
     VertexProgramOutputPropertiesMap vertex_properties_map = {
         set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_POSITION, "v_Position", 4),
         set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_FOG, "v_Fog", 4),
         set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_COLOR0, "v_Color0", 4),
         set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_COLOR1, "v_Color1", 4),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD0, "v_TexCoord0", coord_infos[0].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD1, "v_TexCoord1", coord_infos[1].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD2, "v_TexCoord2", coord_infos[2].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD3, "v_TexCoord3", coord_infos[3].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD4, "v_TexCoord4", coord_infos[4].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD5, "v_TexCoord5", coord_infos[5].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD6, "v_TexCoord6", coord_infos[6].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD7, "v_TexCoord7", coord_infos[7].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD8, "v_TexCoord8", coord_infos[8].comp_count + 1),
-        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD9, "v_TexCoord9", coord_infos[9].comp_count + 1),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD0, "v_TexCoord0", calculate_copy_comp_count(coord_infos[0])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD1, "v_TexCoord1", calculate_copy_comp_count(coord_infos[1])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD2, "v_TexCoord2", calculate_copy_comp_count(coord_infos[2])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD3, "v_TexCoord3", calculate_copy_comp_count(coord_infos[3])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD4, "v_TexCoord4", calculate_copy_comp_count(coord_infos[4])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD5, "v_TexCoord5", calculate_copy_comp_count(coord_infos[5])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD6, "v_TexCoord6", calculate_copy_comp_count(coord_infos[6])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD7, "v_TexCoord7", calculate_copy_comp_count(coord_infos[7])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD8, "v_TexCoord8", calculate_copy_comp_count(coord_infos[8])),
+        set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD9, "v_TexCoord9", calculate_copy_comp_count(coord_infos[9])),
         set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_PSIZE, "v_Psize", 1),
         set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP0, "v_Clip0", 4),
         set_property(SCE_GXM_VERTEX_PROGRAM_OUTPUT_CLIP1, "v_Clip1", 4),

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -460,7 +460,7 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             coords[query_info.coord_index].first = b.createVariable(spv::StorageClassInput,
                 b.makeVectorType(b.makeFloatType(32), /*tex_coord_comp_count*/ 4), coord_name.c_str());
 
-            coords[query_info.coord_index].second = static_cast<int>(DataType::F32);
+            coords[query_info.coord_index].second = query_info.store_type;
         }
 
         query_info.coord = coords[query_info.coord_index];

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -454,7 +454,7 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
         }
     }
 
-    for (auto &query_info: tex_query_infos) {
+    for (auto &query_info : tex_query_infos) {
         if (coords[query_info.coord_index].first == spv::NoResult) {
             // Create an 'in' variable
             // TODO: this really right?
@@ -610,7 +610,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                 store_type = DataType::UINT16;
                 break;
             }
-            
+
             case SCE_GXM_PARAMETER_TYPE_S16: {
                 param_type_name = "ishort";
                 store_type = DataType::INT16;
@@ -622,7 +622,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                 store_type = DataType::UINT8;
                 break;
             }
-            
+
             case SCE_GXM_PARAMETER_TYPE_S8: {
                 param_type_name = "ichar";
                 store_type = DataType::INT8;
@@ -634,7 +634,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                 store_type = DataType::UINT32;
                 break;
             }
-            
+
             case SCE_GXM_PARAMETER_TYPE_S32: {
                 param_type_name = "int";
                 store_type = DataType::INT32;
@@ -655,7 +655,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
             }
 
             LOG_DEBUG(param_log);
-            
+
             int type_size = gxp::get_parameter_type_size(static_cast<SceGxmParameterType>((uint16_t)parameter.type));
             create_input_variable(b, spv_params, utils, var_name.c_str(), param_reg_type, offset, param_type,
                 parameter.array_size * parameter.component_count * 4, 0, store_type);

--- a/src/emulator/shader/src/spirv_recompiler.cpp
+++ b/src/emulator/shader/src/spirv_recompiler.cpp
@@ -307,7 +307,7 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
     const SceGxmProgramParameter *const gxp_parameters = gxp::program_parameters(program);
 
     // Store the coords
-    std::array<shader::usse::Coord, 9> coords;
+    std::array<shader::usse::Coord, 10> coords;
 
     // It may actually be total fragments input
     for (size_t i = 0; i < vertex_outputs_ptr->varyings_count; i++, descriptor++) {

--- a/src/emulator/shader/src/translator/alu.cpp
+++ b/src/emulator/shader/src/translator/alu.cpp
@@ -112,7 +112,6 @@ bool USSETranslatorVisitor::vmad(
         inst.opr.src2.flags |= RegisterFlags::Negative;
     }
 
-
     m_b.setLine(m_recompiler.cur_pc);
 
     // Write mask is a 4-bit immidiate

--- a/src/emulator/shader/src/translator/alu.cpp
+++ b/src/emulator/shader/src/translator/alu.cpp
@@ -68,13 +68,13 @@ bool USSETranslatorVisitor::vmad(
         type = 1;
     }
 
-    // Double regs always true for src0, dest
-    inst.opr.src0 = decode_src12(inst.opr.src0, src0_n, src0_bank, src0_bank_ext, true, 7, m_second_program);
+    // Double regs always true for src1, dest
+    inst.opr.src1 = decode_src12(inst.opr.src1, src0_n, src0_bank, src0_bank_ext, true, 7, m_second_program);
     inst.opr.dest = decode_dest(inst.opr.dest, dest_n, dest_bank, dest_use_bank_ext, true, 7, m_second_program);
 
     // GPI0 and GPI1, setup!
-    inst.opr.src1.bank = usse::RegisterBank::FPINTERNAL;
-    inst.opr.src1.num = gpi0_n;
+    inst.opr.src0.bank = usse::RegisterBank::FPINTERNAL;
+    inst.opr.src0.num = gpi0_n;
 
     inst.opr.src2.bank = usse::RegisterBank::FPINTERNAL;
     inst.opr.src2.num = gpi1_n;
@@ -84,24 +84,24 @@ bool USSETranslatorVisitor::vmad(
         inst.opr.dest.swizzle[3] = usse::SwizzleChannel::_X;
     }
 
-    inst.opr.src0.swizzle = decode_vec34_swizzle(src0_swiz, src0_swiz_ext, type);
-    inst.opr.src1.swizzle = decode_vec34_swizzle(gpi0_swiz, gpi0_swiz_ext, type);
+    inst.opr.src1.swizzle = decode_vec34_swizzle(src0_swiz, src0_swiz_ext, type);
+    inst.opr.src0.swizzle = decode_vec34_swizzle(gpi0_swiz, gpi0_swiz_ext, type);
     inst.opr.src2.swizzle = decode_vec34_swizzle(gpi1_swiz, gpi1_swiz_ext, type);
 
     if (src0_abs) {
-        inst.opr.src0.flags |= RegisterFlags::Absolute;
-    }
-
-    if (src0_neg) {
-        inst.opr.src0.flags |= RegisterFlags::Negative;
-    }
-
-    if (gpi0_abs) {
         inst.opr.src1.flags |= RegisterFlags::Absolute;
     }
 
-    if (gpi0_neg) {
+    if (src0_neg) {
         inst.opr.src1.flags |= RegisterFlags::Negative;
+    }
+
+    if (gpi0_abs) {
+        inst.opr.src0.flags |= RegisterFlags::Absolute;
+    }
+
+    if (gpi0_neg) {
+        inst.opr.src0.flags |= RegisterFlags::Negative;
     }
 
     if (gpi1_abs) {
@@ -112,9 +112,6 @@ bool USSETranslatorVisitor::vmad(
         inst.opr.src2.flags |= RegisterFlags::Negative;
     }
 
-    disasm_str += fmt::format(" {} {} {} {}", disasm::operand_to_str(inst.opr.dest, write_mask), disasm::operand_to_str(inst.opr.src0, write_mask), disasm::operand_to_str(inst.opr.src1, write_mask), disasm::operand_to_str(inst.opr.src2, write_mask));
-
-    LOG_DISASM("{}", disasm_str);
 
     m_b.setLine(m_recompiler.cur_pc);
 
@@ -123,9 +120,12 @@ bool USSETranslatorVisitor::vmad(
     BEGIN_REPEAT(repeat_count, 2)
     GET_REPEAT(inst);
 
-    spv::Id vsrc0 = load(inst.opr.src0, write_mask, src0_repeat_offset);
+    LOG_DISASM("{} {} {} {} {}", disasm_str, disasm::operand_to_str(inst.opr.dest, write_mask), disasm::operand_to_str(inst.opr.src0, write_mask), disasm::operand_to_str(inst.opr.src1, write_mask, src1_repeat_offset),
+        disasm::operand_to_str(inst.opr.src2, write_mask));
+
+    spv::Id vsrc0 = load(inst.opr.src0, write_mask, 0);
     spv::Id vsrc1 = load(inst.opr.src1, write_mask, src1_repeat_offset);
-    spv::Id vsrc2 = load(inst.opr.src2, write_mask, src2_repeat_offset);
+    spv::Id vsrc2 = load(inst.opr.src2, write_mask, 0);
 
     if (vsrc0 == spv::NoResult || vsrc1 == spv::NoResult || vsrc2 == spv::NoResult) {
         return false;

--- a/src/emulator/shader/src/translator/branch_cond.cpp
+++ b/src/emulator/shader/src/translator/branch_cond.cpp
@@ -286,7 +286,7 @@ bool USSETranslatorVisitor::vtst(
         } else if (is_unsigned_integer_data_type(load_data_type)) {
             c0 = m_b.makeUintConstant(0);
         }
-        
+
         std::vector<spv::Id> comps(m_b.getNumComponents(c0), c0);
 
         if (comps.size() > 1) {

--- a/src/emulator/shader/src/translator/branch_cond.cpp
+++ b/src/emulator/shader/src/translator/branch_cond.cpp
@@ -278,7 +278,22 @@ bool USSETranslatorVisitor::vtst(
             pdst_n, disasm::operand_to_str(inst.opr.src1, load_mask), disasm::operand_to_str(inst.opr.src2, load_mask));
 
         lhs = do_alu_op(inst, load_mask);
-        rhs = const_f32_v0[m_b.getNumComponents(lhs)];
+
+        spv::Id c0 = m_b.makeFloatConstant(0.0f);
+
+        if (is_signed_integer_data_type(load_data_type)) {
+            c0 = m_b.makeIntConstant(0);
+        } else if (is_unsigned_integer_data_type(load_data_type)) {
+            c0 = m_b.makeUintConstant(0);
+        }
+        
+        std::vector<spv::Id> comps(m_b.getNumComponents(c0), c0);
+
+        if (comps.size() > 1) {
+            rhs = m_b.makeCompositeConstant(m_b.getTypeId(c0), comps);
+        } else {
+            rhs = c0;
+        }
     }
 
     pred_result = m_b.createOp(used_comp_op, m_b.makeBoolType(), { lhs, rhs });

--- a/src/emulator/shader/src/translator/data.cpp
+++ b/src/emulator/shader/src/translator/data.cpp
@@ -450,13 +450,13 @@ bool USSETranslatorVisitor::vpck(
         // We need to explicitly load src2 when we are fall in these situations:
         // - First, src2 must be needed. The only situation we knows it isn't needed is when the dest mask comp count is 1.
         //   In that case, only src1 is used.
-        // - Two sources are not contiguous. We call it contigous when two sources are not in the same bank. Also,
-        //   the total component that src1 handles, when adding with src1 offset, must reached exactly to offset where src2
+        // - Two sources are not contiguous. We call it contigous when two sources are in the same bank. Also,
+        //   the total component that src1 handles, when adding with src1 offset, must reach exactly to offset where src2
         //   resides
         //
         // Case where this doesn't apply (found when testing, need more confirmation)
-        // - src1 bank is FPINTERNAL.
-        if (!is_two_source_contiguous && src2_needed && inst.opr.src1.bank != RegisterBank::FPINTERNAL) {
+        // - src2 bank is immidiate.
+        if (!is_two_source_contiguous && src2_needed && inst.opr.src2.bank != RegisterBank::IMMEDIATE) {
             // Seperate the mask
             src1_mask = ((dest_mask >> offset_start_masking) & SRC1_LOAD_MASKS[src1_comp_handle]) << offset_start_masking;
             src2_mask = (((dest_mask >> offset_start_masking) & SRC2_LOAD_MASKS[src2_comp_handle]) >> src1_comp_handle) << offset_start_masking;

--- a/src/emulator/shader/src/translator/texture.cpp
+++ b/src/emulator/shader/src/translator/texture.cpp
@@ -34,7 +34,7 @@ spv::Id shader::usse::USSETranslatorVisitor::do_fetch_texture(const spv::Id tex,
     if (coord.second != static_cast<int>(DataType::F32)) {
         coord_id = m_b.createOp(spv::OpVectorExtractDynamic, type_f32, { coord_id, m_b.makeIntConstant(0) });
         coord_id = utils::unpack_one(m_b, m_util_funcs, coord_id, static_cast<DataType>(coord.second));
-        
+
         // Shuffle if number of components is larger than 2
         if (m_b.getNumComponents(coord_id) > 2) {
             coord_id = m_b.createOp(spv::OpVectorShuffle, m_b.makeVectorType(type_f32, 2), { coord_id, coord_id, 0, 1 });

--- a/src/emulator/shader/src/usse_translator_entry.cpp
+++ b/src/emulator/shader/src/usse_translator_entry.cpp
@@ -37,7 +37,7 @@ using USSEMatcher = shader::decoder::Matcher<Visitor, uint64_t>;
 template <typename V>
 boost::optional<const USSEMatcher<V> &> DecodeUSSE(uint64_t instruction) {
     static const std::vector<USSEMatcher<V>> table = {
-// clang-format off
+    // clang-format off
     #define INST(fn, name, bitstring) shader::decoder::detail::detail<USSEMatcher<V>>::GetMatcher(fn, name, bitstring)
 
     // Vector move

--- a/src/emulator/shader/src/usse_utilities.cpp
+++ b/src/emulator/shader/src/usse_utilities.cpp
@@ -683,8 +683,7 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
                     if (elem == spv::NoResult) {
                         // Replace it
                         elem = b.createOp(spv::OpAccessChain, comp_type, { bank_base, b.makeIntConstant((int)((insert_offset + (i + nearest_swizz_on) / size_comp) >> 2)) });
-                        elem = b.createOp(spv::OpVectorExtractDynamic, b.makeFloatType(32), { b.createLoad(elem), b.makeIntConstant((insert_offset % 4 + 
-                            (int)((i + nearest_swizz_on) / size_comp)) % 4) });
+                        elem = b.createOp(spv::OpVectorExtractDynamic, b.makeFloatType(32), { b.createLoad(elem), b.makeIntConstant((insert_offset % 4 + (int)((i + nearest_swizz_on) / size_comp)) % 4) });
 
                         // Extract to f16
                         elem = unpack_one(b, utils, elem, dest.type);

--- a/src/emulator/shader/src/usse_utilities.cpp
+++ b/src/emulator/shader/src/usse_utilities.cpp
@@ -683,7 +683,8 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
                     if (elem == spv::NoResult) {
                         // Replace it
                         elem = b.createOp(spv::OpAccessChain, comp_type, { bank_base, b.makeIntConstant((int)((insert_offset + (i + nearest_swizz_on) / size_comp) >> 2)) });
-                        elem = b.createOp(spv::OpVectorExtractDynamic, b.makeFloatType(32), { b.createLoad(elem), b.makeIntConstant((int)((i + nearest_swizz_on) / size_comp)) });
+                        elem = b.createOp(spv::OpVectorExtractDynamic, b.makeFloatType(32), { b.createLoad(elem), b.makeIntConstant(insert_offset % 4 + 
+                            (int)((i + nearest_swizz_on) / size_comp)) });
 
                         // Extract to f16
                         elem = unpack_one(b, utils, elem, dest.type);

--- a/src/emulator/shader/src/usse_utilities.cpp
+++ b/src/emulator/shader/src/usse_utilities.cpp
@@ -683,8 +683,8 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
                     if (elem == spv::NoResult) {
                         // Replace it
                         elem = b.createOp(spv::OpAccessChain, comp_type, { bank_base, b.makeIntConstant((int)((insert_offset + (i + nearest_swizz_on) / size_comp) >> 2)) });
-                        elem = b.createOp(spv::OpVectorExtractDynamic, b.makeFloatType(32), { b.createLoad(elem), b.makeIntConstant(insert_offset % 4 + 
-                            (int)((i + nearest_swizz_on) / size_comp)) });
+                        elem = b.createOp(spv::OpVectorExtractDynamic, b.makeFloatType(32), { b.createLoad(elem), b.makeIntConstant((insert_offset % 4 + 
+                            (int)((i + nearest_swizz_on) / size_comp)) % 4) });
 
                         // Extract to f16
                         elem = unpack_one(b, utils, elem, dest.type);


### PR DESCRIPTION
- Supply all uniform types: All uniform data on CPU are 32-bit right now (confirmed by testing p4g). The data will be packed to correct types later at runtime on shaders.
- Correct some spots where GPI source are used with repeat offset. It's confirmed that GPI source don't use repeat offset (GPI0, GPI1, GPI2).
- Correct RHS type of VTST (not the same type before). Fix crash on some.