### PR TITLE
TexCoord shenanigans

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -247,12 +247,7 @@ enum SceGxmVertexProgramOutputs : int {
     _SCE_GXM_VERTEX_PROGRAM_OUTPUT_LAST = 1 << 23
 };
 
-union SceGxmVertexOutputTexCoordInfo {
-    bf_t<uint8_t, 0, 2> comp_count;
-    bf_t<uint8_t, 2, 1> type;
-};
-
-using SceGxmVertexOutputTexCoordInfos = std::array<SceGxmVertexOutputTexCoordInfo, 10>;
+using SceGxmVertexOutputTexCoordInfos = std::array<uint8_t, 10>;
 
 #pragma pack(push, 1)
 struct SceGxmProgramVertexOutput {

--- a/vita3k/gxm/src/gxp.cpp
+++ b/vita3k/gxm/src/gxp.cpp
@@ -193,10 +193,8 @@ SceGxmVertexProgramOutputs get_vertex_outputs(const SceGxmProgram &program, SceG
         if (vo2 & coordinfo_mask) {
             res |= (SCE_GXM_VERTEX_PROGRAM_OUTPUT_TEXCOORD0 << i);
 
-            if (coord_infos) {
-                std::uint8_t info = static_cast<std::uint8_t>(vo2 >> to_shift);
-                (*coord_infos)[i] = *reinterpret_cast<SceGxmVertexOutputTexCoordInfo *>(&info);
-            }
+            if (coord_infos)
+                (*coord_infos)[i] = static_cast<std::uint8_t>((vo2 >> to_shift) & 0b111u);
         }
 
         to_shift += 3;


### PR DESCRIPTION
I did some dual fixes for duals involving vec4, but the real meat comes from the stupid tex coord thingy.

Instead of making each TexCoord 2 bits and making each a size, peeps at sony decided to make it infinitely less clear. Now the bits work as following:
```
Bit 0: Enables TexCoord (.xy), Size + 2.
Bit 1: TexCoord .z, Size + 1
Bit 2: TexCoord .w, Size + 1
```