### PR TITLE
gdbstub: tune up

### DIFF
--- a/src/emulator/app/include/app/functions.h
+++ b/src/emulator/app/include/app/functions.h
@@ -39,6 +39,7 @@ enum class AppRunType {
 };
 
 bool init(HostState &state, Config cfg, const Root &root_paths);
+void destory(HostState &state);
 void update_viewport(HostState &state);
 void error_dialog(const std::string &message, SDL_Window *window = nullptr);
 

--- a/src/emulator/app/src/app_init.cpp
+++ b/src/emulator/app/src/app_init.cpp
@@ -303,7 +303,7 @@ void destory(HostState &host) {
 
     // There may be changes that made in the GUI, so we should save, again
     if (host.cfg.overwrite_config)
-        app::serialize_config(host.cfg, host.cfg.config_path);
+        config::serialize_config(host.cfg, host.cfg.config_path);
 }
 
 } // namespace app

--- a/src/emulator/app/src/app_init.cpp
+++ b/src/emulator/app/src/app_init.cpp
@@ -33,6 +33,10 @@
 #include <app/discord.h>
 #endif
 
+#ifdef USE_GDBSTUB
+#include <gdbstub/functions.h>
+#endif
+
 #include <SDL_video.h>
 #include <microprofile.h>
 
@@ -154,9 +158,8 @@ bool init(HostState &state, Config cfg, const Root &root_paths) {
     };
 
     state.cfg = std::move(cfg);
-    if (state.cfg.wait_for_debugger) {
-        state.kernel.wait_for_debugger = state.cfg.wait_for_debugger.value();
-    }
+    state.kernel.wait_for_debugger = state.cfg.wait_for_debugger;
+
     state.base_path = root_paths.get_base_path_string();
 
     // If configuration does not provide a preference path, use SDL's default
@@ -287,6 +290,20 @@ bool init(HostState &state, Config cfg, const Root &root_paths) {
     }
 
     return true;
+}
+
+void destory(HostState &host) {
+#ifdef USE_DISCORD_RICH_PRESENCE
+    discord::shutdown();
+#endif
+
+#ifdef USE_GDBSTUB
+    server_close(host);
+#endif
+
+    // There may be changes that made in the GUI, so we should save, again
+    if (host.cfg.overwrite_config)
+        app::serialize_config(host.cfg, host.cfg.config_path);
 }
 
 } // namespace app

--- a/src/emulator/config/include/config/config.h
+++ b/src/emulator/config/include/config/config.h
@@ -52,6 +52,6 @@ struct Config {
     bool overwrite_config = true;
     bool load_config = false;
     bool discord_rich_presence = true;
-    optional<bool> wait_for_debugger;
+    bool wait_for_debugger;
     std::string online_id = "Vita3K";
 }; // struct Config

