### PR TITLE
game context menu: add misc things

### DIFF
--- a/vita3k/gui/CMakeLists.txt
+++ b/vita3k/gui/CMakeLists.txt
@@ -45,4 +45,4 @@ add_library(
 
 target_include_directories(gui PUBLIC include ${CMAKE_SOURCE_DIR}/vita3k)
 target_link_libraries(gui PUBLIC app host imgui glutil)
-target_link_libraries(gui PRIVATE nativefiledialog stb renderer)
+target_link_libraries(gui PRIVATE nativefiledialog pugixml stb renderer)

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -36,14 +36,14 @@ enum GenericDialogState {
     CANCEL_STATE
 };
 
-void delete_game(GuiState &gui, HostState &host, const std::string &title_id);
-void game_context_menu(GuiState &gui, HostState &host, bool *selected, const std::string &title_id);
+void delete_game(GuiState &gui, HostState &host);
+void game_context_menu(GuiState &gui, HostState &host);
 void get_game_titles(GuiState &gui, HostState &host);
 void get_modules_list(GuiState &gui, HostState &host);
 void init(GuiState &gui, HostState &host);
 void init_background(GuiState &gui, const std::string &image_path);
 void init_icons(GuiState &gui, HostState &host);
-void load_game_background(GuiState &gui, HostState &host, const std::string &title_id);
+void load_game_background(GuiState &gui, HostState &host);
 bool refresh_game_list(GuiState &gui, HostState &host);
 
 void draw_begin(GuiState &gui, HostState &host);

--- a/vita3k/gui/src/game_context_menu.cpp
+++ b/vita3k/gui/src/game_context_menu.cpp
@@ -20,29 +20,31 @@
 #include <gui/functions.h>
 #include <gui/state.h>
 
+#include <host/functions.h>
 #include <host/state.h>
+
+#include <io/vfs.h>
 
 #include <util/log.h>
 #include <util/string_utils.h>
 
+#include <pugixml.hpp>
+#include <sstream>
+
 namespace gui {
 
-static bool delete_game_popup = false;
-static bool delete_savedata_popup = false;
-static bool check_savedata_and_shaderlog = false;
-
-void delete_game(GuiState &gui, HostState &host, const std::string &title_id) {
-    const fs::path game_path{ fs::path(host.pref_path) / "ux0/app" };
+void delete_game(GuiState &gui, HostState &host) {
+    const fs::path game_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
 
     for (const auto &game : gui.game_selector.games) {
         const auto games_index = std::find_if(gui.game_selector.games.begin(), gui.game_selector.games.end(), [&game](const Game &g) {
             return g.app_ver == game.app_ver && g.title == game.title && g.title_id == game.title_id;
         });
 
-        if (title_id == game.title_id) {
-            LOG_INFO_IF(fs::remove_all(game_path / game.title_id), "Successfully deleted '{} [{}]'.", game.title_id, game.title);
+        if (host.io.title_id == game.title_id) {
+            LOG_INFO_IF(fs::remove_all(game_path), "Successfully deleted '{} [{}]'.", game.title_id, game.title);
 
-            if (!fs::exists(game_path / game.title_id)) {
+            if (!fs::exists(game_path)) {
                 gui.delete_game_background = true;
                 gui.delete_game_icon = true;
                 gui.game_selector.games.erase(games_index);
@@ -52,119 +54,293 @@ void delete_game(GuiState &gui, HostState &host, const std::string &title_id) {
     }
 }
 
-void game_context_menu(GuiState &gui, HostState &host, bool *selected, const std::string &title_id) {
-    const fs::path save_data_path{ fs::path(host.pref_path) / "ux0/user/00/savedata" };
-    const fs::path shaderlog_path{ fs::path(host.base_path) / "shaderlog" };
+static std::map<std::string, std::pair<std::vector<double>, std::vector<std::string>>> update_history_infos;
 
-    for (const auto &game : gui.game_selector.games) {
-        if (title_id == game.title_id) {
-            // Context Game Menu
-            if (ImGui::BeginPopupContextItem("#game_context_menu")) {
-                if (ImGui::MenuItem("Boot", game.title.c_str()))
-                    selected[0] = true;
-                if (ImGui::BeginMenu("Copy game info")) {
-                    if (ImGui::MenuItem("ID and Name")) {
-                        ImGui::LogToClipboard();
-                        ImGui::LogText("%s [%s]", game.title_id.c_str(), game.title.c_str());
-                        ImGui::LogFinish();
-                    }
-                    if (ImGui::MenuItem("ID")) {
-                        ImGui::LogToClipboard();
-                        ImGui::LogText("%s", game.title_id.c_str());
-                        ImGui::LogFinish();
-                    }
-                    if (ImGui::MenuItem("Name")) {
-                        ImGui::LogToClipboard();
-                        ImGui::LogText("%s", game.title.c_str());
-                        ImGui::LogFinish();
-                    }
-                    ImGui::EndMenu();
-                }
-                if (ImGui::BeginMenu("Remove")) {
-                    if (ImGui::MenuItem("Game"))
-                        delete_game_popup = true;
-                    if (ImGui::MenuItem("Save Data"))
-                        delete_savedata_popup = true;
-                    if (ImGui::MenuItem("Shader Log")) {
-                        fs::remove_all(shaderlog_path / game.title_id);
-                    }
-                    ImGui::EndMenu();
-                }
-                ImGui::EndPopup();
-            }
+static bool get_update_history(GuiState &gui, HostState &host) {
+    const auto change_info_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id / "sce_sys/changeinfo/" };
 
-            static const auto BUTTON_SIZE = ImVec2(60.f, 0.f);
+    std::string fname = fmt::format("changeinfo_{:0>2d}.xml", host.cfg.sys_lang);
 
-            // Delete Game Popup
-            if (delete_game_popup)
-                ImGui::OpenPopup("Delete Game");
-            ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
-            if (ImGui::BeginPopupModal("Delete Game", &delete_game_popup, ImGuiWindowFlags_AlwaysAutoResize)) {
-                ImGui::PopStyleColor();
-                ImGui::TextColored(GUI_COLOR_TEXT, "Do you really want to delete this game?\n%s [%s] %s", game.title_id.c_str(), game.title.c_str(), game.app_ver.c_str());
-                if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("Deleting a game may take a while!\nDepending on the size of the games and your hardware.");
-                ImGui::Checkbox("Also delete save data and shader log for this game?", &check_savedata_and_shaderlog);
-                ImGui::Separator();
-                ImGui::Spacing();
-                ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 65);
-                if (ImGui::Button("Yes", BUTTON_SIZE)) {
-                    if (check_savedata_and_shaderlog) {
-                        fs::remove_all(shaderlog_path / game.title_id);
-                        fs::remove_all(save_data_path / game.title_id);
-                        check_savedata_and_shaderlog = false;
-                    }
-                    delete_game(gui, host, title_id);
-                    delete_game_popup = false;
-                    ImGui::CloseCurrentPopup();
-                }
-                ImGui::SameLine();
-                if (ImGui::Button("No", BUTTON_SIZE)) {
-                    delete_game_popup = false;
-                    if (check_savedata_and_shaderlog)
-                        check_savedata_and_shaderlog = false;
-                    ImGui::CloseCurrentPopup();
-                }
-                ImGui::EndPopup();
-            } else
-                ImGui::PopStyleColor();
+    if (!fs::exists(change_info_path / fname))
+        fname = "changeinfo.xml";
 
-            // Delete Save Data Popup
-            if (delete_savedata_popup)
-                ImGui::OpenPopup("Delete Save Data");
-            ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);
-            if (ImGui::BeginPopupModal("Delete Save Data", &delete_savedata_popup, ImGuiWindowFlags_AlwaysAutoResize)) {
-                ImGui::PopStyleColor();
-                if (fs::exists(save_data_path / game.title_id)) {
-                    ImGui::TextColored(GUI_COLOR_TEXT, "Do you really want to delete the save data for this game?\n%s [%s]", game.title_id.c_str(), game.title.c_str());
-                    ImGui::Separator();
-                    ImGui::Spacing();
-                    ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 65);
-                    if (ImGui::Button("Yes", BUTTON_SIZE)) {
-                        fs::remove_all(save_data_path / game.title_id);
-                        delete_savedata_popup = false;
-                        ImGui::CloseCurrentPopup();
-                    }
-                    ImGui::SameLine();
-                    if (ImGui::Button("No", BUTTON_SIZE)) {
-                        delete_savedata_popup = false;
-                        ImGui::CloseCurrentPopup();
-                    }
-                } else {
-                    ImGui::TextColored(GUI_COLOR_TEXT, "Save data not found for:\n%s [%s]", game.title_id.c_str(), game.title.c_str());
-                    ImGui::Separator();
-                    ImGui::Spacing();
-                    ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 30);
-                    if (ImGui::Button("Ok", BUTTON_SIZE)) {
-                        delete_savedata_popup = false;
-                        ImGui::CloseCurrentPopup();
-                    }
-                }
+    std::string xml_path = change_info_path.string() + fname;
+    pugi::xml_document doc;
+    pugi::xml_parse_result result = doc.load_file(xml_path.c_str());
 
-                ImGui::EndPopup();
-            } else
-                ImGui::PopStyleColor();
+    for (const auto &update : doc.child("changeinfo")) {
+        update_history_infos[host.io.title_id].first.push_back({ update.attribute("app_ver").as_double() });
+        update_history_infos[host.io.title_id].second.push_back({ update.text().as_string() });
+    }
+
+    for (auto &i : update_history_infos[host.io.title_id].second) {
+        const auto startpos = "<";
+        const auto endpos = ">";
+
+        if (i.find_first_of('\n') != std::string::npos)
+            i.erase(i.begin() + i.find_first_of('\n'));
+
+        while (i.find("</li> <li>") != std::string::npos)
+            if (i.find("</li> <li>") != std::string::npos)
+                i.replace(i.find("</li> <li>"), i.find(endpos) + 2 - i.find(startpos), "\n");
+        while (i.find("<li>") != std::string::npos)
+            if (i.find("<li>") != std::string::npos)
+                i.replace(i.find("<li>"), i.find(endpos) + 1 - i.find(startpos), ". ");
+        while (i.find(startpos) != std::string::npos)
+            if (i.find(">") + 1 != std::string::npos)
+                i.erase(i.find(startpos), i.find(endpos) + 1 - i.find(startpos));
+
+        bool found_space = false;
+        auto end{ std::remove_if(i.begin(), i.end(), [&found_space](unsigned ch) {
+            bool is_space = std::isspace(ch);
+            std::swap(found_space, is_space);
+            return found_space && is_space;
+        }) };
+
+        if (end != i.begin() && std::isspace(static_cast<unsigned>(end[-1])))
+            --end;
+
+        i.erase(end, i.end());
+    }
+
+    return !update_history_infos[host.io.title_id].first.empty() && !update_history_infos[host.io.title_id].second.empty();
+}
+
+enum GameInformation {
+    NAME,
+    TROPHY,
+    PARENTAL,
+    UPDATED,
+    SIZE,
+    VERSION
+};
+
+static std::map<int, std::pair<std::size_t, std::string>> game_info;
+
+static bool get_game_info(GuiState &gui, HostState &host) {
+    game_info.clear();
+    const auto game_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
+
+    if (fs::exists(game_path) && !fs::is_empty(game_path)) {
+        time_t updated = fs::last_write_time(game_path);
+        game_info[UPDATED].second = std::asctime(std::localtime(&updated));
+
+        fs::recursive_directory_iterator end;
+        for (fs::recursive_directory_iterator g(game_path); g != end; ++g) {
+            const fs::path file = *g;
+            if (fs::is_regular_file(file))
+                game_info[SIZE].first += fs::file_size(file);
         }
+        game_info[SIZE].first /= 1048576;
+    }
+
+    vfs::FileBuffer params;
+    if (vfs::read_app_file(params, host.pref_path, host.io.title_id, "sce_sys/param.sfo")) {
+        SfoFile sfo_handle;
+        sfo::load(sfo_handle, params);
+        sfo::get_data_by_key(game_info[NAME].second, sfo_handle, "TITLE");
+        sfo::get_data_by_key(game_info[VERSION].second, sfo_handle, "APP_VER");
+        sfo::get_data_by_key(game_info[PARENTAL].second, sfo_handle, "PARENTAL_LEVEL");
+    }
+
+    return !game_info.empty();
+}
+
+#ifdef _WIN32
+static const char OS_PREFIX[] = "start ";
+#elif __APPLE__
+static const char OS_PREFIX[] = "open ";
+#else
+static const char OS_PREFIX[] = "xdg-open ";
+#endif
+
+static auto delete_game_popup = false;
+static auto delete_savedata_popup = false;
+static auto check_savedata_and_shaderlog = false;
+static auto update_history = false;
+static auto information = false;
+
+void game_context_menu(GuiState &gui, HostState &host) {
+    const auto game_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
+    const auto save_data_path{ fs::path(host.pref_path) / "ux0/user/00/savedata" / host.io.title_id };
+    const auto shaderlog_path{ fs::path(host.base_path) / "shaderlog" / host.io.title_id };
+
+    // Context Game Menu
+    if (ImGui::BeginPopupContextItem("#game_context_menu")) {
+        if (ImGui::MenuItem("Boot", host.game_title.c_str()))
+            gui.game_selector.selected_title_id = host.io.title_id;
+        if (ImGui::BeginMenu("Copy game info")) {
+            if (ImGui::MenuItem("ID and Name")) {
+                ImGui::LogToClipboard();
+                ImGui::LogText("%s [%s]", host.io.title_id.c_str(), host.game_title.c_str());
+                ImGui::LogFinish();
+            }
+            if (ImGui::MenuItem("ID")) {
+                ImGui::LogToClipboard();
+                ImGui::LogText("%s", host.io.title_id.c_str());
+                ImGui::LogFinish();
+            }
+            if (ImGui::MenuItem("Name")) {
+                ImGui::LogToClipboard();
+                ImGui::LogText("%s", host.game_title.c_str());
+                ImGui::LogFinish();
+            }
+            ImGui::EndMenu();
+        }
+        if (ImGui::BeginMenu("Open Folder")) {
+            if (ImGui::MenuItem("Game")) {
+                std::ostringstream game_explorer;
+                game_explorer << OS_PREFIX << game_path.string();
+                system(game_explorer.str().c_str());
+            }
+            if (fs::exists(save_data_path) && ImGui::MenuItem("Save Data")) {
+                std::ostringstream save_data_explorer;
+                save_data_explorer << OS_PREFIX << save_data_path.string();
+                system(save_data_explorer.str().c_str());
+            }
+            ImGui::EndMenu();
+        }
+        if (ImGui::BeginMenu("Delete")) {
+            if (ImGui::MenuItem("Game"))
+                delete_game_popup = true;
+            if (fs::exists(save_data_path) && ImGui::MenuItem("Save Data"))
+                delete_savedata_popup = true;
+            if (ImGui::MenuItem("Shader Log")) {
+                fs::remove_all(shaderlog_path);
+            }
+            ImGui::EndMenu();
+        }
+        if (fs::exists(game_path / "sce_sys/changeinfo/") && ImGui::MenuItem("Update history")) {
+            if (get_update_history(gui, host))
+                update_history = true;
+            else
+                LOG_WARN("Patch note Error for title: {}", host.io.title_id);
+        }
+        if (ImGui::MenuItem("Information") && get_game_info(gui, host))
+            information = true;
+        ImGui::EndPopup();
+    }
+
+    static const auto BUTTON_SIZE = ImVec2(60.f, 0.f);
+    static const auto ICON_SIZE = ImVec2(128.f, 128.f);
+
+    // Delete Game Popup
+    if (delete_game_popup)
+        ImGui::OpenPopup("Delete Game");
+    if (ImGui::BeginPopupModal("Delete Game", &delete_game_popup, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
+        if (gui.game_selector.icons.find(host.io.title_id) != gui.game_selector.icons.end()) {
+            ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2) - (ICON_SIZE.x / 2));
+            ImGui::Image(gui.game_selector.icons[host.io.title_id], ICON_SIZE);
+        }
+        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2) - (host.game_title.size() * 3));
+        ImGui::TextColored(GUI_COLOR_TEXT, "%s", host.game_title.c_str());
+        ImGui::Spacing();
+        ImGui::Spacing();
+        ImGui::TextColored(GUI_COLOR_TEXT, "Do you really want to delete this application?");
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Deleting a game may take a while!\nDepending on the size of the games and your hardware.");
+        ImGui::Checkbox("Also delete save data and shader log for this game?", &check_savedata_and_shaderlog);
+        ImGui::Spacing();
+        ImGui::Spacing();
+        ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 65);
+        if (ImGui::Button("Ok", BUTTON_SIZE)) {
+            if (check_savedata_and_shaderlog) {
+                fs::remove_all(shaderlog_path);
+                fs::remove_all(save_data_path);
+                check_savedata_and_shaderlog = false;
+            }
+            delete_game(gui, host);
+            delete_game_popup = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", BUTTON_SIZE)) {
+            delete_game_popup = false;
+            if (check_savedata_and_shaderlog)
+                check_savedata_and_shaderlog = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+
+    // Delete Save Data Popup
+    if (delete_savedata_popup)
+        ImGui::OpenPopup("Delete Save Data");
+    if (ImGui::BeginPopupModal("Delete Save Data", &delete_savedata_popup, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
+        if (gui.game_selector.icons.find(host.io.title_id) != gui.game_selector.icons.end()) {
+            ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2) - (ICON_SIZE.x / 2));
+            ImGui::Image(gui.game_selector.icons[host.io.title_id], ICON_SIZE);
+        }
+        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2) - (host.game_title.size() * 3));
+        ImGui::TextColored(GUI_COLOR_TEXT, "%s", host.game_title.c_str());
+        ImGui::Spacing();
+        ImGui::Spacing();
+        ImGui::TextColored(GUI_COLOR_TEXT, "Do you really want to delete the save data for this application?");
+        ImGui::Spacing();
+        ImGui::Spacing();
+        ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 65);
+        if (ImGui::Button("Ok", BUTTON_SIZE)) {
+            fs::remove_all(save_data_path);
+            delete_savedata_popup = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", BUTTON_SIZE)) {
+            delete_savedata_popup = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+
+    // Information
+    if (information)
+        ImGui::OpenPopup("Information");
+    if (ImGui::BeginPopupModal("Information", &information, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
+        ImGui::SetCursorPos(ImVec2(10.0f, 10.0f));
+        if (ImGui::Button("X", BUTTON_SIZE))
+            information = false;
+        if (gui.game_selector.icons.find(host.io.title_id) != gui.game_selector.icons.end()) {
+            ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2) - (ICON_SIZE.x / 2));
+            ImGui::Image(gui.game_selector.icons[host.io.title_id], ICON_SIZE);
+        }
+        ImGui::PushItemWidth(360.0f);
+        if (ImGui::ListBoxHeader("##information", (int)game_info.size())) {
+            ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 300.0f);
+            ImGui::TextColored(GUI_COLOR_TEXT, "Name  %s", game_info[NAME].second.c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "Parental Controls  Level %d", *reinterpret_cast<const uint16_t *>(game_info[PARENTAL].second.c_str()));
+            ImGui::TextColored(GUI_COLOR_TEXT, "Updated  %s", game_info[UPDATED].second.c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "Size  %d MB", game_info[SIZE].first);
+            ImGui::TextColored(GUI_COLOR_TEXT, "Version  %s", game_info[VERSION].second.c_str());
+
+            ImGui::PopTextWrapPos();
+            ImGui::ListBoxFooter();
+        }
+        ImGui::PopItemWidth();
+        ImGui::EndPopup();
+    }
+
+    // Update History
+    if (update_history)
+        ImGui::OpenPopup("Update History");
+    if (ImGui::BeginPopupModal("Update History", &update_history, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
+        ImGui::PushItemWidth(400.0f);
+        if (ImGui::ListBoxHeader("##update_history_list", (int)update_history_infos[host.io.title_id].first.size(), 8)) {
+            ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 360.0f);
+            for (auto u = 0; u < update_history_infos[host.io.title_id].first.size(); u++) {
+                ImGui::TextColored(GUI_COLOR_TEXT, "Version %.2f", update_history_infos[host.io.title_id].first[u]);
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", update_history_infos[host.io.title_id].second[u].c_str());
+                ImGui::TextColored(GUI_COLOR_TEXT, "\n");
+            }
+            ImGui::PopTextWrapPos();
+            ImGui::ListBoxFooter();
+        }
+        ImGui::PopItemWidth();
+        ImGui::Spacing();
+        ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 30);
+        if (ImGui::Button("Ok", BUTTON_SIZE))
+            update_history = false;
+
+        ImGui::EndPopup();
     }
 }
 

