### PR TITLE
Orange?

### DIFF
--- a/src/emulator/app/src/screen_render.cpp
+++ b/src/emulator/app/src/screen_render.cpp
@@ -74,7 +74,7 @@ bool gl_screen_renderer::init(const std::string &base_path) {
     );
     glEnableVertexAttribArray(uvAttrib);
 
-    glClearColor(0.968627450f, 0.776470588f, 0.0f, 1.0f);
+    glClearColor(0.125490203f, 0.698039234f, 0.666666687f, 1.0f);
     glClearDepth(1.0f);
 
     return true;

--- a/src/emulator/app/src/screen_render.cpp
+++ b/src/emulator/app/src/screen_render.cpp
@@ -74,7 +74,7 @@ bool gl_screen_renderer::init(const std::string &base_path) {
     );
     glEnableVertexAttribArray(uvAttrib);
 
-    glClearColor(0.125490203f, 0.698039234f, 0.666666687f, 1.0f);
+    glClearColor(0.913725490f, 0.498039215f, 0.007843137f, 1.0f);
     glClearDepth(1.0f);
 
     return true;

--- a/src/emulator/app/src/screen_render.cpp
+++ b/src/emulator/app/src/screen_render.cpp
@@ -74,7 +74,7 @@ bool gl_screen_renderer::init(const std::string &base_path) {
     );
     glEnableVertexAttribArray(uvAttrib);
 
-    glClearColor(0.913725490f, 0.498039215f, 0.007843137f, 1.0f);
+    glClearColor(0.968627450f, 0.776470588f, 0.0f, 1.0f);
     glClearDepth(1.0f);
 
     return true;

--- a/src/emulator/renderer/src/gl/renderer.cpp
+++ b/src/emulator/renderer/src/gl/renderer.cpp
@@ -179,7 +179,7 @@ bool create(std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &p
     }
 
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, render_target->renderbuffers[depth_fb_index]);
-    glClearColor(0.392156899f, 0.584313750f, 0.929411829f, 1.0f);
+    glClearColor(0.968627450f, 0.776470588f, 0.0f, 1.0f);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     return true;


### PR DESCRIPTION
Context:  
![DiscordPTB_2019-08-02_20-57-19-646](https://user-images.githubusercontent.com/7894419/62371748-301ddb00-b568-11e9-811a-a10d9760c71a.png)

The Clear color for `renderer.cpp` is RGB(247,198,0) as asked by velocity to screen pick it. For `screen_render.cpp`, the color is RGB(233,127,2) which is the "orange" color in the logo that is above the dirty magenta.