### PR TITLE
Update Boost for VS2019

### DIFF
--- a/gen-windows.bat
+++ b/gen-windows.bat
@@ -6,7 +6,7 @@ if errorlevel 1 set vs_version=Visual Studio 15 2017 Win64
 if errorlevel 2 set vs_version=Visual Studio 16 2019
 
 REM CI uses pre-built Boost
-IF "%CI%"=="" IF "%vs_version%"=="Visual Studio 15 2017 Win64" (
+IF "%CI%"=="" IF NOT EXIST external\boost-build (
 	REM Create build dir
 	mkdir external\boost-build
 	cd external\boost


### PR DESCRIPTION
**To anyone compiling Vita3K on VS2019:**
You can now delete your large, system-wide boost installation, and run `gen-windows.bat` so that only our [subset](https://github.com/Vita3K/ext-boost) is compiled instead.
Just make sure to remove your environment variables (`BOOST_ROOT`, etc) too.

**To anyone compiling on VS2017:**
You can now switch to VS2019 easily.