### PR TITLE
travis: Fix ccache homebrew installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ matrix:
   include:
     - os: osx
       osx_image: xcode9.3
-      addons:
-        homebrew:
-          packages:
-          - ccache
       install:
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
       - export PATH="/usr/local/opt/ccache/libexec:$PATH"
       before_script:
       - export CMAKE=cmake


### PR DESCRIPTION
Due to an issue with homebrew, ccache is not installed anymore on osx builds, resulting in increased compilation time for this system.

You can see the issue in travis logs by looking at the "Installing Homebrew Packages" part:
```
$ rvm $brew_ruby do brew bundle --verbose --global
/usr/local/bin/brew tap homebrew/bundle
==> Tapping homebrew/bundle
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle'...
Tapped 0 formulae (183 files, 250KB)
Error: Your Homebrew is outdated. Please run `brew update`.
Error: Kernel.exit
```
And in the CMake setup, we have:
```
-- Check for working CXX compiler: /Applications/Xcode-9.3.app/Contents/Developer/usr/bin/g++
-- Check for working CXX compiler: /Applications/Xcode-9.3.app/Contents/Developer/usr/bin/g++ -- works
```

This PR solves this issue (see this travis log: https://travis-ci.org/scribam/Vita3K/jobs/567483878, done in 2 min 18 sec), ccache 3.4.2 is correctly installed and wraps the compiler used:
```
-- Check for working CXX compiler: /usr/local/opt/ccache/libexec/g++
-- Check for working CXX compiler: /usr/local/opt/ccache/libexec/g++ -- works
```

An other solution would have been to add `update: true` to the homebrew node in the `.travis.yml` but it means to update the whole thing which can be time consuming.
- `update: true`: homebrew installation time: 320.98s, ccache version installed: 3.7.2 (https://travis-ci.org/scribam/Vita3K/builds/567476622)
- PR: homebrew installation time: 4.11s, ccache version installed: 3.4.2 (https://travis-ci.org/scribam/Vita3K/jobs/567483878)

The cache needs to be created first so the effect will only appear with a second build.