### PR TITLE
audio: Start audio thread after temp buffer is allocated

### DIFF
--- a/src/emulator/audio/src/audio.cpp
+++ b/src/emulator/audio/src/audio.cpp
@@ -100,10 +100,10 @@ bool init(AudioState &state, ResumeAudioThread resume_thread) {
         return false;
     }
 
-    SDL_PauseAudio(0);
-
     state.device = AudioDevicePtr(nullptr, close_audio);
     state.callback.temp_buffer.resize(state.ro.spec.size);
+
+    SDL_PauseAudio(0);
 
     return true;
 }


### PR DESCRIPTION
Fixes race condition where audio thread tries to access buffer before it is allocated.