--- a/src/emulator/config/src/config.cpp
+++ b/src/emulator/config/src/config.cpp
@@ -129,7 +129,7 @@ static ExitCode parse(Config &cfg, const fs::path &load_path, const std::string 
     get_yaml_value(config_node, "pref-path", &cfg.pref_path, root_pref_path);
     get_yaml_value(config_node, "discord-rich-presence", &cfg.discord_rich_presence, true);
     get_yaml_value(config_node, "online-id", &cfg.online_id, std::string("Vita3K"));
-    get_yaml_value_optional(config_node, "wait-for-debugger", &cfg.wait_for_debugger);
+    get_yaml_value(config_node, "wait-for-debugger", &cfg.wait_for_debugger, false);
 
     if (!fs::exists(cfg.pref_path) && !cfg.pref_path.empty()) {
         LOG_ERROR("Cannot find preference path: {}", cfg.pref_path);
@@ -180,7 +180,7 @@ ExitCode serialize_config(Config &cfg, const fs::path &output_path) {
     config_file_emit_vector(emitter, "lle-modules", cfg.lle_modules);
     config_file_emit_single(emitter, "discord-rich-presence", cfg.discord_rich_presence);
     config_file_emit_single(emitter, "online-id", cfg.online_id);
-    config_file_emit_optional_single(emitter, "wait-for-debugger", cfg.wait_for_debugger);
+    config_file_emit_single(emitter, "wait-for-debugger", cfg.wait_for_debugger);
 
     emitter << YAML::EndMap;
 
@@ -235,10 +235,8 @@ void merge_configs(Config &lhs, const Config &rhs, const std::string &new_pref_p
     }
     if (lhs.discord_rich_presence != rhs.discord_rich_presence && (!init || rhs.discord_rich_presence))
         lhs.discord_rich_presence = rhs.discord_rich_presence;
-    if (rhs.wait_for_debugger.is_initialized()) {
-        if (lhs.wait_for_debugger != rhs.wait_for_debugger && (!init || *rhs.wait_for_debugger))
-            lhs.wait_for_debugger = rhs.wait_for_debugger;
-    }
+    if (lhs.wait_for_debugger != rhs.wait_for_debugger && (!init || rhs.wait_for_debugger))
+        lhs.wait_for_debugger = rhs.wait_for_debugger;
 
     // Not stored in config file
     if (init) {

--- a/src/emulator/cpu/include/cpu/functions.h
+++ b/src/emulator/cpu/include/cpu/functions.h
@@ -40,13 +40,17 @@ uint32_t read_lr(CPUState &state);
 uint32_t read_fpscr(CPUState &state);
 uint32_t read_cpsr(CPUState &state);
 void write_reg(CPUState &state, size_t index, uint32_t value);
+void write_float_reg(CPUState &state, size_t index, float value);
 void write_sp(CPUState &state, uint32_t value);
 void write_pc(CPUState &state, uint32_t value);
 void write_lr(CPUState &state, uint32_t value);
+void write_fpscr(CPUState &state, uint32_t value);
+void write_cpsr(CPUState &state, uint32_t value);
 
 // Debugging helpers
 std::string disassemble(CPUState &state, uint64_t at, bool thumb, uint16_t *insn_size = nullptr);
 std::string disassemble(CPUState &state, uint64_t at, uint16_t *insn_size = nullptr);
 bool hit_breakpoint(CPUState &state);
+void trigger_breakpoint(CPUState &state);
 void log_code_add(CPUState &state);
 void log_mem_add(CPUState &state);

--- a/src/emulator/gdbstub/src/gdb.cpp
+++ b/src/emulator/gdbstub/src/gdb.cpp
@@ -298,7 +298,7 @@ static std::string cmd_write_registers(HostState &state, PacketCommand &command)
         return "";
     CPUState &cpu = *state.kernel.threads[state.gdb.current_thread]->cpu.get();
 
-    std::string content = content_string(command).substr(1);
+    const std::string content = content_string(command).substr(1);
 
     for (uint32_t a = 0; a < content.size() / 8; a++) {
         uint32_t value = parse_hex(content.substr(a * 8, 8));
@@ -313,7 +313,7 @@ static std::string cmd_read_register(HostState &state, PacketCommand &command) {
         return "";
     CPUState &cpu = *state.kernel.threads[state.gdb.current_thread]->cpu.get();
 
-    std::string content = content_string(command);
+    const std::string content = content_string(command);
     int32_t reg = parse_hex(content.substr(1, content.size() - 1));
 
     return be_hex(fetch_reg(cpu, static_cast<uint32_t>(reg)));
@@ -324,7 +324,7 @@ static std::string cmd_write_register(HostState &state, PacketCommand &command) 
         return "";
     CPUState &cpu = *state.kernel.threads[state.gdb.current_thread]->cpu.get();
 
-    std::string content = content_string(command);
+    const std::string content = content_string(command);
     uint32_t equal_index = content.find('=');
     int32_t reg = parse_hex(content.substr(1, equal_index - 1));
     uint32_t value = parse_hex(content.substr(equal_index + 1));
@@ -334,15 +334,15 @@ static std::string cmd_write_register(HostState &state, PacketCommand &command) 
 }
 
 static bool check_memory_region(Address address, Address length, MemState &mem) {
-    auto page_first = static_cast<uint32_t>(address / KB(4));
-    auto page_length = static_cast<uint32_t>(length + KB(4)) / KB(4);
+    const auto page_first = static_cast<uint32_t>(address / KB(4));
+    const auto page_length = static_cast<uint32_t>(length + KB(4)) / KB(4);
 
-    auto pages_begin = mem.allocated_pages.begin();
-    auto range_end = pages_begin + page_first + page_length;
+    const auto pages_begin = mem.allocated_pages.begin();
+    const auto range_end = pages_begin + page_first + page_length;
 
-    bool memory_none = std::find(pages_begin + page_first, range_end, 0) != range_end;
-    bool memory_null = std::find(pages_begin + page_first, range_end, 1) != range_end;
-    bool memory_safe = !(memory_none || memory_null);
+    const bool memory_none = std::find(pages_begin + page_first, range_end, 0) != range_end;
+    const bool memory_null = std::find(pages_begin + page_first, range_end, 1) != range_end;
+    const bool memory_safe = !(memory_none || memory_null);
 
     if (!memory_safe)
         LOG_GDB("Accessing unsafe memory page. {} - {}", page_first, page_length);
@@ -351,13 +351,13 @@ static bool check_memory_region(Address address, Address length, MemState &mem) 
 }
 
 static std::string cmd_read_memory(HostState &state, PacketCommand &command) {
-    std::string content = content_string(command);
-    size_t pos = content.find(',');
+    const std::string content = content_string(command);
+    const size_t pos = content.find(',');
 
-    std::string first = content.substr(1, pos - 1);
-    std::string second = content.substr(pos + 1);
-    uint32_t address = parse_hex(first);
-    uint32_t length = parse_hex(second);
+    const std::string first = content.substr(1, pos - 1);
+    const std::string second = content.substr(pos + 1);
+    const uint32_t address = parse_hex(first);
+    const uint32_t length = parse_hex(second);
 
     if (!check_memory_region(address, length, state.mem))
         return "EAA";
@@ -372,15 +372,15 @@ static std::string cmd_read_memory(HostState &state, PacketCommand &command) {
 }
 
 static std::string cmd_write_memory(HostState &state, PacketCommand &command) {
-    std::string content = content_string(command);
-    size_t pos_first = content.find(',');
-    size_t pos_second = content.find(':');
+    const std::string content = content_string(command);
+    const size_t pos_first = content.find(',');
+    const size_t pos_second = content.find(':');
 
-    std::string first = content.substr(1, pos_first - 1);
-    std::string second = content.substr(pos_first + 1, pos_second - pos_first);
-    uint32_t address = parse_hex(first);
-    uint32_t length = parse_hex(second);
-    std::string hex_data = content.substr(pos_second + 1);
+    const std::string first = content.substr(1, pos_first - 1);
+    const std::string second = content.substr(pos_first + 1, pos_second - pos_first);
+    const uint32_t address = parse_hex(first);
+    const uint32_t length = parse_hex(second);
+    const std::string hex_data = content.substr(pos_second + 1);
 
     if (!check_memory_region(address, length, state.mem))
         return "EAA";
@@ -395,13 +395,17 @@ static std::string cmd_write_memory(HostState &state, PacketCommand &command) {
 // server_next() might not be able to tell the difference between the end of the packet ($) and 0x24 ($).
 // Thus, cmd_write_binary is disabled.
 static std::string cmd_write_binary(HostState &state, PacketCommand &command) {
-    std::string content = content_string(command);
-    size_t pos_first = content.find(',');
-    size_t pos_second = content.find(':');
+    const std::string content = content_string(command);
+    const size_t pos_first = content.find(',');
+    const size_t pos_second = content.find(':');
 
+    const
     std::string first = content.substr(1, pos_first - 1);
+    const
     std::string second = content.substr(pos_first + 1, pos_second - pos_first);
+    const
     uint32_t address = parse_hex(first);
+    const
     uint32_t length = parse_hex(second);
     const char *data = command.content_start + pos_second + 1;
 
@@ -418,7 +422,7 @@ static std::string cmd_write_binary(HostState &state, PacketCommand &command) {
 static std::string cmd_detach(HostState &state, PacketCommand &command) { return "OK"; }
 
 static std::string cmd_continue(HostState &state, PacketCommand &command) {
-    std::string content = content_string(command);
+    const std::string content = content_string(command);
 
     uint64_t index = 5;
     uint64_t next = 0;
@@ -426,9 +430,9 @@ static std::string cmd_continue(HostState &state, PacketCommand &command) {
         next = content.find(';', index + 1);
         std::string text = content.substr(index + 1, next - index - 1);
 
-        uint64_t colon = text.find(':');
+        const uint64_t colon = text.find(':');
 
-        char cmd = text[0];
+        const char cmd = text[0];
         switch (cmd) {
         case 'c':
         case 'C':
@@ -436,7 +440,7 @@ static std::string cmd_continue(HostState &state, PacketCommand &command) {
         case 'S': {
             bool step = cmd == 's' || cmd == 'S';
             if (colon != std::string::npos) {
-                int32_t point = parse_hex(text.substr(colon + 1));
+                const int32_t point = parse_hex(text.substr(colon + 1));
                 ThreadStatePtr thread = state.kernel.threads[point];
                 if (thread) {
                     thread->to_do = step ? ThreadToDo::step : ThreadToDo::run;
@@ -485,8 +489,8 @@ static std::string cmd_continue_supported(HostState &state, PacketCommand &comma
 }
 
 static std::string cmd_thread_alive(HostState &state, PacketCommand &command) {
-    std::string content = content_string(command);
-    int32_t thread_id = parse_hex(content.substr(1));
+    const std::string content = content_string(command);
+    const int32_t thread_id = parse_hex(content.substr(1));
 
     // Assuming a thread is removed from the map when it closes or is killed.
     for (const auto &pair : state.kernel.threads) {
@@ -533,14 +537,13 @@ static std::string cmd_list_threads(HostState &state, PacketCommand &command) {
 }
 
 static std::string cmd_add_breakpoint(HostState &state, PacketCommand &command) {
-    std::string content = content_string(command);
-    uint32_t type, address, kind;
+    const std::string content = content_string(command);
 
-    uint64_t first = content.find(',');
-    uint64_t second = content.find(',', first + 1);
-    type = static_cast<uint32_t>(std::stol(content.substr(1, first - 1)));
-    address = parse_hex(content.substr(first + 1, second - 1 - first));
-    kind = static_cast<uint32_t>(std::stol(content.substr(second + 1, content.size() - second - 1)));
+    const uint64_t first = content.find(',');
+    const uint64_t second = content.find(',', first + 1);
+    const uint32_t type = static_cast<uint32_t>(std::stol(content.substr(1, first - 1)));
+    const uint32_t address = parse_hex(content.substr(first + 1, second - 1 - first));
+    const uint32_t kind = static_cast<uint32_t>(std::stol(content.substr(second + 1, content.size() - second - 1)));
 
     LOG_GDB("GDB Server New Breakpoint at {} ({}, {}).", log_hex(address), type, kind);
     add_breakpoint(state, address);
@@ -549,14 +552,13 @@ static std::string cmd_add_breakpoint(HostState &state, PacketCommand &command) 
 }
 
 static std::string cmd_remove_breakpoint(HostState &state, PacketCommand &command) {
-    std::string content = content_string(command);
-    uint32_t type, address, kind;
+    const std::string content = content_string(command);
 
-    uint64_t first = content.find(',');
-    uint64_t second = content.find(',', first + 1);
-    type = static_cast<uint32_t>(std::stol(content.substr(1, first - 1)));
-    address = parse_hex(content.substr(first + 1, second - 1 - first));
-    kind = static_cast<uint32_t>(std::stol(content.substr(second + 1, content.size() - second - 1)));
+    const uint64_t first = content.find(',');
+    const uint64_t second = content.find(',', first + 1);
+    const uint32_t type = static_cast<uint32_t>(std::stol(content.substr(1, first - 1)));
+    const uint32_t address = parse_hex(content.substr(first + 1, second - 1 - first));
+    const uint32_t kind = static_cast<uint32_t>(std::stol(content.substr(second + 1, content.size() - second - 1)));
 
     LOG_GDB("GDB Server Removed Breakpoint at {} ({}, {}).", log_hex(address), type, kind);
     remove_breakpoint(state, address);
@@ -654,7 +656,7 @@ static int64_t server_next(HostState &state) {
     if (state.gdb.server_die)
         return -1;
 
-    int64_t length = recv(state.gdb.client_socket, buffer, sizeof(buffer), 0);
+    const int64_t length = recv(state.gdb.client_socket, buffer, sizeof(buffer), 0);
     buffer[length] = '\0';
 
     if (length <= 0) {

--- a/src/emulator/gdbstub/src/gdb.cpp
+++ b/src/emulator/gdbstub/src/gdb.cpp
@@ -135,8 +135,7 @@ static PacketCommand parse_command(char *data, int64_t length) {
     command.content_length = command.end_index - command.begin_index;
 
     command.checksum_start = command.data + command.end_index + 1;
-    command.checksum = (uint8_t)std::stoul(
-        std::string(command.checksum_start, 2), nullptr, 16);
+    command.checksum = static_cast<uint8_t>(parse_hex(std::string(command.checksum_start, 2)));
 
     command.is_valid = make_checksum(command.content_start, command.content_length) == command.checksum;
     if (!command.is_valid)
@@ -196,8 +195,8 @@ static SceUID select_thread(HostState &state, int thread_id) {
 }
 
 static std::string cmd_set_current_thread(HostState &state, PacketCommand &command) {
-    int32_t thread_id = std::stoi(
-        std::string(command.content_start + 2, static_cast<unsigned long>(command.content_length - 2)));
+    int32_t thread_id = parse_hex(std::string(
+        command.content_start + 2, static_cast<unsigned long>(command.content_length - 2)));
 
     switch (command.content_start[1]) {
     case 'c':
@@ -245,6 +244,42 @@ static uint32_t fetch_reg(CPUState &state, uint32_t reg) {
     return 0;
 }
 
+static void modify_reg(CPUState &state, uint32_t reg, uint32_t value) {
+    if (reg <= 12) {
+        write_reg(state, reg, value);
+        return;
+    }
+
+    if (reg == 13) {
+        write_sp(state, value);
+        return;
+    }
+    if (reg == 14) {
+        write_lr(state, value);
+        return;
+    }
+    if (reg == 15) {
+        write_pc(state, value);
+        return;
+    }
+
+    if (reg <= 23) {
+        write_float_reg(state, reg - 16, *reinterpret_cast<float *>(&value));
+        return;
+    }
+
+    if (reg == 24) {
+        write_fpscr(state, value);
+        return;
+    }
+    if (reg == 25) {
+        write_cpsr(state, value);
+        return;
+    }
+
+    LOG_GDB("GDB Server Modified Invalid Register {}", reg);
+}
+
 static std::string cmd_read_registers(HostState &state, PacketCommand &command) {
     if (state.gdb.current_thread == -1)
         return "";
@@ -258,7 +293,20 @@ static std::string cmd_read_registers(HostState &state, PacketCommand &command) 
     return stream.str();
 }
 
-static std::string cmd_write_registers(HostState &state, PacketCommand &command) { return ""; }
+static std::string cmd_write_registers(HostState &state, PacketCommand &command) {
+    if (state.gdb.current_thread == -1)
+        return "";
+    CPUState &cpu = *state.kernel.threads[state.gdb.current_thread]->cpu.get();
+
+    std::string content = content_string(command).substr(1);
+
+    for (uint32_t a = 0; a < content.size() / 8; a++) {
+        uint32_t value = parse_hex(content.substr(a * 8, 8));
+        modify_reg(cpu, a, value);
+    }
+
+    return "OK";
+}
 
 static std::string cmd_read_register(HostState &state, PacketCommand &command) {
     if (state.gdb.current_thread == -1)
@@ -272,7 +320,34 @@ static std::string cmd_read_register(HostState &state, PacketCommand &command) {
 }
 
 static std::string cmd_write_register(HostState &state, PacketCommand &command) {
-    return "";
+    if (state.gdb.current_thread == -1)
+        return "";
+    CPUState &cpu = *state.kernel.threads[state.gdb.current_thread]->cpu.get();
+
+    std::string content = content_string(command);
+    uint32_t equal_index = content.find('=');
+    int32_t reg = parse_hex(content.substr(1, equal_index - 1));
+    uint32_t value = parse_hex(content.substr(equal_index + 1));
+    modify_reg(cpu, reg, value);
+
+    return "OK";
+}
+
+static bool check_memory_region(Address address, Address length, MemState &mem) {
+    auto page_first = static_cast<uint32_t>(address / KB(4));
+    auto page_length = static_cast<uint32_t>(length + KB(4)) / KB(4);
+
+    auto pages_begin = mem.allocated_pages.begin();
+    auto range_end = pages_begin + page_first + page_length;
+
+    bool memory_none = std::find(pages_begin + page_first, range_end, 0) != range_end;
+    bool memory_null = std::find(pages_begin + page_first, range_end, 1) != range_end;
+    bool memory_safe = !(memory_none || memory_null);
+
+    if (!memory_safe)
+        LOG_GDB("Accessing unsafe memory page. {} - {}", page_first, page_length);
+
+    return memory_safe;
 }
 
 static std::string cmd_read_memory(HostState &state, PacketCommand &command) {
@@ -280,24 +355,12 @@ static std::string cmd_read_memory(HostState &state, PacketCommand &command) {
     size_t pos = content.find(',');
 
     std::string first = content.substr(1, pos - 1);
-    std::string second = content.substr(pos + 1, content.size() - pos);
+    std::string second = content.substr(pos + 1);
     uint32_t address = parse_hex(first);
     uint32_t length = parse_hex(second);
 
-    auto page_first = static_cast<uint32_t>(address / KB(4));
-    auto page_length = static_cast<uint32_t>(length + KB(4)) / KB(4);
-
-    auto pages_begin = state.mem.allocated_pages.begin();
-    auto range_end = pages_begin + page_first + page_length;
-
-    bool memory_none = std::find(pages_begin + page_first, range_end, 0) != range_end;
-    bool memory_null = std::find(pages_begin + page_first, range_end, 1) != range_end;
-    bool memory_safe = !(memory_none || memory_null);
-
-    if (!memory_safe) {
-        LOG_GDB("Reading from unsafe page. {} - {}", page_first, page_length);
+    if (!check_memory_region(address, length, state.mem))
         return "EAA";
-    }
 
     std::stringstream stream;
 
@@ -308,7 +371,49 @@ static std::string cmd_read_memory(HostState &state, PacketCommand &command) {
     return stream.str();
 }
 
-static std::string cmd_write_memory(HostState &state, PacketCommand &command) { return ""; }
+static std::string cmd_write_memory(HostState &state, PacketCommand &command) {
+    std::string content = content_string(command);
+    size_t pos_first = content.find(',');
+    size_t pos_second = content.find(':');
+
+    std::string first = content.substr(1, pos_first - 1);
+    std::string second = content.substr(pos_first + 1, pos_second - pos_first);
+    uint32_t address = parse_hex(first);
+    uint32_t length = parse_hex(second);
+    std::string hex_data = content.substr(pos_second + 1);
+
+    if (!check_memory_region(address, length, state.mem))
+        return "EAA";
+
+    for (uint32_t a = 0; a < length; a++) {
+        state.mem.memory[address + a] = static_cast<uint8_t>(parse_hex(hex_data.substr(a * 2, 2)));
+    }
+
+    return "OK";
+}
+
+// server_next() might not be able to tell the difference between the end of the packet ($) and 0x24 ($).
+// Thus, cmd_write_binary is disabled.
+static std::string cmd_write_binary(HostState &state, PacketCommand &command) {
+    std::string content = content_string(command);
+    size_t pos_first = content.find(',');
+    size_t pos_second = content.find(':');
+
+    std::string first = content.substr(1, pos_first - 1);
+    std::string second = content.substr(pos_first + 1, pos_second - pos_first);
+    uint32_t address = parse_hex(first);
+    uint32_t length = parse_hex(second);
+    const char *data = command.content_start + pos_second + 1;
+
+    if (!check_memory_region(address, length, state.mem))
+        return "EAA";
+
+    for (uint32_t a = 0; a < length; a++) {
+        state.mem.memory[address + a] = data[a];
+    }
+
+    return "OK";
+}
 
 static std::string cmd_detach(HostState &state, PacketCommand &command) { return "OK"; }
 
@@ -331,7 +436,7 @@ static std::string cmd_continue(HostState &state, PacketCommand &command) {
         case 'S': {
             bool step = cmd == 's' || cmd == 'S';
             if (colon != std::string::npos) {
-                int32_t point = std::stoi(text.substr(colon + 1));
+                int32_t point = parse_hex(text.substr(colon + 1));
                 ThreadStatePtr thread = state.kernel.threads[point];
                 if (thread) {
                     thread->to_do = step ? ThreadToDo::step : ThreadToDo::run;
@@ -377,6 +482,20 @@ static std::string cmd_continue(HostState &state, PacketCommand &command) {
 
 static std::string cmd_continue_supported(HostState &state, PacketCommand &command) {
     return "vCont;c;C;s;S;t;r";
+}
+
+static std::string cmd_thread_alive(HostState &state, PacketCommand &command) {
+    std::string content = content_string(command);
+    int32_t thread_id = parse_hex(content.substr(1));
+
+    // Assuming a thread is removed from the map when it closes or is killed.
+    for (const auto &pair : state.kernel.threads) {
+        if (pair.first == thread_id) {
+            return "OK";
+        }
+    }
+
+    return "E00";
 }
 
 static std::string cmd_kill(HostState &state, PacketCommand &command) {
@@ -458,28 +577,28 @@ static std::string cmd_unimplemented(HostState &state, PacketCommand &command) {
 }
 
 const static PacketFunctionBundle functions[] = {
+    // General
     { "!", cmd_unimplemented },
     { "?", cmd_reason },
-    { "A", cmd_unimplemented },
-    { "b", cmd_unimplemented },
-    { "B", cmd_unimplemented },
-    { "bc", cmd_unimplemented },
-    { "bs", cmd_unimplemented },
-    { "c", cmd_deprecated },
-    { "C", cmd_deprecated },
-    { "d", cmd_unimplemented },
-    { "D", cmd_detach },
-    { "F", cmd_unimplemented },
-    { "g", cmd_read_registers },
-    { "G", cmd_write_registers },
     { "H", cmd_set_current_thread },
+    { "T", cmd_thread_alive },
     { "i", cmd_unimplemented },
     { "I", cmd_unimplemented },
-    { "k", cmd_die },
-    { "m", cmd_read_memory },
-    { "M", cmd_write_memory },
+    { "A", cmd_unimplemented },
+    { "bc", cmd_unimplemented },
+    { "bs", cmd_unimplemented },
+    { "t", cmd_unimplemented },
+
+    // Read/Write
     { "p", cmd_read_register },
     { "P", cmd_write_register },
+    { "g", cmd_read_registers },
+    { "G", cmd_write_registers },
+    { "m", cmd_read_memory },
+    { "M", cmd_write_memory },
+    { "X", cmd_unimplemented }, // change cmd_unimplemented to cmd_write_binary to enable binary downloading
+
+    // Query Packets
     { "qfThreadInfo", cmd_list_threads },
     { "qsThreadInfo", cmd_unimplemented },
     { "qSupported", cmd_supported },
@@ -488,28 +607,31 @@ const static PacketFunctionBundle functions[] = {
     { "qC", cmd_get_current_thread },
     { "q", cmd_unimplemented },
     { "Q", cmd_unimplemented },
+
+    // Shutdown
+    { "d", cmd_unimplemented },
     { "r", cmd_unimplemented },
     { "R", cmd_unimplemented },
-    { "s", cmd_unimplemented },
-    { "S", cmd_unimplemented },
-    { "t", cmd_unimplemented },
-    { "T", cmd_unimplemented },
-    { "vAttach", cmd_unimplemented },
+    { "k", cmd_die },
+
+    // Control Packets
     { "vCont?", cmd_continue_supported },
     { "vCont", cmd_continue },
-    { "vCtrlC", cmd_unimplemented },
-    { "vFile", cmd_unimplemented },
-    { "vFlashErase", cmd_unimplemented },
-    { "vFlashWrite", cmd_unimplemented },
-    { "vFlashDone", cmd_unimplemented },
     { "vKill", cmd_kill },
     { "vMustReplyEmpty", cmd_reply_empty },
-    { "vRun", cmd_unimplemented },
-    { "vStopped", cmd_unimplemented },
     { "v", cmd_unimplemented },
-    { "X", cmd_unimplemented },
+
+    // Breakpoints
     { "z", cmd_remove_breakpoint },
     { "Z", cmd_add_breakpoint },
+
+    // Deprecated
+    { "b", cmd_deprecated },
+    { "B", cmd_deprecated },
+    { "c", cmd_deprecated },
+    { "C", cmd_deprecated },
+    { "s", cmd_deprecated },
+    { "S", cmd_deprecated },
 };
 
 static bool command_begins_with(PacketCommand &command, const std::string &small) {

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -28,6 +28,8 @@
 #include <util/log.h>
 #include <util/string_utils.h>
 
+#include <SDL.h>
+
 #ifdef USE_GDBSTUB
 #include <gdbstub/functions.h>
 #endif
@@ -173,21 +175,12 @@ int main(int argc, char *argv[]) {
 
         app::set_window_title(host);
     }
-#ifdef USE_DISCORD_RICH_PRESENCE
-    discord::shutdown();
-#endif
-
-#ifdef USE_GDBSTUB
-    server_close(host);
-#endif
 
 #ifdef WIN32
     CoUninitialize();
 #endif
 
-    // There may be changes that made in the GUI, so we should save, again
-    if (host.cfg.overwrite_config)
-        config::serialize_config(host.cfg, host.cfg.config_path);
+    app::destory(host);
 
     return Success;
 }

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -28,15 +28,7 @@
 #include <util/log.h>
 #include <util/string_utils.h>
 
-#ifndef USE_DISCORD
-#include <app/discord.h>
-#endif
-
 #include <SDL.h>
-
-#ifdef USE_GDBSTUB
-#include <gdbstub/functions.h>
-#endif
 
 #ifdef USE_DISCORD_RICH_PRESENCE
 #include <app/discord.h>

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -28,8 +28,6 @@
 #include <util/log.h>
 #include <util/string_utils.h>
 
-#include <SDL.h>
-
 #ifdef USE_DISCORD_RICH_PRESENCE
 #include <app/discord.h>
 #endif

--- a/src/emulator/main.cpp
+++ b/src/emulator/main.cpp
@@ -28,6 +28,10 @@
 #include <util/log.h>
 #include <util/string_utils.h>
 
+#ifndef USE_DISCORD
+#include <app/discord.h>
+#endif
+
 #include <SDL.h>
 
 #ifdef USE_GDBSTUB


### PR DESCRIPTION
This PR does a couple of things:

- Adds support for writing to registers or memory through GDB.
- Thread IDs are apparently hexes so the stub no longer interprets them as decimals.
- GDB *should* also catch unicorn errors now.
- Made the configuration option no longer optional for two reasons: 
  - Everything else isn't optional anymore so it kinda looks ugly.
  - I was editing the wrong config file and nothing was changing and I got scared and changed it.
- Makes a proper app:destroy() method to deinitialize the app.
  - In my honest opinion, I think this is a good thing. It separates all the code that terminates stuff from main and gives it a nice cozy home.
  - I understand if you think this shouldn't be included, either because it's not necessary or this isn't the pr to do it (or any other reason).
  - Tell me if you want this to go and I'll remove it.

Before the PR is merged, I need to:
- [x] test writing to memory.
- [x] test writing to registers.

I wanted to test catching unicorn errors but I had trouble getting one to work, even with Waterflame's helpful list (I NEED THE GAMES). It should be able to catch them afaik but I'm not sure how well it would work.