### PR TITLE
app: don't crash if it couldn't find audio device

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -157,8 +157,7 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
     }
 
     if (!init(state.audio, resume_thread)) {
-        LOG_ERROR("Failed to init audio! Your computer probably does not have an audio device.");
-        return false;
+        LOG_WARN("Failed to init audio! Audio will not work.");
     }
 
     if (!init(state.io, state.base_path, state.pref_path)) {

--- a/vita3k/audio/src/audio.cpp
+++ b/vita3k/audio/src/audio.cpp
@@ -20,6 +20,8 @@
 
 #include <microprofile.h>
 
+#include <util/log.h>
+
 #include <algorithm>
 #include <cassert>
 #include <cstring>
@@ -95,7 +97,9 @@ bool init(AudioState &state, ResumeAudioThread resume_thread) {
     desired.callback = &audio_callback;
     desired.userdata = &state;
 
-    if (SDL_OpenAudio(&desired, &state.ro.spec) != 0) {
+    if (SDL_OpenAudioDevice(nullptr, 0, &desired, &state.ro.spec, SDL_AUDIO_ALLOW_FORMAT_CHANGE) == 0) {
+        auto msg = SDL_GetError();
+        LOG_ERROR("SDL audio error: {}", msg);
         return false;
     }
 


### PR DESCRIPTION
# About PR

Tries to skip no audio device error.

Audio callback will not be called if SDL couldn't open the audio properly. So, we can just warn the users and keep going.

fix https://github.com/Vita3K/Vita3K/issues/751