### PR TITLE
Upload github CI master branch artifcats to a CI Release tag

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,8 +14,21 @@ jobs:
       - name: Format check
         run: .github/format-check.sh
 
+  move-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move ci tag
+        uses: s3krit/walking-tag-action@d04f7a5
+        with:
+          TAG_NAME: continous
+          TAG_MESSAGE: |
+            Last commit build by the CI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.ref == 'refs/heads/master'
+
   build:
-    needs: format-check
+    needs: [move-tag, format-check]
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -74,3 +87,24 @@ jobs:
         with:
           name: vita3k-${{ steps.git_short_sha.outputs.value }}-${{ matrix.os }}
           path: build/bin
+
+      - name: Zip Artifacts
+        uses: papeloto/action-zip@5f1c4aa
+        with:
+          files: build/bin
+          dest: ${{ matrix.os }}.zip
+        if: github.ref == 'refs/heads/master'
+
+      - name: Update the CI tag
+        uses: Xotl/cool-github-releases@v1
+        with:
+          mode: update
+          isPrerelease: true
+          tag_name: continous
+          release_name: "Automatic CI builds"
+          body_mrkdwn: |
+            _Corresponding commit: ${{ github.sha }}_
+          assets: ${{ matrix.os }}.zip
+          replace_assets: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        if: github.ref == 'refs/heads/master'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Vita3K/Vita3K.svg?branch=master)](https://travis-ci.org/Vita3K/Vita3K)
 [![Build status](https://ci.appveyor.com/api/projects/status/tlvkwrsj13vq3gor/branch/master?svg=true)](https://ci.appveyor.com/project/Vita3K/vita3k/branch/master)
+![C/C++ CI](https://github.com/Vita3K/Vita3K/workflows/C/C++%20CI/badge.svg)
 
 ## Introduction
 


### PR DESCRIPTION
This creates a Release tag that will contain the latest github ci builds so they can easily linked to. Right now it doesn't set it as pre release automatically and doesn't recreate the tag, so the release will show a old commit number (but contain the latest artifacts)