### PR TITLE
Add stack traceback in unicorn engine

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -27,6 +27,7 @@
 // When adding in a new macro for generation, ALL options must be stated.
 #define CONFIG_INDIVIDUAL(code)                                                                         \
     code(bool, "log-imports", false, log_imports)                                                       \
+    code(bool, "stack-traceback", false, stack_traceback) \
     code(bool, "log-exports", false, log_exports)                                                       \
     code(bool, "log-active-shaders", false, log_active_shaders)                                         \
     code(bool, "log-uniforms", false, log_uniforms)                                                     \

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -175,6 +175,8 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
         ->group("Modules");
     config->add_option("--" + cfg[e_log_level] + ",-l", command_line.log_level, "Logging level:\nTRACE = 0\nDEBUG = 1\nINFO = 2\nWARN = 3\nERROR = 4\nCRITICAL = 5\nOFF = 6")
         ->check(CLI::Range( 0, 6 ))->group("Logging");
+    config->add_flag("--" + cfg[e_stack_traceback] + ",-T", command_line.stack_traceback, "Stack Traceback")
+           ->group("Logging");
     config->add_flag("--" + cfg[e_log_imports] + ",-I", command_line.log_imports, "Log Imports")
         ->group("Logging");
     config->add_flag("--" + cfg[e_log_exports] + ",-E", command_line.log_exports, "Log Exports")

--- a/vita3k/cpu/include/cpu/functions.h
+++ b/vita3k/cpu/include/cpu/functions.h
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <stack>
 
 struct CPUState;
 struct MemState;
@@ -34,13 +35,19 @@ struct CPUContext {
     uint32_t cpsr;
 };
 
+struct StackFrame {
+    uint32_t addr;
+    uint32_t sp;
+    std::string name;
+};
+
 typedef std::function<void(CPUState &cpu, uint32_t, Address)> CallSVC;
 typedef std::function<std::string(Address)> ResolveNIDName;
 typedef std::function<bool(Address)> IsWatchMemoryAddr;
 typedef std::unique_ptr<CPUState, std::function<void(CPUState *)>> CPUStatePtr;
 typedef std::unique_ptr<CPUContext, std::function<void(CPUContext *)>> CPUContextPtr;
 
-CPUStatePtr init_cpu(SceUID thread_id, Address pc, Address sp, CallSVC call_svc, ResolveNIDName resolve_nid_name, IsWatchMemoryAddr is_watch_memory_addr, MemState &mem);
+CPUStatePtr init_cpu(SceUID thread_id, Address pc, Address sp, CallSVC call_svc, ResolveNIDName resolve_nid_name, IsWatchMemoryAddr is_watch_memory_addr, bool trace_stack, MemState &mem);
 int run(CPUState &state, bool callback, Address entry_point);
 int step(CPUState &state, bool callback, Address entry_point);
 void stop(CPUState &state);
@@ -74,3 +81,5 @@ bool log_code_exists(CPUState &state);
 bool log_mem_exists(CPUState &state);
 void save_context(CPUState &state, CPUContext &ctx);
 void load_context(CPUState &state, CPUContext &ctx);
+std::stack<StackFrame> get_stack_frames(CPUState &state);
+void push_stack_frame(CPUState &state, StackFrame sf);

--- a/vita3k/cpu/src/cpu.cpp
+++ b/vita3k/cpu/src/cpu.cpp
@@ -54,6 +54,8 @@ struct CPUState {
 
     bool did_break = false;
     bool did_inject = false;
+
+    std::stack<StackFrame> stack_frames;
 };
 
 constexpr bool TRACE_RETURN_VALUES = true;
