### PR TITLE
modules: move ctrl functions to ctrl folder

### DIFF
--- a/src/emulator/ctrl/CMakeLists.txt
+++ b/src/emulator/ctrl/CMakeLists.txt
@@ -1,7 +1,11 @@
 add_library(
 	ctrl
-	INTERFACE
+	STATIC
+	include/ctrl/definitions.h
+	include/ctrl/functions.h
+	include/ctrl/state.h
+	src/ctrl.cpp
 )
 
-target_include_directories(ctrl INTERFACE include)
-target_link_libraries(ctrl INTERFACE sdl2)
+target_include_directories(ctrl PUBLIC include)
+target_link_libraries(ctrl PUBLIC sdl2 vita-headers)

--- a/src/emulator/ctrl/include/ctrl/definitions.h
+++ b/src/emulator/ctrl/include/ctrl/definitions.h
@@ -1,0 +1,116 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <psp2/ctrl.h>
+
+#include <SDL_gamecontroller.h>
+#include <SDL_scancode.h>
+
+#include <cstring>
+
+static uint64_t timestamp;
+
+struct KeyBinding {
+    SDL_Scancode scancode;
+    uint32_t button;
+};
+
+struct ControllerBinding {
+    SDL_GameControllerButton controller;
+    uint32_t button;
+};
+
+static const KeyBinding key_bindings[] = {
+    { SDL_SCANCODE_RSHIFT, SCE_CTRL_SELECT },
+    { SDL_SCANCODE_RETURN, SCE_CTRL_START },
+    { SDL_SCANCODE_UP, SCE_CTRL_UP },
+    { SDL_SCANCODE_RIGHT, SCE_CTRL_RIGHT },
+    { SDL_SCANCODE_DOWN, SCE_CTRL_DOWN },
+    { SDL_SCANCODE_LEFT, SCE_CTRL_LEFT },
+    { SDL_SCANCODE_Q, SCE_CTRL_LTRIGGER },
+    { SDL_SCANCODE_E, SCE_CTRL_RTRIGGER },
+    { SDL_SCANCODE_V, SCE_CTRL_TRIANGLE },
+    { SDL_SCANCODE_C, SCE_CTRL_CIRCLE },
+    { SDL_SCANCODE_X, SCE_CTRL_CROSS },
+    { SDL_SCANCODE_Z, SCE_CTRL_SQUARE },
+    { SDL_SCANCODE_H, SCE_CTRL_PSBUTTON },
+};
+
+static const KeyBinding key_bindings_ext[] = {
+    { SDL_SCANCODE_RSHIFT, SCE_CTRL_SELECT },
+    { SDL_SCANCODE_RETURN, SCE_CTRL_START },
+    { SDL_SCANCODE_UP, SCE_CTRL_UP },
+    { SDL_SCANCODE_RIGHT, SCE_CTRL_RIGHT },
+    { SDL_SCANCODE_DOWN, SCE_CTRL_DOWN },
+    { SDL_SCANCODE_LEFT, SCE_CTRL_LEFT },
+    { SDL_SCANCODE_Q, SCE_CTRL_L1 },
+    { SDL_SCANCODE_E, SCE_CTRL_R1 },
+    { SDL_SCANCODE_U, SCE_CTRL_L2 },
+    { SDL_SCANCODE_O, SCE_CTRL_R2 },
+    { SDL_SCANCODE_F, SCE_CTRL_L3 },
+    { SDL_SCANCODE_H, SCE_CTRL_R3 },
+    { SDL_SCANCODE_V, SCE_CTRL_TRIANGLE },
+    { SDL_SCANCODE_C, SCE_CTRL_CIRCLE },
+    { SDL_SCANCODE_X, SCE_CTRL_CROSS },
+    { SDL_SCANCODE_Z, SCE_CTRL_SQUARE },
+    { SDL_SCANCODE_H, SCE_CTRL_PSBUTTON },
+};
+
+static const size_t key_binding_count = sizeof(key_bindings) / sizeof(key_bindings[0]);
+static const size_t key_binding_ext_count = sizeof(key_bindings_ext) / sizeof(key_bindings_ext[0]);
+
+static const ControllerBinding controller_bindings[] = {
+    { SDL_CONTROLLER_BUTTON_BACK, SCE_CTRL_SELECT },
+    { SDL_CONTROLLER_BUTTON_START, SCE_CTRL_START },
+    { SDL_CONTROLLER_BUTTON_DPAD_UP, SCE_CTRL_UP },
+    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, SCE_CTRL_RIGHT },
+    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, SCE_CTRL_DOWN },
+    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, SCE_CTRL_LEFT },
+    { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, SCE_CTRL_LTRIGGER },
+    { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, SCE_CTRL_RTRIGGER },
+    { SDL_CONTROLLER_BUTTON_Y, SCE_CTRL_TRIANGLE },
+    { SDL_CONTROLLER_BUTTON_B, SCE_CTRL_CIRCLE },
+    { SDL_CONTROLLER_BUTTON_A, SCE_CTRL_CROSS },
+    { SDL_CONTROLLER_BUTTON_X, SCE_CTRL_SQUARE },
+    { SDL_CONTROLLER_BUTTON_GUIDE, SCE_CTRL_PSBUTTON },
+};
+
+static const ControllerBinding controller_bindings_ext[] = {
+    { SDL_CONTROLLER_BUTTON_BACK, SCE_CTRL_SELECT },
+    { SDL_CONTROLLER_BUTTON_START, SCE_CTRL_START },
+    { SDL_CONTROLLER_BUTTON_DPAD_UP, SCE_CTRL_UP },
+    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, SCE_CTRL_RIGHT },
+    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, SCE_CTRL_DOWN },
+    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, SCE_CTRL_LEFT },
+    { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, SCE_CTRL_L1 },
+    { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, SCE_CTRL_R1 },
+    { SDL_CONTROLLER_BUTTON_LEFTSTICK, SCE_CTRL_L3 },
+    { SDL_CONTROLLER_BUTTON_RIGHTSTICK, SCE_CTRL_R3 },
+    { SDL_CONTROLLER_BUTTON_Y, SCE_CTRL_TRIANGLE },
+    { SDL_CONTROLLER_BUTTON_B, SCE_CTRL_CIRCLE },
+    { SDL_CONTROLLER_BUTTON_A, SCE_CTRL_CROSS },
+    { SDL_CONTROLLER_BUTTON_X, SCE_CTRL_SQUARE },
+    { SDL_CONTROLLER_BUTTON_GUIDE, SCE_CTRL_PSBUTTON },
+};
+
+static const size_t controller_binding_count = sizeof(controller_bindings) / sizeof(controller_bindings[0]);
+
+static bool operator<(const SDL_JoystickGUID &a, const SDL_JoystickGUID &b) {
+    return memcmp(&a, &b, sizeof(a)) < 0;
+}

