### PR TITLE
gui: Add missing PopStyleColor

### DIFF
--- a/vita3k/gui/src/game_selector.cpp
+++ b/vita3k/gui/src/game_selector.cpp
@@ -324,6 +324,7 @@ void draw_game_selector(GuiState &gui, HostState &host) {
                     gui.game_selector.selected_title_id = game.title_id;
             }
         }
+        ImGui::PopStyleColor();
         ImGui::Columns(1);
         ImGui::EndChild();
         break;


### PR DESCRIPTION
The number of PopStyleColor calls must match the number of PushStyleColor calls. It triggers an assert from ImGui when it is not the case on a debug build.