@@ -74,6 +76,39 @@ static inline void func_trace(CPUState &state) {
     if (TRACE_RETURN_VALUES)
         if (is_returning(state.disasm))
             LOG_TRACE("Returning, r0: {}", log_hex(read_reg(state, 0)));
+}
+
+std::stack<StackFrame> get_stack_frames(CPUState &state) {
+    return state.stack_frames;
+}
+
+void push_stack_frame(CPUState &state, StackFrame sf) {
+    state.stack_frames.push(sf);
+}
+
+static void stack_trace_hook(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
+    CPUState &state = *static_cast<CPUState *>(user_data);
+    auto thumb_mode = is_thumb_mode(uc);
+    uint16_t ins = 0;
+    uc_err err = uc_mem_read(uc, address, &ins, sizeof(ins));
+    assert(err == UC_ERR_OK);
+    if (thumb_mode) {
+        if ((ins & 0xff00) == 0xB400 || (ins & 0xff00) == 0xB500 || ins == 0xE92D) {
+            state.stack_frames.push({ static_cast<uint32_t>(address), read_sp(state) });
+        }
+
+        if ((ins & 0xff00) == 0xBC00 || (ins & 0xff00) == 0xBD00 || ins == 0xE8BD) {
+            state.stack_frames.pop();
+        }
+    } else {
+        // TODO make sure this works
+        if (ins == 0xE92D) {
+            state.stack_frames.push({ static_cast<uint32_t>(address), read_sp(state) });
+        }
+        if (ins == 0xE8BD) {
+            state.stack_frames.pop();
+        }
+    }
 }
 
 static void code_hook(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
@@ -204,7 +239,7 @@ static void log_error_details(CPUState &state, uc_err code) {
     LOG_ERROR("Executing: {}", disassemble(state, pc));
 }
 
-CPUStatePtr init_cpu(SceUID thread_id, Address pc, Address sp, CallSVC call_svc, ResolveNIDName resolve_nid_name, IsWatchMemoryAddr is_watch_memory_addr, MemState &mem) {
+CPUStatePtr init_cpu(SceUID thread_id, Address pc, Address sp, CallSVC call_svc, ResolveNIDName resolve_nid_name, IsWatchMemoryAddr is_watch_memory_addr, bool trace_stack, MemState &mem) {
     CPUStatePtr state(new CPUState(), delete_cpu_state);
     state->mem = &mem;
     state->call_svc = call_svc;
@@ -242,6 +277,11 @@ CPUStatePtr init_cpu(SceUID thread_id, Address pc, Address sp, CallSVC call_svc,
     assert(err == UC_ERR_OK);
 
     enable_vfp_fpu(state->uc.get());
+
+    if (trace_stack) {
+        err = uc_hook_add(state->uc.get(), &hh, UC_HOOK_CODE, reinterpret_cast<void *>(&stack_trace_hook), state.get(), 1, 0);
+        assert(err == UC_ERR_OK);
+    }
 
     return state;
 }

--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -304,7 +304,7 @@ void draw_app_selector(GuiState &gui, HostState &host) {
             ImGui::SetColumnWidth(2, COLUMN_SIZE);
             ImGui::SetColumnWidth(3, COLUMN_SIZE);
         }
-        ImGui::SetWindowFontScale(!gui.live_area_font_data.empty() ? 0.82f * scal.x: 1.f);
+        ImGui::SetWindowFontScale(!gui.live_area_font_data.empty() ? 0.82f * scal.x : 1.f);
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
         for (const auto &app : gui.app_selector.apps) {
             bool selected = false;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -353,9 +353,11 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         ImGui::SameLine();
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Log shaders being used on each draw call.");
+        ImGui::Checkbox("Enable Stack Traceback", &host.cfg.stack_traceback);
         ImGui::Checkbox("Log Uniforms", &host.cfg.log_uniforms);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Log shader uniform names and values.");
+        ImGui::SameLine();
         ImGui::Checkbox("Save color surfaces", &host.cfg.color_surface_debug);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Save color surfaces to files.");

--- a/vita3k/host/src/load_self.cpp
+++ b/vita3k/host/src/load_self.cpp
@@ -17,6 +17,7 @@
 
 #include <app/functions.h>
 #include <config/state.h>
+#include <cpu/functions.h>
 #include <host/load_self.h>
 #include <kernel/relocation.h>
 #include <kernel/state.h>

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -426,7 +426,7 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
     };
 
     const SceUID main_thread_id = create_thread(entry_point, host.kernel, host.mem, host.io.title_id.c_str(), SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_MAIN),
-        call_import, resolve_nid_name, nullptr);
+        call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
 
     if (main_thread_id < 0) {
         app::error_dialog("Failed to init main thread.", host.window.get());
@@ -448,7 +448,7 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
 
         auto argp = Ptr<void>();
         const SceUID module_thread_id = create_thread(module_start, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT),
-            call_import, resolve_nid_name, nullptr);
+            call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
         const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
         const auto ret = run_on_current(*module_thread, module_start, 0, argp);
         module_thread->to_do = ThreadToDo::exit;

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -425,8 +425,9 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
         return ::resolve_nid_name(host.kernel, addr);
     };
 
+    auto inject = create_cpu_dep_inject(host);
     const SceUID main_thread_id = create_thread(entry_point, host.kernel, host.mem, host.io.title_id.c_str(), SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_MAIN),
-        call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
+        inject, nullptr);
 
     if (main_thread_id < 0) {
         app::error_dialog("Failed to init main thread.", host.window.get());
@@ -447,8 +448,9 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
         LOG_DEBUG("Running module_start of library: {} at address {}", module_name, log_hex(module_start.address()));
 
         auto argp = Ptr<void>();
+        auto inject = create_cpu_dep_inject(host);
         const SceUID module_thread_id = create_thread(module_start, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT),
-            call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
+            inject, nullptr);
         const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
         const auto ret = run_on_current(*module_thread, module_start, 0, argp);
         module_thread->to_do = ThreadToDo::exit;

