### PR TITLE
vita3k: recommend ninja over make for compiling on linux

### DIFF
--- a/building.md
+++ b/building.md
@@ -71,7 +71,7 @@ cd Vita3K
 - Install dependencies.
 
 ```sh
-sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev
+sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev clang
 ```
 
 - Clone this repo.

--- a/building.md
+++ b/building.md
@@ -71,7 +71,7 @@ cd Vita3K
 - Install dependencies.
 
 ```sh
-sudo apt install git cmake libsdl2-dev pkg-config libgtk-3-dev
+sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev
 ```
 
 - Clone this repo.
@@ -86,7 +86,7 @@ cd Vita3K
 ```sh
 ./gen-linux.sh
 cd build-linux
-make -j$(nproc)
+ninja
 ```
 
 ## Note

--- a/gen-linux.sh
+++ b/gen-linux.sh
@@ -18,4 +18,4 @@ fi
 # Generate project files
 mkdir -p build-linux
 cd build-linux
-cmake ..
+cmake .. -GNinja

--- a/gen-linux.sh
+++ b/gen-linux.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+cmake_args=
+CLANG=
+command -v clang > /dev/null && CLANG=1
+
 # CI uses pre-built Boost
 if [[ -z "${CI}" ]]; then
 	# Create build dir
@@ -15,7 +19,11 @@ if [[ -z "${CI}" ]]; then
 	cd ../..
 fi
 
+if [ "$CLANG" ]; then
+	cmake_args="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+fi
+
 # Generate project files
 mkdir -p build-linux
 cd build-linux
-cmake .. -GNinja
+cmake .. -GNinja ${cmake_args}


### PR DESCRIPTION
this increases the build time tremendously since ninja actually compiles
more files in parallel, while the Makefile results that both nids.cpp
and module_parent.cpp are compiled alone, which probably doubles intial
build time (if not more)

I can provide exact numbers if wanted tomorrow
And update the ci script probably.