### PR TITLE
modules: Add missing return instruction to sceAppUtilDrmOpen

### DIFF
--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -152,7 +152,7 @@ EXPORT(int, sceAppUtilDrmOpen, SceAppUtilDrmAddcontId *dirName, SceAppUtilMountP
     const auto drm_content_id_path{ fs::path(host.pref_path) / (+VitaIoDevice::ux0)._to_string() / host.io.device_paths.addcont0 / reinterpret_cast<char *>(dirName->data) };
 
     if (dirName == nullptr)
-        SCE_APPUTIL_ERROR_NOT_INITIALIZED;
+        return RET_ERROR(SCE_APPUTIL_ERROR_NOT_INITIALIZED);
 
     if (!fs::exists(drm_content_id_path) || (fs::is_empty(drm_content_id_path)))
         return SCE_ERROR_ERRNO_ENOENT;


### PR DESCRIPTION
I guess this is what is expected as, without the return instruction, it does nothing.