### PR TITLE
Wait for lock instead of stop CPU and wait later

### DIFF
--- a/src/emulator/modules/SceAudio/SceAudio.cpp
+++ b/src/emulator/modules/SceAudio/SceAudio.cpp
@@ -86,11 +86,11 @@ EXPORT(int, sceAudioOutOutput, int port, const void *buf) {
         prt->shared.thread = thread_id;
         lock.unlock();
 
-        const std::lock_guard<std::mutex> lock(thread->mutex);
+        std::unique_lock<std::mutex> mlock(thread->mutex);
         if (thread->to_do != ThreadToDo::run)
             return 0;
         thread->to_do = ThreadToDo::wait;
-        stop(*thread->cpu);
+        thread->something_to_do.wait(mlock);
     }
 
     return 0;


### PR DESCRIPTION
Unicorn startup is slow, so better not stop it.

Improve framerate in debug build for Undertale on some places (like start screen). However the more glyph it draws, the more framerate it drop (to 6fps on my i5, and previously 2fps). I think it's fault somewhere in the rendering system?