### PR TITLE
Add hle nid variable exports

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -24,6 +24,8 @@
 #include <host/state.h>
 #include <io/functions.h>
 #include <renderer/functions.h>
+#include <nids/functions.h>
+#include <mem/mem.h>
 #include <rtc/rtc.h>
 #include <util/fs.h>
 #include <util/lock_and_find.h>
@@ -155,7 +157,12 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
 #endif
 
     state.kernel.base_tick = { rtc_base_ticks() };
-
+    
+    for (const auto& var: hle_var_export) {
+        auto addr = alloc(state.mem, var.size, var.name);
+        state.kernel.export_nids.emplace(var.nid, addr);
+    }
+    
     if (renderer::init(state.window, state.renderer, backend)) {
         update_viewport(state);
         return true;

--- a/vita3k/host/src/load_self.cpp
+++ b/vita3k/host/src/load_self.cpp
@@ -82,8 +82,6 @@ static bool load_var_imports(const uint32_t *nids, const Ptr<uint32_t> *entries,
         if (export_address_it != kernel.export_nids.end()) {
             export_address = export_address_it->second;
         } else {
-            // TODO: Proper HLE support for var imports (map with varnid, pointer, size)
-
             const char *const name = import_name(nid);
             constexpr auto STUB_SYMVAL = 0xDEADBEEF;
             LOG_WARN("\tNID NOT FOUND {} ({}) at {}, setting to stub value {}", log_hex(nid), name, log_hex(entry.address()), log_hex(STUB_SYMVAL));

--- a/vita3k/nids/CMakeLists.txt
+++ b/vita3k/nids/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
 	STATIC
 	include/nids/functions.h
 	include/nids/nids.h
+	include/nids/nid_vars.h
 	include/nids/types.h
 	src/nids.cpp
 )

--- a/vita3k/nids/include/nids/functions.h
+++ b/vita3k/nids/include/nids/functions.h
@@ -2,4 +2,23 @@
 
 #include <cstdint>
 
+struct VarExport {
+    uint32_t nid;
+    const char* name;
+    uint8_t* data;
+    unsigned int size;
+};
+
 const char *import_name(uint32_t nid);
+
+static VarExport hle_var_export[] = {
+#define EXPORT_VAR(name, nid, value_type, value) \
+    {  \
+        nid, \
+        #name, \
+        reinterpret_cast<uint8_t*>(new value_type(value)), \
+        sizeof(value_type) \
+    },
+#include <nids/nid_vars.h>
+#undef EXPORT_VAR
+};

--- a/vita3k/nids/include/nids/nid_vars.h
+++ b/vita3k/nids/include/nids/nid_vars.h
@@ -1,0 +1,1 @@
+EXPORT_VAR(_pLibPerfCaptureFlagPtr, 0x936A5F31, uint32_t, 43)


### PR DESCRIPTION
# About this PR

This PR adds support for HLE NID variable exports and export _pLibPerfCaptureFlagPtr as non-zero value.

# Related bug

The saekano game crashed immediately without even tracing the stack. When the _sceUltUlthreadRuntimeCreate was run, it printed that _sceFiberInitializeWithInternalOptionImpl was not implemented and crashed. This kind of error was reported before in https://github.com/Vita3K/compatibility/issues/331.  

It seemed like _sceFiberInitializeWithInternalOptionImpl was the problem here. But, the actual code that crasehd the game turned out to be

```
ldr r1, [r0]
```

Which dereferenced some pointer. It turned out the code dereferenced the _pLibPerfCaptureFlagPtr which was imported in libult elf module. And, if the value is 0, it breakpoints, otherwise do nothing.

However, as _pLibPerfCaptureFlagPtr variable is not exported anywhere, the previous implementation just stubbed it with 0xDEADBEEF, causing the BAD_MEMORY_ACCESS.