### PR TITLE
gui: Compilation fixes for clang-10

### DIFF
--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -446,7 +446,7 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
     const auto theme_str = ImGui::CalcTextSize(title.c_str(), 0, false, SIZE_LIST.x);
     ImGui::PushTextWrapPos(((display_size.x - SIZE_LIST.x) / 2.f) + SIZE_LIST.x);
     ImGui::SetCursorPos(ImVec2((display_size.x / 2.f) - (theme_str.x / 2.f), (35.f * SCAL.y) - (theme_str.y / 2.f)));
-    ImGui::TextColored(GUI_COLOR_TEXT, title.c_str());
+    ImGui::TextColored(GUI_COLOR_TEXT, "%s", title.c_str());
     ImGui::PopTextWrapPos();
     if ((menu == "theme") && selected.empty()) {
         ImGui::SetWindowFontScale(1.2f * SCAL.x);
@@ -475,7 +475,7 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
                 ImGui::SameLine(500.f * SCAL.x);
                 ImGui::SetCursorPosY((50.f * SCAL.y) + ((CALC_TITLE / 2.f) - CALC_TITLE));
                 ImGui::PushTextWrapPos(display_size.x - (150.f * SCAL.x));
-                ImGui::TextColored(GUI_COLOR_TEXT, themes_info[host.cfg.theme_content_id].title.c_str());
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", themes_info[host.cfg.theme_content_id].title.c_str());
                 ImGui::PopTextWrapPos();
                 ImGui::SetWindowFontScale(1.2f);
             }
@@ -512,7 +512,7 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
                 ImGui::PopID();
                 ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + SIZE_PACKAGE.x);
                 ImGui::SetCursorPosY(POS_TITLE);
-                ImGui::TextColored(GUI_COLOR_TEXT, themes_info[theme.first].title.c_str());
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", themes_info[theme.first].title.c_str());
                 ImGui::PopTextWrapPos();
                 ImGui::NextColumn();
             }
@@ -556,7 +556,7 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
                 const auto CALC_TITLE = ImGui::CalcTextSize(themes_info[selected].title.c_str(), nullptr, false, POPUP_SIZE.x - SIZE_MINI_PACKAGE.x - 48.f).y / 2.f;
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (SIZE_MINI_PACKAGE.y / 2.f) - CALC_TITLE);
                 ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + POPUP_SIZE.x - SIZE_MINI_PACKAGE.x - 48.f);
-                ImGui::TextColored(GUI_COLOR_TEXT, themes_info[selected].title.c_str());
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", themes_info[selected].title.c_str());
                 ImGui::PopTextWrapPos();
                 const auto CALC_TEXT = ImGui::CalcTextSize("This theme will be deleted.");
                 ImGui::SetCursorPos(ImVec2(POPUP_SIZE.x / 2 - (CALC_TEXT.x / 2.f), POPUP_SIZE.y / 2.f - (CALC_TEXT.y / 2.f)));
@@ -611,17 +611,17 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
                 ImGui::TextColored(GUI_COLOR_TEXT, "Updated");
                 ImGui::SameLine();
                 ImGui::SetCursorPosX(INFO_POS.x);
-                ImGui::TextColored(GUI_COLOR_TEXT, themes_info[selected].updated.c_str());
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", themes_info[selected].updated.c_str());
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() + INFO_POS.y);
                 ImGui::TextColored(GUI_COLOR_TEXT, "Size");
                 ImGui::SameLine();
                 ImGui::SetCursorPosX(INFO_POS.x);
-                ImGui::TextColored(GUI_COLOR_TEXT, "%d KB", themes_info[selected].size);
+                ImGui::TextColored(GUI_COLOR_TEXT, "%zu KB", themes_info[selected].size);
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() + INFO_POS.y);
                 ImGui::TextColored(GUI_COLOR_TEXT, "Version");
                 ImGui::SameLine();
                 ImGui::SetCursorPosX(INFO_POS.x);
-                ImGui::TextColored(GUI_COLOR_TEXT, "%s", themes_info[selected].version);
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", themes_info[selected].version.c_str());
             }
         }
     } else if (menu == "start") {


### PR DESCRIPTION
```
/home/scribam/CLionProjects/Vita3K/vita3k/gui/src/themes.cpp:624:52: error: no viable conversion from 'std::string' (aka 'basic_string<char>') to 'const char *'
                ImGui::TextColored(GUI_COLOR_TEXT, themes_info[selected].version);
```

The other changes are warning fixes.