### PR TITLE
shader: fix spir-v errors

### DIFF
--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -101,15 +101,20 @@ public:
         const_f32[2] = m_b.makeFloatConstant(2.0f);
 
         for (std::uint8_t i = 1; i < 5; i++) {
-            type_f32_v[i] = m_b.makeVectorType(type_f32, i);
+            if (i == 1) {
+                type_f32_v[i] = type_f32;
+                const_f32_v0[i] = m_b.makeFloatConstant(const_f32[0]);
+            } else {
+                type_f32_v[i] = m_b.makeVectorType(type_f32, i);
 
-            std::vector<spv::Id> consts;
+                std::vector<spv::Id> consts;
 
-            for (std::uint8_t j = 1; j < i + 1; j++) {
-                consts.push_back(const_f32[0]);
+                for (std::uint8_t j = 1; j < i + 1; j++) {
+                    consts.push_back(const_f32[0]);
+                }
+
+                const_f32_v0[i] = m_b.makeCompositeConstant(type_f32_v[i], consts);
             }
-
-            const_f32_v0[i] = m_b.makeCompositeConstant(type_f32_v[i], consts);
         }
 
         do_texture_queries(queries);

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -30,6 +30,8 @@ spv::Id pack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState 
 
 spv::Id make_uniform_vector_from_type(spv::Builder &b, spv::Id type, int val);
 
+spv::Id make_vector_or_scalar_type(spv::Builder &b, spv::Id component, int size);
+
 template <typename F>
 void make_for_loop(spv::Builder &b, spv::Id iterator, spv::Id initial_value_ite, spv::Id iterator_limit, F body) {
     auto blocks = b.makeNewLoop();
@@ -37,7 +39,8 @@ void make_for_loop(spv::Builder &b, spv::Id iterator, spv::Id initial_value_ite,
     b.createBranch(&blocks.head);
 
     b.setBuildPoint(&blocks.head);
-    spv::Id compare_result = b.createOp(spv::OpSLessThan, b.makeBoolType(), { iterator, iterator_limit });
+
+    spv::Id compare_result = b.createBinOp(spv::OpSLessThan, b.makeBoolType(), b.createLoad(iterator), iterator_limit);
 
     b.createLoopMerge(&blocks.merge, &blocks.continue_target, spv::LoopControlMaskNone, {});
     b.createConditionalBranch(compare_result, &blocks.body, &blocks.merge);

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -763,7 +763,7 @@ void convert_gxp_usse_to_spirv(spv::Builder &b, const SceGxmProgram &program, co
 
     std::vector<spv::Id> empty_args;
     if (features.should_use_shader_interlock() && program.is_fragment() && program.is_native_color())
-        b.createOp(spv::OpEndInvocationInterlockEXT, spv::OpTypeVoid, empty_args);
+        b.createNoResultOp(spv::OpEndInvocationInterlockEXT);
 
     b.leaveFunction();
 }


### PR DESCRIPTION
# About PR

Related to #629 

Fixed some spir-v errors following through the validation errors.

Optimization in general fails if the validation fails. (internally they use same parsing function with validation) So, this can benefit the mentioned PR.
