### PR TITLE
Major Leaguer

### DIFF
--- a/src/emulator/gxm/include/gxm/types.h
+++ b/src/emulator/gxm/include/gxm/types.h
@@ -323,7 +323,7 @@ public:
     std::uint32_t primary_program_instr_count;
     std::uint32_t primary_program_offset;
 
-    std::uint32_t unk44;
+    std::uint32_t secondary_program_instr_count;
 
     std::uint32_t secondary_program_offset; // relative to the beginning of this field
     std::uint32_t secondary_program_offset_end; // relative to the beginning of this field

--- a/src/emulator/shader/include/shader/usse_translator.h
+++ b/src/emulator/shader/include/shader/usse_translator.h
@@ -126,25 +126,30 @@ private:
     // Translation helpers
     //
 
-#define BEGIN_REPEAT(repeat_count, jump)                     \
-    const auto repeat_count_num = (uint8_t)repeat_count + 1; \
-    const auto repeat_jump = jump;                           \
+#define BEGIN_REPEAT(repeat_count, jump_all) BEGIN_REPEAT_4(repeat_count, jump_all, jump_all, jump_all, jump_all)
+
+#define BEGIN_REPEAT_4(repeat_count, jump_dest, jump_src0, jump_src1, jump_src2)                  \
+    const auto repeat_count_num = (uint8_t)repeat_count + 1;                                      \
+    const auto repeat_jump_dest = jump_dest;                                                      \
+    const auto repeat_jump_src0 = jump_src0;                                                      \
+    const auto repeat_jump_src1 = jump_src1;                                                      \
+    const auto repeat_jump_src2 = jump_src2;                                                      \
     for (auto current_repeat = 0; current_repeat < repeat_count_num; current_repeat++) {
 #define END_REPEAT() }
 
-#define GET_REPEAT(inst)                                                                     \
-    int dest_repeat_offset = get_repeat_offset(inst.opr.dest, current_repeat) * repeat_jump; \
-    int src0_repeat_offset = get_repeat_offset(inst.opr.src0, current_repeat) * repeat_jump; \
-    int src1_repeat_offset = get_repeat_offset(inst.opr.src1, current_repeat) * repeat_jump; \
-    int src2_repeat_offset = get_repeat_offset(inst.opr.src2, current_repeat) * repeat_jump; \
-    if (inst.opr.dest.bank == RegisterBank::FPINTERNAL)                                      \
-        dest_repeat_offset /= repeat_jump;                                                   \
-    if (inst.opr.src0.bank == RegisterBank::FPINTERNAL)                                      \
-        src0_repeat_offset /= repeat_jump;                                                   \
-    if (inst.opr.src1.bank == RegisterBank::FPINTERNAL)                                      \
-        src1_repeat_offset /= repeat_jump;                                                   \
-    if (inst.opr.src2.bank == RegisterBank::FPINTERNAL)                                      \
-        src2_repeat_offset /= repeat_jump;
+#define GET_REPEAT(inst)                                                                          \
+    int dest_repeat_offset = get_repeat_offset(inst.opr.dest, current_repeat) * repeat_jump_dest; \
+    int src0_repeat_offset = get_repeat_offset(inst.opr.src0, current_repeat) * repeat_jump_src0; \
+    int src1_repeat_offset = get_repeat_offset(inst.opr.src1, current_repeat) * repeat_jump_src1; \
+    int src2_repeat_offset = get_repeat_offset(inst.opr.src2, current_repeat) * repeat_jump_src2; \
+    if (inst.opr.dest.bank == RegisterBank::FPINTERNAL)                                           \
+        dest_repeat_offset /= repeat_jump_dest;                                                   \
+    if (inst.opr.src0.bank == RegisterBank::FPINTERNAL)                                           \
+        src0_repeat_offset /= repeat_jump_src0;                                                   \
+    if (inst.opr.src1.bank == RegisterBank::FPINTERNAL)                                           \
+        src1_repeat_offset /= repeat_jump_src1;                                                   \
+    if (inst.opr.src2.bank == RegisterBank::FPINTERNAL)                                           \
+        src2_repeat_offset /= repeat_jump_src2;
 
     const int get_repeat_offset(Operand &op, const std::uint8_t repeat_index) {
         return repeat_increase[op.index][repeat_index];
@@ -205,28 +210,28 @@ public:
         Imm1 opcode2,
         Imm1 dest_use_bank_ext,
         Imm1 end,
-        Imm1 src0_bank_ext,
+        Imm1 src1_bank_ext,
         Imm2 increment_mode,
         Imm1 gpi0_abs,
         RepeatCount repeat_count,
         bool nosched,
         Imm4 write_mask,
-        Imm1 src0_neg,
-        Imm1 src0_abs,
+        Imm1 src1_neg,
+        Imm1 src1_abs,
         Imm1 gpi1_neg,
         Imm1 gpi1_abs,
         Imm1 gpi0_swiz_ext,
         Imm2 dest_bank,
-        Imm2 src0_bank,
+        Imm2 src1_bank,
         Imm2 gpi0_n,
         Imm6 dest_n,
         Imm4 gpi0_swiz,
         Imm4 gpi1_swiz,
         Imm2 gpi1_n,
         Imm1 gpi0_neg,
-        Imm1 src0_swiz_ext,
-        Imm4 src0_swiz,
-        Imm6 src0_n);
+        Imm1 src1_swiz_ext,
+        Imm4 src1_swiz,
+        Imm6 src1_n);
 
     bool vmad2(
         Imm1 dat_fmt,
@@ -381,25 +386,25 @@ public:
         Imm1 opcode2,
         Imm1 dest_use_bank_ext,
         Imm1 end,
-        Imm1 src0_bank_ext,
+        Imm1 src1_bank_ext,
         Imm2 increment_mode,
         Imm1 gpi0_abs,
         RepeatCount repeat_count,
         bool nosched,
         Imm4 write_mask,
-        Imm1 src0_neg,
-        Imm1 src0_abs,
+        Imm1 src1_neg,
+        Imm1 src1_abs,
         Imm3 clip_plane_n,
         Imm2 dest_bank,
-        Imm2 src0_bank,
+        Imm2 src1_bank,
         Imm2 gpi0_n,
         Imm6 dest_n,
         Imm4 gpi0_swiz,
-        Imm3 src0_swiz_w,
-        Imm3 src0_swiz_z,
-        Imm3 src0_swiz_y,
-        Imm3 src0_swiz_x,
-        Imm6 src0_n);
+        Imm3 src1_swiz_w,
+        Imm3 src1_swiz_z,
+        Imm3 src1_swiz_y,
+        Imm3 src1_swiz_x,
+        Imm6 src1_n);
 
     bool br(
         ExtPredicate pred,

--- a/src/emulator/shader/include/shader/usse_translator.h
+++ b/src/emulator/shader/include/shader/usse_translator.h
@@ -141,15 +141,7 @@ private:
     int dest_repeat_offset = get_repeat_offset(inst.opr.dest, current_repeat) * repeat_jump_dest; \
     int src0_repeat_offset = get_repeat_offset(inst.opr.src0, current_repeat) * repeat_jump_src0; \
     int src1_repeat_offset = get_repeat_offset(inst.opr.src1, current_repeat) * repeat_jump_src1; \
-    int src2_repeat_offset = get_repeat_offset(inst.opr.src2, current_repeat) * repeat_jump_src2; \
-    if (inst.opr.dest.bank == RegisterBank::FPINTERNAL)                                           \
-        dest_repeat_offset /= repeat_jump_dest;                                                   \
-    if (inst.opr.src0.bank == RegisterBank::FPINTERNAL)                                           \
-        src0_repeat_offset /= repeat_jump_src0;                                                   \
-    if (inst.opr.src1.bank == RegisterBank::FPINTERNAL)                                           \
-        src1_repeat_offset /= repeat_jump_src1;                                                   \
-    if (inst.opr.src2.bank == RegisterBank::FPINTERNAL)                                           \
-        src2_repeat_offset /= repeat_jump_src2;
+    int src2_repeat_offset = get_repeat_offset(inst.opr.src2, current_repeat) * repeat_jump_src2;
 
     const int get_repeat_offset(Operand &op, const std::uint8_t repeat_index) {
         return repeat_increase[op.index][repeat_index];

--- a/src/emulator/shader/src/translator/alu.cpp
+++ b/src/emulator/shader/src/translator/alu.cpp
@@ -569,7 +569,8 @@ bool USSETranslatorVisitor::vnmad32(
 
     auto dest_comp_count = dest_mask_to_comp_count(dest_mask);
 
-    LOG_DISASM("{:016x}: {}{} {} {} {}", m_instr, disasm::e_predicate_str(pred), disasm::opcode_str(opcode), disasm::operand_to_str(inst.opr.dest, dest_mask),
+    LOG_DISASM("{:016x}: {}{}.{} {} {} {}", m_instr, disasm::e_predicate_str(pred), disasm::opcode_str(opcode),
+        disasm::data_type_str(inst.opr.dest.type), disasm::operand_to_str(inst.opr.dest, dest_mask),
         disasm::operand_to_str(inst.opr.src1, dest_mask), disasm::operand_to_str(inst.opr.src2, dest_mask));
 
     // Recompile

--- a/src/emulator/shader/src/translator/alu.cpp
+++ b/src/emulator/shader/src/translator/alu.cpp
@@ -35,28 +35,28 @@ bool USSETranslatorVisitor::vmad(
     Imm1 opcode2,
     Imm1 dest_use_bank_ext,
     Imm1 end,
-    Imm1 src0_bank_ext,
+    Imm1 src1_bank_ext,
     Imm2 increment_mode,
     Imm1 gpi0_abs,
     RepeatCount repeat_count,
     bool nosched,
     Imm4 write_mask,
-    Imm1 src0_neg,
-    Imm1 src0_abs,
+    Imm1 src1_neg,
+    Imm1 src1_abs,
     Imm1 gpi1_neg,
     Imm1 gpi1_abs,
     Imm1 gpi0_swiz_ext,
     Imm2 dest_bank,
-    Imm2 src0_bank,
+    Imm2 src1_bank,
     Imm2 gpi0_n,
     Imm6 dest_n,
     Imm4 gpi0_swiz,
     Imm4 gpi1_swiz,
     Imm2 gpi1_n,
     Imm1 gpi0_neg,
-    Imm1 src0_swiz_ext,
-    Imm4 src0_swiz,
-    Imm6 src0_n) {
+    Imm1 src1_swiz_ext,
+    Imm4 src1_swiz,
+    Imm6 src1_n) {
     std::string disasm_str = fmt::format("{:016x}: {}{}", m_instr, disasm::e_predicate_str(pred), "VMAD");
 
     Instruction inst;
@@ -69,7 +69,7 @@ bool USSETranslatorVisitor::vmad(
     }
 
     // Double regs always true for src1, dest
-    inst.opr.src1 = decode_src12(inst.opr.src1, src0_n, src0_bank, src0_bank_ext, true, 7, m_second_program);
+    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_bank_ext, true, 7, m_second_program);
     inst.opr.dest = decode_dest(inst.opr.dest, dest_n, dest_bank, dest_use_bank_ext, true, 7, m_second_program);
 
     // GPI0 and GPI1, setup!
@@ -84,15 +84,15 @@ bool USSETranslatorVisitor::vmad(
         inst.opr.dest.swizzle[3] = usse::SwizzleChannel::_X;
     }
 
-    inst.opr.src1.swizzle = decode_vec34_swizzle(src0_swiz, src0_swiz_ext, type);
+    inst.opr.src1.swizzle = decode_vec34_swizzle(src1_swiz, src1_swiz_ext, type);
     inst.opr.src0.swizzle = decode_vec34_swizzle(gpi0_swiz, gpi0_swiz_ext, type);
     inst.opr.src2.swizzle = decode_vec34_swizzle(gpi1_swiz, gpi1_swiz_ext, type);
 
-    if (src0_abs) {
+    if (src1_abs) {
         inst.opr.src1.flags |= RegisterFlags::Absolute;
     }
 
-    if (src0_neg) {
+    if (src1_neg) {
         inst.opr.src1.flags |= RegisterFlags::Negative;
     }
 
@@ -271,25 +271,25 @@ bool USSETranslatorVisitor::vdp(
     Imm1 opcode2,
     Imm1 dest_use_bank_ext,
     Imm1 end,
-    Imm1 src0_bank_ext,
+    Imm1 src1_bank_ext,
     Imm2 increment_mode,
     Imm1 gpi0_abs,
     RepeatCount repeat_count,
     bool nosched,
     Imm4 write_mask,
-    Imm1 src0_neg,
-    Imm1 src0_abs,
+    Imm1 src1_neg,
+    Imm1 src1_abs,
     Imm3 clip_plane_n,
     Imm2 dest_bank,
-    Imm2 src0_bank,
+    Imm2 src1_bank,
     Imm2 gpi0_n,
     Imm6 dest_n,
     Imm4 gpi0_swiz,
-    Imm3 src0_swiz_w,
-    Imm3 src0_swiz_z,
-    Imm3 src0_swiz_y,
-    Imm3 src0_swiz_x,
-    Imm6 src0_n) {
+    Imm3 src1_swiz_w,
+    Imm3 src1_swiz_z,
+    Imm3 src1_swiz_y,
+    Imm3 src1_swiz_x,
+    Imm6 src1_n) {
     Instruction inst;
 
     // Is this VDP3 or VDP4, op2 = 0 => vec3
@@ -302,9 +302,7 @@ bool USSETranslatorVisitor::vdp(
     }
 
     // Double regs always true for src1, dest
-    // src0 is actually src1
-    // src1 is gpi0, which repeat offset can't affect to
-    inst.opr.src1 = decode_src12(inst.opr.src1, src0_n, src0_bank, src0_bank_ext, true, 7, m_second_program);
+    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_bank_ext, true, 7, m_second_program);
     inst.opr.dest = decode_dest(inst.opr.dest, dest_n, dest_bank, dest_use_bank_ext, true, 7, m_second_program);
 
     inst.opr.src0.bank = usse::RegisterBank::FPINTERNAL;
@@ -324,17 +322,17 @@ bool USSETranslatorVisitor::vdp(
         SwizzleChannel::_UNDEFINED
     };
 
-    inst.opr.src1.swizzle[0] = tb_swizz_dec[src0_swiz_x];
-    inst.opr.src1.swizzle[1] = tb_swizz_dec[src0_swiz_y];
-    inst.opr.src1.swizzle[2] = tb_swizz_dec[src0_swiz_z];
-    inst.opr.src1.swizzle[3] = tb_swizz_dec[src0_swiz_w];
+    inst.opr.src1.swizzle[0] = tb_swizz_dec[src1_swiz_x];
+    inst.opr.src1.swizzle[1] = tb_swizz_dec[src1_swiz_y];
+    inst.opr.src1.swizzle[2] = tb_swizz_dec[src1_swiz_z];
+    inst.opr.src1.swizzle[3] = tb_swizz_dec[src1_swiz_w];
 
     // Set modifiers
-    if (src0_neg) {
+    if (src1_neg) {
         inst.opr.src1.flags |= RegisterFlags::Negative;
     }
 
-    if (src0_abs) {
+    if (src1_abs) {
         inst.opr.src1.flags |= RegisterFlags::Absolute;
     }
 
@@ -345,7 +343,8 @@ bool USSETranslatorVisitor::vdp(
     m_b.setLine(m_recompiler.cur_pc);
 
     // Decoding done
-    BEGIN_REPEAT(repeat_count, 2)
+    // gpi0 is src0. And sorry, but src0 is actually src1.
+    BEGIN_REPEAT_4(repeat_count, 1, 1, 2, 1)
     GET_REPEAT(inst);
 
     LOG_DISASM("{:016x}: {}VDP {} {} {}", m_instr, disasm::e_predicate_str(pred), disasm::operand_to_str(inst.opr.dest, write_mask, dest_repeat_offset),

--- a/src/emulator/shader/src/translator/branch_cond.cpp
+++ b/src/emulator/shader/src/translator/branch_cond.cpp
@@ -267,7 +267,7 @@ bool USSETranslatorVisitor::vtst(
 
     m_b.setLine(m_recompiler.cur_pc);
 
-    if (test_op == Opcode::VSUB || test_op == Opcode::VF16SUB) {
+    if (test_op == Opcode::VSUB || test_op == Opcode::VF16SUB || test_op == Opcode::FPSUB8) {
         LOG_DISASM("{:016x}: {}{}.{}.{} p{} {} {}", m_instr, disasm::e_predicate_str(pred), "CMP", used_comp_str, disasm::data_type_str(load_data_type),
             pdst_n, disasm::operand_to_str(inst.opr.src1, load_mask), disasm::operand_to_str(inst.opr.src2, load_mask));
 

--- a/src/emulator/shader/src/usse_disasm.cpp
+++ b/src/emulator/shader/src/usse_disasm.cpp
@@ -53,7 +53,11 @@ const char *data_type_str(DataType p) {
     case DataType::INT8: return "i8";
     case DataType::INT16: return "i16";
     case DataType::INT32: return "i32";
+    case DataType::UINT8: return "u8";
+    case DataType::UINT16: return "u16";
+    case DataType::UINT32: return "u32";
     case DataType::C10: return "c10";
+    case DataType::O8: return "fx8";
     case DataType::F16: return "f16";
     case DataType::F32: return "f32";
     default: return "invalid";


### PR DESCRIPTION
- Correct repeat jump for VDP: Analyzing 2 shaders in Super Mario Wars, I found out that without SMLSI to adjust repeat amount, src1 has repeat jump of 4, whether dest has repeat jump of 1.
- Correct custom increment mode for single-issue instruction.

More to come, this PR tends to correct all faults and missings in Super Mario Wars and other VitaGL games. Maybe mega

TODO:
- [ ] Implement SOP2 (for fixed alu op)