### PR TITLE
io: Check if the directory exists before to write the file

### DIFF
--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -305,6 +305,11 @@ int write_file(SceUID fd, const void *data, const SceSize size, const IOState &i
     }
 
     const auto file = io.std_files.find(fd);
+
+    if (!fs::is_directory(file->second.get_system_location().parent_path())) {
+        return IO_ERROR(SCE_ERROR_ERRNO_ENOENT); // TODO: Is it the right error code?
+    }
+
     if (file->second.can_write_file()) {
         const auto written = file->second.write(data, 1, size);
         LOG_TRACE("{}: Writing to fd: {}, size: {}", export_name, log_hex(fd), size);


### PR DESCRIPTION
Fix crash when saving the highscore in "2048" (https://github.com/dots-tb/psp2048).

Related code: https://github.com/dots-tb/psp2048/blob/ced08ab88f0415db76f5935c6d6a3eeb627f2189/src/file.c#L25-L36