### PR TITLE
Refactor and fix a bug in fiber

### DIFF
--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -35,6 +35,10 @@ struct SDL_Thread;
 
 struct WatchMemory;
 
+struct InitialFiber;
+
+typedef std::vector<InitialFiber> InitialFibers;
+
 typedef std::shared_ptr<SceKernelMemBlockInfo> SceKernelMemBlockInfoPtr;
 typedef std::map<SceUID, SceKernelMemBlockInfoPtr> Blocks;
 typedef std::map<SceUID, Ptr<Ptr<void>>> SlotToAddress;
@@ -269,6 +273,14 @@ typedef std::map<SceUID, TimerPtr> TimerStates;
 
 using LoadedSysmodules = std::vector<SceSysmoduleModuleId>;
 
+struct SceFiber;
+
+struct InitialFiber {
+    Address start;
+    Address end;
+    SceFiber *fiber;
+};
+
 struct WatchMemory {
     Address start;
     size_t size;
@@ -298,6 +310,7 @@ struct KernelState {
     NotFoundVars not_found_vars;
     WatchMemoryAddrs watch_memory_addrs;
 
+    InitialFibers initial_fibers;
     SceRtcTick base_tick;
     DecoderStates decoders;
     PlayerStates players;

--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -30,27 +30,16 @@ struct CPUContext;
 template <typename T>
 class Resource;
 
-struct InitialFiber;
-
 typedef Resource<Address> ThreadStack;
 typedef std::shared_ptr<ThreadStack> ThreadStackPtr;
 typedef std::unique_ptr<CPUState, std::function<void(CPUState *)>> CPUStatePtr;
 typedef std::unique_ptr<CPUContext, std::function<void(CPUContext *)>> CPUContextPtr;
-typedef std::vector<InitialFiber> InitialFibers;
 
 enum class ThreadToDo {
     exit,
     run,
     step,
     wait,
-};
-
-struct SceFiber;
-
-struct InitialFiber {
-    Address start;
-    Address end;
-    SceFiber *fiber;
 };
 
 struct ThreadState {
@@ -60,7 +49,6 @@ struct ThreadState {
     CPUStatePtr cpu;
     CPUContextPtr cpu_context;
     Ptr<void> fiber;
-    InitialFibers initial_fibers;
     ThreadToDo to_do = ThreadToDo::run;
     std::mutex mutex;
     std::condition_variable something_to_do;

--- a/vita3k/modules/SceFiber/SceFiber.cpp
+++ b/vita3k/modules/SceFiber/SceFiber.cpp
@@ -32,13 +32,47 @@ EXPORT(int, _sceFiberAttachContextAndSwitch) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(SceInt32, _sceFiberInitializeImpl, SceFiber *fiber, char *name, Ptr<SceFiberEntry> entry, SceUInt32 argOnInitialize, Ptr<void> addrContext, SceSize sizeContext, SceFiberOptParam *params) {
-    const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
+InitialFiber *_findIntialFiber(KernelState &kernel, Address sp) {
+    // TODO use interval tree
+    // TODO destroy initial fibers
+    for (auto &ifiber : kernel.initial_fibers) {
+        // stack adress is descending
+        if (ifiber.start < sp && sp <= ifiber.end) {
+            return &ifiber;
+        }
+    }
+    return nullptr;
+}
 
-    if (!thread) {
-        return SCE_KERNEL_ERROR_UNKNOWN_THREAD_ID;
+void _resetFiber(HostState &host, SceFiber *fiber) {
+    auto ifiber = _findIntialFiber(host.kernel, fiber->cpu.sp);
+    assert(ifiber != nullptr);
+    memcpy(fiber, ifiber->fiber, sizeof(*fiber));
+    memset(Ptr<void>(ifiber->start).get(host.mem), 0xCC, ifiber->end - ifiber->start);
+}
+
+int _fiberSwitch(HostState &host, const ThreadStatePtr thread, SceFiber *fiber, CPUContext &backup_cpu_context, SceUInt32 argOnRunTo, Ptr<SceUInt32> argOnRun, bool reset) {
+    save_context(*(thread->cpu), backup_cpu_context);
+
+    bool suspended = false;
+    if (fiber->addrContext == 0 && reset) {
+        _resetFiber(host, fiber);
+    } else if (fiber->entry.address() == fiber->cpu.pc) {
+        fiber->cpu.cpu_registers[1] = argOnRunTo;
+    } else {
+        suspended = true;
+        Address previousArgOnRun = fiber->cpu.cpu_registers[2];
+        if (previousArgOnRun) {
+            *(Ptr<SceUInt32>(previousArgOnRun).get(host.mem)) = argOnRunTo;
+        }
     }
 
+    load_context(*(thread->cpu), fiber->cpu);
+    thread->fiber = Ptr<void>(fiber, host.mem);
+    return suspended ? SCE_FIBER_OK : fiber->cpu.cpu_registers[0];
+}
+
+void _initializeFiber(HostState &host, const ThreadStatePtr thread, SceFiber *fiber, char *name, Ptr<SceFiberEntry> entry, SceUInt32 argOnInitialize, Ptr<void> addrContext, SceSize sizeContext, SceFiberOptParam *params) {
     fiber->entry = entry;
     strncpy(fiber->name, name, 32);
     fiber->argOnInitialize = argOnInitialize;
@@ -52,63 +86,42 @@ EXPORT(SceInt32, _sceFiberInitializeImpl, SceFiber *fiber, char *name, Ptr<SceFi
         auto ctx_name = new char[32];
         strncpy(ctx_name, name, 32);
 
-        auto addr = alloc(host.mem, DEFAULT_FIBER_STACK_SIZE, ctx_name);
-        fiber->cpu.sp = addr + DEFAULT_FIBER_STACK_SIZE;
-        memset(Ptr<void>(addr).get(host.mem), 0xCC, DEFAULT_FIBER_STACK_SIZE);
-
-        SceFiber *fiberCopy = new SceFiber();
-        memcpy(fiberCopy, fiber, sizeof(*fiberCopy));
-
-        InitialFiber ifiber;
-        ifiber.start = addr;
-        ifiber.end = addr + DEFAULT_FIBER_STACK_SIZE;
-        ifiber.fiber = fiberCopy;
-        thread->initial_fibers.push_back(ifiber);
-    } else {
-        fiber->cpu.sp = fiber->addrContext + sizeContext;
-        memset(addrContext.get(host.mem), 0xCC, sizeContext);
+        addrContext = Ptr<void>(alloc(host.mem, DEFAULT_FIBER_STACK_SIZE, ctx_name));
+        sizeContext = DEFAULT_FIBER_STACK_SIZE;
     }
+
+    fiber->cpu.sp = addrContext.address() + sizeContext;
+    memset(addrContext.get(host.mem), 0xCC, sizeContext);
+
+    SceFiber *fiberCopy = new SceFiber();
+    memcpy(fiberCopy, fiber, sizeof(*fiberCopy));
+
+    InitialFiber ifiber;
+    ifiber.start = addrContext.address();
+    ifiber.end = addrContext.address() + sizeContext;
+    ifiber.fiber = fiberCopy;
+    host.kernel.initial_fibers.push_back(ifiber);
+}
+
+EXPORT(SceInt32, _sceFiberInitializeImpl, SceFiber *fiber, char *name, Ptr<SceFiberEntry> entry, SceUInt32 argOnInitialize, Ptr<void> addrContext, SceSize sizeContext, SceFiberOptParam *params) {
+    const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
+    if (!thread) {
+        return SCE_KERNEL_ERROR_UNKNOWN_THREAD_ID;
+    }
+
+    _initializeFiber(host, thread, fiber, name, entry, argOnInitialize, addrContext, sizeContext, params);
 
     return SCE_FIBER_OK;
 }
 
-EXPORT(int, _sceFiberInitializeWithInternalOptionImpl, SceFiber *fiber, char *name, Address entry, SceUInt32 argOnInitialize, Ptr<void> addrContext, SceSize sizeContext) {
+EXPORT(int, _sceFiberInitializeWithInternalOptionImpl, SceFiber *fiber, char *name, Ptr<SceFiberEntry> entry, SceUInt32 argOnInitialize, Ptr<void> addrContext, SceSize sizeContext) {
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
 
     if (!thread) {
         return SCE_KERNEL_ERROR_UNKNOWN_THREAD_ID;
     }
 
-    fiber->entry = entry;
-    strncpy(fiber->name, name, 32);
-
-    fiber->argOnInitialize = argOnInitialize;
-    fiber->addrContext = addrContext.address();
-    fiber->sizeContext = sizeContext;
-    save_context(*(thread->cpu), fiber->cpu);
-    fiber->cpu.cpu_registers[0] = argOnInitialize;
-    fiber->cpu.pc = fiber->entry.address();
-
-    if (addrContext.address() == 0) {
-        auto ctx_name = new char[32];
-        strncpy(ctx_name, name, 32);
-
-        auto addr = alloc(host.mem, DEFAULT_FIBER_STACK_SIZE, ctx_name);
-        fiber->cpu.sp = addr + DEFAULT_FIBER_STACK_SIZE;
-        memset(Ptr<void>(addr).get(host.mem), 0xCC, DEFAULT_FIBER_STACK_SIZE);
-
-        SceFiber *fiberCopy = new SceFiber();
-        memcpy(fiberCopy, fiber, sizeof(*fiberCopy));
-
-        InitialFiber ifiber;
-        ifiber.start = addr;
-        ifiber.end = addr + DEFAULT_FIBER_STACK_SIZE;
-        ifiber.fiber = fiberCopy;
-        thread->initial_fibers.push_back(ifiber);
-    } else {
-        fiber->cpu.sp = fiber->addrContext + sizeContext;
-        memset(addrContext.get(host.mem), 0xCC, sizeContext);
-    }
+    _initializeFiber(host, thread, fiber, name, entry, argOnInitialize, addrContext, sizeContext, nullptr);
 
     return SCE_FIBER_OK;
 }
@@ -155,18 +168,11 @@ EXPORT(SceInt32, sceFiberReturnToThread, SceUInt32 argOnReturn, Ptr<SceUInt32> a
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
     auto fiber = thread->fiber.cast<SceFiber>().get(host.mem);
     save_context(*(thread->cpu), (thread->fiber.cast<SceFiber>().get(host.mem)->cpu));
-
     load_context(*(thread->cpu), *(thread->cpu_context));
 
     Address previousArgOnRun = thread->cpu_context->cpu_registers[2];
     if (fiber->addrContext == 0) {
-        for (auto &ifiber : thread->initial_fibers) {
-            if (ifiber.start <= fiber->cpu.sp && fiber->cpu.sp < ifiber.end) {
-                memcpy(fiber, ifiber.fiber, sizeof(*fiber));
-                memset(Ptr<void>(ifiber.start).get(host.mem), 0xCC, ifiber.end - ifiber.start);
-                break;
-            }
-        }
+        _resetFiber(host, fiber);
     } else if (previousArgOnRun) {
         *(Ptr<SceUInt32>(previousArgOnRun).get(host.mem)) = argOnReturn;
     }
@@ -174,29 +180,11 @@ EXPORT(SceInt32, sceFiberReturnToThread, SceUInt32 argOnReturn, Ptr<SceUInt32> a
     return SCE_FIBER_OK;
 }
 
-EXPORT(SceUInt32, sceFiberRun, Ptr<SceFiber> fiber_ptr, SceUInt32 argOnRunTo, Ptr<SceUInt32> argOnRun) {
+EXPORT(SceUInt32, sceFiberRun, SceFiber *fiber, SceUInt32 argOnRunTo, Ptr<SceUInt32> argOnRun) {
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
-
-    save_context(*(thread->cpu), *(thread->cpu_context));
-
-    bool suspended = false;
-
-    SceFiber *fiber = fiber_ptr.get(host.mem);
-    if (fiber->entry.address() == fiber->cpu.pc) {
-        fiber->cpu.cpu_registers[1] = argOnRunTo;
-    } else {
-        suspended = true;
-        Address previousArgOnRun = fiber->cpu.cpu_registers[2];
-        if (previousArgOnRun) {
-            *(Ptr<SceUInt32>(previousArgOnRun).get(host.mem)) = argOnRunTo;
-        }
-    }
-
-    load_context(*(thread->cpu), fiber->cpu);
+    auto res = _fiberSwitch(host, thread, fiber, *(thread->cpu_context), argOnRunTo, argOnRun, false);
     write_lr(*(thread->cpu), thread->cpu_context.get()->lr);
-    thread->fiber = fiber_ptr.cast<void>();
-
-    return suspended ? SCE_FIBER_OK : fiber->cpu.cpu_registers[0];
+    return res;
 }
 
 EXPORT(int, sceFiberStartContextSizeCheck) {
@@ -207,37 +195,10 @@ EXPORT(int, sceFiberStopContextSizeCheck) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(SceUInt32, sceFiberSwitch, Ptr<SceFiber> fiber_ptr, SceUInt32 argOnRunTo, Ptr<SceUInt32> argOnRun) {
+EXPORT(SceUInt32, sceFiberSwitch, SceFiber *fiber, SceUInt32 argOnRunTo, Ptr<SceUInt32> argOnRun) {
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
-
-    save_context(*(thread->cpu), (thread->fiber.cast<SceFiber>().get(host.mem)->cpu));
-
-    bool suspended = false;
-
-    SceFiber *fiber = fiber_ptr.get(host.mem);
-    if (fiber->addrContext == 0) {
-        for (auto &ifiber : thread->initial_fibers) {
-            if (ifiber.start <= fiber->cpu.sp && fiber->cpu.sp < ifiber.end) {
-                memcpy(fiber, ifiber.fiber, sizeof(*fiber));
-                memset(Ptr<void>(ifiber.start).get(host.mem), 0xCC, ifiber.end - ifiber.start);
-                break;
-            }
-        }
-    } else if (fiber->entry.address() == fiber->cpu.pc) {
-        fiber->cpu.cpu_registers[1] = argOnRunTo;
-    } else {
-        suspended = true;
-        Address previousArgOnRun = fiber->cpu.cpu_registers[2];
-        if (previousArgOnRun) {
-            *(Ptr<SceUInt32>(previousArgOnRun).get(host.mem)) = argOnRunTo;
-        }
-    }
-
-    load_context(*(thread->cpu), fiber->cpu);
-
-    thread->fiber = fiber_ptr.cast<void>();
-
-    return suspended ? SCE_FIBER_OK : fiber->cpu.cpu_registers[0];
+    auto old_fiber = thread->fiber.cast<SceFiber>().get(host.mem);
+    return _fiberSwitch(host, thread, fiber, old_fiber->cpu, argOnRunTo, argOnRun, true);
 }
 
 BRIDGE_IMPL(_sceFiberAttachContextAndRun)


### PR DESCRIPTION
# About PR

- Fix a bug in resetting fiber
- Clean up some duplicated code

# Related bug

Fibers can be created from the thread that will not run them. (a thread can create fiber and pass it to another thread) Since we saved the initial fibers in thread state, sometimes the fiber with null addrContext was not reseted as it could not find its initial fiber.