### PR TITLE
Revert "renderer/gl: Correct viewport formula again"

### DIFF
--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -119,7 +119,7 @@ void sync_viewport(GLContext &context, const GxmContextState &state, const bool 
             context.viewport_flip[3] = 1.0f;
         }
 
-        glViewportIndexedf(0, x, display_h - h - y, w, h);
+        glViewportIndexedf(0, x, y, w, h);
         glDepthRange(viewport.offset.z - viewport.scale.z, viewport.offset.z + viewport.scale.z);
     } else {
         if (hardware_flip) {


### PR DESCRIPTION
Breaks hardware flip.
https://github.com/Vita3K/Vita3K/pull/619#issuecomment-565652849