### PR TITLE
Implement sceKernelSendSignal and sceKernelWaitSignal

### DIFF
--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -23,6 +23,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <string>
+#include <util/semaphore.h>
 
 struct CPUState;
 struct CPUContext;
@@ -63,6 +64,7 @@ struct ThreadState {
     InitialFibers initial_fibers;
     ThreadToDo to_do = ThreadToDo::run;
     std::mutex mutex;
+    sync_utils::Semaphore signal;
     std::condition_variable something_to_do;
     std::vector<std::shared_ptr<ThreadState>> waiting_threads;
     std::string name;

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -717,8 +717,12 @@ EXPORT(int, sceKernelResumeThreadForVM) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelSendSignal) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSendSignal, SceUID target_thread_id) {
+    STUBBED("sceKernelSendSignal");
+    const auto thread = lock_and_find(target_thread_id, host.kernel.threads, host.kernel.mutex);
+    LOG_TRACE("signaling thread {}", target_thread_id);
+    thread->signal.notify();
+    return SCE_KERNEL_OK;
 }
 
 EXPORT(int, sceKernelSetEvent) {

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -1557,8 +1557,28 @@ EXPORT(int, sceKernelWaitSemaCB, SceUID semaid, int signal, SceUInt *timeout) {
     return semaphore_wait(host.kernel, export_name, thread_id, semaid, signal, timeout);
 }
 
-EXPORT(int, sceKernelWaitSignal) {
-    return UNIMPLEMENTED();
+// TODO figure out more about this struct
+struct SceKernelWaitSignalResult {
+    Address tls_address;
+    uint32_t dret;
+};
+
+// TODO figure out more about this struct
+struct SceKernelWaitSignalParams {
+    uint32_t reserved[2];
+    Ptr<SceKernelWaitSignalResult> result_ptr;
+};
+
+EXPORT(int, sceKernelWaitSignal, uint32_t unknown, uint32_t delay, uint32_t timeout, SceKernelWaitSignalParams *params) {
+    STUBBED("sceKernelWaitSignal");
+    const auto thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
+    LOG_TRACE("thread {} is waiting to get signaled", thread_id);
+    thread->signal.wait();
+    LOG_TRACE("thread {} gets signaled", thread_id);
+    if (params != nullptr) {
+        params->result_ptr.get(host.mem)->dret = 0;
+    }
+    return SCE_KERNEL_OK;
 }
 
 EXPORT(int, sceKernelWaitSignalCB) {

--- a/vita3k/util/CMakeLists.txt
+++ b/vita3k/util/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
     include/util/find.h
     include/util/fs.h
     include/util/function_info.h
+    include/util/semaphore.h
     include/util/lock_and_find.h
     include/util/log.h
     include/util/preprocessor.h

--- a/vita3k/util/include/util/semaphore.h
+++ b/vita3k/util/include/util/semaphore.h
@@ -1,0 +1,34 @@
+#include <condition_variable>
+#include <mutex>
+
+namespace sync_utils {
+class Semaphore {
+private:
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    uint64_t count_ = 0; // Initialized as locked.
+
+public:
+    void notify() {
+        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        ++count_;
+        condition_.notify_one();
+    }
+
+    void wait() {
+        std::unique_lock<decltype(mutex_)> lock(mutex_);
+        while (!count_) // Handle spurious wake-ups.
+            condition_.wait(lock);
+        --count_;
+    }
+
+    bool try_wait() {
+        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        if (count_) {
+            --count_;
+            return true;
+        }
+        return false;
+    }
+};
+} //namespace sync_utils


### PR DESCRIPTION
# About PR

- Add semaphore implementation
- Implement sceKernelSendSignal and sceKernelWaitSignal in order to get libult working

# Related bug

Libult was not working with incomplete signals implementation. It was failed with an assertion "dret == 0" If I use a single condition_variable to implement wait and notify behavior, I got "queue_result != null"

With this PR, majority of libult functions start to get working, and it finally moves saenai game and some megas engine games forward to ingame status.