### PR TITLE
stub sceKernelGetThreadInfo

### DIFF
--- a/vita3k/cpu/include/cpu/functions.h
+++ b/vita3k/cpu/include/cpu/functions.h
@@ -38,8 +38,8 @@ typedef std::unique_ptr<CPUState, std::function<void(CPUState *)>> CPUStatePtr;
 typedef std::unique_ptr<CPUContext, std::function<void(CPUContext *)>> CPUContextPtr;
 
 CPUStatePtr init_cpu(Address pc, Address sp, bool log_code, CallSVC call_svc, MemState &mem);
-int run(CPUState &state, bool callback);
-int step(CPUState &state, bool callback);
+int run(CPUState &state, bool callback, Address entry_point);
+int step(CPUState &state, bool callback, Address entry_point);
 void stop(CPUState &state);
 uint32_t read_reg(CPUState &state, size_t index);
 float read_float_reg(CPUState &state, size_t index);

--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -54,4 +54,5 @@ struct ThreadState {
     std::condition_variable something_to_do;
     std::vector<std::shared_ptr<ThreadState>> waiting_threads;
     std::string name;
+    Address entry_point;
 };

--- a/vita3k/kernel/src/thread/thread.cpp
+++ b/vita3k/kernel/src/thread/thread.cpp
@@ -80,6 +80,7 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
 
     const ThreadStatePtr thread = std::make_shared<ThreadState>();
     thread->name = name;
+    thread->entry_point = entry_point.address();
     // TODO: needs testing
     if (init_priority & (SCE_KERNEL_DEFAULT_PRIORITY & 0xF0000000)) {
         thread->priority = init_priority - SCE_KERNEL_DEFAULT_PRIORITY + SCE_KERNEL_DEFAULT_PRIORITY_USER_INTERNAL;
@@ -208,10 +209,10 @@ bool run_thread(ThreadState &thread, bool callback) {
         case ThreadToDo::step:
             lock.unlock();
             if (thread.to_do == ThreadToDo::step) {
-                res = step(*thread.cpu, callback);
+                res = step(*thread.cpu, callback, thread.entry_point);
                 thread.to_do = ThreadToDo::wait;
             } else
-                res = run(*thread.cpu, callback);
+                res = run(*thread.cpu, callback, thread.entry_point);
 #ifdef USE_GDBSTUB
             if (hit_breakpoint(*thread.cpu)) {
                 thread.to_do = ThreadToDo::wait;


### PR DESCRIPTION
Stubs sceKernelGetThreadInfo with a basic implementation. There's a lot more stuff this function reports which we do not track, but this should be enough for simple uses. This PR in conjunction with #631 allows stardew valley to get even further.
[vita3k.log](https://github.com/Vita3K/Vita3K/files/4056733/vita3k.log)

I also moved `entry_point` from `CPUState` to `ThreadState`, let me know if I need to change anything there.