### PR TITLE
game context menu: Add manuals popup

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -36,14 +36,15 @@ enum GenericDialogState {
     CANCEL_STATE
 };
 
-void delete_game(GuiState &gui, HostState &host, const std::string &title_id);
-void game_context_menu(GuiState &gui, HostState &host, bool *selected, const std::string &title_id);
+void delete_game(GuiState &gui, HostState &host);
+void game_context_menu(GuiState &gui, HostState &host, bool *selected);
 void get_game_titles(GuiState &gui, HostState &host);
 void get_modules_list(GuiState &gui, HostState &host);
 void init(GuiState &gui, HostState &host);
 void init_background(GuiState &gui, const std::string &image_path);
 void init_icons(GuiState &gui, HostState &host);
-void load_game_background(GuiState &gui, HostState &host, const std::string &title_id);
+void load_game_background(GuiState &gui, HostState &host);
+void load_manual(GuiState &gui, HostState &host, const std::string &image_name);
 bool refresh_game_list(GuiState &gui, HostState &host);
 
 void draw_begin(GuiState &gui, HostState &host);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -128,6 +128,10 @@ struct GuiState {
     ImTextureID current_background{};
     bool delete_game_background = false;
     bool delete_game_icon = false;
+
+    ImTextureID current_page_manual{};
+    std::map<std::string, ImGui_Texture> manual;
+
     GLuint display = 0;
     std::map<std::string, ImGui_Texture> game_backgrounds;
     ImGuiTextFilter game_search_bar;

--- a/vita3k/gui/src/game_selector.cpp
+++ b/vita3k/gui/src/game_selector.cpp
@@ -67,7 +67,6 @@ static constexpr auto MENUBAR_HEIGHT = 19;
 
 void draw_game_selector(GuiState &gui, HostState &host) {
     const ImVec2 display_size = ImGui::GetIO().DisplaySize;
-    static std::string title_id;
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - MENUBAR_HEIGHT), ImGuiCond_Always);
@@ -86,8 +85,8 @@ void draw_game_selector(GuiState &gui, HostState &host) {
     }
 
     if (gui.delete_game_icon) {
-        if (gui.game_selector.icons.find(title_id) != gui.game_selector.icons.end())
-            gui.game_selector.icons.erase(title_id);
+        if (gui.game_selector.icons.find(host.io.title_id) != gui.game_selector.icons.end())
+            gui.game_selector.icons.erase(host.io.title_id);
         gui.delete_game_icon = false;
     }
 