--- a/src/emulator/ctrl/include/ctrl/functions.h
+++ b/src/emulator/ctrl/include/ctrl/functions.h
@@ -17,14 +17,11 @@
 
 #pragma once
 
-#include <psp2/touch.h>
-#include <psp2/types.h>
+constexpr int SCE_CTRL_MODE_UNKNOWN = 3; // missing in vita-headers
 
 struct CtrlState;
-struct SDL_TouchFingerEvent;
 
-static uint64_t timestamp;
+void add_new_controllers(CtrlState &ctrl);
+void remove_disconnected_controllers(CtrlState &ctrl);
 
-int handle_touch_event(SDL_TouchFingerEvent &finger);
-int toggle_touchscreen();
-int peek_touch(SceFVector2 viewport_pos, SceFVector2 viewport_size, SceIVector2 drawable_size, bool renderer_focused, const CtrlState &ctrl, const SceUInt32 &port, SceTouchData *pData, SceUInt32 count);
+int peek_buffer(CtrlState &ctrl, int port, SceCtrlData *&pad_data, int count, bool ext, bool negative);

--- a/src/emulator/ctrl/include/ctrl/state.h
+++ b/src/emulator/ctrl/include/ctrl/state.h
@@ -1,3 +1,20 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 #pragma once
 
 #include <psp2/ctrl.h>

