### PR TITLE
gui: add grid mode for apps list.

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -32,6 +32,7 @@
     code(bool, "log-uniforms", false, log_uniforms)                                                     \
     code(bool, "pstv-mode", false, pstv_mode)                                                           \
     code(bool, "show-gui", false, show_gui)                                                             \
+    code(bool, "apps-list-grid", false, apps_list_grid)                                                 \
     code(bool, "show-live-area-screen", true, show_live_area_screen)                                    \
     code(int, "icon-size", 64, icon_size)                                                               \
     code(bool, "archive-log", false, archive_log)                                                       \

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -37,7 +37,6 @@ enum GenericDialogState {
 };
 
 void delete_game(GuiState &gui, HostState &host);
-void game_context_menu(GuiState &gui, HostState &host);
 void get_game_titles(GuiState &gui, HostState &host);
 void get_modules_list(GuiState &gui, HostState &host);
 void init(GuiState &gui, HostState &host);

--- a/vita3k/gui/src/game_context_menu.cpp
+++ b/vita3k/gui/src/game_context_menu.cpp
@@ -147,7 +147,7 @@ static std::string context_dialog;
 static auto check_savedata_and_shaderlog = false;
 static auto information = false;
 
-void game_context_menu(GuiState &gui, HostState &host) {
+void draw_app_context_menu(GuiState &gui, HostState &host) {
     const auto game_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
     const auto DLC_PATH{ fs::path(host.pref_path) / "ux0/addcont" / host.io.title_id };
     const auto save_data_path{ fs::path(host.pref_path) / "ux0/user/00/savedata" / host.io.title_id };
@@ -155,6 +155,7 @@ void game_context_menu(GuiState &gui, HostState &host) {
 
     // Game Context Menu
     if (ImGui::BeginPopupContextItem("#game_context_menu")) {
+        ImGui::SetWindowFontScale(1.4f);
         if (ImGui::MenuItem("Boot", host.game_title.c_str()))
             gui.game_selector.selected_title_id = host.io.title_id;
         if (ImGui::MenuItem("Check Game Compatibility")) {
@@ -225,15 +226,16 @@ void game_context_menu(GuiState &gui, HostState &host) {
         ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
         ImGui::Begin("##context_dialog", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
         ImGui::SetNextWindowPosCenter();
+        ImGui::SetNextWindowBgAlpha(0.999f);
         ImGui::BeginChild("##context_dialog_child", WINDOW_SIZE, true, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
         // Update History
         if (context_dialog == "history") {
             ImGui::SetCursorPos(ImVec2(20.f * scal.x, BUTTON_SIZE.y));
             if (ImGui::ListBoxHeader("##update_history_list", ImVec2(WINDOW_SIZE.x - (40.f * scal.x), WINDOW_SIZE.y - (BUTTON_SIZE.y * 2.f) - (25.f * scal.y)))) {
                 for (auto u = 0; u < update_history_infos[host.io.title_id].first.size(); u++) {
-                    ImGui::SetWindowFontScale(1.8f);
-                    ImGui::TextColored(GUI_COLOR_TEXT, "Version %.2f", update_history_infos[host.io.title_id].first[u]);
                     ImGui::SetWindowFontScale(1.4f);
+                    ImGui::TextColored(GUI_COLOR_TEXT, "Version %.2f", update_history_infos[host.io.title_id].first[u]);
+                    ImGui::SetWindowFontScale(1.f);
                     ImGui::PushTextWrapPos(WINDOW_SIZE.x - (80.f * scal.x));
                     ImGui::TextColored(GUI_COLOR_TEXT, "%s\n", update_history_infos[host.io.title_id].second[u].c_str());
                     ImGui::PopTextWrapPos();
@@ -249,7 +251,7 @@ void game_context_menu(GuiState &gui, HostState &host) {
                 ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ICON_SIZE.x / 2.f));
                 ImGui::Image(gui.game_selector.icons[host.io.title_id], ICON_SIZE);
             }
-            ImGui::SetWindowFontScale(1.4f * scal.x);
+            ImGui::SetWindowFontScale(1.5f * scal.x);
             ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(host.game_short_title.c_str()).x / 2.f));
             ImGui::TextColored(GUI_COLOR_TEXT, host.game_short_title.c_str());
             std::string ask_delete = context_dialog == "save" ? "Do you really want to delete this save data for this application?" : "Do you really want to delete this application?";
@@ -291,7 +293,7 @@ void game_context_menu(GuiState &gui, HostState &host) {
         ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
         ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
         ImGui::Begin("##information", &information, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
-        ImGui::SetWindowFontScale(1.4f * scal.x);
+        ImGui::SetWindowFontScale(1.5f * scal.x);
         ImGui::SetCursorPos(ImVec2(10.0f * scal.x, 10.0f * scal.y));
         if (ImGui::Button("X", ImVec2(40.f * scal.x, 40.f * scal.y)) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle))
             information = false;
@@ -300,11 +302,11 @@ void game_context_menu(GuiState &gui, HostState &host) {
             ImGui::Image(gui.game_selector.icons[host.io.title_id], ICON_SIZE);
         }
         const auto calc_name = ImGui::CalcTextSize("Name  ");
-        const auto calc_title = ImGui::CalcTextSize(host.game_title.c_str(), 0, false, 200.f * scal.x).y;
+        const auto calc_title = ImGui::CalcTextSize(host.game_title.c_str(), 0, false, 294.f * scal.x).y;
         ImGui::SetCursorPos(ImVec2((display_size.x / 2.f) - calc_name.x, ((ICON_SIZE.y * 2.4f) + (calc_title / 2.f)) - ((calc_title / 2.f) + (calc_name.y / 2.f))));
         ImGui::TextColored(GUI_COLOR_TEXT, "Name ");
         ImGui::SetCursorPos(ImVec2(display_size.x / 2.f, ((ICON_SIZE.y * 2.4f) + (calc_title / 2.f)) - calc_title));
-        ImGui::PushTextWrapPos(display_size.x - (280.f * scal.x));
+        ImGui::PushTextWrapPos(display_size.x - (186.f * scal.x));
         ImGui::TextColored(GUI_COLOR_TEXT, "%s", host.game_title.c_str());
         ImGui::PopTextWrapPos();
         ImGui::Spacing();

--- a/vita3k/gui/src/game_selector.cpp
+++ b/vita3k/gui/src/game_selector.cpp
@@ -72,7 +72,7 @@ void draw_game_selector(GuiState &gui, HostState &host) {
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - MENUBAR_HEIGHT), ImGuiCond_Always);
     if (gui.user_backgrounds[host.cfg.background_image])
         ImGui::SetNextWindowBgAlpha(host.cfg.background_alpha);
-    ImGui::Begin("Game Selector", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("Game Selector", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
     if (gui.user_backgrounds[host.cfg.background_image]) {
         ImGui::GetBackgroundDrawList()->AddImage(gui.user_backgrounds[host.cfg.background_image],
@@ -89,117 +89,115 @@ void draw_game_selector(GuiState &gui, HostState &host) {
 
     switch (gui.game_selector.state) {
     case SELECT_APP:
-        ImGui::Columns(5);
         ImGui::SetWindowFontScale(1.1f);
-        ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
-        ImGui::Button("Icon"); // Button to fit style, does nothing.
-        ImGui::SetColumnWidth(0, icon_size + /* padding */ 20.f);
-        ImGui::NextColumn();
         std::string title_id_label = "TitleID";
-        switch (gui.game_selector.title_id_sort_state) {
-        case ASCENDANT:
-            title_id_label += " >";
-            ImGui::SetColumnWidth(1, 82.f);
-            break;
-        case DESCENDANT:
-            title_id_label += " <";
-            ImGui::SetColumnWidth(1, 82.f);
-            break;
-        default:
-            ImGui::SetColumnWidth(1, 70.f);
-            break;
-        }
-        if (ImGui::Button(title_id_label.c_str())) {
-            gui.game_selector.title_id_sort_state = static_cast<gui::SortState>(std::max<int>(1, (gui.game_selector.title_id_sort_state + 1) % 3));
-            gui.game_selector.app_ver_sort_state = NOT_SORTED;
-            gui.game_selector.category_sort_state = NOT_SORTED;
-            gui.game_selector.title_sort_state = NOT_SORTED;
+        float title_id_size = ImGui::CalcTextSize(title_id_label.c_str()).x + 50.f;
+        std::string app_ver_label = "Version";
+        float app_ver_size = ImGui::CalcTextSize(app_ver_label.c_str()).x + 30.f;
+        std::string cateogry_label = "Category";
+        float cateogry_size = ImGui::CalcTextSize(cateogry_label.c_str()).x + 30.f;
+        ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
+        if (!host.cfg.apps_list_grid) {
+            ImGui::Columns(5);
+            ImGui::SetColumnWidth(0, icon_size + /* padding */ 20.f);
+            ImGui::NextColumn();
             switch (gui.game_selector.title_id_sort_state) {
             case ASCENDANT:
-                std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
-                    return lhs.title_id < rhs.title_id;
-                });
+                title_id_label += " >";
+                title_id_size += ImGui::CalcTextSize(" >").x;
                 break;
             case DESCENDANT:
-                std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
-                    return lhs.title_id > rhs.title_id;
-                });
-                break;
-            default:
+                title_id_label += " <";
+                title_id_size += ImGui::CalcTextSize(" <").x;
                 break;
             }
-        }
-        ImGui::NextColumn();
-        std::string app_ver_label = "Version";
-        switch (gui.game_selector.app_ver_sort_state) {
-        case ASCENDANT:
-            app_ver_label += " >";
-            ImGui::SetColumnWidth(2, 82.f);
-            break;
-        case DESCENDANT:
-            app_ver_label += " <";
-            ImGui::SetColumnWidth(2, 82.f);
-            break;
-        default:
-            ImGui::SetColumnWidth(2, 70.f);
-            break;
-        }
-        if (ImGui::Button(app_ver_label.c_str())) {
-            gui.game_selector.title_id_sort_state = NOT_SORTED;
-            gui.game_selector.app_ver_sort_state = static_cast<gui::SortState>(std::max<int>(1, (gui.game_selector.app_ver_sort_state + 1) % 3));
-            gui.game_selector.category_sort_state = NOT_SORTED;
-            gui.game_selector.title_sort_state = NOT_SORTED;
+            ImGui::SetColumnWidth(1, title_id_size);
+            if (ImGui::Button(title_id_label.c_str())) {
+                gui.game_selector.title_id_sort_state = static_cast<gui::SortState>(std::max<int>(1, (gui.game_selector.title_id_sort_state + 1) % 3));
+                gui.game_selector.app_ver_sort_state = NOT_SORTED;
+                gui.game_selector.category_sort_state = NOT_SORTED;
+                gui.game_selector.title_sort_state = NOT_SORTED;
+                switch (gui.game_selector.title_id_sort_state) {
+                case ASCENDANT:
+                    std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
+                        return lhs.title_id < rhs.title_id;
+                    });
+                    break;
+                case DESCENDANT:
+                    std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
+                        return lhs.title_id > rhs.title_id;
+                    });
+                    break;
+                default:
+                    break;
+                }
+            }
+            ImGui::NextColumn();
             switch (gui.game_selector.app_ver_sort_state) {
             case ASCENDANT:
-                std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
-                    return lhs.app_ver < rhs.app_ver;
-                });
+                app_ver_label += " >";
+                app_ver_size += ImGui::CalcTextSize(" >").x;
                 break;
             case DESCENDANT:
-                std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
-                    return lhs.app_ver > rhs.app_ver;
-                });
-                break;
-            default:
+                app_ver_label += " <";
+                app_ver_size += ImGui::CalcTextSize(" <").x;
                 break;
             }
-        }
-        ImGui::NextColumn();
-        std::string cateogry_label = "Category";
-        switch (gui.game_selector.category_sort_state) {
-        case ASCENDANT:
-            cateogry_label += " >";
-            ImGui::SetColumnWidth(3, 90.f);
-            break;
-        case DESCENDANT:
-            cateogry_label += " <";
-            ImGui::SetColumnWidth(3, 90.f);
-            break;
-        default:
-            ImGui::SetColumnWidth(3, 76.f);
-            break;
-        }
-        if (ImGui::Button(cateogry_label.c_str())) {
-            gui.game_selector.title_id_sort_state = NOT_SORTED;
-            gui.game_selector.app_ver_sort_state = NOT_SORTED;
-            gui.game_selector.category_sort_state = static_cast<gui::SortState>(std::max<int>(1, (gui.game_selector.category_sort_state + 1) % 3));
-            gui.game_selector.title_sort_state = NOT_SORTED;
+            ImGui::SetColumnWidth(2, app_ver_size);
+            if (ImGui::Button(app_ver_label.c_str())) {
+                gui.game_selector.title_id_sort_state = NOT_SORTED;
+                gui.game_selector.app_ver_sort_state = static_cast<gui::SortState>(std::max<int>(1, (gui.game_selector.app_ver_sort_state + 1) % 3));
+                gui.game_selector.category_sort_state = NOT_SORTED;
+                gui.game_selector.title_sort_state = NOT_SORTED;
+                switch (gui.game_selector.app_ver_sort_state) {
+                case ASCENDANT:
+                    std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
+                        return lhs.app_ver < rhs.app_ver;
+                    });
+                    break;
+                case DESCENDANT:
+                    std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
+                        return lhs.app_ver > rhs.app_ver;
+                    });
+                    break;
+                default:
+                    break;
+                }
+            }
+            ImGui::NextColumn();
             switch (gui.game_selector.category_sort_state) {
             case ASCENDANT:
-                std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
-                    return lhs.category < rhs.category;
-                });
+                cateogry_label += " >";
+                cateogry_size += ImGui::CalcTextSize(" >").x;
                 break;
             case DESCENDANT:
-                std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
-                    return lhs.category > rhs.category;
-                });
-                break;
-            default:
+                cateogry_label += " <";
+                cateogry_size += ImGui::CalcTextSize(" <").x;
                 break;
             }
+            ImGui::SetColumnWidth(3, cateogry_size);
+            if (ImGui::Button(cateogry_label.c_str())) {
+                gui.game_selector.title_id_sort_state = NOT_SORTED;
+                gui.game_selector.app_ver_sort_state = NOT_SORTED;
+                gui.game_selector.category_sort_state = static_cast<gui::SortState>(std::max<int>(1, (gui.game_selector.category_sort_state + 1) % 3));
+                gui.game_selector.title_sort_state = NOT_SORTED;
+                switch (gui.game_selector.category_sort_state) {
+                case ASCENDANT:
+                    std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
+                        return lhs.category < rhs.category;
+                    });
+                    break;
+                case DESCENDANT:
+                    std::sort(gui.game_selector.games.begin(), gui.game_selector.games.end(), [](const Game &lhs, const Game &rhs) {
+                        return lhs.category > rhs.category;
+                    });
+                    break;
+                default:
+                    break;
+                }
+            }
+            ImGui::NextColumn();
         }
-        ImGui::NextColumn();
         std::string title_label = "Title";
         switch (gui.game_selector.title_sort_state) {
         case ASCENDANT:
@@ -234,19 +232,40 @@ void draw_game_selector(GuiState &gui, HostState &host) {
         }
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_SEARCH_BAR_TEXT);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, GUI_COLOR_SEARCH_BAR_BG);
-        ImGui::SameLine(ImGui::GetColumnWidth() - (ImGui::CalcTextSize("Refresh game list").x + ImGui::GetStyle().DisplayWindowPadding.x + 320));
-        if (ImGui::Button("Refresh game list"))
+        ImGui::SameLine(ImGui::GetColumnWidth() - (ImGui::CalcTextSize("Refresh").x + ImGui::GetStyle().DisplayWindowPadding.x + 270));
+        if (ImGui::Button("Refresh"))
             refresh_game_list(gui, host);
