### PR TITLE
Fix load Common Dialog also during app boot

### DIFF
--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -181,6 +181,7 @@ int main(int argc, char *argv[]) {
         gl_renderer.render(host);
 
         gui::draw_begin(gui, host);
+        gui::draw_common_dialog(gui, host);
 
         if (gui.apps_background.find(host.io.title_id) != gui.apps_background.end())
             // Display application background


### PR DESCRIPTION
- fix my mistake causing regression get by https://github.com/Vita3K/Vita3K/pull/689, with re allow common dialog showing or just called during app loading.

Thx to @sunho For catch this issue 