--- a/vita3k/kernel/include/kernel/functions.h
+++ b/vita3k/kernel/include/kernel/functions.h
@@ -24,6 +24,7 @@ template <class T>
 class Ptr;
 struct KernelState;
 struct MemState;
+struct CPUState;
 
 Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID thread_id, int key);
 void stop_all_threads(KernelState &kernel);
@@ -33,3 +34,5 @@ void remove_watch_memory_addr(KernelState &state, Address addr);
 bool is_watch_memory_addr(KernelState &state, Address addr);
 
 void update_watches(KernelState &state);
+
+void log_stack_frames(KernelState &state, CPUState &cpu);

--- a/vita3k/kernel/include/kernel/functions.h
+++ b/vita3k/kernel/include/kernel/functions.h
@@ -34,5 +34,3 @@ void remove_watch_memory_addr(KernelState &state, Address addr);
 bool is_watch_memory_addr(KernelState &state, Address addr);
 
 void update_watches(KernelState &state);
-
-void log_stack_frames(KernelState &state, CPUState &cpu);

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -37,6 +37,8 @@ struct WatchMemory;
 
 struct InitialFiber;
 
+struct ModuleRegion;
+
 typedef std::vector<InitialFiber> InitialFibers;
 
 typedef std::shared_ptr<SceKernelMemBlockInfo> SceKernelMemBlockInfoPtr;
@@ -53,6 +55,7 @@ typedef std::map<uint32_t, Address> ExportNids;
 typedef std::map<Address, uint32_t> NidFromExport;
 typedef std::map<Address, uint32_t> NotFoundVars;
 typedef std::map<Address, WatchMemory> WatchMemoryAddrs;