@@ -218,31 +217,31 @@ void draw_game_selector(GuiState &gui, HostState &host) {
             if (!gui.game_search_bar.PassFilter(game.title.c_str()) && !gui.game_search_bar.PassFilter(game.title_id.c_str()))
                 continue;
             if (!fs::exists(fs::path(host.pref_path) / "ux0/app" / game.title_id)) {
-                title_id = game.title_id;
+                host.io.title_id = game.title_id;
                 LOG_ERROR("Game not found: {} [{}], deleting the entry for it.", game.title_id, game.title);
-                delete_game(gui, host, title_id);
+                delete_game(gui, host);
             }
             if (gui.game_selector.icons.find(game.title_id) != gui.game_selector.icons.end()) {
                 ImGui::Image(gui.game_selector.icons[game.title_id], ImVec2(icon_size, icon_size));
                 if (ImGui::IsItemHovered()) {
+                    host.io.title_id = game.title_id;
                     if (host.cfg.show_game_background) {
                         if (gui.game_backgrounds.find(game.title_id) == gui.game_backgrounds.end())
-                            load_game_background(gui, host, game.title_id);
+                            load_game_background(gui, host);
                         else if (gui.current_background != gui.game_backgrounds[game.title_id])
                             gui.current_background = gui.game_backgrounds[game.title_id];
                     }
                     if (ImGui::IsMouseClicked(0))
                         selected[0] = true;
-                    title_id = game.title_id;
                 }
                 ImGui::OpenPopupOnItemClick("#game_context_menu", 1);
             }
             ImGui::NextColumn();
             ImGui::Selectable(game.title_id.c_str(), &selected[1], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
             if (ImGui::IsItemHovered())
-                title_id = game.title_id;
-            if (title_id == game.title_id)
-                game_context_menu(gui, host, selected, title_id);
+                host.io.title_id = game.title_id;
+            if (host.io.title_id == game.title_id)
+                game_context_menu(gui, host, selected);
             ImGui::NextColumn();
             ImGui::Selectable(game.app_ver.c_str(), &selected[2], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
             ImGui::NextColumn();

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -177,31 +177,57 @@ void init_icons(GuiState &gui, HostState &host) {
     }
 }
 
-void load_game_background(GuiState &gui, HostState &host, const std::string &title_id) {
+void load_game_background(GuiState &gui, HostState &host) {
     int32_t width = 0;
     int32_t height = 0;
     vfs::FileBuffer buffer;
 
-    vfs::read_app_file(buffer, host.pref_path, title_id, "sce_sys/pic0.png");
+    vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/pic0.png");
     if (buffer.empty()) {
-        if (vfs::read_app_file(buffer, host.pref_path, title_id, "sce_sys/livearea/contents/template.xml")) {
-            LOG_INFO("Game background found in template for title {}.", title_id);
-            vfs::read_app_file(buffer, host.pref_path, title_id, "sce_sys/livearea/contents/bg.png");
-            vfs::read_app_file(buffer, host.pref_path, title_id, "sce_sys/livearea/contents/bg0.png");
+        if (vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/livearea/contents/template.xml")) {
+            LOG_INFO("Game background found in template for title {}.", host.io.title_id);
+            vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/livearea/contents/bg.png");
+            vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/livearea/contents/bg0.png");
         } else {
             if (gui.current_background != gui.user_backgrounds[host.cfg.background_image])
                 gui.current_background = gui.user_backgrounds[host.cfg.background_image];
-            LOG_WARN("Game background not found for title {}.", title_id);
+            LOG_WARN("Game background not found for title {}.", host.io.title_id);
             return;
         }
     }
     stbi_uc *data = stbi_load_from_memory(&buffer[0], static_cast<int>(buffer.size()), &width, &height, nullptr, STBI_rgb_alpha);
     if (!data) {
-        LOG_ERROR("Invalid game background for title {}.", title_id);
+        LOG_ERROR("Invalid game background for title {}.", host.io.title_id);
         return;
     }
-    gui.game_backgrounds[title_id].init(gui.imgui_state.get(), data, width, height);
-    gui.current_background = gui.game_backgrounds[title_id];
+    gui.game_backgrounds[host.io.title_id].init(gui.imgui_state.get(), data, width, height);
+    gui.current_background = gui.game_backgrounds[host.io.title_id];
+    stbi_image_free(data);
+}
+
+void load_manual(GuiState &gui, HostState &host, const std::string &image_name) {
+    int32_t width = 0;
+    int32_t height = 0;
+    vfs::FileBuffer buffer;
+    std::string manual_path = "sce_sys/manual/";
+
+    if (fs::exists(fs::path(host.pref_path) / "ux0/app" / host.io.title_id / manual_path / fmt::format("{:0>2d}", host.cfg.sys_lang)))
+        manual_path += fmt::format("{:0>2d}/", host.cfg.sys_lang);
+
+    manual_path += image_name;
+
+    vfs::read_app_file(buffer, host.pref_path, host.io.title_id, manual_path);
+    if (buffer.empty()) {
+        LOG_WARN("Manual not found for title {}.", host.io.title_id);
+        return;
+    }
+    stbi_uc *data = stbi_load_from_memory(&buffer[0], static_cast<int>(buffer.size()), &width, &height, nullptr, STBI_rgb_alpha);
+    if (!data) {
+        LOG_ERROR("Invalid manual image for title: {}", host.io.title_id);
+        return;
+    }
+    gui.manual[image_name].init(gui.imgui_state.get(), data, width, height);
+    gui.current_manual = gui.manual[image_name];
     stbi_image_free(data);
 }
 
@@ -237,7 +263,7 @@ ImTextureID load_image(GuiState &gui, const char *data, const std::size_t size) 
     int width;
     int height;
 
-    stbi_uc *img_data = stbi_load_from_memory(reinterpret_cast<const stbi_uc *>(data), size, &width, &height,
+    stbi_uc *img_data = stbi_load_from_memory(reinterpret_cast<const stbi_uc *>(data), static_cast<int>(size), &width, &height,
         nullptr, STBI_rgb_alpha);
 
     if (!data)


### PR DESCRIPTION
- little rework code for can using host.io.title_id already here

- Add Manual item in context menu
![image](https://user-images.githubusercontent.com/5261759/69955810-cbb35e00-14fe-11ea-980e-483b8ac6f1c3.png)

- Open on Manual dialog with can show your owner languague(automatic, using config sys_lang)
# Result: 
![image](https://user-images.githubusercontent.com/5261759/70112777-c701bd80-1656-11ea-95b5-4dd52c46819c.png)
