### PR TITLE
modules/SceNet: fix compatibility with win 8.1 sdk

### DIFF
--- a/vita3k/modules/SceNet/SceNet.cpp
+++ b/vita3k/modules/SceNet/SceNet.cpp
@@ -277,7 +277,7 @@ EXPORT(unsigned short int, sceNetHtons, unsigned short int n) {
 EXPORT(Ptr<const char>, sceNetInetNtop, int af, const void *src, Ptr<char> dst, unsigned int size) {
     char *dst_ptr = dst.get(host.mem);
 #ifdef WIN32
-    const char *res = InetNtop(af, src, dst_ptr, size);
+    const char *res = InetNtop(af, const_cast<void *>(src), dst_ptr, size);
 #else
     const char *res = inet_ntop(af, src, dst_ptr, size);
 #endif


### PR DESCRIPTION
Second argument of `InetNtop` is of type `char *` in win 8.1 sdk. This causes an error when passing it a `const char *` variable. The 2 simple solutions to this is either what I've done in this PR or do an ifdef for windows 8.1 and only do `const_cast` there. The former seems like the better solution in terms of maintainability.