### PR TITLE
poc: non stop rendering on one thread

### DIFF
--- a/src/emulator/renderer/CMakeLists.txt
+++ b/src/emulator/renderer/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
 	renderer
 	STATIC
+	include/renderer/commands.h
 	include/renderer/functions.h
 	include/renderer/state.h
 	include/renderer/texture_cache_state.h
@@ -8,6 +9,7 @@ add_library(
 	src/attribute_formats.cpp
 	src/compile_program.cpp
 	src/draw.cpp
+	src/driver_thread.cpp
 	src/functions.h
 	src/load_shaders.cpp
 	src/renderer.cpp
@@ -21,5 +23,5 @@ add_library(
 )
 
 target_include_directories(renderer PUBLIC include)
-target_link_libraries(renderer PUBLIC crypto shader glutil vita-headers)
+target_link_libraries(renderer PUBLIC crypto shader glutil threads vita-headers)
 target_link_libraries(renderer PRIVATE sdl2)

--- a/src/emulator/renderer/include/renderer/commands.h
+++ b/src/emulator/renderer/include/renderer/commands.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstdint>
+#include <queue>
+
+#include <boost/optional.hpp>
+
+namespace renderer {
+    enum CommandOpcode {
+        BEGIN_SCENE = 0,
+        END_SCENE = 1,
+        SYNC_STATE = 2,
+        DRAW = 3
+    };
+
+    enum CommandError {
+        COMMAND_RESULT_NO_ERROR = 0,
+        COMMAND_RESULT_ARGUMENT_INVALID = -1
+    };
+
+    constexpr std::size_t MAX_COMMAND_ARGUMENTS = 10;
+
+    struct Command {
+        CommandOpcode opcode;
+        std::uint64_t arguments[MAX_COMMAND_ARGUMENTS];
+        std::size_t argument_count;
+
+        int *status;
+
+        template <typename T>
+        T get(const std::size_t index) {
+            return (T)arguments[index];
+        }
+
+        void complete(const int result_code) {
+            *status = result_code;
+        }
+    };
+
+    template <typename ...Args>
+    boost::optional<Command> make_command(const CommandOpcode opcode, int *status, Args... arguments) {
+        if (sizeof...(Args) > MAX_COMMAND_ARGUMENTS) {
+            return boost::none;
+        }
+        
+        Command new_command;
+        new_command.opcode = opcode;
+        new_command.argument_count = sizeof...(Args);
+        new_command.status = status;
+
+        for (std::size_t i = 0; i < sizeof...(Args); i++) {
+            new_command.arguments[i] = (std::uint64_t)arguments[i];
+        }
+
+        return new_command;
+    }
+}

--- a/src/emulator/renderer/include/renderer/driver_thread.h
+++ b/src/emulator/renderer/include/renderer/driver_thread.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace renderer {
+
+struct State;
+int gpu_driver_thread(renderer::State &state);
+
+}

--- a/src/emulator/renderer/include/renderer/state.h
+++ b/src/emulator/renderer/include/renderer/state.h
@@ -2,17 +2,33 @@
 
 #include <crypto/hash.h>
 #include <renderer/types.h>
+#include <renderer/commands.h>
+#include <threads/queue.h>
+#include <condition_variable>
 
 #include <map>
 #include <string>
 
 namespace renderer {
 
+enum class Backend {
+    OpenGL,
+    Vulkan
+};
+
+struct Command;
+
 struct State {
     GLSLCache fragment_glsl_cache;
     GLSLCache vertex_glsl_cache;
 
     GXPPtrMap gxp_ptr_map;
+    Queue<Command> command_queue;
+
+    void *active_context;
+    std::condition_variable command_queue_finish_one;
+
+    Backend current_backend;
 };
 
 } // namespace renderer

--- a/src/emulator/renderer/src/driver_thread.cpp
+++ b/src/emulator/renderer/src/driver_thread.cpp
@@ -1,0 +1,64 @@
+#include <renderer/driver_thread.h>
+#include <renderer/types.h>
+#include <renderer/commands.h>
+#include <renderer/state.h>
+
+#include <functional>
+
+namespace renderer {
+    static void gpu_handle_context_change(renderer::State &state, void *context_to_bind) {
+        // Context switching is costly, so we should try to avoid it
+        if (context_to_bind != state.active_context) {
+            // Bind this context
+            state.active_context = context_to_bind;
+            
+            // TUTURU, bind it
+        }
+    }
+
+    static void gpu_do_begin_scene(renderer::State &state, std::unique_ptr<Command> &command) {
+        Context *ctx = command->get<renderer::Context*>(0);
+
+        if (!ctx) {
+            command->complete(COMMAND_RESULT_ARGUMENT_INVALID);
+            return;
+        }
+
+        gpu_handle_context_change(state, ctx->gl.get());
+
+        switch (state.current_backend) {
+        case Backend::OpenGL: {
+            break;
+        }
+
+        case Backend::Vulkan: {
+            break;
+        }
+        }
+
+        command->complete(COMMAND_RESULT_NO_ERROR);
+    }
+
+    int gpu_driver_thread(renderer::State &state) {
+        using CommandHandlerFunc = std::function<void(renderer::State&, std::unique_ptr<Command>&)>;
+        static std::map<CommandOpcode, CommandHandlerFunc> handlers = {
+            { CommandOpcode::BEGIN_SCENE, gpu_do_begin_scene }
+        };
+        
+        // Don't handle hustle API change yet....
+        while (true) {
+            std::unique_ptr<Command> cmd = state.command_queue.pop();
+            auto handler_iterator = handlers.find(cmd->opcode);
+
+            if (handler_iterator == handlers.end()) {
+                assert(false);
+            }
+
+            handler_iterator->second(state, cmd);
+
+            // Finish one. Signal all who wait. The one that has its status code changed should
+            // be the one waken up.
+            state.command_queue_finish_one.notify_all();
+        }
+    }
+}


### PR DESCRIPTION
This is trying to solve the problem when a context is created in one thread but is used for rendering in other thread. 

Each GXM context should has a responsible OpenGL context, that's necessary. There was two solution to the problem upper that i think of before:
- Using a GL Scope: This is just costly, because context switching is expensive.
- Detect when the GXM context is used in other thread and bind it to that thread. For eg when it called BeginScene in other thread, we set the opengl context responsibles with the GXM context in current thread. However, how do we free the OpenGL context that was used in previous thread. It's not easy.

This brings me to a solution of doing OpenGL operations only in one thread. This make control of set/unset OpenGL context much easier.

- Command are pushed into command queue, along with pointer to an integer which will report the return code when the request is finished. For sync operation, the thread will wait for the conditional variable and also wait for the request code to change.
- A OpenGL thread processing it, and notify all threads when a request is done. 

I don't know how this make debugging graphics easier though. Open for discussion, if it's welcomed then I will make a full PR