### PR TITLE
kernel: Allow calls with outBits set at NULL.

### DIFF
--- a/src/emulator/kernel/src/thread/sync_primitives.cpp
+++ b/src/emulator/kernel/src/thread/sync_primitives.cpp
@@ -672,7 +672,9 @@ static int eventflag_waitorpoll(KernelState &kernel, const char *export_name, Sc
 
     bool is_fifo = (event->attr & SCE_KERNEL_ATTR_TH_FIFO);
 
-    *outBits = event->flags & flags;
+    if (outBits) {
+        *outBits = event->flags & flags;
+    }
 
     bool condition;
     if (wait & SCE_EVENT_WAITOR) {


### PR DESCRIPTION
Fixes a regression in Danganronpa 2.