### PR TITLE
GXM Texture Fix & YUV2RGB Optimisation

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1862,11 +1862,10 @@ static int init_texture_base(const char *export_name, SceGxmTexture *texture, Pt
     const SceGxmTextureType &texture_type) {
     if (width > 4096 || height > 4096 || mipCount > 13) {
         return RET_ERROR(SCE_GXM_ERROR_INVALID_VALUE);
-    } else if (!data) {
-        return RET_ERROR(SCE_GXM_ERROR_INVALID_ALIGNMENT);
     } else if (!texture) {
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
     }
+    // data can be empty to be filled out later.
 
     // Add supported formats here
 
@@ -1967,8 +1966,6 @@ EXPORT(int, sceGxmTextureInitLinear, SceGxmTexture *texture, Ptr<const void> dat
 EXPORT(int, sceGxmTextureInitLinearStrided, SceGxmTexture *texture, Ptr<const void> data, SceGxmTextureFormat texFormat, uint32_t width, uint32_t height, uint32_t byteStride) {
     if (width > 4096 || height > 4096 || byteStride == 0)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_VALUE);
-    else if (!data)
-        return RET_ERROR(SCE_GXM_ERROR_INVALID_ALIGNMENT);
     else if (!texture)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
 

--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -109,7 +109,7 @@ static size_t decompress_compressed_swizz_texture(SceGxmTextureBaseFormat fmt, v
         return (((width + 3) / 4) * ((height + 3) / 4) * ((ubc_type > 1) ? 16 : 8));
     } else if ((fmt >= SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP) && (fmt <= SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP)) {
         // TODO, is not perfect for PVRT-II.
-        pvr::PVRTDecompressPVRTC(data, (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP) || (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII2BPP), width, height, 
+        pvr::PVRTDecompressPVRTC(data, (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP) || (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII2BPP), width, height,
             (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII2BPP) || (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP), reinterpret_cast<uint8_t *>(dest));
         // TODO, calcule return is not sur.
         return ((width + 3) / 4) * ((height + 3) / 4);


### PR DESCRIPTION
GXM Texture fix:
> Data might be null to indicate no data is given and it will be filled out at a later stage.
(This behaviour is present in openGL, so I assume it might be the same for GXM)

> It fixes Texture corruption for New Game! The Challange Stage (and apparently boots into video but crash on main screen due to network.) Tested another app, seems to work fine as well... (Though the texture was flipped lol)

YUV2RGB Optimisation:
> Cache the SwsContext from frame to frame. Reuse the context if we are using the same frame, else we recreate it.