+typedef std::vector<ModuleRegion> ModuleRegions;
 
 struct WaitingThreadData {
     ThreadStatePtr thread;
@@ -170,6 +173,14 @@ typedef std::map<SceUID, CondvarPtr> CondvarPtrs;
 
 struct WaitingThreadState {
     std::string name; // for debugging
+};
+
+struct ModuleRegion {
+    uint32_t nid;
+    std::string name;
+    Address start;
+    uint32_t size;
+    Address vaddr;
 };
 
 typedef std::map<SceUID, WaitingThreadState> KernelWaitingThreadStates;
@@ -309,6 +320,7 @@ struct KernelState {
     NidFromExport nid_from_export;
     NotFoundVars not_found_vars;
     WatchMemoryAddrs watch_memory_addrs;
+    ModuleRegions module_regions;
 
     InitialFibers initial_fibers;
     SceRtcTick start_tick;

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cpu/functions.h>
 #include <kernel/thread/thread_state.h>
 #include <kernel/types.h>
 #include <mem/ptr.h>
@@ -36,8 +37,6 @@ struct SDL_Thread;
 struct WatchMemory;
 
 struct InitialFiber;
-
-struct ModuleRegion;
 
 typedef std::vector<InitialFiber> InitialFibers;
 
@@ -173,14 +172,6 @@ typedef std::map<SceUID, CondvarPtr> CondvarPtrs;
 
 struct WaitingThreadState {
     std::string name; // for debugging
-};
-
-struct ModuleRegion {
-    uint32_t nid;
-    std::string name;
-    Address start;
-    uint32_t size;
-    Address vaddr;
 };
 
 typedef std::map<SceUID, WaitingThreadState> KernelWaitingThreadStates;

--- a/vita3k/kernel/include/kernel/thread/thread_functions.h
+++ b/vita3k/kernel/include/kernel/thread/thread_functions.h
@@ -26,12 +26,13 @@
 
 struct CPUState;
 struct ThreadState;
+struct CPUDepInject;
 
 typedef std::function<void(CPUState &, uint32_t, SceUID)> CallImport;
 typedef std::function<std::string(Address)> ResolveNIDName;
 typedef std::shared_ptr<ThreadState> ThreadStatePtr;
 
-SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stackSize, CallImport call_import, ResolveNIDName resolve_nid_name, bool trace_stack, const SceKernelThreadOptParam *option);
+SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stack_size, CPUDepInject &inject, const SceKernelThreadOptParam *option);
 int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const Ptr<void> &argp);
 Ptr<void> copy_stack(SceUID thid, SceUID thread_id, const Ptr<void> &argp, KernelState &kernel, MemState &mem);
 bool run_thread(ThreadState &thread, bool callback);

--- a/vita3k/kernel/include/kernel/thread/thread_functions.h
+++ b/vita3k/kernel/include/kernel/thread/thread_functions.h
@@ -31,7 +31,7 @@ typedef std::function<void(CPUState &, uint32_t, SceUID)> CallImport;
 typedef std::function<std::string(Address)> ResolveNIDName;
 typedef std::shared_ptr<ThreadState> ThreadStatePtr;
 
-SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stackSize, CallImport call_import, ResolveNIDName resolve_nid_name, const SceKernelThreadOptParam *option);
+SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stackSize, CallImport call_import, ResolveNIDName resolve_nid_name, bool trace_stack, const SceKernelThreadOptParam *option);
 int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const Ptr<void> &argp);
 Ptr<void> copy_stack(SceUID thid, SceUID thread_id, const Ptr<void> &argp, KernelState &kernel, MemState &mem);
 bool run_thread(ThreadState &thread, bool callback);

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -106,32 +106,3 @@ void update_watches(KernelState &state) {
         }
     }
 }
-
-std::unique_ptr<ModuleRegion> get_region(KernelState &state, Address addr) {
-    for (const auto &region : state.module_regions) {
-        if (region.start <= addr && addr < region.start + region.size) {
-            return std::make_unique<ModuleRegion>(region);
-        }
-    }
-    return nullptr;
-}
-
-void log_stack_frames(KernelState &state, CPUState &cpu) {
-    auto sfs = get_stack_frames(cpu);
-    LOG_INFO("stack information");
-    int i = 0;
-    while (!sfs.empty() && i < 50) {
-        i++;
-        auto sf = sfs.top();
-        sfs.pop();
-
-        auto region = get_region(state, sf.addr);
-        assert(region);
-        auto vaddr = sf.addr - region->start + region->vaddr;
-        LOG_INFO("---------");
-        LOG_INFO("module: {}", region->name);
-        LOG_INFO("vaddr: {}", log_hex(vaddr));
-        LOG_INFO("addr: {}", log_hex(sf.addr));
-        LOG_INFO("fp: {}", sf.sp);
-    }
-}

--- a/vita3k/kernel/src/thread/thread.cpp
+++ b/vita3k/kernel/src/thread/thread.cpp
@@ -71,7 +71,7 @@ static int SDLCALL thread_function(void *data) {
     return r0;
 }
 
-SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stack_size, CallImport call_import, ResolveNIDName resolve_nid_name, const SceKernelThreadOptParam *option = nullptr) {
+SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stack_size, CallImport call_import, ResolveNIDName resolve_nid_name, bool trace_stack, const SceKernelThreadOptParam *option = nullptr) {
     SceUID thid = kernel.get_next_uid();
 
     const ThreadStack::Deleter stack_deleter = [&mem](Address stack) {
@@ -103,7 +103,7 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
         return ::is_watch_memory_addr(kernel, addr);
     };
 
-    thread->cpu = init_cpu(thid, entry_point.address(), stack_top, call_svc, resolve_nid_name, is_watch_memory_addr, mem);
+    thread->cpu = init_cpu(thid, entry_point.address(), stack_top, call_svc, resolve_nid_name, is_watch_memory_addr, trace_stack, mem);
     if (!thread->cpu) {
         return SCE_KERNEL_ERROR_ERROR;
     }

--- a/vita3k/modules/SceAppMgr/SceAppMgrUser.cpp
+++ b/vita3k/modules/SceAppMgr/SceAppMgrUser.cpp
@@ -343,7 +343,7 @@ EXPORT(SceInt32, sceAppMgrLoadExec, const char *appPath, Ptr<char> const argv[],
 
             // Init exec thread
             const auto exec_thread_id = create_thread(exec_entry_point, host.kernel, host.mem, exec_load->module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_MAIN),
-                call_import, resolve_nid_name, nullptr);
+                call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
 
             if (exec_thread_id < 0) {
                 LOG_ERROR("Failed to init exec thread.");

--- a/vita3k/modules/SceAppMgr/SceAppMgrUser.cpp
+++ b/vita3k/modules/SceAppMgr/SceAppMgrUser.cpp
@@ -333,17 +333,10 @@ EXPORT(SceInt32, sceAppMgrLoadExec, const char *appPath, Ptr<char> const argv[],
 
             LOG_INFO("Exec executable {} ({}) loaded", exec_load->module_name, exec_path);
 
-            const CallImport call_import = [&host](CPUState &cpu, uint32_t nid, SceUID exec_thread_id) {
-                ::call_import(host, cpu, nid, exec_thread_id);
-            };
-
-            const ResolveNIDName resolve_nid_name = [&host](Address addr) {
-                return ::resolve_nid_name(host.kernel, addr);
-            };
-
+            auto inject = create_cpu_dep_inject(host);
             // Init exec thread
             const auto exec_thread_id = create_thread(exec_entry_point, host.kernel, host.mem, exec_load->module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_MAIN),
-                call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
+                inject, nullptr);
 
             if (exec_thread_id < 0) {
                 LOG_ERROR("Failed to init exec thread.");

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -711,7 +711,7 @@ EXPORT(int, sceGxmInitialize, const SceGxmInitializeParams *params) {
 
     const auto stack_size = SCE_KERNEL_STACK_SIZE_USER_DEFAULT; // TODO: Verify this is the correct stack size
 
-    host.gxm.display_queue_thread = create_thread(Ptr<void>(read_pc(*main_thread->cpu)), host.kernel, host.mem, "SceGxmDisplayQueue", SCE_KERNEL_HIGHEST_PRIORITY_USER, stack_size, call_import, resolve_nid_name, nullptr);
+    host.gxm.display_queue_thread = create_thread(Ptr<void>(read_pc(*main_thread->cpu)), host.kernel, host.mem, "SceGxmDisplayQueue", SCE_KERNEL_HIGHEST_PRIORITY_USER, stack_size, call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
 
     if (host.gxm.display_queue_thread < 0) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -701,17 +701,10 @@ EXPORT(int, sceGxmInitialize, const SceGxmInitializeParams *params) {
 
     const ThreadStatePtr main_thread = util::find(thread_id, host.kernel.threads);
 
-    const CallImport call_import = [&host](CPUState &cpu, uint32_t nid, SceUID thread_id) {
-        ::call_import(host, cpu, nid, thread_id);
-    };
-
-    const ResolveNIDName resolve_nid_name = [&host](Address addr) {
-        return ::resolve_nid_name(host.kernel, addr);
-    };
-
     const auto stack_size = SCE_KERNEL_STACK_SIZE_USER_DEFAULT; // TODO: Verify this is the correct stack size
 
-    host.gxm.display_queue_thread = create_thread(Ptr<void>(read_pc(*main_thread->cpu)), host.kernel, host.mem, "SceGxmDisplayQueue", SCE_KERNEL_HIGHEST_PRIORITY_USER, stack_size, call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
+    auto inject = create_cpu_dep_inject(host);
+    host.gxm.display_queue_thread = create_thread(Ptr<void>(read_pc(*main_thread->cpu)), host.kernel, host.mem, "SceGxmDisplayQueue", SCE_KERNEL_HIGHEST_PRIORITY_USER, stack_size, inject, nullptr);
 
     if (host.gxm.display_queue_thread < 0) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -934,7 +934,7 @@ EXPORT(SceUID, sceKernelCreateThread, const char *name, SceKernelThreadEntry ent
         return ::resolve_nid_name(host.kernel, addr);
     };
 
-    const SceUID thid = create_thread(entry.cast<const void>(), host.kernel, host.mem, name, init_priority, stack_size, call_import, resolve_nid_name, option);
+    const SceUID thid = create_thread(entry.cast<const void>(), host.kernel, host.mem, name, init_priority, stack_size, call_import, resolve_nid_name, host.cfg.stack_traceback, option);
     if (thid < 0)
         return RET_ERROR(thid);
     return thid;
@@ -1274,7 +1274,7 @@ EXPORT(int, sceKernelLoadStartModule, char *path, SceSize args, Ptr<void> argp, 
     };
 
     const SceUID thid = create_thread(entry_point.cast<const void>(), host.kernel, host.mem, module->module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER,
-        static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), call_import, resolve_nid_name, nullptr);
+        static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
 
     const ThreadStatePtr thread = lock_and_find(thid, host.kernel.threads, host.kernel.mutex);
 

--- a/vita3k/modules/include/modules/module_parent.h
+++ b/vita3k/modules/include/modules/module_parent.h
@@ -24,6 +24,7 @@
 struct CPUState;
 struct HostState;
 struct KernelState;
+struct CPUDepInject;
 
 void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id);
 bool load_module(HostState &host, SceSysmoduleModuleId module_id);
@@ -46,3 +47,5 @@ constexpr int var_exports_size =
 #undef NID
 
 const std::array<VarExport, var_exports_size> &get_var_exports();
+
+CPUDepInject create_cpu_dep_inject(HostState &host);

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -193,7 +193,7 @@ bool load_module(HostState &host, SceSysmoduleModuleId module_id) {
 
                 Ptr<void> argp = Ptr<void>();
                 const SceUID module_thread_id = create_thread(lib_entry_point, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER,
-                    static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), call_import, resolve_nid_name, nullptr);
+                    static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), call_import, resolve_nid_name, host.cfg.stack_traceback, nullptr);
                 const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
                 const auto ret = run_on_current(*module_thread, lib_entry_point, 0, argp);
 


### PR DESCRIPTION
# About PR

- Manually create stack frames by hooking push and pop instructions
- Add log_stack_frames function that prints the stack traceback
- Add gui to toggle this function

# How to use it

If you want to just see how does it reach to this hle function. Just use the code below in EXPORT to print the stack traceback. 
```cpp
const auto thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
log_stack_frames(*thread->cpu);
```
If you want to use stack frames to do more advanced things (such as tracing the arguments or local variables), use get_stack_frames.
```cpp
auto stack_frames = get_stack_frames(*thread->cpu);
```

# Example

We can see the address of subroutines that were traveled to reach this point. We can also see fp (frame pointer) Might use it to access arguments and local variables.
 
<img width="364" alt="Screen Shot 2020-06-19 at 2 58 17 AM" src="https://user-images.githubusercontent.com/12246126/85056398-203bd380-b1da-11ea-9160-3c73e1f7be82.png">

<img width="321" alt="Screen Shot 2020-06-19 at 3 15 27 AM" src="https://user-images.githubusercontent.com/12246126/85057013-21213500-b1db-11ea-98d5-fc843b9d56cb.png">
