### PR TITLE
Gui/Modules: Add sync render option and fix showing render with this option

### DIFF
--- a/src/emulator/config.cpp
+++ b/src/emulator/config.cpp
@@ -108,6 +108,7 @@ ExitCode serialize(Config &cfg, fs::path output_path) {
     config_file_emit_single(emitter, "log-exports", cfg.log_exports);
     config_file_emit_single(emitter, "log-active-shaders", cfg.log_active_shaders);
     config_file_emit_single(emitter, "log-uniforms", cfg.log_uniforms);
+    config_file_emit_single(emitter, "sync-rendering", cfg.sync_rendering);
     config_file_emit_single(emitter, "pstv-mode", cfg.pstv_mode);
     config_file_emit_single(emitter, "show-gui", cfg.show_gui);
     config_file_emit_single(emitter, "show-game-background", cfg.show_game_background);
@@ -153,6 +154,7 @@ static ExitCode parse(Config &cfg, fs::path load_path, const std::string &root_p
     get_yaml_value(config_node, "log-exports", &cfg.log_exports, false);
     get_yaml_value(config_node, "log-active-shaders", &cfg.log_active_shaders, false);
     get_yaml_value(config_node, "log-uniforms", &cfg.log_uniforms, false);
+    get_yaml_value(config_node, "sync-rendering", &cfg.sync_rendering, false);
     get_yaml_value(config_node, "pstv-mode", &cfg.pstv_mode, false);
     get_yaml_value(config_node, "show-gui", &cfg.show_gui, false);
     get_yaml_value(config_node, "show-game-background", &cfg.show_game_background, true);
@@ -217,7 +219,8 @@ ExitCode init(Config &cfg, int argc, char **argv, const Root &root_paths) {
             ("log-imports,I", po::bool_switch(&cfg.log_imports), "Log Imports")
             ("log-exports,E", po::bool_switch(&cfg.log_exports), "Log Exports")
             ("log-active-shaders,S", po::bool_switch(&cfg.log_active_shaders), "Log Active Shaders")
-            ("log-uniforms,U", po::bool_switch(&cfg.log_uniforms), "Log Uniforms");
+            ("log-uniforms,U", po::bool_switch(&cfg.log_uniforms), "Log Uniforms")
+            ("sync-rendering,R", po::bool_switch(&cfg.sync_rendering), "Sync Rendering");
         // clang-format on
 
         // Positional args
@@ -287,6 +290,7 @@ ExitCode init(Config &cfg, int argc, char **argv, const Root &root_paths) {
         LOG_INFO("log-exports: {}", cfg.log_exports);
         LOG_INFO("log-active-shaders: {}", cfg.log_active_shaders);
         LOG_INFO("log-uniforms: {}", cfg.log_uniforms);
+        LOG_INFO("sync-rendering: {}", cfg.sync_rendering);
 
     } catch (std::exception &e) {
         std::cerr << "error: " << e.what() << "\n";

--- a/src/emulator/gui/src/game_selector.cpp
+++ b/src/emulator/gui/src/game_selector.cpp
@@ -154,10 +154,10 @@ void draw_game_selector(HostState &host) {
         }
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_SEARCH_BAR_TEXT);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, GUI_COLOR_SEARCH_BAR_BG);
-        ImGui::SameLine(ImGui::GetColumnWidth() - (ImGui::CalcTextSize("Game Search").x + ImGui::GetStyle().DisplayWindowPadding.x + 300));
+        ImGui::SameLine(ImGui::GetColumnWidth() - (ImGui::CalcTextSize("Game Search").x + ImGui::GetStyle().DisplayWindowPadding.x + 220));
         ImGui::TextColored(GUI_COLOR_TEXT, "Game Search");
         ImGui::SameLine();
-        host.gui.game_search_bar.Draw("##game_search_bar", 300);
+        host.gui.game_search_bar.Draw("##game_search_bar", 220);
 
         ImGui::NextColumn();
         ImGui::Separator();
@@ -165,7 +165,7 @@ void draw_game_selector(HostState &host) {
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
         for (const auto &game : host.gui.game_selector.games) {
             bool selected[4] = { false, false, false, false };
-            if (!host.gui.game_search_bar.PassFilter(game.title.c_str()))
+            if (!host.gui.game_search_bar.PassFilter(game.title.c_str()) && !host.gui.game_search_bar.PassFilter(game.title_id.c_str()))
                 continue;
             if (host.gui.game_selector.icons[game.title_id]) {
                 GLuint texture = host.gui.game_selector.icons[game.title_id].get();

--- a/src/emulator/gui/src/settings_dialog.cpp
+++ b/src/emulator/gui/src/settings_dialog.cpp
@@ -260,6 +260,10 @@ void draw_settings_dialog(HostState &host) {
         ImGui::Checkbox("Log Uniforms", &host.cfg.log_uniforms);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Log shader uniform names and values.");
+        ImGui::Spacing();
+        ImGui::Checkbox("Sync Render", &host.cfg.sync_rendering);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Synchronize host rendering to guest (GXM) rendering.\nUsed for debugging (so that graphics debuggers pick up GXM OpenGL calls)");
         ImGui::EndTabItem();
     } else {
         ImGui::PopStyleColor();

--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -38,6 +38,7 @@ struct Config {
     bool log_exports = false;
     bool log_active_shaders = false;
     bool log_uniforms = false;
+    bool sync_rendering = false;
     std::vector<std::string> lle_modules;
     bool pstv_mode = false;
     bool show_gui = false;

--- a/src/emulator/host/include/host/state.h
+++ b/src/emulator/host/include/host/state.h
@@ -53,10 +53,6 @@ struct DisplayState {
     std::condition_variable condvar;
     std::atomic<bool> abort{ false };
     std::atomic<bool> imgui_render{ true };
-
-    // Synchronize host rendering to guest (GXM) rendering
-    // Used for debugging (so that graphics debuggers pick up GXM OpenGL calls)
-    static constexpr bool sync_rendering{ false };
 };
 
 struct HostState {

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[]) {
         }
         gui::draw_end(host.window.get());
 
-        if (!host.display.sync_rendering)
+        if (!host.cfg.sync_rendering)
             host.display.condvar.notify_all();
         else {
             std::unique_lock<std::mutex> lock(host.display.mutex);

--- a/src/emulator/modules/SceDisplay/SceDisplay.cpp
+++ b/src/emulator/modules/SceDisplay/SceDisplay.cpp
@@ -21,6 +21,19 @@
 
 #include <psp2/display.h>
 
+static int display_wait(HostState &host) {
+    if (!host.cfg.sync_rendering) {
+        std::unique_lock<std::mutex> lock(host.display.mutex);
+        host.display.condvar.wait(lock);
+    } else
+        host.display.condvar.notify_all();
+
+    if (host.display.abort.load())
+        return SCE_DISPLAY_ERROR_NO_PIXEL_DATA;
+
+    return SCE_DISPLAY_ERROR_OK;
+}
+
 EXPORT(int, _sceDisplayGetFrameBuf) {
     return UNIMPLEMENTED();
 }
@@ -77,53 +90,49 @@ EXPORT(int, sceDisplayUnregisterVblankStartCallback) {
 EXPORT(int, sceDisplayWaitSetFrameBuf) {
     STUBBED("move after setframebuf");
 
-    if (!host.display.sync_rendering) {
-        std::unique_lock<std::mutex> lock(host.display.mutex);
-        host.display.condvar.wait(lock);
-    } else
-        host.display.condvar.notify_all();
-
-    if (host.display.abort.load())
-        return SCE_DISPLAY_ERROR_NO_PIXEL_DATA;
-
-    return SCE_DISPLAY_ERROR_OK;
+    return display_wait(host);
 }
 
 EXPORT(int, sceDisplayWaitSetFrameBufCB) {
-    return UNIMPLEMENTED();
+    STUBBED("move after setframebuf");
+
+    return display_wait(host);
 }
 
 EXPORT(int, sceDisplayWaitSetFrameBufMulti) {
-    return UNIMPLEMENTED();
+    STUBBED("move after setframebuf");
+
+    return display_wait(host);
 }
 
 EXPORT(int, sceDisplayWaitSetFrameBufMultiCB) {
-    return UNIMPLEMENTED();
+    STUBBED("move after setframebuf");
+
+    return display_wait(host);
 }
 
 EXPORT(int, sceDisplayWaitVblankStart) {
-    if (!host.display.sync_rendering) {
-        std::unique_lock<std::mutex> lock(host.display.mutex);
-        host.display.condvar.wait(lock);
-    } else
-        host.display.condvar.notify_all();
+    STUBBED("wait for vblank");
 
-    if (host.display.abort.load())
-        return SCE_DISPLAY_ERROR_NO_PIXEL_DATA;
-
-    return SCE_DISPLAY_ERROR_OK;
+    return display_wait(host);
 }
 
 EXPORT(int, sceDisplayWaitVblankStartCB) {
-    return UNIMPLEMENTED();
+    STUBBED("wait for vblank");
+
+    return display_wait(host);
 }
 
 EXPORT(int, sceDisplayWaitVblankStartMulti) {
-    return UNIMPLEMENTED();
+    STUBBED("wait for vblank");
+
+    return display_wait(host);
 }
 
 EXPORT(int, sceDisplayWaitVblankStartMultiCB) {
-    return UNIMPLEMENTED();
+    STUBBED("wait for vblank");
+
+    return display_wait(host);
 }
 
 BRIDGE_IMPL(_sceDisplayGetFrameBuf)


### PR DESCRIPTION
- Get more easy to switch mode with sync rendering without re compile build.
- Fix render on few game if sync rendering is enable (like Dongaronpa).
- Restore id game on search game removed by mistake on my last pr. 
- Fix fps on few game for logo (get 60 fps and no eg: 250).
# Result for option on debug : 
![image](https://user-images.githubusercontent.com/5261759/58851440-13ae1100-8693-11e9-8beb-1c3e9c30a2e4.png)
I have set (Sync Render) for get short name compared other option already here. 