### PR TITLE
some refactor on gui

### DIFF
--- a/vita3k/gui/CMakeLists.txt
+++ b/vita3k/gui/CMakeLists.txt
@@ -16,11 +16,11 @@ add_library(
 	include/gui/imgui_impl_sdl_state.h
 	include/gui/imgui_impl_sdl.h
 	include/gui/state.h
+	src/app_context_menu.cpp
 	src/common_dialog.cpp
 	src/condvars_dialog.cpp
 	src/eventflags_dialog.cpp
 	src/firmware_install_dialog.cpp
-	src/game_context_menu.cpp
 	src/game_install_dialog.cpp
 	src/game_selector.cpp
 	src/gui.cpp

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -36,7 +36,7 @@ enum GenericDialogState {
     CANCEL_STATE
 };
 
-void delete_game(GuiState &gui, HostState &host);
+void delete_app(GuiState &gui, HostState &host);
 void get_game_titles(GuiState &gui, HostState &host);
 void get_modules_list(GuiState &gui, HostState &host);
 void get_themes_list(GuiState &gui, HostState &host);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -153,7 +153,7 @@ struct GuiState {
     std::vector<std::pair<std::string, bool>> modules;
     ImGuiTextFilter module_search_bar;
 
-    bool delete_game_icon = false;
+    bool delete_app_icon = false;
     GLuint display = 0;
 
     ImGuiTextFilter game_search_bar;

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -35,29 +35,30 @@
 
 namespace gui {
 
-void delete_game(GuiState &gui, HostState &host) {
-    const fs::path game_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
+void delete_app(GuiState &gui, HostState &host) {
+    const fs::path app_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
 
-    for (const auto &game : gui.game_selector.games) {
-        const auto games_index = std::find_if(gui.game_selector.games.begin(), gui.game_selector.games.end(), [&game](const Game &g) {
-            return g.app_ver == game.app_ver && g.title == game.title && g.title_id == game.title_id;
+    for (const auto &app : gui.game_selector.games) {
+        const auto apps_index = std::find_if(gui.game_selector.games.begin(), gui.game_selector.games.end(), [&app](const Game &a) {
+            return a.app_ver == app.app_ver && a.title == app.title && a.title_id == app.title_id;
         });
 
-        if (host.io.title_id == game.title_id) {
-            LOG_INFO_IF(fs::remove_all(game_path), "Successfully deleted '{} [{}]'.", game.title_id, game.title);
+        if (host.io.title_id == app.title_id) {
+            LOG_INFO_IF(fs::remove_all(app_path), "Application successfully deleted '{} [{}]'.", app.title_id, app.title);
 
-            if (!fs::exists(game_path)) {
-                gui.delete_game_icon = true;
-                gui.game_selector.games.erase(games_index);
+            if (!fs::exists(app_path)) {
+                gui.delete_app_icon = true;
+                gui.game_selector.games.erase(apps_index);
             } else
-                LOG_ERROR("Failed to delete '{} [{}]'.", game.title_id, game.title);
+                LOG_ERROR("Failed to delete '{} [{}]'.", app.title_id, app.title);
         }
     }
 }
 
-static std::map<std::string, std::pair<std::vector<double>, std::vector<std::string>>> update_history_infos;
+static std::map<double, std::string> update_history_infos;
 
 static bool get_update_history(GuiState &gui, HostState &host) {
+    update_history_infos.clear();
     const auto change_info_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id / "sce_sys/changeinfo/" };
 
     std::string fname = fs::exists(change_info_path / fmt::format("changeinfo_{:0>2d}.xml", host.cfg.sys_lang)) ? fmt::format("changeinfo_{:0>2d}.xml", host.cfg.sys_lang) : "changeinfo.xml";
@@ -65,74 +66,71 @@ static bool get_update_history(GuiState &gui, HostState &host) {
     pugi::xml_document doc;
     pugi::xml_parse_result result = doc.load_file((change_info_path.string() + fname).c_str());
 
-    for (const auto &update : doc.child("changeinfo")) {
-        update_history_infos[host.io.title_id].first.push_back({ update.attribute("app_ver").as_double() });
-        update_history_infos[host.io.title_id].second.push_back({ update.text().as_string() });
-    }
+    for (const auto &info : doc.child("changeinfo"))
+        update_history_infos[info.attribute("app_ver").as_double()] = info.text().as_string();
 
-    for (auto &i : update_history_infos[host.io.title_id].second) {
+    for (auto &update : update_history_infos) {
         const auto startpos = "<";
         const auto endpos = ">";
 
-        if (i.find_first_of('\n') != std::string::npos)
-            i.erase(i.begin() + i.find_first_of('\n'));
+        if (update.second.find_first_of('\n') != std::string::npos)
+            update.second.erase(update.second.begin() + update.second.find_first_of('\n'));
 
-        while (i.find("</li> <li>") != std::string::npos)
-            if (i.find("</li> <li>") != std::string::npos)
-                i.replace(i.find("</li> <li>"), i.find(endpos) + 2 - i.find(startpos), "\n");
-        while (i.find("<li>") != std::string::npos)
-            if (i.find("<li>") != std::string::npos)
-                i.replace(i.find("<li>"), i.find(endpos) + 1 - i.find(startpos), ". ");
-        while (i.find(startpos) != std::string::npos)
-            if (i.find(">") + 1 != std::string::npos)
-                i.erase(i.find(startpos), i.find(endpos) + 1 - i.find(startpos));
+        while (update.second.find("</li> <li>") != std::string::npos)
+            if (update.second.find("</li> <li>") != std::string::npos)
+                update.second.replace(update.second.find("</li> <li>"), update.second.find(endpos) + 2 - update.second.find(startpos), "\n");
+        while (update.second.find("<li>") != std::string::npos)
+            if (update.second.find("<li>") != std::string::npos)
+                update.second.replace(update.second.find("<li>"), update.second.find(endpos) + 1 - update.second.find(startpos), ". ");
+        while (update.second.find(startpos) != std::string::npos)
+            if (update.second.find(">") + 1 != std::string::npos)
+                update.second.erase(update.second.find(startpos), update.second.find(endpos) + 1 - update.second.find(startpos));
 
         bool found_space = false;
-        auto end{ std::remove_if(i.begin(), i.end(), [&found_space](unsigned ch) {
+        auto end{ std::remove_if(update.second.begin(), update.second.end(), [&found_space](unsigned ch) {
             bool is_space = std::isspace(ch);
             std::swap(found_space, is_space);
             return found_space && is_space;
         }) };
 
-        if (end != i.begin() && std::isspace(static_cast<unsigned>(end[-1])))
+        if (end != update.second.begin() && std::isspace(static_cast<unsigned>(end[-1])))
             --end;
 
-        i.erase(end, i.end());
+        update.second.erase(end, update.second.end());
     }
 
-    return !update_history_infos[host.io.title_id].first.empty() && !update_history_infos[host.io.title_id].second.empty();
+    return !update_history_infos.empty();
 }
 
-static std::map<std::string, std::string> game_info;
+static std::map<std::string, std::string> app_info;
 
-static bool get_game_info(GuiState &gui, HostState &host) {
-    game_info.clear();
-    const auto game_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
+static bool get_app_info(GuiState &gui, HostState &host) {
+    app_info.clear();
+    const auto app_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
 
-    if (fs::exists(game_path) && !fs::is_empty(game_path)) {
-        game_info["trophy"] = fs::exists(game_path / "sce_sys/trophy") ? "Eligible" : "Ineligible";
+    if (fs::exists(app_path) && !fs::is_empty(app_path)) {
+        app_info["trophy"] = fs::exists(app_path / "sce_sys/trophy") ? "Eligible" : "Ineligible";
 
-        time_t updated = fs::last_write_time(game_path);
-        game_info["updated"] = std::asctime(std::localtime(&updated));
+        const auto last_writed = fs::last_write_time(app_path);
+        const auto updated = std::localtime(&last_writed);
+        app_info["updated"] = fmt::format("{}/{}/{} {:0>2d}:{:0>2d}", updated->tm_mday, updated->tm_mon + 1, updated->tm_year + 1900, updated->tm_hour, updated->tm_min);
 
-        size_t game_size = 0;
-        fs::recursive_directory_iterator end;
-        for (fs::recursive_directory_iterator g(game_path); g != end; ++g) {
-            const fs::path file = *g;
-            if (fs::is_regular_file(file))
-                game_size += fs::file_size(file);
+        size_t app_size = 0;
+        for (const auto &app : fs::recursive_directory_iterator(app_path)) {
+            if (fs::is_regular_file(app.path()))
+                app_size += fs::file_size(app.path());
         }
-        game_info["size"] = std::to_string(game_size / 1048576);
+        app_info["size"] = std::to_string(app_size / 1048576);
     }
 
     vfs::FileBuffer params;
     if (vfs::read_app_file(params, host.pref_path, host.io.title_id, "sce_sys/param.sfo")) {
         SfoFile sfo_handle;
         sfo::load(sfo_handle, params);
-        sfo::get_data_by_key(game_info["parental"], sfo_handle, "PARENTAL_LEVEL");
+        sfo::get_data_by_key(app_info["parental"], sfo_handle, "PARENTAL_LEVEL");
     }
 
-    return !game_info.empty();
+    return !app_info.empty();
 }
 
 #ifdef _WIN32
@@ -148,24 +146,24 @@ static auto check_savedata_and_shaderlog = false;
 static auto information = false;
 
 void draw_app_context_menu(GuiState &gui, HostState &host) {
-    const auto game_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
+    const auto APP_PATH{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id };
     const auto DLC_PATH{ fs::path(host.pref_path) / "ux0/addcont" / host.io.title_id };
-    const auto save_data_path{ fs::path(host.pref_path) / "ux0/user/00/savedata" / host.io.title_id };
-    const auto shaderlog_path{ fs::path(host.base_path) / "shaderlog" / host.io.title_id };
+    const auto SAVE_DATA_PATH{ fs::path(host.pref_path) / "ux0/user/00/savedata" / host.io.title_id };
+    const auto SHADER_LOG_PATH{ fs::path(host.base_path) / "shaderlog" / host.io.title_id };
 
-    // Game Context Menu
-    if (ImGui::BeginPopupContextItem("#game_context_menu")) {
-        ImGui::SetWindowFontScale(1.4f);
-        if (ImGui::MenuItem("Boot", host.game_title.c_str()))
+    // App Context Menu
+    if (ImGui::BeginPopupContextItem("#app_context_menu")) {
+        ImGui::SetWindowFontScale(1.3f);
+        if (ImGui::MenuItem("Boot", host.game_short_title.c_str()))
             gui.game_selector.selected_title_id = host.io.title_id;
-        if (ImGui::MenuItem("Check Game Compatibility")) {
+        if (ImGui::MenuItem("Check App Compatibility")) {
             const std::string compat_url = host.io.title_id.find("PCS") != std::string::npos ? "https://vita3k.org/compatibility?g=" + host.io.title_id : "https://github.com/Vita3K/homebrew-compatibility/issues?q=" + host.game_title;
             system((OS_PREFIX + compat_url).c_str());
         }
-        if (ImGui::BeginMenu("Copy game info")) {
+        if (ImGui::BeginMenu("Copy App Info")) {
             if (ImGui::MenuItem("ID and Name")) {
                 ImGui::LogToClipboard();
-                ImGui::LogText("%s [%s]", host.io.title_id.c_str(), host.game_title.c_str());
+                ImGui::LogText("%s [%s]", host.game_title.c_str(), host.io.title_id.c_str());
                 ImGui::LogFinish();
             }
             if (ImGui::MenuItem("ID")) {
@@ -181,35 +179,35 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Open Folder")) {
-            if (ImGui::MenuItem("Game"))
-                system((OS_PREFIX + game_path.string()).c_str());
+            if (ImGui::MenuItem("Application"))
+                system((OS_PREFIX + APP_PATH.string()).c_str());
             if (fs::exists(DLC_PATH) && ImGui::MenuItem("Dlc"))
                 system((OS_PREFIX + DLC_PATH.string()).c_str());
-            if (fs::exists(save_data_path) && ImGui::MenuItem("Save Data"))
-                system((OS_PREFIX + save_data_path.string()).c_str());
+            if (fs::exists(SAVE_DATA_PATH) && ImGui::MenuItem("Save Data"))
+                system((OS_PREFIX + SAVE_DATA_PATH.string()).c_str());
             ImGui::EndMenu();
         }
         if (!host.cfg.show_live_area_screen && ImGui::MenuItem("Live Area", nullptr, &gui.live_area.live_area_dialog))
             init_live_area(gui, host);
         if (ImGui::BeginMenu("Delete")) {
-            if (ImGui::MenuItem("Game"))
-                context_dialog = "game";
-            if (fs::exists(DLC_PATH) && ImGui::MenuItem("Dlc"))
+            if (ImGui::MenuItem("Application"))
+                context_dialog = "app";
+            if (fs::exists(DLC_PATH) && ImGui::MenuItem("DLC"))
                 fs::remove_all(DLC_PATH);
-            if (fs::exists(save_data_path) && ImGui::MenuItem("Save Data"))
+            if (fs::exists(SAVE_DATA_PATH) && ImGui::MenuItem("Save Data"))
                 context_dialog = "save";
             if (ImGui::MenuItem("Shader Log")) {
-                fs::remove_all(shaderlog_path);
+                fs::remove_all(SHADER_LOG_PATH);
             }
             ImGui::EndMenu();
         }
-        if (fs::exists(game_path / "sce_sys/changeinfo/") && ImGui::MenuItem("Update history")) {
+        if (fs::exists(APP_PATH / "sce_sys/changeinfo/") && ImGui::MenuItem("Update History")) {
             if (get_update_history(gui, host))
                 context_dialog = "history";
             else
                 LOG_WARN("Patch note Error for title: {}", host.io.title_id);
         }
-        ImGui::MenuItem("Information", nullptr, &information) && get_game_info(gui, host);
+        ImGui::MenuItem("Information", nullptr, &information) && get_app_info(gui, host);
         ImGui::EndPopup();
     }
 
@@ -225,45 +223,48 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
         ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
         ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
         ImGui::Begin("##context_dialog", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
-        ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
         ImGui::SetNextWindowBgAlpha(0.999f);
-        ImGui::BeginChild("##context_dialog_child", WINDOW_SIZE, true, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+        ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+        ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f);
+        ImGui::BeginChild("##context_dialog_child", WINDOW_SIZE, false, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f);
         // Update History
         if (context_dialog == "history") {
-            ImGui::SetCursorPos(ImVec2(20.f * scal.x, BUTTON_SIZE.y));
-            if (ImGui::ListBoxHeader("##update_history_list", ImVec2(WINDOW_SIZE.x - (40.f * scal.x), WINDOW_SIZE.y - (BUTTON_SIZE.y * 2.f) - (25.f * scal.y)))) {
-                for (auto u = 0; u < update_history_infos[host.io.title_id].first.size(); u++) {
-                    ImGui::SetWindowFontScale(1.4f);
-                    ImGui::TextColored(GUI_COLOR_TEXT, "Version %.2f", update_history_infos[host.io.title_id].first[u]);
-                    ImGui::SetWindowFontScale(1.f);
-                    ImGui::PushTextWrapPos(WINDOW_SIZE.x - (80.f * scal.x));
-                    ImGui::TextColored(GUI_COLOR_TEXT, "%s\n", update_history_infos[host.io.title_id].second[u].c_str());
-                    ImGui::PopTextWrapPos();
-                    ImGui::TextColored(GUI_COLOR_TEXT, "\n");
-                }
-                ImGui::ListBoxFooter();
+            ImGui::SetNextWindowPos(ImVec2(ImGui::GetWindowPos().x + 20.f * scal.x, ImGui::GetWindowPos().y + BUTTON_SIZE.y));
+            ImGui::BeginChild("##info_update_list", ImVec2(WINDOW_SIZE.x - (30.f * scal.x), WINDOW_SIZE.y - (BUTTON_SIZE.y * 2.f) - (25.f * scal.y)), false, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+            for (const auto &update : update_history_infos) {
+                ImGui::SetWindowFontScale(1.4f);
+                ImGui::TextColored(GUI_COLOR_TEXT, "Version %.2f", update.first);
+                ImGui::SetWindowFontScale(1.f);
+                ImGui::PushTextWrapPos(WINDOW_SIZE.x - (80.f * scal.x));
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s\n", update.second.c_str());
+                ImGui::PopTextWrapPos();
+                ImGui::TextColored(GUI_COLOR_TEXT, "\n");
             }
+            ImGui::EndChild();
             ImGui::SetWindowFontScale(1.4f * scal.x);
             ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (BUTTON_SIZE.x / 2.f), WINDOW_SIZE.y - BUTTON_SIZE.y - (22.f * scal.y)));
         } else {
             // Delete Data
             if (gui.game_selector.icons.find(host.io.title_id) != gui.game_selector.icons.end()) {
-                ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ICON_SIZE.x / 2.f));
+                ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (ICON_SIZE.x / 2.f), 25.f * scal.y));
                 ImGui::Image(gui.game_selector.icons[host.io.title_id], ICON_SIZE);
             }
             ImGui::SetWindowFontScale(1.5f * scal.x);
             ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(host.game_short_title.c_str()).x / 2.f));
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", host.game_short_title.c_str());
+            ImGui::SetWindowFontScale(1.2f * scal.x);
             std::string ask_delete = context_dialog == "save" ? "Do you really want to delete this save data for this application?" : "Do you really want to delete this application?";
             ImGui::SetCursorPos(ImVec2(WINDOW_SIZE.x / 2 - ImGui::CalcTextSize(ask_delete.c_str()).x / 2, (WINDOW_SIZE.y / 2) + 10));
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", ask_delete.c_str());
-            if (context_dialog == "game") {
+            if (context_dialog == "app") {
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("Deleting a game may take a while\ndepending on its size and your hardware.");
-                std::string checkbox_delete = "Also delete save data and shader log for this game?";
+                    ImGui::SetTooltip("Deleting a application may take a while\ndepending on its size and your hardware.");
+                std::string checkbox_delete = "Also delete save data and shader log for this application?";
                 ImGui::SetCursorPosX((WINDOW_SIZE.x / 2) - (ImGui::CalcTextSize(checkbox_delete.c_str()).x / 2) - 36.f);
                 ImGui::Checkbox(checkbox_delete.c_str(), &check_savedata_and_shaderlog);
             }
+            ImGui::SetWindowFontScale(1.4f * scal.x);
             ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2) - (BUTTON_SIZE.x + (20.f * scal.x)), WINDOW_SIZE.y - BUTTON_SIZE.y - (22.0f * scal.y)));
             if (ImGui::Button("Cancel", BUTTON_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle)) {
                 check_savedata_and_shaderlog = false;
@@ -273,18 +274,19 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
             ImGui::SetCursorPosX(WINDOW_SIZE.x / 2 + 20.f);
         }
         if (ImGui::Button("Ok", BUTTON_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_cross)) {
-            if (context_dialog == "game") {
+            if (context_dialog == "app") {
                 if (check_savedata_and_shaderlog) {
-                    fs::remove_all(shaderlog_path);
-                    fs::remove_all(save_data_path);
+                    fs::remove_all(SAVE_DATA_PATH);
+                    fs::remove_all(SHADER_LOG_PATH);
                     check_savedata_and_shaderlog = false;
                 }
-                delete_game(gui, host);
+                delete_app(gui, host);
             } else if (context_dialog == "save")
-                fs::remove_all(save_data_path);
+                fs::remove_all(SAVE_DATA_PATH);
             context_dialog.clear();
         }
         ImGui::EndChild();
+        ImGui::PopStyleVar(2);
         ImGui::End();
     }
 
@@ -311,16 +313,16 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
         ImGui::PopTextWrapPos();
         ImGui::Spacing();
         ImGui::SetCursorPosX((display_size.x / 2.f) - ImGui::CalcTextSize("Trophy Earning  ").x);
-        ImGui::TextColored(GUI_COLOR_TEXT, "Trophy Earning  %s", game_info["trophy"].c_str());
+        ImGui::TextColored(GUI_COLOR_TEXT, "Trophy Earning  %s", app_info["trophy"].c_str());
         ImGui::Spacing();
         ImGui::SetCursorPosX((display_size.x / 2.f) - ImGui::CalcTextSize("Parental Controls  ").x);
-        ImGui::TextColored(GUI_COLOR_TEXT, "Parental Controls  Level %d", *reinterpret_cast<const uint16_t *>(game_info["parental"].c_str()));
+        ImGui::TextColored(GUI_COLOR_TEXT, "Parental Controls  Level %d", *reinterpret_cast<const uint16_t *>(app_info["parental"].c_str()));
         ImGui::Spacing();
         ImGui::SetCursorPosX(((display_size.x / 2.f) - ImGui::CalcTextSize("Updated  ").x));
-        ImGui::TextColored(GUI_COLOR_TEXT, "Updated  %s", game_info["updated"].c_str());
+        ImGui::TextColored(GUI_COLOR_TEXT, "Updated  %s", app_info["updated"].c_str());
         ImGui::Spacing();
         ImGui::SetCursorPosX((display_size.x / 2.f) - ImGui::CalcTextSize("Size  ").x);
-        ImGui::TextColored(GUI_COLOR_TEXT, "Size  %s MB", game_info["size"].c_str());
+        ImGui::TextColored(GUI_COLOR_TEXT, "Size  %s MB", app_info["size"].c_str());
         ImGui::Spacing();
         ImGui::SetCursorPosX((display_size.x / 2.f) - ImGui::CalcTextSize("Version  ").x);
         ImGui::TextColored(GUI_COLOR_TEXT, "Version  %s", host.game_version.c_str());

--- a/vita3k/gui/src/game_selector.cpp
+++ b/vita3k/gui/src/game_selector.cpp
@@ -71,12 +71,13 @@ static auto MENUBAR_HEIGHT = 22.f;
 
 void draw_game_selector(GuiState &gui, HostState &host) {
     const ImVec2 display_size = ImGui::GetIO().DisplaySize;
+    const auto scal = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - MENUBAR_HEIGHT), ImGuiCond_Always);
     if (!gui.theme_backgrounds.empty() || !gui.user_backgrounds.empty())
         ImGui::SetNextWindowBgAlpha(host.cfg.background_alpha);
-    ImGui::Begin("Game Selector", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("app_selector", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
     if (gui.start_background && !gui.file_menu.pkg_install_dialog) {
         if (ImGui::IsAnyWindowHovered() || ImGui::IsAnyItemActive() || ImGui::IsAnyItemHovered())
@@ -120,10 +121,10 @@ void draw_game_selector(GuiState &gui, HostState &host) {
     else if (!gui.user_backgrounds.empty())
         ImGui::GetBackgroundDrawList()->AddImage(gui.user_backgrounds[host.cfg.user_backgrounds[gui.current_user_bg]], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
 
-    if (gui.delete_game_icon) {
+    if (gui.delete_app_icon) {
         if (gui.game_selector.icons.find(host.io.title_id) != gui.game_selector.icons.end())
             gui.game_selector.icons.erase(host.io.title_id);
-        gui.delete_game_icon = false;
+        gui.delete_app_icon = false;
     }
 
     const float icon_size = static_cast<float>(host.cfg.icon_size);
@@ -131,12 +132,12 @@ void draw_game_selector(GuiState &gui, HostState &host) {
     switch (gui.game_selector.state) {
     case SELECT_APP:
         ImGui::SetWindowFontScale(1.1f);
-        std::string title_id_label = "TitleID";
-        float title_id_size = ImGui::CalcTextSize(title_id_label.c_str()).x + 50.f;
+        std::string title_id_label = "Title ID";
+        float title_id_size = (ImGui::CalcTextSize(title_id_label.c_str()).x + 50.f) * scal.x;
         std::string app_ver_label = "Version";
-        float app_ver_size = ImGui::CalcTextSize(app_ver_label.c_str()).x + 30.f;
+        float app_ver_size = (ImGui::CalcTextSize(app_ver_label.c_str()).x + 30.f) * scal.x;
         std::string cateogry_label = "Category";
-        float cateogry_size = ImGui::CalcTextSize(cateogry_label.c_str()).x + 30.f;
+        float cateogry_size = (ImGui::CalcTextSize(cateogry_label.c_str()).x + 30.f) * scal.x;
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
         if (!host.cfg.apps_list_grid) {
             ImGui::Columns(5);
@@ -284,10 +285,10 @@ void draw_game_selector(GuiState &gui, HostState &host) {
             ImGui::Columns(1);
         }
         ImGui::Separator();
-        static const auto POS_GAME_LIST = ImVec2(54.f, 72.f);
-        ImGui::SetNextWindowPos(host.cfg.apps_list_grid ? POS_GAME_LIST : ImVec2(0.f, 72.f), ImGuiCond_Always);
-        ImGui::BeginChild("##apps_list", ImVec2(host.cfg.apps_list_grid ? display_size.x - POS_GAME_LIST.x : display_size.x, display_size.y - POS_GAME_LIST.y), false, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
-        static const auto GRID_ICON_SIZE = ImVec2(128.f, 128.f);
+        static const auto POS_APP_LIST = ImVec2(54.f, 70.f);
+        ImGui::SetNextWindowPos(host.cfg.apps_list_grid ? POS_APP_LIST : ImVec2(1.f, 68.f), ImGuiCond_Always);
+        ImGui::BeginChild("##apps_list", ImVec2(host.cfg.apps_list_grid ? display_size.x - POS_APP_LIST.x : display_size.x, display_size.y - POS_APP_LIST.y), false, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+        const auto GRID_ICON_SIZE = ImVec2(128.f * scal.x, 128.f * scal.y);
         if (!host.cfg.apps_list_grid) {
             ImGui::Columns(5, nullptr, true);
             ImGui::SetColumnWidth(0, icon_size + /* padding */ 20.f);
@@ -296,21 +297,22 @@ void draw_game_selector(GuiState &gui, HostState &host) {
             ImGui::SetColumnWidth(3, cateogry_size);
         } else {
             ImGui::Columns(4, nullptr, false);
-            ImGui::SetColumnWidth(0, GRID_ICON_SIZE.x + 80.f);
-            ImGui::SetColumnWidth(1, GRID_ICON_SIZE.x + 80.f);
-            ImGui::SetColumnWidth(2, GRID_ICON_SIZE.x + 80.f);
-            ImGui::SetColumnWidth(3, GRID_ICON_SIZE.x + 80.f);
+            const auto COLUMN_SIZE = GRID_ICON_SIZE.x + (80.f * scal.x);
+            ImGui::SetColumnWidth(0, COLUMN_SIZE);
+            ImGui::SetColumnWidth(1, COLUMN_SIZE);
+            ImGui::SetColumnWidth(2, COLUMN_SIZE);
+            ImGui::SetColumnWidth(3, COLUMN_SIZE);
         }
-        ImGui::SetWindowFontScale(!gui.live_area_font_data.empty() ? 0.76f : 1.f);
+        ImGui::SetWindowFontScale(!gui.live_area_font_data.empty() ? 0.82f * scal.x : 1.f);
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
         for (const auto &game : gui.game_selector.games) {
             bool selected = false;
-            if (!gui.game_search_bar.PassFilter(game.title.c_str()) && !gui.game_search_bar.PassFilter(game.title_id.c_str()))
+            if (!gui.game_search_bar.PassFilter(game.stitle.c_str()) && !gui.game_search_bar.PassFilter(game.title.c_str()) && !gui.game_search_bar.PassFilter(game.title_id.c_str()))
                 continue;
             if (!fs::exists(fs::path(host.pref_path) / "ux0/app" / game.title_id)) {
                 host.io.title_id = game.title_id;
-                LOG_ERROR("Game not found: {} [{}], deleting the entry for it.", game.title_id, game.title);
-                delete_game(gui, host);
+                LOG_ERROR("Application not found: {} [{}], deleting the entry for it.", game.title_id, game.title);
+                delete_app(gui, host);
             }
             const auto POS_ICON = ImGui::GetCursorPosY();
             if (gui.game_selector.icons.find(game.title_id) != gui.game_selector.icons.end()) {
@@ -318,7 +320,7 @@ void draw_game_selector(GuiState &gui, HostState &host) {
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ((ImGui::GetColumnWidth() / 2.f) - (GRID_ICON_SIZE.x / 2.f) - 10.f));
                 ImGui::Image(gui.game_selector.icons[game.title_id], host.cfg.apps_list_grid ? GRID_ICON_SIZE : ImVec2(icon_size, icon_size));
             }
-            const auto POS_TEXT = ImGui::GetCursorPos();
+            const auto POS_STITLE = ImVec2(ImGui::GetCursorPosX() + (30.f * scal.x), ImGui::GetCursorPosY());
             ImGui::SetCursorPosY(POS_ICON);
             if (host.cfg.apps_list_grid)
                 ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ((ImGui::GetColumnWidth() / 2.f) - (GRID_ICON_SIZE.x / 2.f) - 10.f));
@@ -348,9 +350,9 @@ void draw_game_selector(GuiState &gui, HostState &host) {
                 ImGui::PopStyleVar();
                 ImGui::NextColumn();
             } else {
-                ImGui::SetCursorPos(ImVec2(POS_TEXT.x + ((ImGui::GetColumnWidth() / 2.f) - (GRID_ICON_SIZE.x / 2.f) - 10.f), POS_TEXT.y));
-                ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + GRID_ICON_SIZE.x);
-                ImGui::TextColored(GUI_COLOR_TEXT, "%s", game.title.c_str());
+                ImGui::SetCursorPos(ImVec2(POS_STITLE.x + ((GRID_ICON_SIZE.x / 2.f) - (ImGui::CalcTextSize(game.stitle.c_str(), 0, false, GRID_ICON_SIZE.x).x / 2.f)), POS_STITLE.y));
+                ImGui::PushTextWrapPos(POS_STITLE.x + GRID_ICON_SIZE.x);
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", game.stitle.c_str());
                 ImGui::PopTextWrapPos();
                 ImGui::NextColumn();
             }

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -59,8 +59,8 @@ static void init_style() {
     style->Colors[ImGuiCol_Text] = ImVec4(0.95f, 0.95f, 0.95f, 1.00f);
     style->Colors[ImGuiCol_TextDisabled] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
     style->Colors[ImGuiCol_WindowBg] = ImVec4(0.07f, 0.08f, 0.10f, 0.80f);
-    style->Colors[ImGuiCol_ChildBg] = ImVec4(0.07f, 0.07f, 0.09f, 0.90f);
-    style->Colors[ImGuiCol_PopupBg] = ImVec4(0.07f, 0.07f, 0.09f, 0.90f);
+    style->Colors[ImGuiCol_ChildBg] = ImVec4(0.15f, 0.16f, 0.18f, 1.00f);
+    style->Colors[ImGuiCol_PopupBg] = ImVec4(0.15f, 0.16f, 0.18f, 1.00f);
     style->Colors[ImGuiCol_Border] = ImVec4(0.80f, 0.80f, 0.80f, 0.88f);
     style->Colors[ImGuiCol_BorderShadow] = ImVec4(0.92f, 0.91f, 0.88f, 0.00f);
     style->Colors[ImGuiCol_FrameBg] = ImVec4(0.10f, 0.09f, 0.12f, 0.80f);
@@ -77,9 +77,9 @@ static void init_style() {
     style->Colors[ImGuiCol_CheckMark] = ImVec4(1.00f, 0.55f, 0.00f, 1.00f);
     style->Colors[ImGuiCol_SliderGrab] = ImVec4(1.00f, 0.55f, 0.00f, 1.00f);
     style->Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
-    style->Colors[ImGuiCol_Button] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
-    style->Colors[ImGuiCol_ButtonHovered] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
-    style->Colors[ImGuiCol_ButtonActive] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
+    style->Colors[ImGuiCol_Button] = ImVec4(0.20f, 0.21f, 0.23f, 1.00f);
+    style->Colors[ImGuiCol_ButtonHovered] = ImVec4(0.08f, 0.66f, 0.87f, 0.50f);
+    style->Colors[ImGuiCol_ButtonActive] = ImVec4(0.08f, 0.66f, 0.87f, 1.00f);
     style->Colors[ImGuiCol_Header] = ImVec4(1.00f, 1.00f, 0.00f, 0.50f);
     style->Colors[ImGuiCol_HeaderHovered] = ImVec4(1.00f, 1.00f, 0.00f, 0.30f);
     style->Colors[ImGuiCol_HeaderActive] = ImVec4(1.00f, 1.00f, 0.00f, 0.70f);


### PR DESCRIPTION
- Refactor code for stock information update
- Refactor viewing update app style.
- small split stuff refacftor game to app inside, rename file game context to app context.
- some refactor on game selector, on grid mode change title to short title and set it in center icon position, like psvita used.
- Add scaling for grid mode for can run it un full screen or with resizeing window.
- Add possible search app with short title.
- fix search bar with label for don't scroll with wheel mouse.

# Result: 
- clock (updatted) showed like real psvita
![image](https://user-images.githubusercontent.com/5261759/82011272-c5f8a180-9674-11ea-879a-af6f284e12ad.png)

- Update history more close real psvita
![image](https://user-images.githubusercontent.com/5261759/82520598-e61cda80-9b24-11ea-9d50-4ec2441b0427.png)

- fix text size for ask, fix box outside screen, and fix icon position 
![image](https://user-images.githubusercontent.com/5261759/82520639-f5038d00-9b24-11ea-89a0-d75001687b65.png)


- using short title for box not get monster size
![image](https://user-images.githubusercontent.com/5261759/82017974-93ef3b80-9684-11ea-8d7a-07a6815ca030.png)

- game selector using short title with centering position on gris mod
![image](https://user-images.githubusercontent.com/5261759/82016738-f85ccb80-9681-11ea-9c20-bc50dc57b244.png)
