### PR TITLE
sceAppUtil: implement sceAppUtilSaveDataGetQuota

### DIFF
--- a/vita3k/io/include/io/vfs.h
+++ b/vita3k/io/include/io/vfs.h
@@ -24,8 +24,16 @@
 class VitaIoDevice;
 
 namespace vfs {
+
+struct SpaceInfo {
+    unsigned long long max_capacity;
+    unsigned long long used;
+    unsigned long long free;
+};
+
 using FileBuffer = std::vector<SceUInt8>;
 
 bool read_file(VitaIoDevice device, FileBuffer &buf, const std::string &pref_path, const fs::path &vfs_file_path);
 bool read_app_file(FileBuffer &buf, const std::string &pref_path, const std::string &title_id, const fs::path &vfs_file_path);
+SpaceInfo get_space_info(const VitaIoDevice device, const std::string &vfs_path, const std::string &pref_path);
 } // namespace vfs

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -71,6 +71,15 @@ bool read_app_file(FileBuffer &buf, const std::string &pref_path, const std::str
     return read_file(VitaIoDevice::ux0, buf, pref_path, fs::path("app") / title_id / vfs_file_path);
 }
 
+SpaceInfo get_space_info(const VitaIoDevice device, const std::string &vfs_path, const std::string &pref_path) {
+    SpaceInfo space_info;
+    const auto host_path = device::construct_emulated_path(device, vfs_path, pref_path);
+    space_info.max_capacity = fs::space(host_path).capacity;
+    space_info.free = fs::space(host_path).available;
+    space_info.used = fs::space(host_path).capacity - space_info.free;
+    return space_info;
+}
+
 } // namespace vfs
 
 // ****************************

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -23,6 +23,7 @@
 #include <host/app_util.h>
 #include <io/device.h>
 #include <io/functions.h>
+#include <io/vfs.h>
 
 #include <cstring>
 
@@ -197,8 +198,10 @@ EXPORT(int, sceAppUtilSaveDataDataSave, emu::SceAppUtilSaveDataFileSlot *slot, e
     return 0;
 }
 
-EXPORT(int, sceAppUtilSaveDataGetQuota) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceAppUtilSaveDataGetQuota, SceSize *quotaSizeKiB, SceSize *usedSizeKiB, const SceAppUtilMountPoint *mountPoint) {
+    *quotaSizeKiB = vfs::get_space_info(VitaIoDevice::ux0, host.io.device_paths.savedata0, host.pref_path).max_capacity / 1024;
+    *usedSizeKiB = vfs::get_space_info(VitaIoDevice::ux0, host.io.device_paths.savedata0, host.pref_path).used / 1024;
+    return 0;
 }
 
 EXPORT(int, sceAppUtilSaveDataMount) {


### PR DESCRIPTION
Steins;Gate fails to check for available space to create the system data.

(credits to @Zangetsu38  for testing it and posting the log)
![steinsgate](https://user-images.githubusercontent.com/36709480/68348864-e95df500-0103-11ea-8cef-8e8945e09972.png)

and it progresses to menu with this
![image](https://user-images.githubusercontent.com/36709480/68349026-5c676b80-0104-11ea-98f9-227664a8531b.png)

---

#### ~~It's worth noting that i couldn't find this import on vitasdk so i don't know if it expects the size to be in bytes, KBs or MBs (boost::space() returns it in bytes), or if it accepts a parameter~~ it expects the size in KBs, and takes 2 arguments
#### ~~it's also worth noting that similar (if not identical) imports exist in sceAppMgr.cpp (`_sceAppMgrSaveDataGetQuota`) and sceAppMgrUser.cpp (`sceAppMgrSaveDataGetQuota`) that i've also been unable to find on vitasdk~~ bent answered this

