### PR TITLE
gui: move apps background on boot app.

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -32,7 +32,6 @@
     code(bool, "log-uniforms", false, log_uniforms)                                                     \
     code(bool, "pstv-mode", false, pstv_mode)                                                           \
     code(bool, "show-gui", false, show_gui)                                                             \
-    code(bool, "show-game-background", true, show_game_background)                                      \
     code(bool, "show-live-area-screen", true, show_live_area_screen)                                    \
     code(int, "icon-size", 64, icon_size)                                                               \
     code(bool, "archive-log", false, archive_log)                                                       \

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -41,11 +41,11 @@ void game_context_menu(GuiState &gui, HostState &host);
 void get_game_titles(GuiState &gui, HostState &host);
 void get_modules_list(GuiState &gui, HostState &host);
 void init(GuiState &gui, HostState &host);
+void init_app_background(GuiState &gui, HostState &host);
 void init_background(GuiState &gui, const std::string &image_path);
 void init_icons(GuiState &gui, HostState &host);
 void init_live_area(GuiState &gui, HostState &host);
 bool init_manual(GuiState &gui, HostState &host);
-void load_game_background(GuiState &gui, HostState &host);
 bool refresh_game_list(GuiState &gui, HostState &host);
 
 void draw_begin(GuiState &gui, HostState &host);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -149,13 +149,13 @@ struct GuiState {
     std::vector<std::pair<std::string, bool>> modules;
     ImGuiTextFilter module_search_bar;
 
-    ImTextureID current_background{};
-    bool delete_game_background = false;
     bool delete_game_icon = false;
     GLuint display = 0;
-    std::map<std::string, ImGui_Texture> game_backgrounds;
+
     ImGuiTextFilter game_search_bar;
     std::map<std::string, ImGui_Texture> user_backgrounds;
+
+    std::map<std::string, ImGui_Texture> apps_background;
 
     std::map<std::string, std::map<std::string, ImGui_Texture>> live_area_contents;
     std::map<std::string, std::map<std::string, std::map<std::string, std::vector<ImGui_Texture>>>> live_items;

--- a/vita3k/gui/src/game_context_menu.cpp
+++ b/vita3k/gui/src/game_context_menu.cpp
@@ -47,7 +47,6 @@ void delete_game(GuiState &gui, HostState &host) {
             LOG_INFO_IF(fs::remove_all(game_path), "Successfully deleted '{} [{}]'.", game.title_id, game.title);
 
             if (!fs::exists(game_path)) {
-                gui.delete_game_background = true;
                 gui.delete_game_icon = true;
                 gui.game_selector.games.erase(games_index);
             } else

--- a/vita3k/gui/src/game_selector.cpp
+++ b/vita3k/gui/src/game_selector.cpp
@@ -32,13 +32,11 @@ namespace gui {
 bool refresh_game_list(GuiState &gui, HostState &host) {
     auto game_list_size = gui.game_selector.games.size();
 
-    if (gui.current_background != gui.user_backgrounds[host.cfg.background_image])
-        gui.current_background = gui.user_backgrounds[host.cfg.background_image];
+    gui.apps_background.clear();
     gui.game_selector.games.clear();
     gui.game_selector.icons.clear();
     gui.live_area_contents.clear();
     gui.live_items.clear();
-    gui.delete_game_background = true;
 
     get_game_titles(gui, host);
 
@@ -65,25 +63,20 @@ bool refresh_game_list(GuiState &gui, HostState &host) {
     return true;
 }
 
-static constexpr auto MENUBAR_HEIGHT = 19;
+static auto MENUBAR_HEIGHT = 22.f;
 
 void draw_game_selector(GuiState &gui, HostState &host) {
     const ImVec2 display_size = ImGui::GetIO().DisplaySize;
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - MENUBAR_HEIGHT), ImGuiCond_Always);
-    if (gui.current_background)
+    if (gui.user_backgrounds[host.cfg.background_image])
         ImGui::SetNextWindowBgAlpha(host.cfg.background_alpha);
     ImGui::Begin("Game Selector", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
-    if (gui.current_background) {
-        ImGui::GetBackgroundDrawList()->AddImage(reinterpret_cast<void *>(gui.current_background),
-            ImVec2(0, 0), display_size);
-    }
-
-    if (gui.delete_game_background) {
-        gui.game_backgrounds.clear();
-        gui.delete_game_background = false;
+    if (gui.user_backgrounds[host.cfg.background_image]) {
+        ImGui::GetBackgroundDrawList()->AddImage(gui.user_backgrounds[host.cfg.background_image],
+            ImVec2(0, MENUBAR_HEIGHT), display_size);
     }
 
     if (gui.delete_game_icon) {
@@ -268,12 +261,6 @@ void draw_game_selector(GuiState &gui, HostState &host) {
                     host.game_short_title = game.stitle;
                     host.game_title = game.title;
                     host.io.title_id = game.title_id;
-                    if (host.cfg.show_game_background) {
-                        if (gui.game_backgrounds.find(game.title_id) == gui.game_backgrounds.end())
-                            load_game_background(gui, host);
-                        else if (gui.current_background != gui.game_backgrounds[game.title_id])
-                            gui.current_background = gui.game_backgrounds[game.title_id];
-                    }
                     if (ImGui::IsMouseClicked(0))
                         selected[0] = true;
                 }
@@ -294,8 +281,6 @@ void draw_game_selector(GuiState &gui, HostState &host) {
             ImGui::NextColumn();
             ImGui::Selectable(game.category.c_str(), &selected[3], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
             ImGui::NextColumn();
-            if (ImGui::IsItemHovered() && (gui.current_background != gui.user_backgrounds[host.cfg.background_image]))
-                gui.current_background = gui.user_backgrounds[host.cfg.background_image];
             ImGui::Selectable(game.title.c_str(), &selected[4], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, static_cast<float>(icon_size)));
             ImGui::NextColumn();
             if (std::find(std::begin(selected), std::end(selected), true) != std::end(selected)) {

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -165,7 +165,6 @@ void init_background(GuiState &gui, const std::string &image_path) {
     }
 
     gui.user_backgrounds[image_path].init(gui.imgui_state.get(), data, width, height);
-    gui.current_background = gui.user_backgrounds[image_path];
     stbi_image_free(data);
 }
 
@@ -203,26 +202,23 @@ void init_icons(GuiState &gui, HostState &host) {
     }
 }
 
-void load_game_background(GuiState &gui, HostState &host) {
+void init_app_background(GuiState &gui, HostState &host) {
     int32_t width = 0;
     int32_t height = 0;
     vfs::FileBuffer buffer;
 
     vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/pic0.png");
     if (buffer.empty()) {
-        if (gui.current_background != gui.user_backgrounds[host.cfg.background_image])
-            gui.current_background = gui.user_backgrounds[host.cfg.background_image];
-        LOG_WARN("Game background not found for title {}.", host.io.title_id);
+        LOG_WARN("Background not found for application {} [{}].", host.io.title_id, host.game_title);
         return;
     }
 
     stbi_uc *data = stbi_load_from_memory(&buffer[0], static_cast<int>(buffer.size()), &width, &height, nullptr, STBI_rgb_alpha);
     if (!data) {
-        LOG_ERROR("Invalid game background for title {}.", host.io.title_id);
+        LOG_ERROR("Invalid background for application {} [{}].", host.io.title_id, host.game_title);
         return;
     }
-    gui.game_backgrounds[host.io.title_id].init(gui.imgui_state.get(), data, width, height);
-    gui.current_background = gui.game_backgrounds[host.io.title_id];
+    gui.apps_background[host.io.title_id].init(gui.imgui_state.get(), data, width, height);
     stbi_image_free(data);
 }
 

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -100,8 +100,6 @@ static bool change_user_image_background(GuiState &gui, HostState &host) {
 
         if (gui.user_backgrounds.find(image_path_str) == gui.user_backgrounds.end())
             init_background(gui, image_path_str);
-        else
-            gui.current_background = gui.user_backgrounds[image_path_str];
 
         if (gui.user_backgrounds.find(image_path_str) != gui.user_backgrounds.end()) {
             host.cfg.background_image = image_path_str;
@@ -298,9 +296,6 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         ImGui::Checkbox("Live Area Game Screen", &host.cfg.show_live_area_screen);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Check the box to open Live Area by default when clicking on a game.\nIf disabled, use the right click on game to open it.");
-        ImGui::Checkbox("Game Background", &host.cfg.show_game_background);
-        if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("Uncheck the box to disable viewing Game background.");
         ImGui::Spacing();
         ImGui::SliderInt("Game Icon Size \nSelect your preferred icon size.", &host.cfg.icon_size, 32, 128);
         ImGui::Spacing();
@@ -314,8 +309,6 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
             ImGui::PopItemWidth();
             ImGui::Spacing();
             if (ImGui::Button("Reset Image")) {
-                if (gui.current_background == gui.user_backgrounds[host.cfg.background_image])
-                    gui.current_background = nullptr;
                 host.cfg.background_image.clear();
                 gui.user_backgrounds.clear();
             }
@@ -324,16 +317,15 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         }
         if (ImGui::Button(image_button.c_str()))
             LOG_INFO_IF(change_user_image_background(gui, host), "Succes change image: {}", host.cfg.background_image);
-        if (gui.current_background) {
+        if (gui.user_backgrounds[host.cfg.background_image]) {
             ImGui::Spacing();
             ImGui::SliderFloat("Background Alpha\nSelect your preferred transparent background effect.", &host.cfg.background_alpha, 0.999f, 0.000f);
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("The minimum slider is opaque and the maximum is transparent.");
         }
         ImGui::EndTabItem();
-    } else {
+    } else
         ImGui::PopStyleColor();
-    }
 
     // Debug
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR_OPTIONS);

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -376,6 +376,8 @@ ExitCode load_app(Ptr<const void> &entry_point, HostState &host, GuiState &gui, 
         return ModuleLoadFailed;
     }
 
+    gui::init_app_background(gui, host);
+
     if (!host.cfg.show_gui)
         host.display.imgui_render = false;
 

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -154,6 +154,23 @@ int main(int argc, char *argv[]) {
     if (!gl_renderer.init(host.base_path))
         return RendererInitFailed;
 
+    if (gui.apps_background.find(host.io.title_id) != gui.apps_background.end()) {
+        while (host.frame_count == 0) {
+            // Driver acto!
+            renderer::process_batches(*host.renderer.get(), host.renderer->features, host.mem, host.cfg, host.base_path.c_str(),
+                host.io.title_id.c_str());
+
+            gui::draw_begin(gui, host);
+
+            // Display application background
+            ImGui::GetForegroundDrawList()->AddImage(gui.apps_background[host.io.title_id],
+                ImVec2(0.f, 0.f), ImGui::GetIO().DisplaySize);
+
+            host.display.condvar.notify_all();
+            gui::draw_end(gui, host.window.get());
+        }
+    }
+
     while (handle_events(host, gui)) {
         // Driver acto!
         renderer::process_batches(*host.renderer.get(), host.renderer->features, host.mem, host.cfg, host.base_path.c_str(),


### PR DESCRIPTION
- move app background in boot app like psvita

# Result:
![image](https://cdn.discordapp.com/attachments/570773633270546442/704881120541671455/unknown.png )