### PR TITLE
Fix minor index errors

### DIFF
--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -704,7 +704,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     spv::Id temp_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(20), 0);
     spv::Id index_arr_type = b.makeArrayType(i32_type, b.makeIntConstant(2), 0);
     spv::Id pred_arr_type = b.makeArrayType(b_type, b.makeIntConstant(4), 0);
-    spv::Id o_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(10), 0);
+    spv::Id o_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(11), 0);
 
     // Create register banks
     spv_params.ins = b.createVariable(spv::StorageClassPrivate, pa_arr_type, "pa");

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -775,7 +775,7 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
             std::vector<spv::Id> ops;
             for (auto j = 0; j < 4 / size_comp; j++) {
                 if (dest_mask & (1 << (nearest_swizz_on + i + j))) {
-                    if (b.isScalar(source)) {
+                    if (b.isScalar(source) || total_comp_source == 1) {
                         ops.push_back(source);
                     } else {
                         ops.push_back(b.createOp(spv::OpVectorExtractDynamic, b.makeFloatType(32), { source, b.makeIntConstant(std::min(i + j, (int)total_comp_source - 1)) }));


### PR DESCRIPTION
# About PR

- Make outs variables larger to fit v_TexCoord9.
- Fix spir-v to glsl compilation error regarding vector with one component.
- Make LBP into intro
# Error points

![image](https://user-images.githubusercontent.com/12246126/85219230-0c13f400-b3dd-11ea-9257-940ad97a745c.png)

There was "Cannot subdivide a scalar value!" caused by spir-v to glsl compiler trying to encode OpVectorExtractDynamic of vec1 as index representation.  

