### PR TITLE
DLC Install

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -115,12 +115,23 @@ bool install_vpk(HostState &host, GuiState &gui, const fs::path &path) {
     }
 
     SfoFile sfo_handle;
+    std::string content_id, dlc_foldername;
     sfo::load(sfo_handle, params);
     sfo::get_data_by_key(host.io.title_id, sfo_handle, "TITLE_ID");
     sfo::get_data_by_key(host.game_title, sfo_handle, "TITLE");
     sfo::get_data_by_key(host.game_version, sfo_handle, "APP_VER");
+    sfo::get_data_by_key(host.game_category, sfo_handle, "CATEGORY");
+    sfo::get_data_by_key(content_id, sfo_handle, "CONTENT_ID");
+    dlc_foldername = content_id.substr(20);
+    fs::path output_path;
 
-    fs::path output_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
+    if (host.game_category == "gd") {
+        output_path = fs::path(host.pref_path + "/" + "ux0/app" + "/" + host.io.title_id);
+    }
+    else if (host.game_category == "ac") {
+        output_path = fs::path(host.pref_path + "/" + "ux0/addcont" + "/" + host.io.title_id + "/" + dlc_foldername);
+        host.game_title = host.game_title + " (DLC)";
+    }
 
     const auto created = fs::create_directories(output_path);
     if (!created) {


### PR DESCRIPTION
I completely forgot to add DLC installation support for `install_vpk`, now user can install .vpk/.zip/nonpdrm DLC (one by one) 
.zip contents must be immediate 
```
├───DLC_FOLDER.zip
│   └───sce_sys
│       └───param.sfo
```