### PR TITLE
renderer/gl: check status instead of info length

### DIFF
--- a/vita3k/renderer/src/gl/compile_program.cpp
+++ b/vita3k/renderer/src/gl/compile_program.cpp
@@ -26,11 +26,9 @@ static SharedGLObject compile_glsl(GLenum type, const std::string &source) {
     glCompileShader(shader->get());
 
     GLint log_length = 0;
-    GLint status = 0;
-    glGetShaderiv(shader->get(), GL_COMPILE_STATUS, &status);
     glGetShaderiv(shader->get(), GL_INFO_LOG_LENGTH, &log_length);
 
-    if (!status) {
+    if (log_length > 1) {
         std::vector<GLchar> log;
         log.resize(log_length);
         glGetShaderInfoLog(shader->get(), log_length, nullptr, log.data());
@@ -163,11 +161,9 @@ SharedGLObject compile_program(ProgramCache &program_cache, ShaderCache &vertex_
     }
 
     GLint log_length = 0;
-    GLint status = 0;
-    glGetProgramiv(program->get(), GL_LINK_STATUS, &status);
     glGetProgramiv(program->get(), GL_INFO_LOG_LENGTH, &log_length);
 
-    if (!status) {
+    if (log_length > 1) {
         std::vector<GLchar> log;
         log.resize(log_length);
         glGetProgramInfoLog(program->get(), log_length, nullptr, log.data());

--- a/vita3k/renderer/src/gl/compile_program.cpp
+++ b/vita3k/renderer/src/gl/compile_program.cpp
@@ -26,9 +26,11 @@ static SharedGLObject compile_glsl(GLenum type, const std::string &source) {
     glCompileShader(shader->get());
 
     GLint log_length = 0;
+    GLint status = 0;
+    glGetShaderiv(shader->get(), GL_COMPILE_STATUS, &status);
     glGetShaderiv(shader->get(), GL_INFO_LOG_LENGTH, &log_length);
 
-    if (log_length > 0) {
+    if (!status) {
         std::vector<GLchar> log;
         log.resize(log_length);
         glGetShaderInfoLog(shader->get(), log_length, nullptr, log.data());
@@ -161,9 +163,11 @@ SharedGLObject compile_program(ProgramCache &program_cache, ShaderCache &vertex_
     }
 
     GLint log_length = 0;
+    GLint status = 0;
+    glGetProgramiv(program->get(), GL_LINK_STATUS, &status);
     glGetProgramiv(program->get(), GL_INFO_LOG_LENGTH, &log_length);
 
-    if (log_length > 0) {
+    if (!status) {
         std::vector<GLchar> log;
         log.resize(log_length);
         glGetProgramInfoLog(program->get(), log_length, nullptr, log.data());

--- a/vita3k/renderer/src/gl/compile_program.cpp
+++ b/vita3k/renderer/src/gl/compile_program.cpp
@@ -28,6 +28,7 @@ static SharedGLObject compile_glsl(GLenum type, const std::string &source) {
     GLint log_length = 0;
     glGetShaderiv(shader->get(), GL_INFO_LOG_LENGTH, &log_length);
 
+    // Intel driver returns an info log length of at least 1 even if it is empty.
     if (log_length > 1) {
         std::vector<GLchar> log;
         log.resize(log_length);
@@ -163,6 +164,7 @@ SharedGLObject compile_program(ProgramCache &program_cache, ShaderCache &vertex_
     GLint log_length = 0;
     glGetProgramiv(program->get(), GL_INFO_LOG_LENGTH, &log_length);
 
+    // Intel driver returns an info log length of at least 1 even if it is empty.
     if (log_length > 1) {
         std::vector<GLchar> log;
         log.resize(log_length);


### PR DESCRIPTION
I was debugging on bootcamp again and noticed it was printing an empty error message for every shader it recompiled. This pr should fix this again.