### PR TITLE
Implement some gxm function

### DIFF
--- a/vita3k/gxm/include/gxm/functions.h
+++ b/vita3k/gxm/include/gxm/functions.h
@@ -10,6 +10,7 @@ size_t get_width(const SceGxmTexture *texture);
 size_t get_height(const SceGxmTexture *texture);
 SceGxmTextureFormat get_format(const SceGxmTexture *texture);
 SceGxmTextureBaseFormat get_base_format(SceGxmTextureFormat src);
+size_t get_stride_in_bytes(const SceGxmTexture *texture);
 bool is_paletted_format(SceGxmTextureFormat src);
 bool is_yuv_format(SceGxmTextureFormat src);
 size_t attribute_format_size(SceGxmAttributeFormat format);

--- a/vita3k/gxm/src/textures.cpp
+++ b/vita3k/gxm/src/textures.cpp
@@ -24,6 +24,10 @@ SceGxmTextureBaseFormat get_base_format(SceGxmTextureFormat src) {
     return static_cast<SceGxmTextureBaseFormat>(src & 0xFF000000);
 }
 
+size_t get_stride_in_bytes(const SceGxmTexture *texture) {
+    return ((texture->mip_filter | (texture->min_filter << 1) | (texture->mip_count << 3) | (texture->lod_bias << 7)) + 1) * 4;
+}
+
 bool is_paletted_format(SceGxmTextureFormat src) {
     const auto base_format = get_base_format(src);
 


### PR DESCRIPTION
thx @pent0 for your help and your time for search and help me.
- implement sceGxmTextureInitLinearStrided.
Get ingame/menu or just show any render for lot game.

- implement sceGxmTextureGetStride.

# Result: 
- STEINS;GATE 0 menu now (ingame on ngs wip)
![image](https://user-images.githubusercontent.com/5261759/81885850-87db7f00-959b-11ea-99dc-980bd2cd0a1c.png)

- CHAOS;CHILD Menu video news game no play
![image](https://user-images.githubusercontent.com/5261759/81902167-f8949280-95bf-11ea-85b8-c3d6654273af.png)

- CHAOS;CHILD らぶchu☆chu!! Menu same other video issue no play
![image](https://user-images.githubusercontent.com/5261759/81902259-1c57d880-95c0-11ea-8740-abde6cd3e271.png)


- ingame
![image](https://user-images.githubusercontent.com/5261759/81897983-00e8cf80-95b8-11ea-83e3-89207e9328c2.png)
![image](https://user-images.githubusercontent.com/5261759/81898118-54f3b400-95b8-11ea-861e-2671ce6ea0b8.png)


- Jet set radio - intro show this loading animation and crash
![image](https://user-images.githubusercontent.com/5261759/81901781-5bd1f500-95bf-11ea-953d-795f0c9833c5.png)
