### PR TITLE
Gui/config/io: Add multi user support

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -35,7 +35,6 @@ struct Config {
     bool log_exports = false;
     bool log_active_shaders = false;
     bool log_uniforms = false;
-    std::vector<std::string> lle_modules;
     bool pstv_mode = false;
     bool show_gui = false;
     bool show_game_background = true;
@@ -53,10 +52,12 @@ struct Config {
     bool load_config = false;
     bool discord_rich_presence = true;
     bool wait_for_debugger = false;
-    std::string online_id = "Vita3K";
     bool color_surface_debug = false;
     bool hardware_flip = false;
     bool performance_overlay = false;
     std::string backend_renderer = "OpenGL";
+    int user_id = 0;
+    std::vector<std::string> online_id = { "Vita3K" };
+    std::vector<std::string> lle_modules = {};
 
 }; // struct Config

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -118,7 +118,7 @@ static ExitCode parse(Config &cfg, const fs::path &load_path, const std::string 
     get_yaml_value(config_node, "pstv-mode", &cfg.pstv_mode, false);
     get_yaml_value(config_node, "show-gui", &cfg.show_gui, false);
     get_yaml_value(config_node, "show-game-background", &cfg.show_game_background, true);
-    get_yaml_value(config_node, "icon-size", &cfg.icon_size, static_cast<int>(64));
+    get_yaml_value(config_node, "icon-size", &cfg.icon_size, 64);
     get_yaml_value(config_node, "archive-log", &cfg.archive_log, false);
     get_yaml_value(config_node, "texture-cache", &cfg.texture_cache, true);
     get_yaml_value(config_node, "sys-button", &cfg.sys_button, static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS));
@@ -128,12 +128,13 @@ static ExitCode parse(Config &cfg, const fs::path &load_path, const std::string 
     get_yaml_value(config_node, "log-level", &cfg.log_level, static_cast<int>(spdlog::level::trace));
     get_yaml_value(config_node, "pref-path", &cfg.pref_path, root_pref_path);
     get_yaml_value(config_node, "discord-rich-presence", &cfg.discord_rich_presence, true);
-    get_yaml_value(config_node, "online-id", &cfg.online_id, std::string("Vita3K"));
     get_yaml_value(config_node, "wait-for-debugger", &cfg.wait_for_debugger, false);
     get_yaml_value(config_node, "color-surface-debug", &cfg.color_surface_debug, false);
     get_yaml_value(config_node, "hardware-flip", &cfg.hardware_flip, false);
     get_yaml_value(config_node, "performance-overlay", &cfg.performance_overlay, false);
     get_yaml_value(config_node, "backend-renderer", &cfg.backend_renderer, std::string("OpenGL"));
+    get_yaml_value(config_node, "user-id", &cfg.user_id, 0);
+    get_yaml_value(config_node, "online-id", &cfg.online_id, std::vector<std::string>{ "Vita3K" });
 
     if (!fs::exists(cfg.pref_path) && !cfg.pref_path.empty()) {
         LOG_ERROR("Cannot find preference path: {}", cfg.pref_path);
@@ -181,14 +182,15 @@ ExitCode serialize_config(Config &cfg, const fs::path &output_path) {
     config_file_emit_single(emitter, "background-alpha", cfg.background_alpha);
     config_file_emit_single(emitter, "log-level", cfg.log_level);
     config_file_emit_single(emitter, "pref-path", cfg.pref_path);
-    config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
     config_file_emit_single(emitter, "discord-rich-presence", cfg.discord_rich_presence);
-    config_file_emit_single(emitter, "online-id", cfg.online_id);
     config_file_emit_single(emitter, "wait-for-debugger", cfg.wait_for_debugger);
     config_file_emit_single(emitter, "color-surface-debug", cfg.color_surface_debug);
     config_file_emit_single(emitter, "hardware-flip", cfg.hardware_flip);
     config_file_emit_single(emitter, "performance-overlay", cfg.performance_overlay);
     config_file_emit_single(emitter, "backend-renderer", cfg.backend_renderer);
+    config_file_emit_single(emitter, "user-id", cfg.user_id);
+    config_file_emit_vector(emitter, "online-id", cfg.online_id);
+    config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
 
     emitter << YAML::EndMap;
 
@@ -220,7 +222,7 @@ void merge_configs(Config &lhs, const Config &rhs, const std::string &new_pref_p
         lhs.show_gui = rhs.show_gui;
     if (lhs.show_game_background != rhs.show_game_background && (!init || !rhs.show_game_background))
         lhs.show_game_background = rhs.show_game_background;
-    if (lhs.icon_size != rhs.icon_size && (!init || rhs.icon_size != static_cast<int>(64)))
+    if (lhs.icon_size != rhs.icon_size && (!init || rhs.icon_size != 64))
         lhs.icon_size = rhs.icon_size;
     if (lhs.archive_log != rhs.archive_log && (!init || rhs.archive_log))
         lhs.archive_log = rhs.archive_log;
@@ -254,6 +256,10 @@ void merge_configs(Config &lhs, const Config &rhs, const std::string &new_pref_p
         lhs.performance_overlay = rhs.performance_overlay;
     if (lhs.backend_renderer != rhs.backend_renderer && (!init || rhs.backend_renderer != std::string("OpenGL")))
         lhs.backend_renderer = rhs.backend_renderer;
+    if (lhs.user_id != rhs.user_id && (!init || rhs.user_id != 0))
+        lhs.user_id = rhs.user_id;
+    if (lhs.online_id != rhs.online_id && (!init || rhs.online_id != std::vector<std::string>({ "Vita3K" })))
+        lhs.online_id = rhs.online_id;
 
     // Not stored in config file
     if (init) {

--- a/vita3k/gui/CMakeLists.txt
+++ b/vita3k/gui/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
 	src/mutexes_dialog.cpp
 	src/perf_overlay.cpp
 	src/private.h
+	src/profiles_manager_dialog.cpp
 	src/reinstall.cpp
 	src/semaphores_dialog.cpp
 	src/settings_dialog.cpp

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -73,6 +73,7 @@ struct DebugMenuState {
 };
 
 struct ConfigurationMenuState {
+    bool profiles_manager_dialog = false;
     bool settings_dialog = false;
 };
 
@@ -108,6 +109,8 @@ struct GuiState {
     char disassembly_address[9] = "00000000";
     char disassembly_count[5] = "100";
     std::vector<std::string> disassembly;
+
+    std::string online_id;
 
     ImGuiTextFilter module_search_bar;
 

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -96,7 +96,7 @@ static void init_style() {
     style->Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.25f, 1.00f, 0.00f, 1.00f);
     style->Colors[ImGuiCol_PlotHistogram] = ImVec4(0.40f, 0.39f, 0.38f, 0.63f);
     style->Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.25f, 1.00f, 0.00f, 1.00f);
-    style->Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.25f, 1.00f, 0.00f, 0.43f);
+    style->Colors[ImGuiCol_TextSelectedBg] = ImVec4(1.00f, 1.00f, 0.00f, 0.50f);
     style->Colors[ImGuiCol_ModalWindowDarkening] = ImVec4(1.00f, 0.98f, 0.95f, 0.73f);
 }
 
@@ -167,7 +167,7 @@ static void init_icons(GuiState &gui, HostState &host) {
             LOG_WARN("Default icon not found for title {}, {}.", game.title_id, game.title);
             continue;
         }
-        stbi_uc *data = stbi_load_from_memory(&buffer[0], buffer.size(), &width, &height, nullptr, STBI_rgb_alpha);
+        stbi_uc *data = stbi_load_from_memory(&buffer[0], static_cast<int>(buffer.size()), &width, &height, nullptr, STBI_rgb_alpha);
         if (width != 128 || height != 128) {
             LOG_ERROR("Invalid icon for title {}, {}.", game.title_id, game.title);
             continue;
@@ -197,7 +197,7 @@ void load_game_background(GuiState &gui, HostState &host, const std::string &tit
             return;
         }
     }
-    stbi_uc *data = stbi_load_from_memory(&buffer[0], buffer.size(), &width, &height, nullptr, STBI_rgb_alpha);
+    stbi_uc *data = stbi_load_from_memory(&buffer[0], static_cast<int>(buffer.size()), &width, &height, nullptr, STBI_rgb_alpha);
     if (!data) {
         LOG_ERROR("Invalid game background for title {}.", title_id);
         return;
@@ -315,6 +315,8 @@ void draw_ui(GuiState &gui, HostState &host) {
     if (gui.debug_menu.disassembly_dialog)
         draw_disassembly_dialog(gui, host);
 
+    if (gui.configuration_menu.profiles_manager_dialog)
+        draw_profiles_manager_dialog(gui, host);
     if (gui.configuration_menu.settings_dialog)
         draw_settings_dialog(gui, host);
 

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -41,6 +41,7 @@ static void draw_debug_menu(DebugMenuState &state) {
 static void draw_config_menu(ConfigurationMenuState &state) {
     if (ImGui::BeginMenu("Configuration")) {
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+        ImGui::MenuItem("Profiles Manager", nullptr, &state.profiles_manager_dialog);
         ImGui::MenuItem("Settings", nullptr, &state.settings_dialog);
         ImGui::PopStyleColor();
         ImGui::EndMenu();

--- a/vita3k/gui/src/private.h
+++ b/vita3k/gui/src/private.h
@@ -48,6 +48,7 @@ void draw_condvars_dialog(GuiState &gui, HostState &host);
 void draw_event_flags_dialog(GuiState &gui, HostState &host);
 void draw_allocations_dialog(GuiState &gui, HostState &host);
 void draw_disassembly_dialog(GuiState &gui, HostState &host);
+void draw_profiles_manager_dialog(GuiState &gui, HostState &host);
 void draw_settings_dialog(GuiState &gui, HostState &host);
 void draw_controls_dialog(GuiState &gui, HostState &host);
 void draw_about_dialog(GuiState &gui);

--- a/vita3k/gui/src/profiles_manager_dialog.cpp
+++ b/vita3k/gui/src/profiles_manager_dialog.cpp
@@ -1,0 +1,228 @@
+// Vita3K emulator project
+// Copyright (C) 2019 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "private.h"
+
+#include <config/functions.h>
+#include <host/state.h>
+#include <misc/cpp/imgui_stdlib.h>
+#include <util/log.h>
+
+namespace gui {
+
+void draw_profiles_manager_dialog(GuiState &gui, HostState &host) {
+    ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+    ImGui::Begin("Profiles Manager", &gui.configuration_menu.profiles_manager_dialog, ImGuiWindowFlags_AlwaysAutoResize);
+    ImGui::PopStyleColor();
+
+    const auto update_online_id = std::find(host.cfg.online_id.begin(), host.cfg.online_id.end(), gui.online_id);
+    static const fs::path user_path{ fs::path(host.pref_path) / "ux0/user" };
+    static const auto BUTTON_SIZE = ImVec2(60.f, 0.f);
+
+    // Add user
+    ImGui::InputTextWithHint("##online_id", "Write your online ID", &gui.online_id);
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Set your Online ID with a maximum of 16 characters.");
+    ImGui::SameLine();
+    if (ImGui::Button("Add Online ID") && !gui.online_id.empty())
+        ImGui::OpenPopup("Add Online ID");
+    ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+    if (ImGui::BeginPopupModal("Add Online ID", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::PopStyleColor();
+
+        if (gui.online_id.length() > 16)
+            ImGui::TextColored(GUI_COLOR_TEXT, "Error: Need reduce to length for online ID.\nCurrently the length is: %d.", gui.online_id.length());
+        else if (update_online_id != host.cfg.online_id.end())
+            ImGui::TextColored(GUI_COLOR_TEXT, "Error: '%s' Online ID already exists.", gui.online_id.c_str());
+        else
+            ImGui::TextColored(GUI_COLOR_TEXT, "Success: '%s' Online ID added.", gui.online_id.c_str());
+
+        ImGui::Separator();
+        ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 30);
+        if (ImGui::Button("OK", BUTTON_SIZE)) {
+            if (update_online_id == host.cfg.online_id.end() && !(gui.online_id.length() > 16)) {
+                host.cfg.online_id.push_back(gui.online_id);
+                host.cfg.user_id += ((int)host.cfg.online_id.size() - 1) - host.cfg.user_id;
+                host.io.user_id = fmt::format("{:0>2d}", host.cfg.user_id);
+                if (!fs::exists(user_path / host.io.user_id))
+                    fs::create_directories(user_path / host.io.user_id / "savedata");
+                gui.online_id.clear();
+            }
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::EndPopup();
+    } else
+        ImGui::PopStyleColor();
+
+    // User list
+    ImGui::PushItemWidth(300);
+    if (ImGui::ListBoxHeader("##online_id_list", (int)host.cfg.online_id.size(), 4)) {
+        for (auto i = 0; i < host.cfg.online_id.size(); i++) {
+            ImGui::TextColored(GUI_COLOR_TEXT, "User ID: %02d, Online ID: %s", i, host.cfg.online_id[i].c_str());
+        }
+        ImGui::ListBoxFooter();
+    }
+    ImGui::PopItemWidth();
+    ImGui::Spacing();
+    if (host.cfg.online_id.size() > 1) {
+        ImGui::PushItemWidth(210);
+        ImGui::TextColored(GUI_COLOR_TEXT, "Select Your User.");
+        ImGui::Combo(
+            "##select_user", &host.cfg.user_id,
+            [](void *vec, int idx, const char **list_online_id) {
+                auto &vector = *static_cast<std::vector<std::string> *>(vec);
+                if (idx < 0 || idx >= static_cast<int>(vector.size())) {
+                    return false;
+                }
+                *list_online_id = vector.at(idx).c_str();
+                return true;
+            },
+            static_cast<void *>(&host.cfg.online_id), static_cast<int>(host.cfg.online_id.size()));
+        ImGui::SameLine();
+        ImGui::TextColored(GUI_COLOR_TEXT, "User ID: %02d", host.cfg.user_id);
+        ImGui::PopItemWidth();
+
+        // Delete User
+        ImGui::Spacing();
+        if (ImGui::Button("Delete Selected User"))
+            ImGui::OpenPopup("Delete User");
+        ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+        if (ImGui::BeginPopupModal("Delete User", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::PopStyleColor();
+            const auto delete_online_id = std::find(host.cfg.online_id.begin(), host.cfg.online_id.end(), host.cfg.online_id[host.cfg.user_id]);
+
+            if (fs::exists(user_path / host.io.user_id)) {
+                ImGui::TextColored(GUI_COLOR_TEXT, "Do you want also delete folder for this user?\nUser ID: %s, Online ID: %s", host.io.user_id.c_str(), host.cfg.online_id[host.cfg.user_id].c_str());
+                ImGui::Separator();
+                ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 100);
+                if (ImGui::Button("Yes", BUTTON_SIZE)) {
+                    fs::remove_all(user_path / host.io.user_id);
+                    host.cfg.online_id.erase(delete_online_id);
+                    if (host.cfg.user_id < static_cast<int>(host.cfg.online_id.size())) {
+                        auto o = host.cfg.user_id + 1, n = host.cfg.user_id; 
+                        for (o, n; o < host.cfg.online_id.size() + 1 && n < host.cfg.online_id.size(); o++, n++) {
+                            auto old_user_id = fmt::format("{:0>2d}", o);
+                            auto new_user_id = fmt::format("{:0>2d}", n);
+                            if (fs::exists(user_path / old_user_id) && !fs::exists(user_path / new_user_id))
+                                fs::rename(user_path / old_user_id, user_path / new_user_id);
+                        }
+                    }
+                    ImGui::CloseCurrentPopup();
+                }
+
+                ImGui::SameLine();
+                if (ImGui::Button("No", BUTTON_SIZE)) {
+                    host.cfg.online_id.erase(delete_online_id);
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("Cancel", BUTTON_SIZE)) {
+                    ImGui::CloseCurrentPopup();
+                }
+
+            } else {
+                ImGui::TextColored(GUI_COLOR_TEXT, "Do you really want delete this user?\nUser ID: %s, Online ID: %s", host.io.user_id.c_str(), host.cfg.online_id[host.cfg.user_id].c_str());
+                ImGui::Separator();
+                ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 65);
+                if (ImGui::Button("Yes", BUTTON_SIZE)) {
+                    host.cfg.online_id.erase(delete_online_id);
+                    ImGui::CloseCurrentPopup();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("No", BUTTON_SIZE)) {
+                    ImGui::CloseCurrentPopup();
+                }
+            }
+
+            ImGui::EndPopup();
+        } else
+            ImGui::PopStyleColor();
+    }
+
+    // Rename User
+    ImGui::SameLine();
+    std::string rename_button = "Rename Main User";
+    if (host.cfg.user_id > 0)
+        rename_button = "Rename Selected User";
+    if (ImGui::Button(rename_button.c_str())) {
+        ImGui::OpenPopup("Rename Online ID");
+        if (!gui.online_id.empty())
+            gui.online_id.clear();
+        gui.online_id = host.cfg.online_id[host.cfg.user_id];
+    }
+    ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+    if (ImGui::BeginPopupModal("Rename Online ID", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::PopStyleColor();
+        ImGui::InputTextWithHint("##online_id", "Write change online ID", &gui.online_id);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Set your Online ID with a maximum of 16 characters.");
+        ImGui::Separator();
+        ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 65);
+        if (ImGui::Button("Apply", BUTTON_SIZE))
+            ImGui::OpenPopup("Apply Rename Online ID");
+        ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
+        if (ImGui::BeginPopupModal("Apply Rename Online ID", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::PopStyleColor();
+
+            if (gui.online_id.empty())
+                ImGui::TextColored(GUI_COLOR_TEXT, "Error: Text is empty, write you Online ID.");
+            else if (gui.online_id.length() > 16)
+                ImGui::TextColored(GUI_COLOR_TEXT, "Error: Need reduce to length for online ID.\nCurrently the length is: %d.", gui.online_id.length());
+            else if (update_online_id != host.cfg.online_id.end())
+                ImGui::TextColored(GUI_COLOR_TEXT, "Error: '%s' Online ID already exists.", gui.online_id.c_str());
+            else
+                ImGui::TextColored(GUI_COLOR_TEXT, "Success: '%s' Online ID renamed to '%s'.", host.cfg.online_id[host.cfg.user_id].c_str(), gui.online_id.c_str());
+
+            ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 30);
+            if (ImGui::Button("OK", BUTTON_SIZE)) {
+                if (gui.online_id.empty())
+                    gui.online_id = host.cfg.online_id[host.cfg.user_id];
+                else if (update_online_id == host.cfg.online_id.end() && !(gui.online_id.length() > 16)) {
+                    host.cfg.online_id[host.cfg.user_id].replace(host.cfg.online_id[host.cfg.user_id].begin(), host.cfg.online_id[host.cfg.user_id].end(), gui.online_id);
+                    gui.online_id = host.cfg.online_id[host.cfg.user_id];
+                }
+                ImGui::CloseCurrentPopup();
+            }
+
+            ImGui::EndPopup();
+        } else
+            ImGui::PopStyleColor();
+
+        ImGui::SameLine();
+        if (ImGui::Button("Close", BUTTON_SIZE)) {
+            gui.online_id.clear();
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::EndPopup();
+    } else
+        ImGui::PopStyleColor();
+
+    if (static_cast<int>(host.cfg.online_id.size()) - 1 < host.cfg.user_id)
+        --host.cfg.user_id;
+
+    if (host.io.user_id.empty() || std::stoi(host.io.user_id) != host.cfg.user_id)
+        host.io.user_id = fmt::format("{:0>2d}", host.cfg.user_id);
+
+    if (host.cfg.overwrite_config)
+        config::serialize_config(host.cfg, host.cfg.config_path);
+
+    ImGui::End();
+}
+
+} // namespace gui

--- a/vita3k/io/include/io/functions.h
+++ b/vita3k/io/include/io/functions.h
@@ -35,6 +35,7 @@ struct IOState;
 inline SceUID invalid_fd = -1;
 
 void init_device_paths(IOState &io);
+bool init_savedata_game_path(IOState &io, const fs::path &pref_path);
 bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path);
 
 SceUID open_file(IOState &io, const char *path, const int flags, const std::string &pref_path, const char *export_name);

--- a/vita3k/io/include/io/state.h
+++ b/vita3k/io/include/io/state.h
@@ -103,7 +103,9 @@ struct IOState {
     } device_paths;
 
     std::string title_id;
-    std::string pref_save_path;
+
+    std::string user_id;
+
     SceUID next_fd = 0;
     TtyFiles tty_files;
     StdFiles std_files;

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -92,15 +92,19 @@ bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path) {
     const fs::path uma0_data{ uma0 / "data" };
     const fs::path ux0_app{ ux0 / "app" };
     const fs::path ux0_user{ ux0 / "user" };
-    const fs::path ux0_user00{ ux0_user / "00" };
-    const fs::path ux0_savedata{ ux0_user00 / "savedata" };
 
-    fs::create_directory(ux0_data);
-    fs::create_directory(ux0_app);
-    fs::create_directory(ux0_user);
-    fs::create_directory(ux0_user00);
-    fs::create_directory(ux0_savedata);
-    fs::create_directory(uma0_data);
+    if (!fs::exists(ux0))
+        fs::create_directories(ux0);
+    if (!fs::exists(ux0_data))
+        fs::create_directory(ux0_data);
+    if (!fs::exists(ux0_app))
+        fs::create_directory(ux0_app);
+    if (!fs::exists(ux0_user))
+        fs::create_directory(ux0_user);
+    if (!fs::exists(uma0))
+        fs::create_directory(uma0);
+    if (!fs::exists(uma0_data))
+        fs::create_directory(uma0_data);
 
     fs::create_directory(base_path / "shaderlog");
 
@@ -108,9 +112,24 @@ bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path) {
 }
 
 void init_device_paths(IOState &io) {
-    io.device_paths.savedata0 = "user/00/savedata/" + io.title_id;
+    io.device_paths.savedata0 = "user/" + io.user_id + "/savedata/" + io.title_id;
     io.device_paths.app0 = "app/" + io.title_id;
     io.device_paths.addcont0 = "addcont/" + io.title_id;
+}
+
+bool init_savedata_game_path(IOState &io, const fs::path &pref_path) {
+    const fs::path user_id_path{ pref_path / (+VitaIoDevice::ux0)._to_string() / "user" / io.user_id };
+    const fs::path savedata_path{ user_id_path / "savedata" };
+    const fs::path savedata_game_path{ savedata_path / io.title_id };
+
+    if (!fs::exists(user_id_path))
+        fs::create_directory(user_id_path);
+    if (!fs::exists(savedata_path))
+        fs::create_directory(savedata_path);
+    if (!fs::exists(savedata_game_path))
+        fs::create_directory(savedata_game_path);
+
+    return true;
 }
 
 static std::string translate_path(const char *path, VitaIoDevice &device, const IOState::DevicePaths &device_paths) {
@@ -254,7 +273,7 @@ int write_file(SceUID fd, const void *data, const SceSize size, const IOState &i
             if (s.back() == '\n')
                 s.pop_back();
 
-            LOG_INFO("*** TTY: {}", s);
+            LOG_TRACE("*** TTY: {}", s);
             return size;
         }
         return IO_ERROR_UNK();

--- a/vita3k/modules/SceNpManager/SceNpManager.cpp
+++ b/vita3k/modules/SceNpManager/SceNpManager.cpp
@@ -106,12 +106,12 @@ EXPORT(int, sceNpManagerGetNpId, SceNpId *id) {
         return SCE_NP_MANAGER_ERROR_NOT_INITIALIZED;
     }
 
-    if (host.cfg.online_id.length() > 16) {
+    if (host.cfg.online_id[host.cfg.user_id].length() > 16) {
         LOG_ERROR("Your online ID has over 16 characters, try again with shorter name");
         return SCE_NP_MANAGER_ERROR_ID_NOT_AVAIL;
     }
 
-    std::copy(host.cfg.online_id.begin(), host.cfg.online_id.end(), id->online_id.name);
+    host.cfg.online_id[host.cfg.user_id].copy(id->online_id.name, host.cfg.online_id[host.cfg.user_id].length());
     id->online_id.term = '\0';
     id->online_id.dummy = 0;
 

--- a/vita3k/np/src/trophy/context.cpp
+++ b/vita3k/np/src/trophy/context.cpp
@@ -1,5 +1,6 @@
 #include <io/device.h>
 #include <io/functions.h>
+#include <io/state.h>
 #include <np/functions.h>
 #include <np/state.h>
 #include <np/trophy/context.h>
@@ -299,7 +300,7 @@ emu::np::trophy::ContextHandle create_trophy_context(NpState &np, IOState &io, c
 
     // Try to open the trophy save file. The context will automatically took the default profile to perform trophy
     // operations on.
-    auto trophy_progress_save_file = device::construct_normalized_path(VitaIoDevice::ux0, "user/00/trophy/data/" + unique_trophy_folder);
+    auto trophy_progress_save_file = device::construct_normalized_path(VitaIoDevice::ux0, "user/" + io.user_id + "/trophy/data/" + unique_trophy_folder);
 
     create_dir(io, trophy_progress_save_file.c_str(), 0, pref_path, "create_trophy_context", true);
     trophy_progress_save_file += "TROPUSR.DAT";


### PR DESCRIPTION
- Add Profiles Manager for support multi user with user_id for savedata, and with online id.
- Add popup for confirm and ask if user wan delete folder with save/trophy corresponding user id. 
- Re works creation folder for Save Data.
- move tty log inside trace log level, before can get it on different file etc (improve perfomance if spaming)

# Result : 
- List user
![image](https://user-images.githubusercontent.com/5261759/62006876-f7849880-b146-11e9-9269-c47f0e2ed4ec.png)

- Both case for delete user popup ask user.
![image](https://user-images.githubusercontent.com/5261759/61992084-c67a6a00-b059-11e9-835c-a33abcc11de6.png)
![image](https://user-images.githubusercontent.com/5261759/61992086-ce3a0e80-b059-11e9-8ffd-667efaad5c84.png)
- Rename user
![image](https://user-images.githubusercontent.com/5261759/62006895-30247200-b147-11e9-9f8f-ef7f2ec63dae.png)





