### PR TITLE
Improve code log and memory log & add toggling them through gui

### DIFF
--- a/vita3k/cpu/include/cpu/functions.h
+++ b/vita3k/cpu/include/cpu/functions.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <mem/mem.h> // Address.
+#include <util/types.h>
 
 #include <cstdint>
 #include <functional>
@@ -34,10 +35,12 @@ struct CPUContext {
 };
 
 typedef std::function<void(CPUState &cpu, uint32_t, Address)> CallSVC;
+typedef std::function<std::string(Address)> ResolveNIDName;
+typedef std::function<bool(Address)> IsWatchMemoryAddr;
 typedef std::unique_ptr<CPUState, std::function<void(CPUState *)>> CPUStatePtr;
 typedef std::unique_ptr<CPUContext, std::function<void(CPUContext *)>> CPUContextPtr;
 
-CPUStatePtr init_cpu(Address pc, Address sp, bool log_code, CallSVC call_svc, MemState &mem);
+CPUStatePtr init_cpu(SceUID thread_id, Address pc, Address sp, CallSVC call_svc, ResolveNIDName resolve_nid_name, IsWatchMemoryAddr is_watch_memory_addr, MemState &mem);
 int run(CPUState &state, bool callback, Address entry_point);
 int step(CPUState &state, bool callback, Address entry_point);
 void stop(CPUState &state);
@@ -65,6 +68,9 @@ bool hit_breakpoint(CPUState &state);
 void trigger_breakpoint(CPUState &state);
 void log_code_add(CPUState &state);
 void log_mem_add(CPUState &state);
-
+void log_code_remove(CPUState &state);
+void log_mem_remove(CPUState &state);
+bool log_code_exists(CPUState &state);
+bool log_mem_exists(CPUState &state);
 void save_context(CPUState &state, CPUContext &ctx);
 void load_context(CPUState &state, CPUContext &ctx);

--- a/vita3k/cpu/src/cpu.cpp
+++ b/vita3k/cpu/src/cpu.cpp
@@ -21,13 +21,19 @@
 #include <disasm/state.h>
 #include <mem/ptr.h>
 #include <util/log.h>
+#include <util/types.h>
 
 #include <unicorn/unicorn.h>
 
 #include <cassert>
 #include <cstring>
 
+#include <spdlog/fmt/fmt.h>
+#include <util/string_utils.h>
+
 typedef std::unique_ptr<uc_struct, std::function<void(uc_struct *)>> UnicornPtr;
