### PR TITLE
external: Update SPIRV-Cross to version 2020-05-19

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,7 +65,7 @@
 	branch = v1.x
 [submodule "external/SPIRV-Cross"]
 	path = external/SPIRV-Cross
-	url = https://github.com/Vita3K/SPIRV-Cross
+	url = https://github.com/KhronosGroup/SPIRV-Cross.git
 [submodule "vita3k/shaders-db"]
 	path = vita3k/shaders-db
 	url = https://github.com/Vita3K/shaders-db

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -197,6 +197,7 @@ option(SPIRV_CROSS_ENABLE_CPP "Enable C++ target support." OFF)
 option(SPIRV_CROSS_ENABLE_REFLECT "Enable JSON reflection target support." OFF)
 option(SPIRV_CROSS_ENABLE_C_API "Enable C API wrapper support in static library." OFF)
 option(SPIRV_CROSS_ENABLE_UTIL "Enable util module support." OFF)
+option(SPIRV_CROSS_SKIP_INSTALL "Skips installation targets." ON)
 add_subdirectory(SPIRV-Cross)
 
 add_library(dlmalloc STATIC "${CMAKE_CURRENT_SOURCE_DIR}/dlmalloc/dlmalloc.cc")


### PR DESCRIPTION
And restore the official repository for this submodule as Vita3k's one is not necessary anymore.

How to update this submodule after the merge?
```
git submodule sync
git submodule update --init external/SPIRV-Cross
```