### PR TITLE
io: Fix parent path when emulated_path has a trailing slash

### DIFF
--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -544,7 +544,9 @@ int create_dir(IOState &io, const char *dir, int mode, const std::string &pref_p
         return fs::create_directories(emulated_path);
     if (fs::exists(emulated_path))
         return IO_ERROR(SCE_ERROR_ERRNO_EEXIST);
-    if (!fs::exists(emulated_path.parent_path())) // Vita cannot recursively create directories
+
+    const auto parent_path = fs::path(emulated_path).remove_trailing_separator().parent_path();
+    if (!fs::exists(parent_path)) // Vita cannot recursively create directories
         return IO_ERROR(SCE_ERROR_ERRNO_ENOENT);
 
     LOG_TRACE("{}: Creating new dir {} ({})", export_name, dir, device::construct_normalized_path(device, translated_path));


### PR DESCRIPTION
If the `emulated_path` has a trailing slash, calling `parent_path()` on it only removes the trailing slash and doesn't actually return the expected parent path.

Example with the game Pingo (https://github.com/Grzybojad/Pingo/releases/tag/2.1):
```
std::string pathData = "ux0:/data/Pingo/";
[...]
sceIoMkdir( pathData.c_str(), 0777 );
```

`emulated_path` on my computer is "C:/Users/scribam/AppData/Roaming/Vita3K/Vita3K/ux0/data/Pingo/"
- master: `emulated_path.parent_path()` is "C:/Users/scribam/AppData/Roaming/Vita3K/Vita3K/ux0/data/Pingo" and the game crashes
- pr: `emulated_path.remove_trailing_separator().parent_path()` is "C:/Users/scribam/AppData/Roaming/Vita3K/Vita3K/ux0/data" and the game doesn't crash, the directory is created and files inside it too.
