### PR TITLE
fix akiba crash not found mem block

### DIFF
--- a/vita3k/modules/SceSysmem/SceSysmem.cpp
+++ b/vita3k/modules/SceSysmem/SceSysmem.cpp
@@ -101,7 +101,9 @@ EXPORT(int, sceKernelFreeMemBlock, SceUID uid) {
 
     KernelState *const state = &host.kernel;
     const Blocks::const_iterator block = state->blocks.find(uid);
-    assert(block != state->blocks.end());
+    // TODO, is really that ?
+    if (block == state->blocks.end())
+        return RET_ERROR(SCE_KERNEL_ERROR_ILLEGAL_BLOCK_ID);
 
     free(host.mem, block->second->mappedBase.address());
     state->blocks.erase(block);


### PR DESCRIPTION
inspired by @KorewaWatchful code hack
- fix crashing on akiba, durriing boot game with it spam try free block uid 0 not found

# Result: 
- Acces on intro logo, and if disable play video get menu and after shader crash
![image](https://user-images.githubusercontent.com/5261759/82133956-26611d80-97f2-11ea-9002-ff10b85febb8.png)
