### PR TITLE
Support alignment in sceKernelAllocMemBlock

### DIFF
--- a/vita3k/mem/include/mem/mem.h
+++ b/vita3k/mem/include/mem/mem.h
@@ -37,6 +37,7 @@ struct MemState {
     Allocated allocated_pages;
     std::mutex generation_mutex;
     GenerationNames generation_names;
+    std::map<Address, Address> aligned_addr_to_original;
     std::map<Address, uint32_t> breakpoints;
 };
 
@@ -54,6 +55,7 @@ constexpr size_t GB(size_t gb) {
 
 bool init(MemState &state);
 Address alloc(MemState &state, size_t size, const char *name);
+Address alloc(MemState &state, size_t size, const char *name, unsigned int alignment);
 Address alloc_at(MemState &state, Address address, size_t size, const char *name);
 void free(MemState &state, Address address);
 uint32_t mem_available(MemState &state);

--- a/vita3k/modules/SceSysmem/SceSysmem.cpp
+++ b/vita3k/modules/SceSysmem/SceSysmem.cpp
@@ -20,7 +20,15 @@
 #include <kernel/state.h>
 #include <kernel/types.h>
 
-struct SceKernelAllocMemBlockOpt;
+struct SceKernelAllocMemBlockOpt {
+    SceSize size;
+    SceUInt32 attr;
+    SceSize alignment;
+    SceUInt32 uidBaseBlock;
+    const char *strBaseBlockName;
+    int flags;
+    int reserved[10];
+};
 
 struct SceKernelFreeMemorySizeInfo {
     int size; //!< sizeof(SceKernelFreeMemorySizeInfo)
@@ -35,7 +43,12 @@ EXPORT(SceUID, sceKernelAllocMemBlock, const char *name, SceKernelMemBlockType t
     assert(type != 0);
     assert(size != 0);
 
-    const Ptr<void> address(alloc(mem, size, name));
+    Ptr<void> address;
+    if (optp == nullptr) {
+        address = alloc(mem, size, name);
+    } else {
+        address = alloc(mem, size, name, optp->alignment);
+    }
     if (!address) {
         return RET_ERROR(SCE_KERNEL_ERROR_NO_MEMORY);
     }


### PR DESCRIPTION
In the saekano game, the following error was preventing to load the opening video before entering  the loading scene after the logo scene.

<img width="623" alt="Screen Shot 2020-06-05 at 1 15 33 PM" src="https://user-images.githubusercontent.com/12246126/83836544-b679ef00-a72e-11ea-99a9-92453615fba5.png">

It turned out that the video decoder allocate the memory block by non-null sceKernelAllocMemBlockOpt with alignment option. The game crashes manually when it found out the block address is not aligned.
 
Provided sceKernelAllocMemBlockOpt:
<img width="318" alt="Screen Shot 2020-06-05 at 1 23 15 PM" src="https://user-images.githubusercontent.com/12246126/83836885-d362f200-a72f-11ea-8a7d-a83484fb1bda.png">
 
This PR add the memory alignment implementation. With this PR, the game can now finish the  logo scene and enter the loading scene.