### PR TITLE
Import call logging blacklist & optimization

### DIFF
--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -24,7 +24,13 @@
 #include <util/lock_and_find.h>
 #include <util/log.h>
 
-static bool LOG_IMPORT_CALLS = false;
+static
+#ifdef NDEBUG // Leave it as non-constexpr on Debug so that we can enable/disable it at will via set_log_import_calls
+    constexpr
+#endif
+    bool LOG_IMPORT_CALLS
+    = false;
+
 static constexpr bool LOG_UNK_NIDS_ALWAYS = false;
 
 #define NID(name, nid) extern const ImportFn import_##name;
@@ -91,6 +97,9 @@ void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id)
     }
 }
 
-void log_import_calls(bool enabled) {
+#ifndef NDEBUG
+// Import logging is really slow and this allows us to enable/disable it from whenever we please, for easy in debugging
+void set_log_import_calls(bool enabled) {
     LOG_IMPORT_CALLS = enabled;
 }
+#endif

--- a/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/src/emulator/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -25,6 +25,9 @@
 #include <SDL_timer.h>
 #include <psp2/kernel/error.h>
 
+#include <chrono>
+#include <thread>
+
 EXPORT(int, __sceKernelCreateLwMutex) {
     return UNIMPLEMENTED();
 }


### PR DESCRIPTION
- Blacklist some commonly used NIDs that spam the log too much (debug-only feature, irrelevant to users)
- A potential perf improvement to import calling, though unlikely because of branch prediction.
- Linux build hotfix