### PR TITLE
shader: Compare SCE_GXM_PARAMETER_CATEGORY* with the right parameter member

### DIFF
--- a/vita3k/shader/src/usse_program_analyzer.cpp
+++ b/vita3k/shader/src/usse_program_analyzer.cpp
@@ -155,14 +155,14 @@ void get_uniform_buffer_sizes(const SceGxmProgram &program, UniformBufferSizes &
     for (size_t i = 0; i < program.parameter_count; ++i) {
         const SceGxmProgramParameter &parameter = gxp_parameters[i];
 
-        if (parameter.type == SCE_GXM_PARAMETER_CATEGORY_UNIFORM_BUFFER) {
+        if (parameter.category == SCE_GXM_PARAMETER_CATEGORY_UNIFORM_BUFFER) {
             int buffer_size = match_uniform_buffer_with_buffer_size(program, parameter, buffers);
 
             // Search for the buffer from analyzed list
             if (buffer_size != -1) {
                 sizes[parameter.resource_index] = buffer_size;
             }
-        } else if (parameter.type == SCE_GXM_PARAMETER_CATEGORY_UNIFORM || parameter.type == SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE) {
+        } else if (parameter.category == SCE_GXM_PARAMETER_CATEGORY_UNIFORM || parameter.category == SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE) {
             const auto con = gxp::get_container_by_index(program, parameter.container_index);
 
             if (con) {


### PR DESCRIPTION
https://github.com/Vita3K/Vita3K/blob/fcf844ce052c01194d1517d21868dd09533c027a/vita3k/gxm/include/gxm/types.h#L1356-L1360

https://github.com/Vita3K/Vita3K/blob/fcf844ce052c01194d1517d21868dd09533c027a/vita3k/gxm/include/gxm/types.h#L157-L163

- `parameter.category` is supposed to be a `SceGxmParameterCategory`
- `parameter.type` is supposed to be a `SceGxmParameterType`

I think it does not make sense to compare a `SceGxmParameterType` with a SCE_GXM_PARAMETER_CATEGORY_*

It fixes some asserts in VitaQuake, in `match_uniform_buffer_with_buffer_size` and `get_uniform_buffer_base`. You can see there the comparison between a `parameter.category` and a SCE_GXM_PARAMETER_CATEGORY_*