--- a/src/emulator/ctrl/src/ctrl.cpp
+++ b/src/emulator/ctrl/src/ctrl.cpp
@@ -1,0 +1,193 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <ctrl/definitions.h>
+#include <ctrl/functions.h>
+#include <ctrl/state.h>
+
+#include <SDL_haptic.h>
+#include <SDL_keyboard.h>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+
+static float keys_to_axis(const uint8_t *keys, SDL_Scancode code1, SDL_Scancode code2) {
+    float temp = 0;
+    if (keys[code1]) {
+        temp -= 1;
+    }
+    if (keys[code2]) {
+        temp += 1;
+    }
+
+    return temp;
+}
+
+static void apply_keyboard(uint32_t *buttons, float axes[4], bool ext) {
+    const uint8_t *const keys = SDL_GetKeyboardState(nullptr);
+    const size_t selected_key_binding_count = ext ? key_binding_ext_count : key_binding_count;
+    for (int i = 0; i < selected_key_binding_count; ++i) {
+        const KeyBinding &binding = ext ? key_bindings_ext[i] : key_bindings[i];
+        if (keys[binding.scancode]) {
+            *buttons |= binding.button;
+        }
+    }
+
+    axes[0] += keys_to_axis(keys, SDL_SCANCODE_A, SDL_SCANCODE_D);
+    axes[1] += keys_to_axis(keys, SDL_SCANCODE_W, SDL_SCANCODE_S);
+    axes[2] += keys_to_axis(keys, SDL_SCANCODE_J, SDL_SCANCODE_L);
+    axes[3] += keys_to_axis(keys, SDL_SCANCODE_I, SDL_SCANCODE_K);
+}
+
+static float axis_to_axis(int16_t axis) {
+    const auto unsigned_axis = static_cast<float>(axis - INT16_MIN);
+    assert(unsigned_axis >= 0);
+    assert(unsigned_axis <= UINT16_MAX);
+
+    const float f = unsigned_axis / UINT16_MAX;
+
+    const float output = (f * 2) - 1;
+    assert(output >= -1);
+    assert(output <= 1);
+
+    return output;
+}
+
+static void apply_controller(uint32_t *buttons, float axes[4], SDL_GameController *controller, bool ext) {
+    for (int i = 0; i < controller_binding_count; ++i) {
+        const ControllerBinding &binding = ext ? controller_bindings_ext[i] : controller_bindings[i];
+        if (SDL_GameControllerGetButton(controller, binding.controller)) {
+            *buttons |= binding.button;
+        }
+    }
+
+    if (ext) {
+        if (SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERLEFT) > 0x3FFF) {
+            *buttons |= SCE_CTRL_L2;
+        }
+        if (SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERRIGHT) > 0x3FFF) {
+            *buttons |= SCE_CTRL_R2;
+        }
+    }
+
+    axes[0] += axis_to_axis(SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX));
+    axes[1] += axis_to_axis(SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY));
+    axes[2] += axis_to_axis(SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX));
+    axes[3] += axis_to_axis(SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTY));
+}
+
+static uint8_t float_to_byte(float f) {
+    const float mapped = (f * 0.5f) + 0.5f;
+    const float clamped = std::max<float>(0.0f, std::min<float>(mapped, 1.0f));
+    assert(clamped >= 0);
+    assert(clamped <= 1);
+
+    return static_cast<uint8_t>(clamped * 255);
+}
+
+static int reserve_port(CtrlState &ctrl) {
+    for (int i = 0; i < 4; i++) {
+        if (ctrl.free_ports[i]) {
+            ctrl.free_ports[i] = false;
+            return i + 1;
+        }
+    }
+
+    // No free port found.
+    return 0;
+}
+
+void remove_disconnected_controllers(CtrlState &ctrl) {
+    for (auto controller = ctrl.controllers.begin(); controller != ctrl.controllers.end();) {
+        if (SDL_GameControllerGetAttached(controller->second.controller.get())) {
+            ++controller;
+        } else {
+            ctrl.free_ports[controller->second.port - 1] = true;
+            controller = ctrl.controllers.erase(controller);
+            ctrl.controllers_num--;
+        }
+    }
+}
+
+void add_new_controllers(CtrlState &ctrl) {
+    const int num_joysticks = SDL_NumJoysticks();
+    for (int joystick_index = 0; joystick_index < num_joysticks; ++joystick_index) {
+        if (ctrl.controllers_num >= 4) {
+            return;
+        }
+        if (SDL_IsGameController(joystick_index)) {
+            const SDL_JoystickGUID guid = SDL_JoystickGetDeviceGUID(joystick_index);
+            if (ctrl.controllers.find(guid) == ctrl.controllers.end()) {
+                Controller new_controller;
+                const GameControllerPtr controller(SDL_GameControllerOpen(joystick_index), SDL_GameControllerClose);
+                new_controller.controller = controller;
+                SDL_Haptic *haptic = SDL_HapticOpenFromJoystick(SDL_GameControllerGetJoystick(controller.get()));
+                SDL_HapticRumbleInit(haptic);
+                const HapticPtr handle(haptic, SDL_HapticClose);
+                new_controller.haptic = handle;
+                new_controller.port = reserve_port(ctrl);
+                ctrl.controllers.emplace(guid, new_controller);
+                ctrl.controllers_num++;
+            }
+        }
+    }
+}
+
+int peek_buffer(CtrlState &ctrl, int port, SceCtrlData *&pad_data, int count, bool ext, bool negative) {
+    if (port == 0) {
+        port++;
+    }
+    remove_disconnected_controllers(ctrl);
+    add_new_controllers(ctrl);
+
+    memset(pad_data, 0, sizeof(*pad_data));
+    pad_data->timeStamp = timestamp++; // TODO Use the real time and units.
+
+    std::array<float, 4> axes{ 0, 0, 0, 0 };
+    if (port == 1) {
+        apply_keyboard(&pad_data->buttons, axes.data(), ext);
+    }
+    for (const auto &controller : ctrl.controllers) {
+        if (controller.second.port == port) {
+            apply_controller(&pad_data->buttons, axes.data(), controller.second.controller.get(), ext);
+        }
+    }
+
+    SceCtrlPadInputMode mode = ext ? ctrl.input_mode_ext : ctrl.input_mode;
+    if (mode == SCE_CTRL_MODE_DIGITAL) {
+        pad_data->lx = 0x80;
+        pad_data->ly = 0x80;
+        pad_data->rx = 0x80;
+        pad_data->ry = 0x80;
+    } else {
+        pad_data->lx = float_to_byte(axes[0]);
+        pad_data->ly = float_to_byte(axes[1]);
+        pad_data->rx = float_to_byte(axes[2]);
+        pad_data->ry = float_to_byte(axes[3]);
+    }
+
+    if (negative) {
+        pad_data->buttons = 0xFFFFFFFF - pad_data->buttons;
+    }
+
+    for (int i = 1; i < count; i++) {
+        memcpy(&pad_data[i], &pad_data[0], sizeof(SceCtrlData));
+    }
+
+    return count;
+}

