### PR TITLE
renderer: consider different uniform sampler order

### DIFF
--- a/vita3k/renderer/include/renderer/gl/types.h
+++ b/vita3k/renderer/include/renderer/gl/types.h
@@ -36,9 +36,6 @@ typedef std::unique_ptr<void, std::function<void(SDL_GLContext)>> GLContextPtr;
 struct SceGxmProgramParameter;
 
 namespace renderer::gl {
-static constexpr GLint COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0; ///< The slot that has our color attachment (for programmable blending) - image2D.
-static constexpr GLint COLOR_ATTACHMENT_TEXTURE_SLOT_SAMPLER = 12; ///< The slot that has our color attachment (for programmable blending) - sampler2D.
-
 struct ExcludedUniform {
     std::string name;
     GLuint program;

--- a/vita3k/renderer/src/gl/compile_program.cpp
+++ b/vita3k/renderer/src/gl/compile_program.cpp
@@ -183,6 +183,19 @@ SharedGLObject compile_program(ProgramCache &program_cache, ShaderCache &vertex_
     glDetachShader(program->get(), fragment_shader->get());
     glDetachShader(program->get(), vertex_shader->get());
 
+    glUseProgram(program->get());
+    const auto fragment_program_gxp = fragment_program_gxm.program.get(mem);
+    const auto parameters = gxp::program_parameters(*fragment_program_gxp);
+    for (uint32_t i = 0; i < fragment_program_gxp->parameter_count; ++i) {
+        const auto parameter = &parameters[i];
+        if (parameter->category == SCE_GXM_PARAMETER_CATEGORY_SAMPLER) {
+            const auto name = gxp::parameter_name_raw(*parameter);
+            GLint loc = glGetUniformLocation(program->get(), name.c_str());
+            glUniform1i(loc, parameter->resource_index);
+        }
+    }
+    glUseProgram(0);
+
     program_cache.emplace(hashes, program);
 
     return program;

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -106,18 +106,6 @@ void draw(GLState &renderer, GLContext &context, GxmContextState &state, const F
         }
     }
 
-    if (fragment_gxp_program.is_native_color() && features.is_programmable_blending_need_to_bind_color_attachment()) {
-        GLint loc = glGetUniformLocation(program_id, "f_colorAttachment");
-
-        // It maybe a hand-written shader. So colorAttachment didn't exist
-        if (loc != -1) {
-            if (features.should_use_shader_interlock())
-                glUniform1i(loc, COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE);
-            else
-                glUniform1i(loc, COLOR_ATTACHMENT_TEXTURE_SLOT_SAMPLER);
-        }
-    }
-
     if (do_hardware_flip) {
         // Try to configure the vertex shader, to output coordinates suited for GXM viewport
         GLuint flip_vec_loc = glGetUniformLocation(program_id, "flip_vec");

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -6,6 +6,7 @@
 #include <renderer/gl/functions.h>
 #include <renderer/gl/types.h>
 
+#include <shader/spirv_recompiler.h>
 #include <shader/usse_program_analyzer.h>
 
 #include <features/state.h>
@@ -245,10 +246,12 @@ bool create(WindowPtr &window, std::unique_ptr<State> &state) {
         const std::string minor = version.substr(dot_pos + 1);
 
         gl_state.features.direct_pack_unpack_half = false;
+        gl_state.features.use_shader_binding = false;
 
         if (std::atoi(major.c_str()) >= 4 && minor.length() >= 1) {
             if (minor[0] >= '2') {
                 gl_state.features.direct_pack_unpack_half = true;
+                gl_state.features.use_shader_binding = true;
             }
         }
     }
@@ -415,11 +418,11 @@ void set_context(GLContext &context, GxmContextState &state, const GLRenderTarge
     // Bind it for programmable blending
     if (features.is_programmable_blending_need_to_bind_color_attachment()) {
         if (features.should_use_shader_interlock())
-            glBindImageTexture(COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE, rt->color_attachment[0], 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA8);
+            glBindImageTexture(shader::COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE, rt->color_attachment[0], 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA8);
         else {
             // Hopefully no one will use slot 12
             // TODO: Move color attachment futher or try to preserve it
-            glActiveTexture(GL_TEXTURE0 + COLOR_ATTACHMENT_TEXTURE_SLOT_SAMPLER);
+            glActiveTexture(GL_TEXTURE0 + shader::COLOR_ATTACHMENT_TEXTURE_SLOT_SAMPLER);
             glBindTexture(GL_TEXTURE_2D, rt->color_attachment[0]);
         }
     }

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -15,6 +15,8 @@ class Builder;
 }
 
 namespace shader {
+static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0; ///< The slot that has our color attachment (for programmable blending) - image2D.
+static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_SAMPLER = 12; ///< The slot that has our color attachment (for programmable blending) - sampler2D.
 
 // Dump generated SPIR-V disassembly up to this point
 void spirv_disasm_print(const usse::SpirvCode &spirv_binary, std::string *spirv_dump = nullptr);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -564,6 +564,14 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
 
             spv::Id color_attachment = b.createVariable(spv::StorageClassUniformConstant, image_type, "f_colorAttachment");
             translation_state.interfaces.push_back(color_attachment);
+
+            if (features.use_shader_binding) {
+                if (features.should_use_shader_interlock())
+                    b.addDecoration(color_attachment, spv::DecorationBinding, COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE);
+                else
+                    b.addDecoration(color_attachment, spv::DecorationBinding, COLOR_ATTACHMENT_TEXTURE_SLOT_SAMPLER);
+            }
+
             spv::Id current_coord = b.createVariable(spv::StorageClassInput, v4, "gl_FragCoord");
             translation_state.interfaces.push_back(current_coord);
             translation_state.frag_coord_id = current_coord;
@@ -835,8 +843,8 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         case SCE_GXM_PARAMETER_CATEGORY_SAMPLER: {
             const auto sampler_spv_var = create_param_sampler(b, parameter);
             samplers.emplace(parameter.resource_index, sampler_spv_var);
-
-            // TODO: I really want to give you binding.
+            if (features.use_shader_binding)
+                b.addDecoration(sampler_spv_var, spv::DecorationBinding, parameter.resource_index);
 
             break;
         }


### PR DESCRIPTION
# About PR

Samplers cannot be bound by uniform buffer object. We need to bind them manually.

# Fixes

I think, literally all games that use shader with uniform sampler

I checked that it fixes lbp intro screen little bit.