### PR TITLE
Implement sceKernelLibcClock

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -173,6 +173,7 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
     }
 #endif
 
+    state.kernel.start_tick = { rtc_base_ticks() };
     state.kernel.base_tick = { rtc_base_ticks() };
 
     if (renderer::init(state.window, state.renderer, backend)) {

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -298,6 +298,7 @@ struct KernelState {
     NotFoundVars not_found_vars;
     WatchMemoryAddrs watch_memory_addrs;
 
+    SceRtcTick start_tick;
     SceRtcTick base_tick;
     DecoderStates decoders;
     PlayerStates players;

--- a/vita3k/modules/SceProcessmgr/SceProcessmgr.cpp
+++ b/vita3k/modules/SceProcessmgr/SceProcessmgr.cpp
@@ -124,8 +124,8 @@ EXPORT(int, sceKernelIsGameBudget) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelLibcClock) {
-    return UNIMPLEMENTED();
+EXPORT(VitaTime, sceKernelLibcClock) {
+    return rtc_get_ticks(host.kernel.base_tick.tick) - rtc_get_ticks(host.kernel.start_tick.tick);
 }
 
 EXPORT(int, sceKernelLibcGettimeofday, VitaTimeval *timeAddr, VitaTimezone *tzAddr) {


### PR DESCRIPTION
# About PR

- Implement sceKernelLibcClock

# Details

Turned out it's just the same as c clock function.

In libc,
<img width="578" alt="Screen Shot 2020-06-13 at 8 50 32 AM" src="https://user-images.githubusercontent.com/12246126/84554503-18e87600-ad53-11ea-898d-0d0575701d92.png">

About type, it's the same as time_t
<img width="223" alt="Screen Shot 2020-06-13 at 9 27 54 AM" src="https://user-images.githubusercontent.com/12246126/84555480-2ce2a680-ad58-11ea-8c08-39be6e481026.png">