--- a/src/emulator/module/include/module/load_module.h
+++ b/src/emulator/module/include/module/load_module.h
@@ -15,6 +15,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#pragma once
+
 #include <host/state.h>
 #include <kernel/thread/thread_functions.h>
 

--- a/src/emulator/modules/SceCtrl/SceCtrl.cpp
+++ b/src/emulator/modules/SceCtrl/SceCtrl.cpp
@@ -17,277 +17,11 @@
 
 #include "SceCtrl.h"
 
-#include <util/log.h>
+#include <ctrl/functions.h>
 
-#include <psp2/ctrl.h>
 #include <psp2/kernel/error.h>
 
-#include <SDL_gamecontroller.h>
 #include <SDL_haptic.h>
-#include <SDL_keyboard.h>
-
-#include <algorithm>
-#include <array>
-
-// TODO Move elsewhere.
-static uint64_t timestamp;
-
-struct KeyBinding {
-    SDL_Scancode scancode;
-    uint32_t button;
-};
-
-struct ControllerBinding {
-    SDL_GameControllerButton controller;
-    uint32_t button;
-};
-
-static const KeyBinding key_bindings[] = {
-    { SDL_SCANCODE_RSHIFT, SCE_CTRL_SELECT },
-    { SDL_SCANCODE_RETURN, SCE_CTRL_START },
-    { SDL_SCANCODE_UP, SCE_CTRL_UP },
-    { SDL_SCANCODE_RIGHT, SCE_CTRL_RIGHT },
-    { SDL_SCANCODE_DOWN, SCE_CTRL_DOWN },
-    { SDL_SCANCODE_LEFT, SCE_CTRL_LEFT },
-    { SDL_SCANCODE_Q, SCE_CTRL_LTRIGGER },
-    { SDL_SCANCODE_E, SCE_CTRL_RTRIGGER },
-    { SDL_SCANCODE_V, SCE_CTRL_TRIANGLE },
-    { SDL_SCANCODE_C, SCE_CTRL_CIRCLE },
-    { SDL_SCANCODE_X, SCE_CTRL_CROSS },
-    { SDL_SCANCODE_Z, SCE_CTRL_SQUARE },
-    { SDL_SCANCODE_H, SCE_CTRL_PSBUTTON },
-};
-
-static const KeyBinding key_bindings_ext[] = {
-    { SDL_SCANCODE_RSHIFT, SCE_CTRL_SELECT },
-    { SDL_SCANCODE_RETURN, SCE_CTRL_START },
-    { SDL_SCANCODE_UP, SCE_CTRL_UP },
-    { SDL_SCANCODE_RIGHT, SCE_CTRL_RIGHT },
-    { SDL_SCANCODE_DOWN, SCE_CTRL_DOWN },
-    { SDL_SCANCODE_LEFT, SCE_CTRL_LEFT },
-    { SDL_SCANCODE_Q, SCE_CTRL_L1 },
-    { SDL_SCANCODE_E, SCE_CTRL_R1 },
-    { SDL_SCANCODE_U, SCE_CTRL_L2 },
-    { SDL_SCANCODE_O, SCE_CTRL_R2 },
-    { SDL_SCANCODE_F, SCE_CTRL_L3 },
-    { SDL_SCANCODE_H, SCE_CTRL_R3 },
-    { SDL_SCANCODE_V, SCE_CTRL_TRIANGLE },
-    { SDL_SCANCODE_C, SCE_CTRL_CIRCLE },
-    { SDL_SCANCODE_X, SCE_CTRL_CROSS },
-    { SDL_SCANCODE_Z, SCE_CTRL_SQUARE },
-    { SDL_SCANCODE_H, SCE_CTRL_PSBUTTON },
-};
-
-static const size_t key_binding_count = sizeof(key_bindings) / sizeof(key_bindings[0]);
-static const size_t key_binding_ext_count = sizeof(key_bindings_ext) / sizeof(key_bindings_ext[0]);
-
-static const ControllerBinding controller_bindings[] = {
-    { SDL_CONTROLLER_BUTTON_BACK, SCE_CTRL_SELECT },
-    { SDL_CONTROLLER_BUTTON_START, SCE_CTRL_START },
-    { SDL_CONTROLLER_BUTTON_DPAD_UP, SCE_CTRL_UP },
-    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, SCE_CTRL_RIGHT },
-    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, SCE_CTRL_DOWN },
-    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, SCE_CTRL_LEFT },
-    { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, SCE_CTRL_LTRIGGER },
-    { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, SCE_CTRL_RTRIGGER },
-    { SDL_CONTROLLER_BUTTON_Y, SCE_CTRL_TRIANGLE },
-    { SDL_CONTROLLER_BUTTON_B, SCE_CTRL_CIRCLE },
-    { SDL_CONTROLLER_BUTTON_A, SCE_CTRL_CROSS },
-    { SDL_CONTROLLER_BUTTON_X, SCE_CTRL_SQUARE },
-    { SDL_CONTROLLER_BUTTON_GUIDE, SCE_CTRL_PSBUTTON },
-};
-
-static const ControllerBinding controller_bindings_ext[] = {
-    { SDL_CONTROLLER_BUTTON_BACK, SCE_CTRL_SELECT },
-    { SDL_CONTROLLER_BUTTON_START, SCE_CTRL_START },
-    { SDL_CONTROLLER_BUTTON_DPAD_UP, SCE_CTRL_UP },
-    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, SCE_CTRL_RIGHT },
-    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, SCE_CTRL_DOWN },
-    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, SCE_CTRL_LEFT },
-    { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, SCE_CTRL_L1 },
-    { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, SCE_CTRL_R1 },
-    { SDL_CONTROLLER_BUTTON_LEFTSTICK, SCE_CTRL_L3 },
-    { SDL_CONTROLLER_BUTTON_RIGHTSTICK, SCE_CTRL_R3 },
-    { SDL_CONTROLLER_BUTTON_Y, SCE_CTRL_TRIANGLE },
-    { SDL_CONTROLLER_BUTTON_B, SCE_CTRL_CIRCLE },
-    { SDL_CONTROLLER_BUTTON_A, SCE_CTRL_CROSS },
-    { SDL_CONTROLLER_BUTTON_X, SCE_CTRL_SQUARE },
-    { SDL_CONTROLLER_BUTTON_GUIDE, SCE_CTRL_PSBUTTON },
-};
-
-static const size_t controller_binding_count = sizeof(controller_bindings) / sizeof(controller_bindings[0]);
-
-static bool operator<(const SDL_JoystickGUID &a, const SDL_JoystickGUID &b) {
-    return memcmp(&a, &b, sizeof(a)) < 0;
-}
-
-static float keys_to_axis(const uint8_t *keys, SDL_Scancode code1, SDL_Scancode code2) {
-    float temp = 0;
-    if (keys[code1]) {
-        temp -= 1;
-    }
-    if (keys[code2]) {
-        temp += 1;
-    }
-
-    return temp;
-}
-
-static void apply_keyboard(uint32_t *buttons, float axes[4], bool ext) {
-    const uint8_t *const keys = SDL_GetKeyboardState(nullptr);
-    const size_t selected_key_binding_count = ext ? key_binding_ext_count : key_binding_count;
-    for (int i = 0; i < selected_key_binding_count; ++i) {
-        const KeyBinding &binding = ext ? key_bindings_ext[i] : key_bindings[i];
-        if (keys[binding.scancode]) {
-            *buttons |= binding.button;
-        }
-    }
-
-    axes[0] += keys_to_axis(keys, SDL_SCANCODE_A, SDL_SCANCODE_D);
-    axes[1] += keys_to_axis(keys, SDL_SCANCODE_W, SDL_SCANCODE_S);
-    axes[2] += keys_to_axis(keys, SDL_SCANCODE_J, SDL_SCANCODE_L);
-    axes[3] += keys_to_axis(keys, SDL_SCANCODE_I, SDL_SCANCODE_K);
-}
-
-static float axis_to_axis(int16_t axis) {
-    const float unsigned_axis = static_cast<float>(axis - INT16_MIN);
-    assert(unsigned_axis >= 0);
-    assert(unsigned_axis <= UINT16_MAX);
-
-    const float f = unsigned_axis / UINT16_MAX;
-
-    const float output = (f * 2) - 1;
-    assert(output >= -1);
-    assert(output <= 1);
-
-    return output;
-}
-
-static void apply_controller(uint32_t *buttons, float axes[4], SDL_GameController *controller, bool ext) {
-    for (int i = 0; i < controller_binding_count; ++i) {
-        const ControllerBinding &binding = ext ? controller_bindings_ext[i] : controller_bindings[i];
-        if (SDL_GameControllerGetButton(controller, binding.controller)) {
-            *buttons |= binding.button;
-        }
-    }
-
-    if (ext) {
-        if (SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERLEFT) > 0x3FFF) {
-            *buttons |= SCE_CTRL_L2;
-        }
-        if (SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_TRIGGERRIGHT) > 0x3FFF) {
-            *buttons |= SCE_CTRL_R2;
-        }
-    }
-
-    axes[0] += axis_to_axis(SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX));
-    axes[1] += axis_to_axis(SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY));
-    axes[2] += axis_to_axis(SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX));
-    axes[3] += axis_to_axis(SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTY));
-}
-
-static uint8_t float_to_byte(float f) {
-    const float mapped = (f * 0.5f) + 0.5f;
-    const float clamped = std::max<float>(0.0f, std::min<float>(mapped, 1.0f));
-    assert(clamped >= 0);
-    assert(clamped <= 1);
-
-    return static_cast<uint8_t>(clamped * 255);
-}
-
-static int reserve_port(CtrlState &state) {
-    for (int i = 0; i < 4; i++) {
-        if (state.free_ports[i]) {
-            state.free_ports[i] = false;
-            return i + 1;
-        }
-    }
-
-    // No free port found.
-    return 0;
-}
-
-static void remove_disconnected_controllers(CtrlState &state) {
-    for (ControllerList::iterator controller = state.controllers.begin(); controller != state.controllers.end();) {
-        if (SDL_GameControllerGetAttached(controller->second.controller.get())) {
-            ++controller;
-        } else {
-            state.free_ports[controller->second.port - 1] = true;
-            controller = state.controllers.erase(controller);
-            state.controllers_num--;
-        }
-    }
-}
-
-static void add_new_controllers(CtrlState &state) {
-    const int num_joysticks = SDL_NumJoysticks();
-    for (int joystick_index = 0; joystick_index < num_joysticks; ++joystick_index) {
-        if (state.controllers_num >= 4) {
-            return;
-        }
-        if (SDL_IsGameController(joystick_index)) {
-            const SDL_JoystickGUID guid = SDL_JoystickGetDeviceGUID(joystick_index);
-            if (state.controllers.find(guid) == state.controllers.end()) {
-                Controller new_controller;
-                const GameControllerPtr controller(SDL_GameControllerOpen(joystick_index), SDL_GameControllerClose);
-                new_controller.controller = controller;
-                SDL_Haptic *haptic = SDL_HapticOpenFromJoystick(SDL_GameControllerGetJoystick(controller.get()));
-                SDL_HapticRumbleInit(haptic);
-                const HapticPtr handle(haptic, SDL_HapticClose);
-                new_controller.haptic = handle;
-                new_controller.port = reserve_port(state);
-                state.controllers.emplace(guid, new_controller);
-                state.controllers_num++;
-            }
-        }
-    }
-}
-
-static int peek_buffer(HostState &host, int port, SceCtrlData *&pad_data, int count, bool ext, bool negative) {
-    if (port == 0) {
-        port++;
-    }
-    CtrlState &state = host.ctrl;
-    remove_disconnected_controllers(state);
-    add_new_controllers(state);
-
-    memset(pad_data, 0, sizeof(*pad_data));
-    pad_data->timeStamp = timestamp++; // TODO Use the real time and units.
-
-    std::array<float, 4> axes;
-    axes.fill(0);
-    if (port == 1) {
-        apply_keyboard(&pad_data->buttons, axes.data(), ext);
-    }
-    for (const auto &controller : state.controllers) {
-        if (controller.second.port == port) {
-            apply_controller(&pad_data->buttons, axes.data(), controller.second.controller.get(), ext);
-        }
-    }
-
-    SceCtrlPadInputMode mode = ext ? state.input_mode_ext : state.input_mode;
-    if (mode == SCE_CTRL_MODE_DIGITAL) {
-        pad_data->lx = 0x80;
-        pad_data->ly = 0x80;
-        pad_data->rx = 0x80;
-        pad_data->ry = 0x80;
-    } else {
-        pad_data->lx = float_to_byte(axes[0]);
-        pad_data->ly = float_to_byte(axes[1]);
-        pad_data->rx = float_to_byte(axes[2]);
-        pad_data->ry = float_to_byte(axes[3]);
-    }
-
-    if (negative) {
-        pad_data->buttons = 0xFFFFFFFF - pad_data->buttons;
-    }
-
-    for (int i = 1; i < count; i++) {
-        memcpy(&pad_data[i], &pad_data[0], sizeof(SceCtrlData));
-    }
-
-    return count;
-}
 
 EXPORT(int, sceCtrlClearRapidFire) {
     return UNIMPLEMENTED();
@@ -314,9 +48,8 @@ EXPORT(int, sceCtrlGetButtonIntercept) {
 }
 
 EXPORT(int, sceCtrlGetControllerPortInfo, SceCtrlPortInfo *info) {
-    CtrlState &state = host.ctrl;
-    remove_disconnected_controllers(state);
-    add_new_controllers(state);
+    remove_disconnected_controllers(host.ctrl);
+    add_new_controllers(host.ctrl);
     info->port[0] = host.cfg.pstv_mode ? SCE_CTRL_TYPE_VIRT : SCE_CTRL_TYPE_PHY;
     for (int i = 0; i < 4; i++) {
         info->port[i + 1] = (host.cfg.pstv_mode && !host.ctrl.free_ports[i]) ? SCE_CTRL_TYPE_DS3 : SCE_CTRL_TYPE_UNPAIRED;
@@ -356,84 +89,84 @@ EXPORT(int, sceCtrlPeekBufferNegative, int port, SceCtrlData *pad_data, int coun
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, false, true);
+    return peek_buffer(host.ctrl, port, pad_data, count, false, true);
 }
 
 EXPORT(int, sceCtrlPeekBufferNegative2, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, true, true);
+    return peek_buffer(host.ctrl, port, pad_data, count, true, true);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositive, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, false, false);
+    return peek_buffer(host.ctrl, port, pad_data, count, false, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositive2, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, true, false);
+    return peek_buffer(host.ctrl, port, pad_data, count, true, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositiveExt, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, false, false);
+    return peek_buffer(host.ctrl, port, pad_data, count, false, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositiveExt2, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, true, false);
+    return peek_buffer(host.ctrl, port, pad_data, count, true, false);
 }
 
 EXPORT(int, sceCtrlReadBufferNegative, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, false, true);