-        ImGui::SameLine(ImGui::GetColumnWidth() - (ImGui::CalcTextSize("Game Search").x + ImGui::GetStyle().DisplayWindowPadding.x + 220));
-        ImGui::TextColored(GUI_COLOR_TEXT, "Game Search");
+        ImGui::PopStyleColor(3);
+        ImGui::SameLine(ImGui::GetColumnWidth() - (ImGui::CalcTextSize("Search").x + ImGui::GetStyle().DisplayWindowPadding.x + 180));
+        ImGui::TextColored(GUI_COLOR_TEXT, "Search");
         ImGui::SameLine();
-        gui.game_search_bar.Draw("##game_search_bar", 220);
-        ImGui::NextColumn();
+        gui.game_search_bar.Draw("##game_search_bar", 180);
+        if (!host.cfg.apps_list_grid) {
+            ImGui::NextColumn();
+            ImGui::Columns(1);
+        }
         ImGui::Separator();
-        ImGui::SetWindowFontScale(1);
+        static const auto POS_GAME_LIST = ImVec2(54.f, 72.f);
+        ImGui::SetNextWindowPos(host.cfg.apps_list_grid ? POS_GAME_LIST : ImVec2(0.f, 72.f), ImGuiCond_Always);
+        ImGui::BeginChild("##apps_list", ImVec2(host.cfg.apps_list_grid ? display_size.x - POS_GAME_LIST.x : display_size.x, display_size.y - POS_GAME_LIST.y), false, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+        static const auto GRID_ICON_SIZE = ImVec2(128.f, 128.f);
+        if (!host.cfg.apps_list_grid) {
+            ImGui::Columns(5, nullptr, true);
+            ImGui::SetColumnWidth(0, icon_size + /* padding */ 20.f);
+            ImGui::SetColumnWidth(1, title_id_size);
+            ImGui::SetColumnWidth(2, app_ver_size);
+            ImGui::SetColumnWidth(3, cateogry_size);
+        } else {
+            ImGui::Columns(4, nullptr, false);
+            ImGui::SetColumnWidth(0, GRID_ICON_SIZE.x + 80.f);
+            ImGui::SetColumnWidth(1, GRID_ICON_SIZE.x + 80.f);
+            ImGui::SetColumnWidth(2, GRID_ICON_SIZE.x + 80.f);
+            ImGui::SetColumnWidth(3, GRID_ICON_SIZE.x + 80.f);
+        }
+        ImGui::SetWindowFontScale(0.74f);
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
         for (const auto &game : gui.game_selector.games) {
-            bool selected[5] = { false };
+            bool selected = false;
             if (!gui.game_search_bar.PassFilter(game.title.c_str()) && !gui.game_search_bar.PassFilter(game.title_id.c_str()))
                 continue;
             if (!fs::exists(fs::path(host.pref_path) / "ux0/app" / game.title_id)) {
@@ -254,20 +273,21 @@ void draw_game_selector(GuiState &gui, HostState &host) {
                 LOG_ERROR("Game not found: {} [{}], deleting the entry for it.", game.title_id, game.title);
                 delete_game(gui, host);
             }
+            const auto POS_ICON = ImGui::GetCursorPosY();
             if (gui.game_selector.icons.find(game.title_id) != gui.game_selector.icons.end()) {
-                ImGui::Image(gui.game_selector.icons[game.title_id], ImVec2(icon_size, icon_size));
-                if (ImGui::IsItemHovered()) {
-                    host.game_version = game.app_ver;
-                    host.game_short_title = game.stitle;
-                    host.game_title = game.title;
-                    host.io.title_id = game.title_id;
-                    if (ImGui::IsMouseClicked(0))
-                        selected[0] = true;
-                }
-                ImGui::OpenPopupOnItemClick("#game_context_menu", 1);
+                if (host.cfg.apps_list_grid)
+                    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ((ImGui::GetColumnWidth() / 2.f) - (GRID_ICON_SIZE.x / 2.f) - 10.f));
+                ImGui::Image(gui.game_selector.icons[game.title_id], host.cfg.apps_list_grid ? GRID_ICON_SIZE : ImVec2(icon_size, icon_size));
             }
-            ImGui::NextColumn();
-            ImGui::Selectable(game.title_id.c_str(), &selected[1], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
+            const auto POS_TEXT = ImGui::GetCursorPos();
+            ImGui::SetCursorPosY(POS_ICON);
+            if (host.cfg.apps_list_grid)
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ((ImGui::GetColumnWidth() / 2.f) - (GRID_ICON_SIZE.x / 2.f) - 10.f));
+            else
+                ImGui::SetCursorPosY(POS_ICON);
+            ImGui::PushID(game.title_id.c_str());
+            ImGui::Selectable("##icon", &selected, host.cfg.apps_list_grid ? ImGuiSelectableFlags_None : ImGuiSelectableFlags_SpanAllColumns, host.cfg.apps_list_grid ? GRID_ICON_SIZE : ImVec2(0.f, icon_size));
+            ImGui::PopID();
             if (ImGui::IsItemHovered()) {
                 host.game_version = game.app_ver;
                 host.game_short_title = game.stitle;
@@ -275,15 +295,28 @@ void draw_game_selector(GuiState &gui, HostState &host) {
                 host.io.title_id = game.title_id;
             }
             if (host.io.title_id == game.title_id)
-                game_context_menu(gui, host);
-            ImGui::NextColumn();
-            ImGui::Selectable(game.app_ver.c_str(), &selected[2], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
-            ImGui::NextColumn();
-            ImGui::Selectable(game.category.c_str(), &selected[3], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, icon_size));
-            ImGui::NextColumn();
-            ImGui::Selectable(game.title.c_str(), &selected[4], ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, static_cast<float>(icon_size)));
-            ImGui::NextColumn();
-            if (std::find(std::begin(selected), std::end(selected), true) != std::end(selected)) {
+                draw_app_context_menu(gui, host);
+            ImGui::SetWindowFontScale(0.76f);
+            if (!host.cfg.apps_list_grid) {
+                ImGui::NextColumn();
+                ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.0f, 0.5f));
+                ImGui::Selectable(game.title_id.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
+                ImGui::NextColumn();
+                ImGui::Selectable(game.app_ver.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
+                ImGui::NextColumn();
+                ImGui::Selectable(game.category.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
+                ImGui::NextColumn();
+                ImGui::Selectable(game.title.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
+                ImGui::PopStyleVar();
+                ImGui::NextColumn();
+            } else {
+                ImGui::SetCursorPos(ImVec2(POS_TEXT.x + ((ImGui::GetColumnWidth() / 2.f) - (GRID_ICON_SIZE.x / 2.f) - 10.f), POS_TEXT.y));
+                ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + GRID_ICON_SIZE.x);
+                ImGui::TextColored(GUI_COLOR_TEXT, game.title.c_str());
+                ImGui::PopTextWrapPos();
+                ImGui::NextColumn();
+            }
+            if (selected) {
                 if (host.cfg.show_live_area_screen) {
                     init_live_area(gui, host);
                     gui.live_area.live_area_dialog = true;
@@ -291,7 +324,8 @@ void draw_game_selector(GuiState &gui, HostState &host) {
                     gui.game_selector.selected_title_id = game.title_id;
             }
         }
-        ImGui::PopStyleColor(4);
+        ImGui::Columns(1);
+        ImGui::EndChild();
         break;
     }
     ImGui::End();

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -314,6 +314,9 @@ void draw_end(GuiState &gui, SDL_Window *window) {
 void draw_live_area(GuiState &gui, HostState &host) {
     ImGui::PushFont(gui.live_area_font);
 
+    if (gui.game_selector.selected_title_id.empty())
+        draw_game_selector(gui, host);
+    draw_app_context_menu(gui, host);
     if (gui.live_area.live_area_dialog)
         draw_live_area_dialog(gui, host);
     if (gui.live_area.manual_dialog)

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -67,7 +67,6 @@ static void draw_debug_menu(DebugMenuState &state) {
         ImGui::MenuItem("Event Flags", nullptr, &state.eventflags_dialog);
         ImGui::MenuItem("Memory Allocations", nullptr, &state.allocations_dialog);
         ImGui::MenuItem("Disassembly", nullptr, &state.disassembly_dialog);
-        ImGui::PopStyleColor();
         ImGui::EndMenu();
     }
 }
@@ -76,7 +75,6 @@ static void draw_config_menu(ConfigurationMenuState &state) {
     if (ImGui::BeginMenu("Configuration")) {
         ImGui::MenuItem("Profiles Manager", nullptr, &state.profiles_manager_dialog);
         ImGui::MenuItem("Settings", nullptr, &state.settings_dialog);
-        ImGui::PopStyleColor();
         ImGui::EndMenu();
     }
 }
@@ -84,7 +82,6 @@ static void draw_config_menu(ConfigurationMenuState &state) {
 static void draw_controls_menu(ControlMenuState &state) {
     if (ImGui::BeginMenu("Controls")) {
         ImGui::MenuItem("Keyboard Controls", nullptr, &state.controls_dialog);
-        ImGui::PopStyleColor();
         ImGui::EndMenu();
     }
 }

--- a/vita3k/gui/src/private.h
+++ b/vita3k/gui/src/private.h
@@ -56,6 +56,7 @@ void draw_profiles_manager_dialog(GuiState &gui, HostState &host);
 void draw_settings_dialog(GuiState &gui, HostState &host);
 void draw_controls_dialog(GuiState &gui, HostState &host);
 void draw_about_dialog(GuiState &gui);
+void draw_app_context_menu(GuiState &gui, HostState &host);
 void draw_live_area_dialog(GuiState &gui, HostState &host);
 void draw_manual_dialog(GuiState &gui, HostState &host);
 

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -116,12 +116,9 @@ void get_modules_list(GuiState &gui, HostState &host) {
 
     const auto modules_path{ fs::path(host.pref_path) / "vs0/sys/external/" };
     if (fs::exists(modules_path) && !fs::is_empty(modules_path)) {
-        fs::recursive_directory_iterator end;
-        const std::string ext = ".suprx";
-        for (fs::recursive_directory_iterator m(modules_path); m != end; ++m) {
-            const fs::path lle = *m;
-            if (m->path().extension() == ext)
-                gui.modules.push_back({ lle.filename().replace_extension().string(), false });
+        for (const auto &module : fs::recursive_directory_iterator(modules_path)) {
+            if (module.path().extension() == ".suprx")
+                gui.modules.push_back({ module.path().filename().replace_extension().string(), false });
         }
 
         for (auto &m : gui.modules)
@@ -188,9 +185,8 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         if (ImGui::Button("Refresh list"))
             get_modules_list(gui, host);
         ImGui::EndTabItem();
-    } else {
+    } else
         ImGui::PopStyleColor();
-    }
 
     // GPU
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
@@ -200,9 +196,8 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Check the box to enable texture flipping from GPU side.\nIt is recommended to disable this option for homebrew.");
         ImGui::EndTabItem();
-    } else {
+    } else
         ImGui::PopStyleColor();
-    }
 
     // System
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
@@ -222,9 +217,8 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Check the box to enable PS TV mode.");
         ImGui::EndTabItem();
-    } else {
+    } else
         ImGui::PopStyleColor();
-    }
 
     // Emulator
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
@@ -281,9 +275,8 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
                 ImGui::SetTooltip("Reset Vita3K emulator path to default.\nNeed move folder old to default manualy.");
         }
         ImGui::EndTabItem();
-    } else {
+    } else
         ImGui::PopStyleColor();
-    }
 
     // GUI
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
@@ -297,7 +290,15 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Check the box to open Live Area by default when clicking on a game.\nIf disabled, use the right click on game to open it.");
         ImGui::Spacing();