+
+constexpr bool LOG_REGISTERS = false;
 
 union DoubleReg {
     double d;
@@ -35,20 +41,21 @@ union DoubleReg {
 };
 
 struct CPUState {
+    SceUID thread_id;
     MemState *mem = nullptr;
     CallSVC call_svc;
+    ResolveNIDName resolve_nid_name;
     DisasmState disasm;
+    IsWatchMemoryAddr is_watch_memory_addr;
     UnicornPtr uc;
+    uc_hook memory_read_hook = 0;
+    uc_hook memory_write_hook = 0;
+    uc_hook code_hook = 0;
+
     bool did_break = false;
 };
 
-// Log code for specified threads (arg to create_thread)
-static const bool LOG_CODE = true;
-static const bool TRACE_RETURN_VALUES = true;
-
-// Log code run on all threads
-static bool LOG_CODE_ALL = false;
-static bool LOG_MEM_ACCESS = false;
+constexpr bool TRACE_RETURN_VALUES = true;
 
 static void delete_cpu_state(CPUState *state) {
     delete state;
@@ -71,14 +78,31 @@ static inline void func_trace(CPUState &state) {
 static void code_hook(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
     CPUState &state = *static_cast<CPUState *>(user_data);
     std::string disassembly = disassemble(state, address);
-    LOG_TRACE("{}: {} {}", log_hex((uint64_t)uc), log_hex(address), disassembly);
+    if (LOG_REGISTERS) {
+        for (int i = 0; i < 12; i++) {
+            auto reg_name = fmt::format("r{}", i);
+            auto reg_name_with_value = fmt::format("{}({})", reg_name, log_hex(read_reg(state, i)));
+            string_utils::replace(disassembly, reg_name, reg_name_with_value);
+        }
+
+        string_utils::replace(disassembly, "lr", fmt::format("lr({})", log_hex(read_lr(state))));
+        string_utils::replace(disassembly, "sp", fmt::format("sp({})", log_hex(read_sp(state))));
+    }
+
+    auto name = state.resolve_nid_name(address);
+    if (name != "") {
+        LOG_TRACE("{} ({}): {} {} entering export function {}", log_hex((uint64_t)uc), state.thread_id, log_hex(address), disassembly, name);
+    } else {
+        LOG_TRACE("{} ({}): {} {}", log_hex((uint64_t)uc), state.thread_id, log_hex(address), disassembly);
+    }
 
     func_trace(state);
 }
 
-static void log_memory_access(uc_engine *uc, const char *type, Address address, int size, int64_t value, MemState &mem) {
+static void log_memory_access(uc_engine *uc, const char *type, Address address, int size, int64_t value, MemState &mem, CPUState &cpu) {
     const char *const name = mem_name(address, mem);
-    LOG_TRACE("{}: {} {} bytes, address {} ( {} ), value {}", log_hex((uint64_t)uc), type, size, log_hex(address), name, log_hex(value));
+    auto pc = read_pc(cpu);
+    LOG_TRACE("{} ({}): {} {} bytes, address {} ( {} ), value {} at {}", log_hex((uint64_t)uc), cpu.thread_id, type, size, log_hex(address), name, log_hex(value), log_hex(pc));
 }
 
 static void read_hook(uc_engine *uc, uc_mem_type type, uint64_t address, int size, int64_t value, void *user_data) {
@@ -86,14 +110,19 @@ static void read_hook(uc_engine *uc, uc_mem_type type, uint64_t address, int siz
 
     CPUState &state = *static_cast<CPUState *>(user_data);
     MemState &mem = *state.mem;
-    memcpy(&value, Ptr<const void>(static_cast<Address>(address)).get(mem), size);
-    log_memory_access(uc, "Read", static_cast<Address>(address), size, value, mem);
+    if (state.is_watch_memory_addr(address)) {
+        memcpy(&value, Ptr<const void>(static_cast<Address>(address)).get(mem), size);
+        log_memory_access(uc, "Read", static_cast<Address>(address), size, value, mem, state);
+    }
 }
 
 static void write_hook(uc_engine *uc, uc_mem_type type, uint64_t address, int size, int64_t value, void *user_data) {
     CPUState &state = *static_cast<CPUState *>(user_data);
     MemState &mem = *state.mem;
-    log_memory_access(uc, "Write", static_cast<Address>(address), size, value, mem);
+    if (state.is_watch_memory_addr(address)) {
+        MemState &mem = *state.mem;
+        log_memory_access(uc, "Write", static_cast<Address>(address), size, value, mem, state);
+    }
 }
 
 constexpr uint32_t INT_SVC = 2;
@@ -167,11 +196,13 @@ static void log_error_details(CPUState &state, uc_err code) {
     LOG_ERROR("r12: 0x{:0>8x}", registers[12]);
 }
 
-CPUStatePtr init_cpu(Address pc, Address sp, bool log_code, CallSVC call_svc, MemState &mem) {
+CPUStatePtr init_cpu(SceUID thread_id, Address pc, Address sp, CallSVC call_svc, ResolveNIDName resolve_nid_name, IsWatchMemoryAddr is_watch_memory_addr, MemState &mem) {
     CPUStatePtr state(new CPUState(), delete_cpu_state);
     state->mem = &mem;
     state->call_svc = call_svc;
-
+    state->resolve_nid_name = resolve_nid_name;
+    state->is_watch_memory_addr = is_watch_memory_addr;
+    state->thread_id = thread_id;
     if (!init(state->disasm)) {
         return CPUStatePtr();
     }
@@ -184,14 +215,6 @@ CPUStatePtr init_cpu(Address pc, Address sp, bool log_code, CallSVC call_svc, Me
     temp_uc = nullptr;
 
     uc_hook hh = 0;
-
-    if ((log_code && LOG_CODE) || LOG_CODE_ALL) {
-        log_code_add(*state);
-    }
-
-    if (LOG_MEM_ACCESS) {
-        log_mem_add(*state);
-    }
 
     err = uc_hook_add(state->uc.get(), &hh, UC_HOOK_INTR, reinterpret_cast<void *>(&intr_hook), state.get(), 1, 0);
     assert(err == UC_ERR_OK);
@@ -416,19 +439,41 @@ std::string disassemble(CPUState &state, uint64_t at, uint16_t *insn_size) {
 }
 
 void log_code_add(CPUState &state) {
-    uc_hook hh = 0;
-    const uc_err err = uc_hook_add(state.uc.get(), &hh, UC_HOOK_CODE, reinterpret_cast<void *>(&code_hook), &state, 1, 0);
+    const uc_err err = uc_hook_add(state.uc.get(), &state.code_hook, UC_HOOK_CODE, reinterpret_cast<void *>(&code_hook), &state, 1, 0);
 
     assert(err == UC_ERR_OK);
 }
 
+void log_code_remove(CPUState &state) {
+    auto err = uc_hook_del(state.uc.get(), state.code_hook);
+    assert(err == UC_ERR_OK);
+    state.code_hook = 0;
+}
+
 void log_mem_add(CPUState &state) {
-    uc_hook hh = 0;
-    uc_err err = uc_hook_add(state.uc.get(), &hh, UC_HOOK_MEM_READ, reinterpret_cast<void *>(&read_hook), &state, 1, 0);
+    uc_err err = uc_hook_add(state.uc.get(), &state.memory_read_hook, UC_HOOK_MEM_READ, reinterpret_cast<void *>(&read_hook), &state, 1, 0);
     assert(err == UC_ERR_OK);
 
-    err = uc_hook_add(state.uc.get(), &hh, UC_HOOK_MEM_WRITE, reinterpret_cast<void *>(&write_hook), &state, 1, 0);
+    err = uc_hook_add(state.uc.get(), &state.memory_write_hook, UC_HOOK_MEM_WRITE, reinterpret_cast<void *>(&write_hook), &state, 1, 0);
     assert(err == UC_ERR_OK);
+}
+
+void log_mem_remove(CPUState &state) {
+    auto err = uc_hook_del(state.uc.get(), state.memory_read_hook);
+    assert(err == UC_ERR_OK);
+    state.memory_read_hook = 0;
+
+    err = uc_hook_del(state.uc.get(), state.memory_write_hook);
+    assert(err == UC_ERR_OK);
+    state.memory_write_hook = 0;
+}
+
+bool log_code_exists(CPUState &state) {
+    return state.code_hook != 0;
+}
+
+bool log_mem_exists(CPUState &state) {
+    return state.memory_read_hook != 0 && state.memory_write_hook != 0;
 }
 
 static void delete_cpu_context(CPUContext *ctx) {

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -27,8 +27,12 @@
 
 #include <misc/cpp/imgui_stdlib.h>
 
+#include <cpu/functions.h>
+
 #include <util/fs.h>
 #include <util/log.h>
+
+#include <kernel/functions.h>
 
 #include <algorithm>
 #include <nfd.h>
@@ -360,6 +364,21 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         ImGui::Checkbox("Save color surfaces", &host.cfg.color_surface_debug);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Save color surfaces to files.");
+        ImGui::Spacing();
+        if (ImGui::Button(host.kernel.watch_code ? "Unwatch code" : "Watch code")) {
+            host.kernel.watch_code = !host.kernel.watch_code;
+            update_watches(host.kernel);
+        }
+        ImGui::SameLine();
+        if (ImGui::Button(host.kernel.watch_memory ? "Unwatch memory" : "Watch memory")) {
+            host.kernel.watch_memory = !host.kernel.watch_memory;
+            update_watches(host.kernel);
+        }
+        ImGui::Spacing();
+        if (ImGui::Button(host.kernel.watch_import_calls ? "Unwatch import calls" : "Watch import calls")) {
+            host.kernel.watch_import_calls = !host.kernel.watch_import_calls;
+            update_watches(host.kernel);
+        }
         ImGui::EndTabItem();
     } else
         ImGui::PopStyleColor();

--- a/vita3k/host/src/load_self.cpp
+++ b/vita3k/host/src/load_self.cpp
@@ -96,6 +96,7 @@ static bool load_var_imports(const uint32_t *nids, const Ptr<uint32_t> *entries,
 
             // Use same stub for other var imports
             kernel.export_nids.emplace(nid, export_address);
+            kernel.not_found_vars.emplace(export_address, nid);
         }
 
         if (reloc_entries_count > 0)
@@ -244,6 +245,7 @@ static bool load_func_exports(Ptr<const void> &entry_point, const uint32_t *nids
             continue;
 
         kernel.export_nids.emplace(nid, entry.address());
+        kernel.nid_from_export.emplace(entry.address(), nid);
 
         if (cfg.log_exports) {
             const char *const name = import_name(nid);
@@ -283,6 +285,7 @@ static bool load_var_exports(const uint32_t *nids, const Ptr<uint32_t> *entries,
         }
 
         kernel.export_nids.emplace(nid, entry.address());
+        kernel.nid_from_export.emplace(entry.address(), nid);
     }
 
     return true;

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -416,8 +416,12 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
         ::call_import(host, cpu, nid, main_thread_id);
     };
 
+    const ResolveNIDName resolve_nid_name = [&host](Address addr) {
+        return ::resolve_nid_name(host.kernel, addr);
+    };
+
     const SceUID main_thread_id = create_thread(entry_point, host.kernel, host.mem, host.io.title_id.c_str(), SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_MAIN),
-        call_import, false);
+        call_import, resolve_nid_name, nullptr);
 
     if (main_thread_id < 0) {
         app::error_dialog("Failed to init main thread.", host.window.get());
@@ -439,7 +443,7 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
 
         auto argp = Ptr<void>();
         const SceUID module_thread_id = create_thread(module_start, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT),
-            call_import, false);
+            call_import, resolve_nid_name, nullptr);
         const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
         const auto ret = run_on_current(*module_thread, module_start, 0, argp);
         module_thread->to_do = ThreadToDo::exit;

--- a/vita3k/kernel/include/kernel/functions.h
+++ b/vita3k/kernel/include/kernel/functions.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <kernel/types.h>
 #include <util/types.h>
 
 template <class T>
@@ -26,3 +27,9 @@ struct MemState;
 
 Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID thread_id, int key);
 void stop_all_threads(KernelState &kernel);
+
+void add_watch_memory_addr(KernelState &state, Address addr, size_t size);
+void remove_watch_memory_addr(KernelState &state, Address addr);
+bool is_watch_memory_addr(KernelState &state, Address addr);
+
+void update_watches(KernelState &state);

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -33,6 +33,8 @@ struct ThreadState;
 
 struct SDL_Thread;
 
+struct WatchMemory;
+
 typedef std::shared_ptr<SceKernelMemBlockInfo> SceKernelMemBlockInfoPtr;
 typedef std::map<SceUID, SceKernelMemBlockInfoPtr> Blocks;
 typedef std::map<SceUID, Ptr<Ptr<void>>> SlotToAddress;
@@ -44,6 +46,9 @@ typedef std::map<SceUID, ThreadPtr> ThreadPtrs;
 typedef std::shared_ptr<SceKernelModuleInfo> SceKernelModuleInfoPtr;
 typedef std::map<SceUID, SceKernelModuleInfoPtr> SceKernelModuleInfoPtrs;
 typedef std::map<uint32_t, Address> ExportNids;
+typedef std::map<Address, uint32_t> NidFromExport;
+typedef std::map<Address, uint32_t> NotFoundVars;
+typedef std::map<Address, WatchMemory> WatchMemoryAddrs;
 
 struct WaitingThreadData {
     ThreadStatePtr thread;
@@ -264,6 +269,11 @@ typedef std::map<SceUID, TimerPtr> TimerStates;
 
 using LoadedSysmodules = std::vector<SceSysmoduleModuleId>;
 
+struct WatchMemory {
+    Address start;
+    size_t size;
+};
+
 struct KernelState {
     std::mutex mutex;
     Blocks blocks;
@@ -284,6 +294,10 @@ struct KernelState {
     SceKernelModuleInfoPtrs loaded_modules;
     LoadedSysmodules loaded_sysmodules;
     ExportNids export_nids;
+    NidFromExport nid_from_export;
+    NotFoundVars not_found_vars;
+    WatchMemoryAddrs watch_memory_addrs;
+
     SceRtcTick base_tick;
     DecoderStates decoders;
     PlayerStates players;
@@ -291,6 +305,9 @@ struct KernelState {
     TimerStates timers;
     Ptr<uint32_t> process_param;
     bool wait_for_debugger = false;
+    bool watch_import_calls = false;
+    bool watch_code = false;
+    bool watch_memory = false;
 
     SceUID get_next_uid() {
         return next_uid++;

--- a/vita3k/kernel/include/kernel/thread/thread_functions.h
+++ b/vita3k/kernel/include/kernel/thread/thread_functions.h
@@ -28,9 +28,10 @@ struct CPUState;
 struct ThreadState;
 
 typedef std::function<void(CPUState &, uint32_t, SceUID)> CallImport;
+typedef std::function<std::string(Address)> ResolveNIDName;
 typedef std::shared_ptr<ThreadState> ThreadStatePtr;
 
-SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stackSize, CallImport call_import, bool log_code);
+SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stackSize, CallImport call_import, ResolveNIDName resolve_nid_name, const SceKernelThreadOptParam *option);
 int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const Ptr<void> &argp);
 Ptr<void> copy_stack(SceUID thid, SceUID thread_id, const Ptr<void> &argp, KernelState &kernel, MemState &mem);
 bool run_thread(ThreadState &thread, bool callback);

--- a/vita3k/modules/SceAppMgr/SceAppMgrUser.cpp
+++ b/vita3k/modules/SceAppMgr/SceAppMgrUser.cpp
@@ -337,9 +337,13 @@ EXPORT(SceInt32, sceAppMgrLoadExec, const char *appPath, Ptr<char> const argv[],
                 ::call_import(host, cpu, nid, exec_thread_id);
             };
 
+            const ResolveNIDName resolve_nid_name = [&host](Address addr) {
+                return ::resolve_nid_name(host.kernel, addr);
+            };
+
             // Init exec thread
             const auto exec_thread_id = create_thread(exec_entry_point, host.kernel, host.mem, exec_load->module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_MAIN),
-                call_import, false);
+                call_import, resolve_nid_name, nullptr);
 
             if (exec_thread_id < 0) {
                 LOG_ERROR("Failed to init exec thread.");

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -705,9 +705,13 @@ EXPORT(int, sceGxmInitialize, const SceGxmInitializeParams *params) {
         ::call_import(host, cpu, nid, thread_id);
     };
 
+    const ResolveNIDName resolve_nid_name = [&host](Address addr) {
+        return ::resolve_nid_name(host.kernel, addr);
+    };
+
     const auto stack_size = SCE_KERNEL_STACK_SIZE_USER_DEFAULT; // TODO: Verify this is the correct stack size
 
-    host.gxm.display_queue_thread = create_thread(Ptr<void>(read_pc(*main_thread->cpu)), host.kernel, host.mem, "SceGxmDisplayQueue", SCE_KERNEL_HIGHEST_PRIORITY_USER, stack_size, call_import, false);
+    host.gxm.display_queue_thread = create_thread(Ptr<void>(read_pc(*main_thread->cpu)), host.kernel, host.mem, "SceGxmDisplayQueue", SCE_KERNEL_HIGHEST_PRIORITY_USER, stack_size, call_import, resolve_nid_name, nullptr);
 
     if (host.gxm.display_queue_thread < 0) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -930,7 +930,11 @@ EXPORT(SceUID, sceKernelCreateThread, const char *name, SceKernelThreadEntry ent
         ::call_import(host, cpu, nid, thread_id);
     };
 
-    const SceUID thid = create_thread(entry.cast<const void>(), host.kernel, host.mem, name, init_priority, stack_size, call_import, false);
+    const ResolveNIDName resolve_nid_name = [&host](Address addr) {
+        return ::resolve_nid_name(host.kernel, addr);
+    };
+
+    const SceUID thid = create_thread(entry.cast<const void>(), host.kernel, host.mem, name, init_priority, stack_size, call_import, resolve_nid_name, option);
     if (thid < 0)
         return RET_ERROR(thid);
     return thid;
@@ -1265,8 +1269,12 @@ EXPORT(int, sceKernelLoadStartModule, char *path, SceSize args, Ptr<void> argp, 
         ::call_import(host, cpu, nid, thread_id);
     };
 
+    const ResolveNIDName resolve_nid_name = [&host](Address addr) {
+        return ::resolve_nid_name(host.kernel, addr);
+    };
+
     const SceUID thid = create_thread(entry_point.cast<const void>(), host.kernel, host.mem, module->module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER,
-        static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), call_import, false);
+        static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), call_import, resolve_nid_name, nullptr);
 
     const ThreadStatePtr thread = lock_and_find(thid, host.kernel.threads, host.kernel.mutex);
 

--- a/vita3k/modules/include/modules/module_parent.h
+++ b/vita3k/modules/include/modules/module_parent.h
@@ -22,6 +22,10 @@
 
 struct CPUState;
 struct HostState;
+struct KernelState;
 
 void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id);
 bool load_module(HostState &host, SceSysmoduleModuleId module_id);
+Address resolve_export(KernelState &kernel, uint32_t nid);
+uint32_t resolve_nid(KernelState &kernel, Address addr);
+std::string resolve_nid_name(KernelState &kernel, Address addr);

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -31,12 +31,6 @@
 
 #include <unordered_set>
 
-#ifdef NDEBUG // Leave it as non-constexpr on Debug so that we can enable/disable it at will via set_log_import_calls
-constexpr
-#endif
-    bool LOG_IMPORT_CALLS
-    = false;
-
 static constexpr bool LOG_UNK_NIDS_ALWAYS = false;
 
 #define NID(name, nid) extern const ImportFn import_##name;
@@ -61,7 +55,7 @@ static ImportFn resolve_import(uint32_t nid) {
  * \param nid NID to resolve
  * \return Resolved address, 0 if not found
  */
-static Address resolve_export(KernelState &kernel, uint32_t nid) {
+Address resolve_export(KernelState &kernel, uint32_t nid) {
     const ExportNids::iterator export_address = kernel.export_nids.find(nid);
     if (export_address == kernel.export_nids.end()) {
         return 0;
@@ -70,10 +64,32 @@ static Address resolve_export(KernelState &kernel, uint32_t nid) {
     return export_address->second;
 }
 
-static void log_import_call(char emulation_level, uint32_t nid, SceUID thread_id, const std::unordered_set<uint32_t> &nid_blacklist) {
+uint32_t resolve_nid(KernelState &kernel, Address addr) {
+    auto nid = kernel.nid_from_export.find(addr);
+    if (nid == kernel.nid_from_export.end()) {
+        // resolve the thumbs address
+        addr = addr | 1;
+        nid = kernel.nid_from_export.find(addr);
+        if (nid == kernel.nid_from_export.end()) {
+            return 0;
+        }
+    }
+
+    return nid->second;
+}
+
+std::string resolve_nid_name(KernelState &kernel, Address addr) {
+    auto nid = resolve_nid(kernel, addr);
+    if (nid == 0) {
+        return "";
+    }
+    return import_name(nid);
+}
+
+static void log_import_call(char emulation_level, uint32_t nid, SceUID thread_id, const std::unordered_set<uint32_t> &nid_blacklist, Address pc) {
     if (nid_blacklist.find(nid) == nid_blacklist.end()) {
         const char *const name = import_name(nid);
-        LOG_TRACE("[{}LE] TID: {:<3} FUNC: {} {}", emulation_level, thread_id, log_hex(nid), name);
+        LOG_TRACE("[{}LE] TID: {:<3} FUNC: {} {} at {}", emulation_level, thread_id, log_hex(nid), name, log_hex(pc));
     }
 }
 
@@ -83,14 +99,14 @@ void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id)
     if (!export_pc) {
         // HLE - call our C++ function
 
-        if (LOG_IMPORT_CALLS) {
+        if (host.kernel.watch_import_calls) {
             const std::unordered_set<uint32_t> hle_nid_blacklist = {
                 0xB295EB61, // sceKernelGetTLSAddr
                 0x46E7BE7B, // sceKernelLockLwMutex
                 0x91FA6614, // sceKernelUnlockLwMutex
             };
-
-            log_import_call('H', nid, thread_id, hle_nid_blacklist);
+            auto pc = read_pc(cpu);
+            log_import_call('H', nid, thread_id, hle_nid_blacklist, pc);
         }
         const ImportFn fn = resolve_import(nid);
         if (fn) {
@@ -105,10 +121,10 @@ void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id)
     } else {
         // LLE - directly run ARM code imported from some loaded module
 
-        if (LOG_IMPORT_CALLS) {
+        if (host.kernel.watch_import_calls) {
             const std::unordered_set<uint32_t> lle_nid_blacklist = {};
-
-            log_import_call('L', nid, thread_id, lle_nid_blacklist);
+            auto pc = read_pc(cpu);
+            log_import_call('L', nid, thread_id, lle_nid_blacklist, pc);
         }
         const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
         const std::lock_guard<std::mutex> lock(thread->mutex);
@@ -122,6 +138,9 @@ void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id)
 bool load_module(HostState &host, SceSysmoduleModuleId module_id) {
     const CallImport call_import = [&host](CPUState &cpu, uint32_t nid, SceUID main_thread_id) {
         ::call_import(host, cpu, nid, main_thread_id);
+    };
+    const ResolveNIDName resolve_nid_name = [&host](Address addr) {
+        return ::resolve_nid_name(host.kernel, addr);
     };
 
     LOG_INFO("Loading module ID: {}", log_hex(module_id));
@@ -151,7 +170,7 @@ bool load_module(HostState &host, SceSysmoduleModuleId module_id) {
 
                 Ptr<void> argp = Ptr<void>();
                 const SceUID module_thread_id = create_thread(lib_entry_point, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER,
-                    static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), call_import, false);
+                    static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), call_import, resolve_nid_name, nullptr);
                 const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
                 const auto ret = run_on_current(*module_thread, lib_entry_point, 0, argp);
 
@@ -173,10 +192,3 @@ bool load_module(HostState &host, SceSysmoduleModuleId module_id) {
     host.kernel.loaded_sysmodules.push_back(module_id);
     return true;
 }
-
-#ifndef NDEBUG
-// Import logging is really slow and this allows us to enable/disable it from whenever we please, for easy in debugging
-void set_log_import_calls(bool enabled) {
-    LOG_IMPORT_CALLS = enabled;
-}
-#endif

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -31,6 +31,9 @@
 #include <sstream>
 #include <string>
 
+#include <memory>
+#include <stdexcept>
+
 #include <immintrin.h>
 
 namespace logging {
@@ -155,8 +158,10 @@ std::string remove_special_chars(std::string str) {
 // Based on: https://stackoverflow.com/a/23135441
 // Search and replace "in" with "out" in the given string
 void replace(std::string &str, const std::string &in, const std::string &out) {
-    for (auto start = str.find(in); start != std::string::npos; start = str.find(in)) {
-        str.replace(str.find(in), in.length(), out);
+    size_t pos = 0;
+    while ((pos = str.find(in, pos)) != std::string::npos) {
+        str.replace(pos, in.length(), out);
+        pos += out.length();
     }
 }
 


### PR DESCRIPTION
# About PR

- Add pc information in import call and memory log (unicorn hook)
- If the export function is reached, log its name
- Optionally add register values in code log (LOG_REGISTERS)
- Add variable access watch
- Add toggling code, memory log, and import call log through gui
- Add thread id in code and memory log

# Variable access watch

You can trace the access to variables you're interested in by adding the following code in interface.cpp or anywhere that can assess KernelState.

```cpp
add_watch_memory(kernel, 0x5353, 10); 
// 0x5353 is the address of the variable
// 10 is the size of the variable
```
# Reason for toggling

It's very hard to debug the unicorn errors since we don't have something like stack traceback. Code, memory, and import call logs might serve as a great alternative to the traceback. However, they drastically slow down the game to the extent it seems to take forever to reach the unicorn error point. (adding unicorn hooks slows down the emulation a lot) Thus, the ability to toggle them in runtime is really helpful.

# Screenshots

gui:
<img width="342" alt="Screen Shot 2020-06-07 at 9 57 23 AM" src="https://user-images.githubusercontent.com/12246126/83957748-5e192d80-a8a5-11ea-81dc-f45781aa914a.png">

improved logs:
<img width="931" alt="Screen Shot 2020-06-07 at 9 58 14 AM" src="https://user-images.githubusercontent.com/12246126/83957811-a89aaa00-a8a5-11ea-9582-58c192e97bdf.png">