+    return peek_buffer(host.ctrl, port, pad_data, count, false, true);
 }
 
 EXPORT(int, sceCtrlReadBufferNegative2, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, true, true);
+    return peek_buffer(host.ctrl, port, pad_data, count, true, true);
 }
 
 EXPORT(int, sceCtrlReadBufferPositive, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, false, false);
+    return peek_buffer(host.ctrl, port, pad_data, count, false, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositive2, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, true, false);
+    return peek_buffer(host.ctrl, port, pad_data, count, true, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositiveExt, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, false, false);
+    return peek_buffer(host.ctrl, port, pad_data, count, false, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositiveExt2, int port, SceCtrlData *pad_data, int count) {
     if (port > 1 && !host.cfg.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
-    return peek_buffer(host, port, pad_data, count, true, false);
+    return peek_buffer(host.ctrl, port, pad_data, count, true, false);
 }
 
 EXPORT(int, sceCtrlRegisterBdRMCCallback) {
@@ -449,11 +182,10 @@ EXPORT(int, sceCtrlSetActuator, int port, const SceCtrlActuator *pState) {
         return RET_ERROR(SCE_CTRL_ERROR_NOT_SUPPORTED);
     }
 
-    CtrlState &state = host.ctrl;
-    remove_disconnected_controllers(state);
-    add_new_controllers(state);
+    remove_disconnected_controllers(host.ctrl);
+    add_new_controllers(host.ctrl);
 
-    for (const auto &controller : state.controllers) {
+    for (const auto &controller : host.ctrl.controllers) {
         if (controller.second.port == port) {
             SDL_Haptic *handle = controller.second.haptic.get();
             if (pState->small == 0 && pState->large == 0) {
@@ -493,10 +225,8 @@ EXPORT(int, sceCtrlSetRapidFire) {
     return UNIMPLEMENTED();
 }
 
-#define SCE_CTRL_MODE_UNKNOWN 3 // missing in vita-headers
-
 EXPORT(int, sceCtrlSetSamplingMode, SceCtrlPadInputMode mode) {
-    SceCtrlPadInputMode old = host.ctrl.input_mode;
+    const auto old = host.ctrl.input_mode;
     if (mode < SCE_CTRL_MODE_DIGITAL || mode > SCE_CTRL_MODE_UNKNOWN) {
         return RET_ERROR(SCE_CTRL_ERROR_INVALID_ARG);
     }
@@ -505,7 +235,7 @@ EXPORT(int, sceCtrlSetSamplingMode, SceCtrlPadInputMode mode) {
 }
 
 EXPORT(int, sceCtrlSetSamplingModeExt, SceCtrlPadInputMode mode) {
-    SceCtrlPadInputMode old = host.ctrl.input_mode_ext;
+    const auto old = host.ctrl.input_mode_ext;
     if (mode < SCE_CTRL_MODE_DIGITAL || mode > SCE_CTRL_MODE_UNKNOWN) {
         return RET_ERROR(SCE_CTRL_ERROR_INVALID_ARG);
     }

--- a/src/emulator/threads/include/threads/queue.h
+++ b/src/emulator/threads/include/threads/queue.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef queue_h
 #define queue_h
 

--- a/src/emulator/touch/src/touch.cpp
+++ b/src/emulator/touch/src/touch.cpp
@@ -17,13 +17,14 @@
 
 #include <touch/touch.h>
 
+#include <ctrl/state.h>
+
 #include <psp2/touch.h>
 
 #include <SDL_events.h>
 
 #include <cstring>
 
-static uint64_t timestamp;
 static SDL_TouchFingerEvent finger_buffer[8];
 static uint8_t finger_count = 0;
 static long int finger_id_ref;
@@ -90,11 +91,7 @@ int handle_touch_event(SDL_TouchFingerEvent &finger) {
 }
 
 static bool registered_touch() {
-    if (finger_count > 0) {
-        return true;
-    }
-
-    return false;
+    return finger_count > 0;
 }
 
 int toggle_touchscreen() {
@@ -147,7 +144,7 @@ int peek_touch(const SceFVector2 viewport_pos, const SceFVector2 viewport_size, 
         if (!ctrl.touch_mode[port]) {
             pData->reportNum = 0;
         }
-    } else if (registered_touch() == true && port == touchscreen_port) {
+    } else if (registered_touch() && port == touchscreen_port) {
         pData[0] = recover_touch_events();
     }
 


### PR DESCRIPTION
Cleanup commit.

Moves functions from `SceCtrl` to `ctrl`, and cleans up functions.

Also adds in some missing include guards.