### PR TITLE
shader/translator: Add null spir-v check guards.

### DIFF
--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -36,7 +36,7 @@ struct SceGxmTexture {
     uint32_t vaddr_mode : 3;
     uint32_t uaddr_mode : 3;
     uint32_t mip_filter : 1;
-    uint32_t min_filter: 2;
+    uint32_t min_filter : 2;
     uint32_t mag_filter : 2;
     uint32_t unk1 : 3;
     uint32_t mip_count : 4;

--- a/src/emulator/host/src/host.cpp
+++ b/src/emulator/host/src/host.cpp
@@ -27,7 +27,7 @@
 #include <unordered_set>
 
 #ifdef NDEBUG // Leave it as non-constexpr on Debug so that we can enable/disable it at will via set_log_import_calls
-    constexpr
+constexpr
 #endif
     bool LOG_IMPORT_CALLS
     = false;

--- a/src/emulator/renderer/include/renderer/texture_cache_state.h
+++ b/src/emulator/renderer/include/renderer/texture_cache_state.h
@@ -2,8 +2,8 @@
 
 #include <glutil/object_array.h>
 
-#include <psp2/gxm.h>
 #include <gxm/types.h>
+#include <psp2/gxm.h>
 
 #include <array>
 

--- a/src/emulator/shader/src/translator/branch_cond.cpp
+++ b/src/emulator/shader/src/translator/branch_cond.cpp
@@ -296,6 +296,11 @@ bool USSETranslatorVisitor::vtst(
         }
     }
 
+    if (lhs == spv::NoResult || rhs == spv::NoResult) {
+        LOG_ERROR("Source not loaded (lhs: {}, rhs: {})", lhs, rhs);
+        return false;
+    }
+
     pred_result = m_b.createOp(used_comp_op, m_b.makeBoolType(), { lhs, rhs });
 
     Operand pred_op{};
@@ -380,6 +385,11 @@ bool USSETranslatorVisitor::br(
         }
 
         pred_v = load(pred_opr, 0b0001);
+
+        if (pred_v == spv::NoResult) {
+            LOG_ERROR("Pred not loaded");
+            return false;
+        }
 
         if (do_neg) {
             std::vector<spv::Id> ops{ pred_v };

--- a/src/emulator/shader/src/translator/data.cpp
+++ b/src/emulator/shader/src/translator/data.cpp
@@ -187,6 +187,11 @@ bool USSETranslatorVisitor::vmov(
         spv::Id src0 = load(inst.opr.src0, dest_mask, src0_repeat_offset);
         spv::Id src2 = load(inst.opr.src2, dest_mask, src2_repeat_offset);
 
+        if (src0 == spv::NoResult || src2 == spv::NoResult) {
+            LOG_ERROR("Source not loaded (src0: {}, src2: {})", src0, src2);
+            return false;
+        }
+
         conditional_result = m_b.createBinOp(compare_op, m_b.makeVectorType(m_b.makeBoolType(), m_b.getNumComponents(src0)),
             src2, src0);
 
@@ -199,6 +204,12 @@ bool USSETranslatorVisitor::vmov(
     }
 
     spv::Id source = load(inst.opr.src1, dest_mask, src1_repeat_offset);
+
+    if (source == spv::NoResult) {
+        LOG_ERROR("Source not Loaded");
+        return false;
+    }
+
     store(inst.opr.dest, source, dest_mask, dest_repeat_offset);
 
     if (is_conditional) {
@@ -490,9 +501,19 @@ bool USSETranslatorVisitor::vpck(
 
     spv::Id source = load(inst.opr.src1, src1_mask, src1_repeat_offset);
 
+    if (source == spv::NoResult) {
+        LOG_ERROR("Source not loaded");
+        return false;
+    }
+
     if (src2_mask != 0) {
         // Need to load this also, then create a merge between these twos
         spv::Id source2 = load(inst.opr.src2, src2_mask, src2_repeat_offset);
+
+        if (source2 == spv::NoResult) {
+            LOG_ERROR("Source 2 not loaded");
+            return false;
+        }
 
         // Merge using op vector shuffle
         const int num_comp = static_cast<int>(dest_mask_to_comp_count(dest_mask));

--- a/src/emulator/shader/src/translator/texture.cpp
+++ b/src/emulator/shader/src/translator/texture.cpp
@@ -137,6 +137,11 @@ bool USSETranslatorVisitor::smp(
     // Load the coord
     const spv::Id coord = load(inst.opr.src0, 0b0011);
 
+    if (coord == spv::NoResult) {
+        LOG_ERROR("Coord not loaded");
+        return false;
+    }
+
     spv::Id sampler = spv::NoResult;
     if (m_spirv_params.samplers.count(inst.opr.src1.num)) {
         sampler = m_spirv_params.samplers.at(inst.opr.src1.num);

--- a/src/emulator/shader/src/usse_utilities.cpp
+++ b/src/emulator/shader/src/usse_utilities.cpp
@@ -511,7 +511,7 @@ spv::Id shader::usse::utils::load(spv::Builder &b, const SpirvShaderParameters &
     if (first_pass == spv::NoResult) {
         return first_pass;
     }
-    
+
     if (size_comp != 4) {
         // Second pass: Do unpack
         // We already handle shift offset above, so now let's use 0


### PR DESCRIPTION
- Add all spir-v check guard if shader value don't success loaded, prevent crashing, normally for lot case.
- Add log error for can debug it in futur and probably fix/improve render.
- Run clang format.