### PR TITLE
module: load firmware module for pvf and Ft2.

### DIFF
--- a/vita3k/module/include/module/load_module.h
+++ b/vita3k/module/include/module/load_module.h
@@ -33,7 +33,7 @@ inline SysmodulePaths init_sysmodule_paths() {
     p[SCE_SYSMODULE_NET] = { "libnet", "libnetctl" };
     p[SCE_SYSMODULE_HTTP] = { "libhttp" };
     p[SCE_SYSMODULE_SSL] = { "libssl" };
-    p[SCE_SYSMODULE_HTTPS] = { "libssl" }; // no https module, I'm assuming it also uses libssl
+    p[SCE_SYSMODULE_HTTPS] = { "libhttp", "libssl" };
     p[SCE_SYSMODULE_PERF] = { "libperf" };
     p[SCE_SYSMODULE_FIBER] = { "libfiber" };
     p[SCE_SYSMODULE_ULT] = { "libult" };
@@ -44,7 +44,7 @@ inline SysmodulePaths init_sysmodule_paths() {
     p[SCE_SYSMODULE_SULPHA] = { "libsulpha" };
     p[SCE_SYSMODULE_SAS] = { "libsas" };
     p[SCE_SYSMODULE_PGF] = { "libpgf" };
-    p[SCE_SYSMODULE_APPUTIL] = { "libapputil" };
+    p[SCE_SYSMODULE_APPUTIL] = { "apputil" };
     p[SCE_SYSMODULE_FIOS2] = { "libfios2" };
     p[SCE_SYSMODULE_IME] = { "libime" };
     p[SCE_SYSMODULE_NP_BASIC] = { "np_basic" };


### PR DESCRIPTION
After confirme this is preloaded before boot all game.

- Add load lle pvf get some game perfectly show text now.
Request for gravity rush menu
- Reworks pre load modules if app modules don't exist 

- preload modules on psvita for all game boot
>00:21:06 [SceLibKernel               ]:Starting...  OK        801usec
00:21:06 [SceDriverUser              ]:Starting...  OK        780usec
00:21:06 [SceAvcodecUser             ]:Starting...  OK          1usec
00:21:06 [SceGpuEs4User              ]:Starting...  OK        829usec
00:21:06 [SceGxm                     ]:Starting...  OK        590usec
00:21:06 [SceLibFios2                ]:Starting...  OK       1140usec
00:21:06 [SceLibc                    ]:Starting...  OK     297935usec
00:21:06 [SceShellSvc                ]:Starting...  OK       2944usec
00:21:06 [SceCommonDialog            ]:Starting...  OK       1931usec
00:21:06 [SceLibDbg                  ]:Starting...  OK          1usec
00:21:06 [SceLibft2                  ]:Starting...  OK          1usec
00:21:06 [SceLibPvf                  ]:Starting...  OK          1usec
00:21:06 [SceAppUtil                 ]:Starting...  OK        594usec
00:21:06 [ScePerf                    ]:Starting...  OK        597usec

- fix name for apputil, and load also libhttp for SCE_SYSMODULE_HTTPS module, after test and look on debug, it open function http and ssl in same time