### PR TITLE
Texture dumping

### DIFF
--- a/src/emulator/app.cpp
+++ b/src/emulator/app.cpp
@@ -335,6 +335,7 @@ ExitCode load_app(Ptr<const void> &entry_point, HostState &host, const std::wstr
         return ModuleLoadFailed;
     }
 
+    // Hide GUI if it's disabled in the config
     if (!host.cfg.show_gui) {
         auto &imgui_render = host.display.imgui_render;
 
@@ -342,6 +343,11 @@ ExitCode load_app(Ptr<const void> &entry_point, HostState &host, const std::wstr
         while (!imgui_render.compare_exchange_weak(old_imgui_render, !old_imgui_render)) {
         }
     }
+
+    // Delete all textures used in Game Select
+    host.gui.user_backgrounds.clear();
+    host.gui.game_backgrounds.clear();
+    host.gui.game_selector.icons.clear();
 
 #ifdef USE_GDBSTUB
     server_open(host);

--- a/src/emulator/config.cpp
+++ b/src/emulator/config.cpp
@@ -109,6 +109,7 @@ ExitCode serialize(Config &cfg, fs::path output_path) {
     config_file_emit_single(emitter, "log-active-shaders", cfg.log_active_shaders);
     config_file_emit_single(emitter, "log-uniforms", cfg.log_uniforms);
     config_file_emit_single(emitter, "sync-rendering", cfg.sync_rendering);
+    config_file_emit_single(emitter, "dump-textures", cfg.dump_textures);
     config_file_emit_single(emitter, "pstv-mode", cfg.pstv_mode);
     config_file_emit_single(emitter, "show-gui", cfg.show_gui);
     config_file_emit_single(emitter, "show-game-background", cfg.show_game_background);
@@ -155,6 +156,7 @@ static ExitCode parse(Config &cfg, fs::path load_path, const std::string &root_p
     get_yaml_value(config_node, "log-active-shaders", &cfg.log_active_shaders, false);
     get_yaml_value(config_node, "log-uniforms", &cfg.log_uniforms, false);
     get_yaml_value(config_node, "sync-rendering", &cfg.sync_rendering, false);
+    get_yaml_value(config_node, "dump-textures", &cfg.dump_textures, false);
     get_yaml_value(config_node, "pstv-mode", &cfg.pstv_mode, false);
     get_yaml_value(config_node, "show-gui", &cfg.show_gui, false);
     get_yaml_value(config_node, "show-game-background", &cfg.show_game_background, true);
@@ -220,7 +222,8 @@ ExitCode init(Config &cfg, int argc, char **argv, const Root &root_paths) {
             ("log-exports,E", po::bool_switch(&cfg.log_exports), "Log Exports")
             ("log-active-shaders,S", po::bool_switch(&cfg.log_active_shaders), "Log Active Shaders")
             ("log-uniforms,U", po::bool_switch(&cfg.log_uniforms), "Log Uniforms")
-            ("sync-rendering,R", po::bool_switch(&cfg.sync_rendering), "Sync Rendering");
+            ("sync-rendering,R", po::bool_switch(&cfg.sync_rendering), "Sync Rendering")
+            ("dump-textures,D", po::bool_switch(&cfg.dump_textures), "Dump Textures");
         // clang-format on
 
         // Positional args
@@ -291,6 +294,7 @@ ExitCode init(Config &cfg, int argc, char **argv, const Root &root_paths) {
         LOG_INFO("log-active-shaders: {}", cfg.log_active_shaders);
         LOG_INFO("log-uniforms: {}", cfg.log_uniforms);
         LOG_INFO("sync-rendering: {}", cfg.sync_rendering);
+        LOG_INFO("dump-textures: {}", cfg.dump_textures);
 
     } catch (std::exception &e) {
         std::cerr << "error: " << e.what() << "\n";

--- a/src/emulator/gui/src/settings_dialog.cpp
+++ b/src/emulator/gui/src/settings_dialog.cpp
@@ -264,6 +264,10 @@ void draw_settings_dialog(HostState &host) {
         ImGui::Checkbox("Sync Render", &host.cfg.sync_rendering);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Synchronize host rendering to guest (GXM) rendering.\nUsed for debugging (so that graphics debuggers pick up GXM OpenGL calls)");
+        ImGui::SameLine();
+        ImGui::Checkbox("Dump Textures", &host.cfg.dump_textures);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Save textures to PNG files as they are being used.");
         ImGui::EndTabItem();
     } else {
         ImGui::PopStyleColor();

--- a/src/emulator/host/include/host/config.h
+++ b/src/emulator/host/include/host/config.h
@@ -39,6 +39,7 @@ struct Config {
     bool log_active_shaders = false;
     bool log_uniforms = false;
     bool sync_rendering = false;
+    bool dump_textures = false;
     std::vector<std::string> lle_modules;
     bool pstv_mode = false;
     bool show_gui = false;

--- a/src/emulator/io/src/io.cpp
+++ b/src/emulator/io/src/io.cpp
@@ -209,7 +209,9 @@ bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path) {
     fs::create_directory(uma0);
     fs::create_directory(uma0_data);
 
+    // TODO: Construct and store these paths in a centralized location like base_path and pref_path
     fs::create_directory(base_path / "shaderlog");
+    fs::create_directory(base_path / "texturelog");
 
     return true;
 }

--- a/src/emulator/modules/SceGxm/SceGxm.cpp
+++ b/src/emulator/modules/SceGxm/SceGxm.cpp
@@ -416,7 +416,7 @@ EXPORT(int, sceGxmDraw, SceGxmContext *context, SceGxmPrimitiveType primType, Sc
         context->state.fragment_last_reserve_status = SceGxmLastReserveStatus::Available;
     }
 
-    if (!renderer::sync_state(context->renderer, context->state, host.mem, host.cfg.texture_cache, host.cfg.log_active_shaders, host.cfg.log_uniforms)) {
+    if (!renderer::sync_state(context->renderer, context->state, host.mem, host.cfg.texture_cache, host.cfg.log_active_shaders, host.cfg.log_uniforms, host.cfg.dump_textures, host.base_path, host.io.title_id)) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 

--- a/src/emulator/renderer/CMakeLists.txt
+++ b/src/emulator/renderer/CMakeLists.txt
@@ -21,5 +21,5 @@ add_library(
 )
 
 target_include_directories(renderer PUBLIC include)
-target_link_libraries(renderer PUBLIC crypto glutil vita-headers)
+target_link_libraries(renderer PUBLIC stb crypto glutil vita-headers)
 target_link_libraries(renderer PRIVATE shader gxm microprofile sdl2 util)

--- a/src/emulator/renderer/include/renderer/functions.h
+++ b/src/emulator/renderer/include/renderer/functions.h
@@ -25,8 +25,13 @@ bool create(FragmentProgram &fp, State &state, const SceGxmProgram &program, con
 bool create(VertexProgram &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
 void begin_scene(const RenderTarget &rt);
 void end_scene(Context &context, SceGxmSyncObject *sync_object, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels);
-bool sync_state(Context &context, const GxmContextState &state, const MemState &mem, bool enable_texture_cache, bool log_active_shaders, bool log_uniforms);
+bool sync_state(Context &context, const GxmContextState &state, const MemState &mem, bool enable_texture_cache, bool log_active_shaders, bool log_uniforms, bool dump_textures, const std::string &base_path, const std::string &title_id);
 void draw(Context &context, const GxmContextState &state, SceGxmPrimitiveType type, SceGxmIndexFormat format, const void *indices, size_t count, const MemState &mem);
 void finish(Context &context);
 void wait_sync_object(SceGxmSyncObject *sync_object);
+
+namespace texture {
+void dump(const emu::SceGxmTexture &gxm_texture, const MemState &mem, const std::string &base_path, const std::string &title_id);
+}
+
 } // namespace renderer

--- a/src/emulator/renderer/src/functions.h
+++ b/src/emulator/renderer/src/functions.h
@@ -55,6 +55,7 @@ const uint32_t *get_texture_palette(const emu::SceGxmTexture &texture, const Mem
 // Texture cache.
 bool init(TextureCacheState &cache);
 void cache_and_bind_texture(TextureCacheState &cache, const emu::SceGxmTexture &gxm_texture, const MemState &mem);
+TextureCacheHash hash_texture_data(const emu::SceGxmTexture &texture, const MemState &mem);
 
 } // namespace texture
 

--- a/src/emulator/renderer/src/sync_state.cpp
+++ b/src/emulator/renderer/src/sync_state.cpp
@@ -97,7 +97,7 @@ static void set_stencil_state(GLenum face, const GxmStencilState &state) {
     glStencilMaskSeparate(face, state.write_mask);
 }
 
-bool sync_state(Context &context, const GxmContextState &state, const MemState &mem, bool enable_texture_cache, bool log_active_shaders, bool log_uniforms) {
+bool sync_state(Context &context, const GxmContextState &state, const MemState &mem, bool enable_texture_cache, bool log_active_shaders, bool log_uniforms, bool dump_textures, const std::string &base_path, const std::string &title_id) {
     R_PROFILE(__func__);
 
     // TODO Use some kind of caching to avoid setting every draw call?
@@ -257,6 +257,9 @@ bool sync_state(Context &context, const GxmContextState &state, const MemState &
         } else {
             texture::bind_texture(context.texture_cache, texture, mem);
         }
+
+        if (dump_textures)
+            texture::dump(texture, mem, base_path, title_id);
     }
     glActiveTexture(GL_TEXTURE0);
 

--- a/src/emulator/renderer/src/texture.cpp
+++ b/src/emulator/renderer/src/texture.cpp
@@ -9,6 +9,11 @@
 #include <mem/ptr.h>
 #include <util/log.h>
 
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
+
+#include <set>
+
 namespace renderer {
 namespace texture {
 
@@ -80,6 +85,51 @@ void upload_bound_texture(const emu::SceGxmTexture &gxm_texture, const MemState 
     glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<gl::GLint>(stride));
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, format, type, pixels);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+}
+
+
+// Dumps bound texture to a file
+void dump(const emu::SceGxmTexture &gxm_texture, const MemState &mem, const std::string &base_path, const std::string &title_id) {
+    static uint32_t g_tex_index = 0;
+    static std::vector<uint8_t> g_pixels; // re-use the same vector instead of allocating one every time
+    static std::set<TextureCacheHash> g_dumped_hashes;
+
+    const TextureCacheHash hash = hash_texture_data(gxm_texture, mem);
+
+    if (g_dumped_hashes.find(hash) != g_dumped_hashes.end())
+        return;
+
+    g_dumped_hashes.insert(hash);
+
+    const size_t width = gxm::get_width(&gxm_texture);
+    const size_t height = gxm::get_height(&gxm_texture);
+
+    const SceGxmTextureFormat format = gxm::get_format(&gxm_texture);
+    const SceGxmTextureBaseFormat base_format = gxm::get_base_format(format);
+    const size_t bpp = texture::bits_per_pixel(base_format);
+    const size_t components = bpp / 8;
+    const size_t stride = (width + 7) & ~7; // NOTE: This is correct only with linear textures.
+    const size_t size = (bpp * stride * height) / 8;
+
+    g_pixels.resize(size);
+
+    const auto gl_format = texture::translate_format(format);
+    const auto gl_type = texture::translate_type(format);
+    glGetTexImage(GL_TEXTURE_2D, 0, gl_format, gl_type, (void *)g_pixels.data());
+
+    // TODO: Create the texturelog path elsewhere on init once and pass it here whole
+    // TODO: Same for shaderlog path
+    const fs::path texturelog_path{ fs::path(base_path) / "texturelog" / title_id };
+    if (!fs::exists(texturelog_path))
+        fs::create_directories(texturelog_path);
+
+    const auto tex_filename = fmt::format("tex_{}_{:08X}.png", g_tex_index, hash);
+    const auto filepath = texturelog_path / tex_filename;
+
+    if (!stbi_write_png(filepath.string().c_str(), width, height, components, (void *)g_pixels.data(), stride * components))
+        LOG_WARN("Failed to save texture: {}", filepath.string());
+
+    ++g_tex_index;
 }
 
 } // namespace texture

--- a/src/emulator/renderer/src/texture_cache.cpp
+++ b/src/emulator/renderer/src/texture_cache.cpp
@@ -39,7 +39,7 @@ static TextureCacheHash hash_palette_data(const emu::SceGxmTexture &texture, siz
     return palette_hash;
 }
 
-static TextureCacheHash hash_texture_data(const emu::SceGxmTexture &texture, const MemState &mem) {
+TextureCacheHash hash_texture_data(const emu::SceGxmTexture &texture, const MemState &mem) {
     R_PROFILE(__func__);
 
     const SceGxmTextureFormat format = gxm::get_format(&texture);


### PR DESCRIPTION
Dumps textures in `shaderlog/<TITLE_ID>` as they are used.

Exposed in the config (config file + cmd arg) and in the Debug settings dialog.

Some games change textures every frame and the way the dumper is implemented, it dumps _all_ variations as long as the texture contents are different. So you might want to enable this at runtime from the Debug settings whenever you want to get the textures, and then and disable it (but you might miss some that appeared before and are not used anymore).

It only works with implemented texture formats.

### Examples

#### Alone with You:
<details>
 <summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/6632271/59183288-5892e580-8b74-11e9-95b3-f786dd26f573.png)
(up until the intro screen)
</details>


####  Darius Burst: Chronicle Saviours
<details>
 <summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/6632271/59183363-77917780-8b74-11e9-8c4e-e5992d843e8d.png)
(up until the main menu)
</details>

#### Downwell
<details>
 <summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/6632271/59183500-d0611000-8b74-11e9-9362-88885d09cb54.png)
</details>

---

### Testers needed
'Danganronpa: Trigger Havoc' crashes my driver, needs more testing to find a pattern or (unlikely) whether it's a driver bug (could be if it only happens on Nvidia).