--- a/vita3k/gui/src/game_selector.cpp
+++ b/vita3k/gui/src/game_selector.cpp
@@ -67,7 +67,6 @@ static constexpr auto MENUBAR_HEIGHT = 19;
 
 void draw_game_selector(GuiState &gui, HostState &host) {
     const ImVec2 display_size = ImGui::GetIO().DisplaySize;
-    static std::string title_id;
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - MENUBAR_HEIGHT), ImGuiCond_Always);
@@ -86,8 +85,8 @@ void draw_game_selector(GuiState &gui, HostState &host) {
     }
 
     if (gui.delete_game_icon) {
-        if (gui.game_selector.icons.find(title_id) != gui.game_selector.icons.end())
-            gui.game_selector.icons.erase(title_id);
+        if (gui.game_selector.icons.find(host.io.title_id) != gui.game_selector.icons.end())
+            gui.game_selector.icons.erase(host.io.title_id);
         gui.delete_game_icon = false;
     }
 
@@ -218,31 +217,31 @@ void draw_game_selector(GuiState &gui, HostState &host) {
             if (!gui.game_search_bar.PassFilter(game.title.c_str()) && !gui.game_search_bar.PassFilter(game.title_id.c_str()))
                 continue;
             if (!fs::exists(fs::path(host.pref_path) / "ux0/app" / game.title_id)) {
-                title_id = game.title_id;
+                host.io.title_id = game.title_id;
                 LOG_ERROR("Game not found: {} [{}], deleting the entry for it.", game.title_id, game.title);
-                delete_game(gui, host, title_id);
+                delete_game(gui, host);
             }
             if (gui.game_selector.icons.find(game.title_id) != gui.game_selector.icons.end()) {
                 ImGui::Image(gui.game_selector.icons[game.title_id], ImVec2(icon_size, icon_size));
                 if (ImGui::IsItemHovered()) {
+                    host.io.title_id = game.title_id;
                     if (host.cfg.show_game_background) {
                         if (gui.game_backgrounds.find(game.title_id) == gui.game_backgrounds.end())
-                            load_game_background(gui, host, game.title_id);
+                            load_game_background(gui, host);
                         else if (gui.current_background != gui.game_backgrounds[game.title_id])
                             gui.current_background = gui.game_backgrounds[game.title_id];
                     }
                     if (ImGui::IsMouseClicked(0))
                         selected[0] = true;
-                    title_id = game.title_id;
                 }
                 ImGui::OpenPopupOnItemClick("#game_context_menu", 1);
             }
             ImGui::NextColumn();
             ImGui::Selectable(game.title_id.c_str(), &selected[1], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
             if (ImGui::IsItemHovered())
-                title_id = game.title_id;
-            if (title_id == game.title_id)
-                game_context_menu(gui, host, selected, title_id);
+                host.io.title_id = game.title_id;
+            if (host.io.title_id == game.title_id)
+                game_context_menu(gui, host);
             ImGui::NextColumn();
             ImGui::Selectable(game.app_ver.c_str(), &selected[2], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
             ImGui::NextColumn();

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -177,31 +177,25 @@ void init_icons(GuiState &gui, HostState &host) {
     }
 }
 
-void load_game_background(GuiState &gui, HostState &host, const std::string &title_id) {
+void load_game_background(GuiState &gui, HostState &host) {
     int32_t width = 0;
     int32_t height = 0;
     vfs::FileBuffer buffer;
 
-    vfs::read_app_file(buffer, host.pref_path, title_id, "sce_sys/pic0.png");
+    vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/pic0.png");
     if (buffer.empty()) {
-        if (vfs::read_app_file(buffer, host.pref_path, title_id, "sce_sys/livearea/contents/template.xml")) {
-            LOG_INFO("Game background found in template for title {}.", title_id);
-            vfs::read_app_file(buffer, host.pref_path, title_id, "sce_sys/livearea/contents/bg.png");
-            vfs::read_app_file(buffer, host.pref_path, title_id, "sce_sys/livearea/contents/bg0.png");
-        } else {
-            if (gui.current_background != gui.user_backgrounds[host.cfg.background_image])
-                gui.current_background = gui.user_backgrounds[host.cfg.background_image];
-            LOG_WARN("Game background not found for title {}.", title_id);
-            return;
-        }
+        if (gui.current_background != gui.user_backgrounds[host.cfg.background_image])
+            gui.current_background = gui.user_backgrounds[host.cfg.background_image];
+        LOG_WARN("Game background not found for title {}.", host.io.title_id);
+        return;
     }
     stbi_uc *data = stbi_load_from_memory(&buffer[0], static_cast<int>(buffer.size()), &width, &height, nullptr, STBI_rgb_alpha);
     if (!data) {
-        LOG_ERROR("Invalid game background for title {}.", title_id);
+        LOG_ERROR("Invalid game background for title {}.", host.io.title_id);
         return;
     }
-    gui.game_backgrounds[title_id].init(gui.imgui_state.get(), data, width, height);
-    gui.current_background = gui.game_backgrounds[title_id];
+    gui.game_backgrounds[host.io.title_id].init(gui.imgui_state.get(), data, width, height);
+    gui.current_background = gui.game_backgrounds[host.io.title_id];
     stbi_image_free(data);
 }
 


### PR DESCRIPTION
- Add Open folder for game and savedata
- Add Update History on game context menu.
- Add game information.
- Refactor order/name for have same real psvita hw (set real psvita element after emulate element).

# Result:

- Context menu:
![image](https://user-images.githubusercontent.com/5261759/72001990-e1771a00-3246-11ea-802a-d47049945895.png)

- Update history:
![image](https://user-images.githubusercontent.com/5261759/72001721-4c742100-3246-11ea-9f58-af4ba0051efe.png)

- Information:
![image](https://user-images.githubusercontent.com/5261759/72001671-37978d80-3246-11ea-85a8-bdb6e3691bed.png)