-        ImGui::SliderInt("Game Icon Size \nSelect your preferred icon size.", &host.cfg.icon_size, 32, 128);
+        ImGui::Checkbox("Grid mode", &host.cfg.apps_list_grid);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Check the box to enable app list in grid mode.");
+        if (!host.cfg.apps_list_grid) {
+            ImGui::Spacing();
+            ImGui::SliderInt("Game Icon Size", &host.cfg.icon_size, 32, 128);
+            if (ImGui::IsItemHovered())
+                ImGui::SetTooltip("Select your preferred icon size.");
+        }
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "Background Image");
@@ -319,9 +320,9 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
             LOG_INFO_IF(change_user_image_background(gui, host), "Succes change image: {}", host.cfg.background_image);
         if (gui.user_backgrounds[host.cfg.background_image]) {
             ImGui::Spacing();
-            ImGui::SliderFloat("Background Alpha\nSelect your preferred transparent background effect.", &host.cfg.background_alpha, 0.999f, 0.000f);
+            ImGui::SliderFloat("Background Alpha", &host.cfg.background_alpha, 0.999f, 0.000f);
             if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("The minimum slider is opaque and the maximum is transparent.");
+                ImGui::SetTooltip("Select your preferred transparent background effect.\nThe minimum slider is opaque and the maximum is transparent.");
         }
         ImGui::EndTabItem();
     } else
@@ -350,9 +351,8 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Save color surfaces to files.");
         ImGui::EndTabItem();
-    } else {
+    } else
         ImGui::PopStyleColor();
-    }
 
     if (host.cfg.overwrite_config)
         config::serialize_config(host.cfg, host.cfg.config_path);

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -127,7 +127,6 @@ int main(int argc, char *argv[]) {
 #endif
             gui::draw_live_area(gui, host);
             gui::draw_ui(gui, host);
-            gui::draw_game_selector(gui, host);
 
             gui::draw_end(gui, host.window.get());
         } else {


### PR DESCRIPTION
- Add grid mode for Apps list 
- refactor code for game selector and can now scrool without lost bar for id/ and search

# Result:
- grid mode 
![image](https://user-images.githubusercontent.com/5261759/81136122-eb8df880-8f5a-11ea-9f08-f5e0801e3271.png)

- scroll good now
![image](https://user-images.githubusercontent.com/5261759/81136197-2c860d00-8f5b-11ea-80a1-c7b49d9d0733.png)

