### PR TITLE
Some fixes done while using Retroarch

### DIFF
--- a/vita3k/io/src/device.cpp
+++ b/vita3k/io/src/device.cpp
@@ -56,7 +56,7 @@ std::string remove_device_from_path(const std::string &path, const VitaIoDevice 
     auto out = path;
     out = out.substr(device_length, out.size());
     if (!mod_path.empty())
-        out.front() == '/' ? out = mod_path + out : out = mod_path + '/' + out;
+        !out.empty() && out.front() == '/' ? out = mod_path + out : out = mod_path + '/' + out;
     if (!out.empty() && out.front() == '/')
         out = out.substr(1, out.length());
 


### PR DESCRIPTION
- out.front() was failing on empty out
- Semaphores were crazy with value rising high and hit some assert on thread->to_do status. The cause was spurious wake ups that can be fixed with predicates. Thanks @isJuhn 