### PR TITLE
Move usse-decoder-gen to Vita3k & improve it

### DIFF
--- a/tools/usse-decoder-gen/autogen.py
+++ b/tools/usse-decoder-gen/autogen.py
@@ -157,7 +157,7 @@ def update_visitor():
 
     # update sources
     def src_pat(name):
-        return r'(bool USSETranslatorVisitor::' + name + r'\()[^)]+(\))'
+        return r'(bool USSETranslatorVisitor::' + name + r'\()[^)]*(\))'
     
     files = glob('../../vita3k/shader/src/translator/*.cpp')
     for file in files:

--- a/tools/usse-decoder-gen/autogen.py
+++ b/tools/usse-decoder-gen/autogen.py
@@ -1,0 +1,122 @@
+import yaml
+import string
+import sys
+
+
+# Need Python 3.6 or newer for stable insertion order dicts
+assert sys.version_info >= (3, 6), 'Needs Python 3.6 or newer'
+
+# Set this to true to indent the annotation string in line with the match string
+STAIRCASE_INDENT = True
+
+
+def allocate_char(chars_used, name):
+    # Pick a character from the identifier
+    for c in name:
+        if c not in chars_used and c in string.ascii_letters:
+            return c
+
+    # Fallback to the first free alphabetic character
+    c = 'a'
+    while c in chars_used:
+        if c == 'z':
+            c = 'A'
+        else:
+            c = chr(ord(c) + 1)
+    return c
+
+
+funcdefs = []
+matchers = []
+
+d = yaml.load(open('grammar.yaml'))
+
+for k, v in d.items():
+    members = []
+    description = v.get('description', '')
+    offset = 64
+    for member in v['members']:
+        for mk, mv in member.items():
+            if isinstance(mv, str):
+                # Literal binary match
+                mv = {'size': len(mv), 'match': mv}
+            elif isinstance(mv, int):
+                # Simple bit field
+                mv = {'size': mv}
+
+            if 'type' not in mv:
+                mv['type'] = f'Imm{mv["size"]}'
+
+            if 'offset' in mv:
+                # Re-adjust offset and potentially insert DONTCARE bits
+                new_offset = mv['offset'] + mv['size']
+                assert new_offset <= offset, f'Offset {new_offset} must be less or equal to current offset {offset}'
+                dontcare_bits = offset - new_offset
+                if dontcare_bits != 0:
+                    members.append(
+                        ('DONTCARE', 64-offset, {'size': dontcare_bits, 'type': f'Imm{dontcare_bits}'}))
+                    offset = new_offset
+
+            members.append((mk, 64-offset, mv))
+            offset -= mv['size']
+
+    # Insert DONTCARE bits at the end (if any)
+    if offset > 0:
+        dontcare_bits = offset
+        members.append(
+            ('DONTCARE', 64-offset, {'size': dontcare_bits, 'type': f'Imm{dontcare_bits}'}))
+        offset = 0
+
+    assert offset == 0, f'Definition of {k} does not fit in 64 bits'
+
+    v["handler"] = k.lower()
+    args = ',\n    '.join(f'{props["type"]} {name}' for name,
+                          offset, props in members if name != 'DONTCARE' and 'match' not in props)
+    func = f'bool USSETranslatorVisitor::{v["handler"]}(\n    {args})\n{{\n}}'
+    funcdefs.append(func)
+
+    # Create match string and assign bit characters
+    matchstr = ''
+    annotations = []
+    chars_used = {}
+    PREFIX = f'INST(&V::{v["handler"]}, "{k} ()", "'
+    SUFFIX = '"),'
+    indent = len(PREFIX)
+    for name, offset, props in members:
+        indentation = ' ' * (indent + offset) if STAIRCASE_INDENT else '  '
+        size = props['size']
+        if name == 'DONTCARE':
+            matchstr += '-' * size
+            annotations.append(f'{indentation}{"-"*size} = don\'t care')
+        elif 'match' in props:
+            # Literal bit pattern match
+            matchstr += props['match']
+            annotations.append(f'{indentation}{props["match"]} = {name}')
+        else:
+            char = allocate_char(chars_used, name)
+            chars_used[char] = name
+            matchstr += char * size
+            bitinfo = '1 bit' if size == 1 else f'{size} bits'
+            arginfo = '' if props['type'].startswith(
+                'Imm') else f', {props["type"]}'
+            annotations.append(
+                f'{indentation}{char*size} = {name} ({bitinfo}{arginfo})')
+
+    annotation = '\n'.join(annotations)
+    matchers.append(f'// {description}\n/*\n{annotation}\n*/\n{PREFIX}{matchstr}{SUFFIX}')
+
+
+def dump(fp):
+    print('// Functions\n', file=fp)
+    for funcdef in funcdefs:
+        print(funcdef, file=fp)
+        print('', file=fp)
+
+    print('\n\n// Matchers\n', file=fp)
+    for matcher in matchers:
+        print(matcher, file=fp)
+        print('', file=fp)
+
+
+dump(sys.stdout)
+dump(open('autogen_out.cpp', 'w'))

--- a/tools/usse-decoder-gen/grammar.yaml
+++ b/tools/usse-decoder-gen/grammar.yaml
@@ -1,0 +1,1176 @@
+VMOV:
+    description: Vector move
+    members:
+        - op1: '00111'
+        - pred:
+            size: 3
+            type: ExtPredicate
+        - skipinv:
+            size: 1
+            type: bool
+        - test_bit_2: 1
+        - src0_comp_sel: 1
+        - syncstart:
+            size: 1
+            type: bool
+        - dest_bank_ext: 1
+        - end_or_src0_bank_ext: 1
+        - src1_bank_ext: 1
+        - src2_bank_ext: 1
+        - move_type:
+            size: 2
+            type: MoveType
+        - repeat_count:
+            size: 2
+            type: RepeatCount
+        - nosched:
+            size: 1
+            type: bool
+        - move_data_type:
+            size: 3
+            type: DataType
+        - test_bit_1: 1
+        - src0_swiz: 4
+        - src0_bank_sel: 1
+        - dest_bank_sel: 2
+        - src1_bank_sel: 2
+        - src2_bank_sel: 2
+        - dest_mask:
+            size: 4
+            type: Imm4
+        - dest_n: 6
+        - src0_n: 6
+        - src1_n: 6
+        - src2_n: 6
+VMAD:
+    description: "Vector multiply-add"
+    members:
+        - opcode1: '00011'
+        - pred:
+            size: 3
+            type: ExtPredicate
+        - skipinv: 1
+        - gpi1_swiz_ext: 1
+        - present_bit_1: '1'
+        - opcode2: 1
+        - dest_use_bank_ext: 1
+        - end: 1
+        - src1_bank_ext: 1
+        - increment_mode: 2
+        - gpi0_abs: 1
+        - repeat_count:
+            size: 2
+            type: RepeatCount
+        - nosched:
+            size: 1
+            type: bool
+        - write_mask: 4
+        - src1_neg: 1
+        - src1_abs: 1
+        - gpi1_neg: 1
+        - gpi1_abs: 1
+        - gpi0_swiz_ext: 1
+        - dest_bank: 2
+        - src1_bank: 2
+        - gpi0_n: 2
+        - dest_n: 6
+        - gpi0_swiz: 4
+        - gpi1_swiz: 4
+        - gpi1_n: 2
+        - gpi0_neg: 1
+        - src1_swiz_ext:
+            size: 1
+            offset: 10
+        - src1_swiz: 4
+        - src1_n: 6
+VMAD2:
+    description: Vector multiply-add (Normal version)
+    members:
+        - opcode1: '00000'
+        - dat_fmt:
+            offset: 58
+            size: 1
+        - pred: 
+            offset: 56
+            size: 2
+        - skipinv:
+            offset: 55
+            size: 1
+        - src0_swiz_bits2:
+            size: 1
+            offset: 53
+        - syncstart:
+            offset: 52
+            size: 1
+        - src0_abs:
+            offset: 50
+            size: 1
+        - src1_bank_ext:
+            offset: 49
+            size: 1
+        - src2_bank_ext:
+            offset: 48
+            size: 1
+        - src2_swiz:
+            offset: 45
+            size: 3
+        - src1_swiz_bit2:
+            offset: 44
+            size: 1
+        - nosched:
+            offset: 43
+            size: 1
+        - dest_mask:
+            offset: 39
+            size: 4
+        - src1_mod:
+            size: 2
+            offset: 37
+        - src2_mod:
+            size: 2
+            offset: 35
+        - src0_bank:
+            size: 1
+            offset: 34
+        - dest_bank:
+            size: 2
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - dest_n:
+            offset: 22
+            size: 6
+        - src1_swiz_bits01:
+            size: 2
+            offset: 20
+        - src0_swiz_bits01:
+            size: 2
+            offset: 18
+        - src0_n:
+            size: 6
+            offset: 12
+        - src1_n:
+            size: 6
+            offset: 6
+        - src2_n:
+            size: 6
+            offset: 0
+VDP:
+    description: Vector Dot Product (single issue)
+    members:
+        - opcode1: '00011'
+        - pred:
+            size: 3
+            type: ExtPredicate
+        - skipinv: 1
+        - clip_plane_enable:
+            size: 1
+            type: bool
+        - present_bit_0: '0'
+        - opcode2: 1
+        - dest_use_bank_ext: 1
+        - end: 1
+        - src1_bank_ext: 1
+        - increment_mode: 2
+        - gpi0_abs: 1
+        - repeat_count:
+            size: 2
+            type: RepeatCount
+        - nosched:
+            size: 1
+            type: bool
+        - write_mask: 4
+        - src1_neg: 1
+        - src1_abs: 1
+        - clip_plane_n: 3
+        - dest_bank: 2 
+        - src1_bank: 2
+        - gpi0_n: 2
+        - dest_n: 6
+        - gpi0_swiz: 4
+        - src1_swiz_w: 3
+        - src1_swiz_z: 3
+        - src1_swiz_y: 3
+        - src1_swiz_x: 3
+        - src1_n: 6
+VNMAD32:
+    description: Vector operations except for MAD (F32)
+    members:
+        - opcode1: '00001'
+        - pred:
+            size: 3
+            type: ExtPredicate
+        - skipinv:
+            size: 1
+            type: bool
+        - src1_swiz_10_11:
+            size: 2
+        - syncstart:
+            size: 1
+            type: bool
+        - dest_bank_ext: 1
+        - src1_swiz_9: 1
+        - src1_bank_ext: 1
+        - src2_bank_ext: 1
+        - src2_swiz: 4
+        - nosched:
+            size: 1
+            type: bool
+        - dest_mask:
+            size: 4
+            type: Imm4
+        - src1_mod: 2
+        - src2_mod: 1
+        - src1_swiz_7_8: 2
+        - dest_bank_sel: 2
+        - src1_bank_sel: 2
+        - src2_bank_sel: 2
+        - dest_n: 6
+        - src1_swiz_0_6: 7
+        - op2: 3
+        - src1_n: 6
+        - src2_n: 6
+VNMAD16:
+    description: Vector operations except for MAD (F16)
+    members:
+        - opcode1: '00010'
+        - pred:
+            size: 3
+            type: ExtPredicate
+        - skipinv:
+            size: 1
+            type: bool
+        - src1_swiz_10_11:
+            size: 2
+        - syncstart:
+            size: 1
+            type: bool
+        - dest_bank_ext: 1
+        - src1_swiz_9: 1
+        - src1_bank_ext: 1
+        - src2_bank_ext: 1
+        - src2_swiz: 4
+        - nosched:
+            size: 1
+            type: bool
+        - dest_mask:
+            size: 4
+            type: Imm4
+        - src1_mod: 2
+        - src2_mod: 1
+        - src1_swiz_7_8: 2
+        - dest_bank_sel: 2
+        - src1_bank_sel: 2
+        - src2_bank_sel: 2
+        - dest_n: 6
+        - src1_swiz_0_6: 7
+        - op2: 3
+        - src1_n: 6
+        - src2_n: 6
+VLDST:
+    description: Load and Store
+    members:
+        - op1_cnst: '111'
+        - op1:
+            size: 2
+            offset: 59
+        - pred:
+            size: 3
+            offset: 56
+            type: ExtPredicate
+        - skipinv:
+            size: 1
+            offset: 55
+        - nosched:
+            size: 1
+            offset: 54
+        - moe_expand:
+            size: 1
+            offest: 53
+        - sync_start:
+            size: 1
+            offset: 52
+        - cache_ext:
+            size: 1
+            offset: 51
+        - src0_bank_ext:
+            size: 1
+            offset: 50
+        - src1_bank_ext:
+            size: 1
+            offset: 49
+        - src2_bank_ext:
+            size: 1
+            offset: 48
+        - mask_count:
+            size: 4
+            offset: 44
+        - addr_mode:
+            size: 2
+            offset: 42
+        - mode:
+            size: 2
+            offset: 40
+        - dest_bank_primattr:
+            size: 1
+            offset: 39
+        - range_enable:
+            size: 1
+            offset: 38
+        - data_type:
+            size: 2
+            offset: 36
+        - increment_or_decrement:
+            size: 1
+            offset: 35
+        - src0_bank:
+            size: 1
+            offset: 34
+        - cache_by_pass12:
+            size: 1
+            offset: 33
+        - drc_sel:
+            size: 1
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - dest_n:
+            size: 7
+            offset: 21
+        - src0_n:
+            size: 7
+            offset: 14
+        - src1_n:
+            size: 7
+            offset: 7
+        - src2_n:
+            size: 7
+            offset: 0
+VTST:
+    description: Test Instructions
+    members:
+        - op1: '01001'
+        - pred:
+            size: 3
+            offset: 56
+            type: ExtPredicate
+        - skipinv:
+            size: 1
+            offset: 55
+        - onceonly:
+            size: 1
+            offset: 53
+        - syncstart:
+            size: 1
+            offset: 52
+        - dest_ext:
+            size: 1
+            offset: 51
+        - src1_neg:
+            size: 1
+            offset: 50
+        - src1_ext:
+            size: 1
+            offset: 49
+        - src2_ext:
+            size: 1
+            offset: 48
+        - prec:
+            size: 1
+            offset: 47
+        - src2_vscomp:
+            size: 1
+            offset: 46
+        - rpt_count:
+            type: RepeatCount
+            size: 2
+            offset: 44
+        - sign_test:
+            size: 2
+            offset: 42
+        - zero_test:
+            size: 2
+            offset: 40
+        - test_crcomb_and:
+            size: 1
+            offset: 39
+        - chan_cc:
+            size: 3
+            offset: 36
+        - pdst_n:
+            size: 2
+            offset: 34
+        - dest_bank:
+            size: 2
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - dest_n:
+            offset: 21
+            size: 7
+        - test_wben:
+            offset: 20
+            size: 1
+        - alu_sel:
+            size: 2
+            offset: 18
+        - alu_op:
+            size: 4
+            offset: 14
+        - src1_n:
+            size: 7
+            offset: 7
+        - src2_n:
+            size: 7
+            offset: 0
+VTSTMSK:
+    description: Test mask Instructions
+    members:
+        - op1: '01111'
+        - pred:
+            size: 3
+            offset: 56
+            type: ExtPredicate
+        - skipinv:
+            size: 1
+            offset: 55
+        - onceonly:
+            size: 1
+            offset: 53
+        - syncstart:
+            size: 1
+            offset: 52
+        - dest_ext:
+            size: 1
+            offset: 51
+        - test_flag_2:
+            size: 1
+            offset: 50
+        - src1_ext:
+            size: 1
+            offset: 49
+        - src2_ext:
+            size: 1
+            offset: 48
+        - prec:
+            size: 1
+            offset: 47
+        - src2_vscomp:
+            size: 1
+            offset: 46
+        - rpt_count:
+            type: RepeatCount
+            size: 2
+            offset: 44
+        - sign_test:
+            size: 2
+            offset: 42
+        - zero_test:
+            size: 2
+            offset: 40
+        - test_crcomb_and:
+            size: 1
+            offset: 39
+        - tst_mask_type:
+            size: 2
+            offset: 36
+        - dest_bank:
+            size: 2
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - dest_n:
+            offset: 21
+            size: 7
+        - test_wben:
+            offset: 20
+            size: 1
+        - alu_sel:
+            size: 2
+            offset: 18
+        - alu_op:
+            size: 4
+            offset: 14
+        - src1_n:
+            size: 7
+            offset: 7
+        - src2_n:
+            size: 7
+            offset: 0
+VPCK:
+    description: Vector pack/unpack
+    members:
+        - op1: '01000'
+        - pred:
+            size: 3
+            type: ExtPredicate
+        - skipinv:
+            size: 1
+            type: bool
+        - nosched:
+            size: 1
+            type: bool
+        - unknown: 1
+        - syncstart:
+            size: 1
+            type: bool
+        - dest_bank_ext: 1
+        - end: 1
+        - src1_bank_ext: 1
+        - src2_bank_ext: 1
+        - repeat_count:
+            size: 3
+            type: RepeatCount
+            offset: 44
+        - src_fmt: 3
+        - dest_fmt: 3
+        - dest_mask: 4
+        - dest_bank_sel: 2
+        - src1_bank_sel: 2
+        - src2_bank_sel: 2
+        - dest_n: 
+            offset: 21
+            size: 7
+        - comp_sel_3:
+            offset: 19
+            size: 2
+        - scale:
+            offset: 18
+            size: 1
+        - comp_sel_1:
+            offset: 16
+            size: 2
+        - comp_sel_2: 
+            offset: 14
+            size: 2
+        - src1_n: 
+            offset: 8
+            size: 6
+        - comp0_sel_bit1:
+            offset: 7
+            size: 1
+        - src2_n:
+            offset: 1
+            size: 6
+        - comp_sel_0_bit0: 
+            offset: 0
+            size: 1
+VBW:
+    description: Bitwise Instructions
+    members:
+        - op1_cnst: '01'
+        - op1: 3
+        - pred:
+            type: ExtPredicate
+            size: 3
+        - skipinv:
+            type: bool
+            size: 1
+        - nosched:
+            type: bool
+            size: 1
+        - repeat_count: 1
+        - sync_start: 1
+        - dest_ext: 1
+        - end: 1
+        - src1_ext: 1
+        - src2_ext: 1
+        - mask_count: 4
+        - src2_invert: 1
+        - src2_rot: 5
+        - src2_exth: 2
+        - op2: 1
+        - bitwise_partial: 1
+        - dest_bank: 2
+        - src1_bank: 2
+        - src2_bank: 2
+        - dest_n: 7
+        - src2_sel: 7
+        - src1_n: 7
+        - src2_n: 7   
+SMP:
+    description: Sample Instructions
+    members:
+        - op1: '11100'
+        - pred:
+            type: ExtPredicate
+            offset: 56
+            size: 3
+        - skipinv:
+            size: 1
+            offset: 55
+        - nosched:
+            size: 1
+            offset: 54
+        - syncstart:
+            offset: 52
+            size: 1
+        - minpack:
+            size: 1
+            offset: 51
+        - src0_ext:
+            size: 1
+            offset: 50
+        - src1_ext:
+            offset: 49
+            size: 1
+        - src2_ext:
+            offset: 48
+            size: 1
+        - fconv_type:
+            offset: 46
+            size: 2
+        - mask_count:
+            size: 2
+            offset: 44
+        - dim:
+            size: 2
+            offset: 42
+        - lod_mode:
+            size: 2
+            offset: 40
+        - dest_use_pa:
+            size: 1
+            type: bool
+            offset: 39
+        - sb_mode:
+            offset: 37
+            size: 2
+        - src0_type:
+            offset: 35
+            size: 2
+        - src0_bank:
+            size: 1
+            offset: 34
+        - drc_sel:
+            size: 2
+            offset: 32
+        - src1_bank:
+            offset: 30
+            size: 2
+        - src2_bank:
+            offset: 28
+            size: 2
+        - dest_n:
+            size: 7
+            offset: 21
+        - src0_n:
+            size: 7
+            offset: 14
+        - src1_n:
+            size: 7
+            offset: 7
+        - src2_n:
+            size: 7
+            offset: 0
+VCOMP:
+    description: Vector Complex Instructions
+    members:
+        - op1: '00110'
+        - pred:
+            size: 3
+            type: ExtPredicate
+            offset: 56
+        - skipinv:
+            size: 1
+            type: bool
+            offset: 55
+        - dest_type:
+            size: 2
+            offset: 53
+        - syncstart:
+            size: 1
+            type: bool
+            offset: 52
+        - dest_bank_ext:
+            size: 1
+            type: bool
+            offset: 51
+        - end:
+            size: 1
+            type: bool
+            offset: 50
+        - src1_bank_ext:
+            size: 1
+            type: bool
+            offset: 49
+        - repeat_count:
+            size: 4
+            type: RepeatCount
+            offset: 44
+        - nosched:
+            size: 1
+            offset: 43
+            type: bool
+        - op2:
+            size: 2
+            offset: 41
+        - src_type:
+            size: 2
+            offset: 39
+        - src1_mod:
+            size: 2
+            offset: 37
+        - src_comp:
+            size: 2
+            offset: 35
+        - dest_bank:
+            size: 2
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - dest_n:
+            offset: 21
+            size: 7
+        - src1_n:
+            offset: 7
+            size: 7
+        - write_mask:
+            size: 4
+            offset: 0
+SOP2:
+    description: Sum of Products
+    members:
+        - op1: '10000'
+        - pred:
+            offset: 57
+            size: 2
+        - cmod1:
+            offset: 56
+            size: 1
+        - skipinv:
+            offset: 55
+            size: 1
+        - nosched:
+            offset: 54
+            size: 1
+        - asel1:
+            offset: 52
+            size: 2
+        - dest_bank_ext:
+            offset: 51
+            size: 1
+        - end:
+            offset: 50
+            size: 1
+        - src1_bank_ext:
+            offset: 49
+            size: 1
+        - src2_bank_ext:
+            offset: 48
+            size: 1
+        - cmod2:
+            offset: 47
+            size: 1
+        - count:
+            offset: 44
+            size: 3
+        - amod1:
+            offset: 43
+            size: 1
+        - asel2:
+            offset: 41
+            size: 2
+        - csel1:
+            offset: 38
+            size: 3
+        - csel2:
+            offset: 35
+            size: 3
+        - amod2:
+            offset: 34
+            size: 1
+        - dest_bank:
+            offset: 32
+            size: 2
+        - src1_bank:
+            offset: 30
+            size: 2
+        - src2_bank:
+            offset: 28
+            size: 2
+        - dest_n:
+            offset: 21
+            size: 7
+        - src1_mod:
+            offset: 20
+            size: 1
+        - cop:
+            offset: 18
+            size: 2
+        - aop:
+            offset: 16
+            size: 2
+        - asrc1_mod:
+            offset: 15
+            size: 1
+        - dest_mod:
+            offset: 14
+            size: 1
+        - src1_n:
+            offset: 7
+            size: 7
+        - src2_n:
+            offset: 0
+            size: 7
+BR:
+    description: Branch
+    members:
+        - op1: '11111'
+        - pred:
+            type: ExtPredicate
+            size: 3
+            offset: 56
+        - syncend:
+            size: 1
+            offset: 55
+        - opcat_extra:
+            match: '0'
+            size: 1
+            offset: 54
+        - op2_flow_ctrl:
+            match: '00'
+            size: 2
+            offset: 52
+        - exception:
+            type: bool
+            size: 1
+            offset: 51
+        - pwait:
+            type: bool
+            size: 1
+            offset: 45
+        - sync_ext:
+            size: 1
+            offset: 44
+        - nosched:
+            type: bool
+            size: 1
+            offset: 43
+        - br_monitor:
+            type: bool
+            size: 1
+            offset: 42
+        - save_link:
+            type: bool
+            size: 1
+            offset: 41
+        - br_op:
+            match: '00'
+            offset: 39
+            size: 2
+        - br_type:
+            offset: 38
+            size: 1
+        - any_inst:
+            offset: 21
+            size: 1
+        - all_inst:
+            offset: 20
+            size: 1
+        - br_off:
+            size: 20
+            offset: 0
+            type: uint32_t
+PHAS:
+    description: Phase
+    members:
+        - op1: '11111'
+        - op2:
+            size: 3
+            offset: 56
+            match: '010'
+        - sprvv:
+            size: 1
+            offset: 55
+        - phas:
+            match: '100'
+            offset: 52
+            size: 3
+        - end:
+            size: 1
+            offset: 51
+        - imm:
+            size: 1
+            offset: 50
+        - src1_bank_ext:
+            size: 1
+            offset: 49
+        - src2_bank_ext:
+            size: 1
+            offset: 48
+        - mode:
+            size: 1
+            offset: 45
+        - rate_hi:
+            size: 1
+            offset: 44
+        - rate_lo_or_nosched:
+            size: 1
+            offset: 43
+        - wait_cond:
+            size: 3
+            offset: 40
+        - temp_count:
+            size: 8
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - exe_addr_high:
+            size: 6
+            offset: 14
+        - src1_n_or_exe_addr_mid:
+            size: 7
+            offset: 7
+        - src2_n_or_exe_addr_low:
+            size: 7
+            offset: 0
+NOP:
+    description: Nop
+    members:
+        - op1: '11111'
+        - opcat_extra:
+            match: '0'
+            size: 1
+            offset: 54
+        - op2_flow_ctrl:
+            match: '00'
+            size: 2
+            offset: 52
+        - nop:
+            match: '101'
+            offset: 38
+            size: 3
+SMLSI:
+    description: SMLSI control instruction
+    members:
+        - op1: '11111'
+        - op2:
+            size: 3
+            offset: 56
+            match: '010'
+        - opcat: 
+            match: '01'
+            size: 2
+            offset: 52
+        - nosched:
+            offset: 50
+            size: 1
+        - temp_limit:
+            offset: 44
+            size: 4
+        - pa_limit:
+            offset: 40
+            size: 4
+        - sa_limit:
+            offset: 36
+            size: 4
+        - dest_inc_mode:
+            offset: 35
+            size: 1
+        - src0_inc_mode:
+            offset: 34
+            size: 1
+        - src1_inc_mode:
+            offset: 33
+            size: 1
+        - src2_inc_mode:
+            offset: 32
+            size: 1
+        - dest_inc:
+            offset: 24
+            size: 8
+        - src0_inc:
+            offset: 16
+            size: 8
+        - src1_inc:
+            offset: 8
+            size: 8
+        - src2_inc:
+            offset: 0
+            size: 8
+EMIT:
+    description: Emit Output
+    members:
+        - op1: '11111'
+        - op2:
+            size: 3
+            offset: 56
+            match: '011'
+        - sideband_high:
+            size: 2
+            offset: 54
+        - opcat:
+            size: 2
+            offset: 52
+            match: '10'
+        - src0_bank_ext:
+            size: 1
+            offset: 51
+        - end:
+            size: 1
+            offset: 50
+        - src1_bank_ext:
+            size: 1
+            offset: 49
+        - src2_bank_ext:
+            size: 1
+            offset: 48
+        - target:
+            size: 2
+            offset: 46
+        - task_start_or_mte_hi:
+            size: 1
+            offset: 45
+        - task_end_or_mte_lo:
+            size: 1
+            offset: 44
+        - nosched:
+            size: 1
+            offset: 43
+        - sideband_mid:
+            size: 6
+            offset: 35
+        - src0_bank:
+            size: 1
+            offset: 34
+        - incp:
+            size: 2
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - sideband_low:
+            size: 6
+            offset: 22
+        - freep:
+            size: 1
+            offset: 21
+        - src0_n:
+            size: 7
+            offset: 14
+        - src1_n:
+            size: 7
+            offset: 7
+        - src2_n:
+            size: 7
+            offset: 0
+VDUAL:
+    description: Dual issue instruction
+    members:
+        - op1: '0010'
+        - comp_count_type:
+            size: 1
+            offset: 59
+        - gpi1_neg:
+            size: 1
+            offset: 58
+        - sv_pred:
+            size: 2
+            offset: 56
+        - skipinv:
+            size: 1
+            offset: 55
+        - dual_op1_ext_vec3_or_has_w_vec4:
+            size: 1
+            offset: 54
+        - type_f16:
+            size: 1
+            offset: 53
+            type: bool
+        - gpi1_swizz_ext:
+            size: 1
+            offset: 52
+        - unified_store_swizz:
+            size: 4
+            offset: 48
+        - unified_store_neg:
+            size: 1
+            offset: 47
+        - dual_op1:
+            size: 3
+            offset: 44
+        - dual_op2_ext:
+            size: 1
+            offset: 43
+        - prim_ustore:
+            offset: 42
+            size: 1
+            type: bool
+        - gpi0_swizz:
+            offset: 38
+            size: 4
+        - gpi1_swizz:
+            offset: 34
+            size: 4
+        - prim_dest_bank:
+            size: 2
+            offset: 32
+        - unified_store_slot_bank:
+            size: 2
+            offset: 30
+        - prim_dest_num_gpi_case:
+            size: 2
+            offset: 28
+        - prim_dest_num:
+            size: 7
+            offset: 21
+        - dual_op2:
+            size: 3
+            offset: 18
+        - src_config:
+            size: 2
+            offset: 16
+        - gpi2_slot_num_bit_1:
+            size: 1
+            offset: 15
+        - gpi2_slot_num_bit_0_or_unified_store_abs:
+            size: 1
+            offset: 14
+        - gpi1_slot_num:
+            size: 2
+            offset: 12
+        - gpi0_slot_num:
+            size: 2
+            offset: 10
+        - write_mask_non_gpi:
+            size: 3
+            offset: 7
+        - unified_store_slot_num:
+            size: 7
+            offset: 0
+SPEC:
+    description: Special
+    members:
+        - op1: '11111'
+        - special:
+            size: 1
+            offset: 54
+            type: bool
+        - category:
+            size: 2
+            type: SpecialCategory

--- a/tools/usse-decoder-gen/grammar.yaml
+++ b/tools/usse-decoder-gen/grammar.yaml
@@ -55,7 +55,7 @@ VMAD:
         - opcode2: 1
         - dest_use_bank_ext: 1
         - end: 1
-        - src1_bank_ext: 1
+        - src0_bank_ext: 1
         - increment_mode: 2
         - gpi0_abs: 1
         - repeat_count:
@@ -65,24 +65,24 @@ VMAD:
             size: 1
             type: bool
         - write_mask: 4
-        - src1_neg: 1
-        - src1_abs: 1
+        - src0_neg: 1
+        - src0_abs: 1
         - gpi1_neg: 1
         - gpi1_abs: 1
         - gpi0_swiz_ext: 1
         - dest_bank: 2
-        - src1_bank: 2
+        - src0_bank: 2
         - gpi0_n: 2
         - dest_n: 6
         - gpi0_swiz: 4
         - gpi1_swiz: 4
         - gpi1_n: 2
         - gpi0_neg: 1
-        - src1_swiz_ext:
+        - src0_swiz_ext:
             size: 1
             offset: 10
-        - src1_swiz: 4
-        - src1_n: 6
+        - src0_swiz: 4
+        - src0_n: 6
 VMAD2:
     description: Vector multiply-add (Normal version)
     members:
@@ -159,44 +159,6 @@ VMAD2:
         - src2_n:
             size: 6
             offset: 0
-VDP:
-    description: Vector Dot Product (single issue)
-    members:
-        - opcode1: '00011'
-        - pred:
-            size: 3
-            type: ExtPredicate
-        - skipinv: 1
-        - clip_plane_enable:
-            size: 1
-            type: bool
-        - present_bit_0: '0'
-        - opcode2: 1
-        - dest_use_bank_ext: 1
-        - end: 1
-        - src1_bank_ext: 1
-        - increment_mode: 2
-        - gpi0_abs: 1
-        - repeat_count:
-            size: 2
-            type: RepeatCount
-        - nosched:
-            size: 1
-            type: bool
-        - write_mask: 4
-        - src1_neg: 1
-        - src1_abs: 1
-        - clip_plane_n: 3
-        - dest_bank: 2 
-        - src1_bank: 2
-        - gpi0_n: 2
-        - dest_n: 6
-        - gpi0_swiz: 4
-        - src1_swiz_w: 3
-        - src1_swiz_z: 3
-        - src1_swiz_y: 3
-        - src1_swiz_x: 3
-        - src1_n: 6
 VNMAD32:
     description: Vector operations except for MAD (F32)
     members:
@@ -271,89 +233,149 @@ VNMAD16:
         - op2: 3
         - src1_n: 6
         - src2_n: 6
-VLDST:
-    description: Load and Store
+VPCK:
+    description: Vector pack/unpack
     members:
-        - op1_cnst: '111'
-        - op1:
-            size: 2
-            offset: 59
+        - op1: '01000'
         - pred:
             size: 3
-            offset: 56
             type: ExtPredicate
         - skipinv:
             size: 1
-            offset: 55
+            type: bool
         - nosched:
             size: 1
-            offset: 54
-        - moe_expand:
+            type: bool
+        - unknown: 1
+        - syncstart:
             size: 1
-            offest: 53
-        - sync_start:
-            size: 1
-            offset: 52
-        - cache_ext:
-            size: 1
-            offset: 51
-        - src0_bank_ext:
-            size: 1
-            offset: 50
-        - src1_bank_ext:
-            size: 1
-            offset: 49
-        - src2_bank_ext:
-            size: 1
-            offset: 48
-        - mask_count:
-            size: 4
+            type: bool
+        - dest_bank_ext: 1
+        - end: 1
+        - src1_bank_ext: 1
+        - src2_bank_ext: 1
+        - repeat_count:
+            size: 3
+            type: RepeatCount
             offset: 44
-        - addr_mode:
-            size: 2
-            offset: 42
-        - mode:
-            size: 2
-            offset: 40
-        - dest_bank_primattr:
-            size: 1
-            offset: 39
-        - range_enable:
-            size: 1
-            offset: 38
-        - data_type:
-            size: 2
-            offset: 36
-        - increment_or_decrement:
-            size: 1
-            offset: 35
-        - src0_bank:
-            size: 1
-            offset: 34
-        - cache_by_pass12:
-            size: 1
-            offset: 33
-        - drc_sel:
-            size: 1
-            offset: 32
-        - src1_bank:
-            size: 2
-            offset: 30
-        - src2_bank:
-            size: 2
-            offset: 28
-        - dest_n:
-            size: 7
+        - src_fmt: 3
+        - dest_fmt: 3
+        - dest_mask: 4
+        - dest_bank_sel: 2
+        - src1_bank_sel: 2
+        - src2_bank_sel: 2
+        - dest_n: 
             offset: 21
-        - src0_n:
             size: 7
+        - comp_sel_3:
+            offset: 19
+            size: 2
+        - scale:
+            offset: 18
+            size: 1
+        - comp_sel_1:
+            offset: 16
+            size: 2
+        - comp_sel_2: 
             offset: 14
-        - src1_n:
-            size: 7
+            size: 2
+        - src1_n: 
+            offset: 8
+            size: 6
+        - comp0_sel_bit1:
             offset: 7
+            size: 1
         - src2_n:
-            size: 7
+            offset: 1
+            size: 6
+        - comp_sel_0_bit0: 
             offset: 0
+            size: 1
+SOP2:
+    description: Sum of Products
+    members:
+        - op1: '10000'
+        - pred:
+            offset: 57
+            size: 2
+        - cmod1:
+            offset: 56
+            size: 1
+        - skipinv:
+            offset: 55
+            size: 1
+        - nosched:
+            offset: 54
+            size: 1
+        - asel1:
+            offset: 52
+            size: 2
+        - dest_bank_ext:
+            offset: 51
+            size: 1
+        - end:
+            offset: 50
+            size: 1
+        - src1_bank_ext:
+            offset: 49
+            size: 1
+        - src2_bank_ext:
+            offset: 48
+            size: 1
+        - cmod2:
+            offset: 47
+            size: 1
+        - count:
+            offset: 44
+            size: 3
+        - amod1:
+            offset: 43
+            size: 1
+        - asel2:
+            offset: 41
+            size: 2
+        - csel1:
+            offset: 38
+            size: 3
+        - csel2:
+            offset: 35
+            size: 3
+        - amod2:
+            offset: 34
+            size: 1
+        - dest_bank:
+            offset: 32
+            size: 2
+        - src1_bank:
+            offset: 30
+            size: 2
+        - src2_bank:
+            offset: 28
+            size: 2
+        - dest_n:
+            offset: 21
+            size: 7
+        - src1_mod:
+            offset: 20
+            size: 1
+        - cop:
+            offset: 18
+            size: 2
+        - aop:
+            offset: 16
+            size: 2
+        - asrc1_mod:
+            offset: 15
+            size: 1
+        - dest_mod:
+            offset: 14
+            size: 1
+        - src1_n:
+            offset: 7
+            size: 7
+        - src2_n:
+            offset: 0
+            size: 7
 VTST:
     description: Test Instructions
     members:
@@ -513,64 +535,6 @@ VTSTMSK:
         - src2_n:
             size: 7
             offset: 0
-VPCK:
-    description: Vector pack/unpack
-    members:
-        - op1: '01000'
-        - pred:
-            size: 3
-            type: ExtPredicate
-        - skipinv:
-            size: 1
-            type: bool
-        - nosched:
-            size: 1
-            type: bool
-        - unknown: 1
-        - syncstart:
-            size: 1
-            type: bool
-        - dest_bank_ext: 1
-        - end: 1
-        - src1_bank_ext: 1
-        - src2_bank_ext: 1
-        - repeat_count:
-            size: 3
-            type: RepeatCount
-            offset: 44
-        - src_fmt: 3
-        - dest_fmt: 3
-        - dest_mask: 4
-        - dest_bank_sel: 2
-        - src1_bank_sel: 2
-        - src2_bank_sel: 2
-        - dest_n: 
-            offset: 21
-            size: 7
-        - comp_sel_3:
-            offset: 19
-            size: 2
-        - scale:
-            offset: 18
-            size: 1
-        - comp_sel_1:
-            offset: 16
-            size: 2
-        - comp_sel_2: 
-            offset: 14
-            size: 2
-        - src1_n: 
-            offset: 8
-            size: 6
-        - comp0_sel_bit1:
-            offset: 7
-            size: 1
-        - src2_n:
-            offset: 1
-            size: 6
-        - comp_sel_0_bit0: 
-            offset: 0
-            size: 1
 VBW:
     description: Bitwise Instructions
     members:
@@ -580,18 +544,20 @@ VBW:
             type: ExtPredicate
             size: 3
         - skipinv:
-            type: bool
             size: 1
         - nosched:
+            size: 1
+        - repeat_sel:
             type: bool
             size: 1
-        - repeat_count: 1
         - sync_start: 1
         - dest_ext: 1
         - end: 1
         - src1_ext: 1
         - src2_ext: 1
-        - mask_count: 4
+        - repeat_count:
+            type: RepeatCount
+            size: 4
         - src2_invert: 1
         - src2_rot: 5
         - src2_exth: 2
@@ -603,7 +569,139 @@ VBW:
         - dest_n: 7
         - src2_sel: 7
         - src1_n: 7
-        - src2_n: 7   
+        - src2_n: 7
+PHAS:
+    description: Phase
+    members:
+        - op1: '11111'
+        - op2:
+            size: 3
+            offset: 56
+            match: '010'
+        - sprvv:
+            size: 1
+            offset: 55
+        - phas:
+            match: '100'
+            offset: 52
+            size: 3
+        - end:
+            size: 1
+            offset: 51
+        - imm:
+            size: 1
+            offset: 50
+        - src1_bank_ext:
+            size: 1
+            offset: 49
+        - src2_bank_ext:
+            size: 1
+            offset: 48
+        - mode:
+            size: 1
+            offset: 45
+        - rate_hi:
+            size: 1
+            offset: 44
+        - rate_lo_or_nosched:
+            size: 1
+            offset: 43
+        - wait_cond:
+            size: 3
+            offset: 40
+        - temp_count:
+            size: 8
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - exe_addr_high:
+            size: 6
+            offset: 14
+        - src1_n_or_exe_addr_mid:
+            size: 7
+            offset: 7
+        - src2_n_or_exe_addr_low:
+            size: 7
+            offset: 0   
+NOP:
+    description: Nop
+    members:
+        - op1: '11111'
+        - opcat_extra:
+            match: '0'
+            size: 1
+            offset: 54
+        - op2_flow_ctrl:
+            match: '00'
+            size: 2
+            offset: 52
+        - nop:
+            match: '101'
+            offset: 38
+            size: 3
+BR:
+    description: Branch
+    members:
+        - op1: '11111'
+        - pred:
+            type: ExtPredicate
+            size: 3
+            offset: 56
+        - syncend:
+            size: 1
+            offset: 55
+        - opcat_extra:
+            match: '0'
+            size: 1
+            offset: 54
+        - op2_flow_ctrl:
+            match: '00'
+            size: 2
+            offset: 52
+        - exception:
+            type: bool
+            size: 1
+            offset: 51
+        - pwait:
+            type: bool
+            size: 1
+            offset: 45
+        - sync_ext:
+            size: 1
+            offset: 44
+        - nosched:
+            type: bool
+            size: 1
+            offset: 43
+        - br_monitor:
+            type: bool
+            size: 1
+            offset: 42
+        - save_link:
+            type: bool
+            size: 1
+            offset: 41
+        - br_op:
+            match: '00'
+            offset: 39
+            size: 2
+        - br_type:
+            offset: 38
+            size: 1
+        - any_inst:
+            offset: 21
+            size: 1
+        - all_inst:
+            offset: 20
+            size: 1
+        - br_off:
+            size: 20
+            offset: 0
+            type: uint32_t
 SMP:
     description: Sample Instructions
     members:
@@ -679,6 +777,157 @@ SMP:
         - src2_n:
             size: 7
             offset: 0
+SMLSI:
+    description: SMLSI control instruction
+    members:
+        - op1: '11111'
+        - op2:
+            size: 3
+            offset: 56
+            match: '010'
+        - opcat: 
+            match: '01'
+            size: 2
+            offset: 52
+        - nosched:
+            offset: 50
+            size: 1
+        - temp_limit:
+            offset: 44
+            size: 4
+        - pa_limit:
+            offset: 40
+            size: 4
+        - sa_limit:
+            offset: 36
+            size: 4
+        - dest_inc_mode:
+            offset: 35
+            size: 1
+        - src0_inc_mode:
+            offset: 34
+            size: 1
+        - src1_inc_mode:
+            offset: 33
+            size: 1
+        - src2_inc_mode:
+            offset: 32
+            size: 1
+        - dest_inc:
+            offset: 24
+            size: 8
+        - src0_inc:
+            offset: 16
+            size: 8
+        - src1_inc:
+            offset: 8
+            size: 8
+        - src2_inc:
+            offset: 0
+            size: 8
+KILL:
+    description: Kill program
+    members:
+        - op1: '11111'
+        - op2:
+            size: 3
+            match: '001'
+        - DONTCARE:
+            size: 2
+        - opcat: 
+            match: '11'
+            size: 2
+        - kill:
+            match: '000000000'
+            size: 9
+        - pred:
+            type: ShortPredicate
+            size: 2
+        - kill2:
+            match: '0000001101111'
+            size: 13
+        - DONTCARE:
+            size: 28
+# EMIT:
+#     description: Emit Output
+#     members:
+#         - op1: '11111'
+#         - op2:
+#             size: 3
+#             offset: 56
+#             match: '011'
+#         - sideband_high:
+#             size: 2
+#             offset: 54
+#         - opcat:
+#             size: 2
+#             offset: 52
+#             match: '10'
+#         - src0_bank_ext:
+#             size: 1
+#             offset: 51
+#         - end:
+#             size: 1
+#             offset: 50
+#         - src1_bank_ext:
+#             size: 1
+#             offset: 49
+#         - src2_bank_ext:
+#             size: 1
+#             offset: 48
+#         - target:
+#             size: 2
+#             offset: 46
+#         - task_start_or_mte_hi:
+#             size: 1
+#             offset: 45
+#         - task_end_or_mte_lo:
+#             size: 1
+#             offset: 44
+#         - nosched:
+#             size: 1
+#             offset: 43
+#         - sideband_mid:
+#             size: 6
+#             offset: 35
+#         - src0_bank:
+#             size: 1
+#             offset: 34
+#         - incp:
+#             size: 2
+#             offset: 32
+#         - src1_bank:
+#             size: 2
+#             offset: 30
+#         - src2_bank:
+#             size: 2
+#             offset: 28
+#         - sideband_low:
+#             size: 6
+#             offset: 22
+#         - freep:
+#             size: 1
+#             offset: 21
+#         - src0_n:
+#             size: 7
+#             offset: 14
+#         - src1_n:
+#             size: 7
+#             offset: 7
+#         - src2_n:
+#             size: 7
+#             offset: 0
+SPEC:
+    description: Special
+    members:
+        - op1: '11111'
+        - special:
+            size: 1
+            offset: 54
+            type: bool
+        - category:
+            size: 2
+            type: SpecialCategory
 VCOMP:
     description: Vector Complex Instructions
     members:
@@ -745,340 +994,44 @@ VCOMP:
         - write_mask:
             size: 4
             offset: 0
-SOP2:
-    description: Sum of Products
+VDP:
+    description: Vector Dot Product (single issue)
     members:
-        - op1: '10000'
+        - opcode1: '00011'
         - pred:
-            offset: 57
-            size: 2
-        - cmod1:
-            offset: 56
-            size: 1
-        - skipinv:
-            offset: 55
-            size: 1
-        - nosched:
-            offset: 54
-            size: 1
-        - asel1:
-            offset: 52
-            size: 2
-        - dest_bank_ext:
-            offset: 51
-            size: 1
-        - end:
-            offset: 50
-            size: 1
-        - src1_bank_ext:
-            offset: 49
-            size: 1
-        - src2_bank_ext:
-            offset: 48
-            size: 1
-        - cmod2:
-            offset: 47
-            size: 1
-        - count:
-            offset: 44
             size: 3
-        - amod1:
-            offset: 43
-            size: 1
-        - asel2:
-            offset: 41
-            size: 2
-        - csel1:
-            offset: 38
-            size: 3
-        - csel2:
-            offset: 35
-            size: 3
-        - amod2:
-            offset: 34
-            size: 1
-        - dest_bank:
-            offset: 32
-            size: 2
-        - src1_bank:
-            offset: 30
-            size: 2
-        - src2_bank:
-            offset: 28
-            size: 2
-        - dest_n:
-            offset: 21
-            size: 7
-        - src1_mod:
-            offset: 20
-            size: 1
-        - cop:
-            offset: 18
-            size: 2
-        - aop:
-            offset: 16
-            size: 2
-        - asrc1_mod:
-            offset: 15
-            size: 1
-        - dest_mod:
-            offset: 14
-            size: 1
-        - src1_n:
-            offset: 7
-            size: 7
-        - src2_n:
-            offset: 0
-            size: 7
-BR:
-    description: Branch
-    members:
-        - op1: '11111'
-        - pred:
             type: ExtPredicate
-            size: 3
-            offset: 56
-        - syncend:
+        - skipinv: 1
+        - clip_plane_enable:
             size: 1
-            offset: 55
-        - opcat_extra:
-            match: '0'
-            size: 1
-            offset: 54
-        - op2_flow_ctrl:
-            match: '00'
-            size: 2
-            offset: 52
-        - exception:
             type: bool
-            size: 1
-            offset: 51
-        - pwait:
-            type: bool
-            size: 1
-            offset: 45
-        - sync_ext:
-            size: 1
-            offset: 44
-        - nosched:
-            type: bool
-            size: 1
-            offset: 43
-        - br_monitor:
-            type: bool
-            size: 1
-            offset: 42
-        - save_link:
-            type: bool
-            size: 1
-            offset: 41
-        - br_op:
-            match: '00'
-            offset: 39
+        - present_bit_0: '0'
+        - opcode2: 1
+        - dest_use_bank_ext: 1
+        - end: 1
+        - src0_bank_ext: 1
+        - increment_mode: 2
+        - gpi0_abs: 1
+        - repeat_count:
             size: 2
-        - br_type:
-            offset: 38
-            size: 1
-        - any_inst:
-            offset: 21
-            size: 1
-        - all_inst:
-            offset: 20
-            size: 1
-        - br_off:
-            size: 20
-            offset: 0
-            type: uint32_t
-PHAS:
-    description: Phase
-    members:
-        - op1: '11111'
-        - op2:
-            size: 3
-            offset: 56
-            match: '010'
-        - sprvv:
-            size: 1
-            offset: 55
-        - phas:
-            match: '100'
-            offset: 52
-            size: 3
-        - end:
-            size: 1
-            offset: 51
-        - imm:
-            size: 1
-            offset: 50
-        - src1_bank_ext:
-            size: 1
-            offset: 49
-        - src2_bank_ext:
-            size: 1
-            offset: 48
-        - mode:
-            size: 1
-            offset: 45
-        - rate_hi:
-            size: 1
-            offset: 44
-        - rate_lo_or_nosched:
-            size: 1
-            offset: 43
-        - wait_cond:
-            size: 3
-            offset: 40
-        - temp_count:
-            size: 8
-            offset: 32
-        - src1_bank:
-            size: 2
-            offset: 30
-        - src2_bank:
-            size: 2
-            offset: 28
-        - exe_addr_high:
-            size: 6
-            offset: 14
-        - src1_n_or_exe_addr_mid:
-            size: 7
-            offset: 7
-        - src2_n_or_exe_addr_low:
-            size: 7
-            offset: 0
-NOP:
-    description: Nop
-    members:
-        - op1: '11111'
-        - opcat_extra:
-            match: '0'
-            size: 1
-            offset: 54
-        - op2_flow_ctrl:
-            match: '00'
-            size: 2
-            offset: 52
-        - nop:
-            match: '101'
-            offset: 38
-            size: 3
-SMLSI:
-    description: SMLSI control instruction
-    members:
-        - op1: '11111'
-        - op2:
-            size: 3
-            offset: 56
-            match: '010'
-        - opcat: 
-            match: '01'
-            size: 2
-            offset: 52
-        - nosched:
-            offset: 50
-            size: 1
-        - temp_limit:
-            offset: 44
-            size: 4
-        - pa_limit:
-            offset: 40
-            size: 4
-        - sa_limit:
-            offset: 36
-            size: 4
-        - dest_inc_mode:
-            offset: 35
-            size: 1
-        - src0_inc_mode:
-            offset: 34
-            size: 1
-        - src1_inc_mode:
-            offset: 33
-            size: 1
-        - src2_inc_mode:
-            offset: 32
-            size: 1
-        - dest_inc:
-            offset: 24
-            size: 8
-        - src0_inc:
-            offset: 16
-            size: 8
-        - src1_inc:
-            offset: 8
-            size: 8
-        - src2_inc:
-            offset: 0
-            size: 8
-EMIT:
-    description: Emit Output
-    members:
-        - op1: '11111'
-        - op2:
-            size: 3
-            offset: 56
-            match: '011'
-        - sideband_high:
-            size: 2
-            offset: 54
-        - opcat:
-            size: 2
-            offset: 52
-            match: '10'
-        - src0_bank_ext:
-            size: 1
-            offset: 51
-        - end:
-            size: 1
-            offset: 50
-        - src1_bank_ext:
-            size: 1
-            offset: 49
-        - src2_bank_ext:
-            size: 1
-            offset: 48
-        - target:
-            size: 2
-            offset: 46
-        - task_start_or_mte_hi:
-            size: 1
-            offset: 45
-        - task_end_or_mte_lo:
-            size: 1
-            offset: 44
+            type: RepeatCount
         - nosched:
             size: 1
-            offset: 43
-        - sideband_mid:
-            size: 6
-            offset: 35
-        - src0_bank:
-            size: 1
-            offset: 34
-        - incp:
-            size: 2
-            offset: 32
-        - src1_bank:
-            size: 2
-            offset: 30
-        - src2_bank:
-            size: 2
-            offset: 28
-        - sideband_low:
-            size: 6
-            offset: 22
-        - freep:
-            size: 1
-            offset: 21
-        - src0_n:
-            size: 7
-            offset: 14
-        - src1_n:
-            size: 7
-            offset: 7
-        - src2_n:
-            size: 7
-            offset: 0
+            type: bool
+        - write_mask: 4
+        - src0_neg: 1
+        - src0_abs: 1
+        - clip_plane_n: 3
+        - dest_bank: 2 
+        - src0_bank: 2
+        - gpi0_n: 2
+        - dest_n: 6
+        - gpi0_swiz: 4
+        - src0_swiz_w: 3
+        - src0_swiz_z: 3
+        - src0_swiz_y: 3
+        - src0_swiz_x: 3
+        - src0_n: 6
 VDUAL:
     description: Dual issue instruction
     members:
@@ -1163,14 +1116,86 @@ VDUAL:
         - unified_store_slot_num:
             size: 7
             offset: 0
-SPEC:
-    description: Special
+VLDST:
+    description: Load and Store
     members:
-        - op1: '11111'
-        - special:
+        - op1_cnst: '111'
+        - op1:
+            size: 2
+            offset: 59
+        - pred:
+            size: 3
+            offset: 56
+            type: ExtPredicate
+        - skipinv:
+            size: 1
+            offset: 55
+        - nosched:
             size: 1
             offset: 54
-            type: bool
-        - category:
+        - moe_expand:
+            size: 1
+            offest: 53
+        - sync_start:
+            size: 1
+            offset: 52
+        - cache_ext:
+            size: 1
+            offset: 51
+        - src0_bank_ext:
+            size: 1
+            offset: 50
+        - src1_bank_ext:
+            size: 1
+            offset: 49
+        - src2_bank_ext:
+            size: 1
+            offset: 48
+        - mask_count:
+            size: 4
+            offset: 44
+        - addr_mode:
             size: 2
-            type: SpecialCategory
+            offset: 42
+        - mode:
+            size: 2
+            offset: 40
+        - dest_bank_primattr:
+            size: 1
+            offset: 39
+        - range_enable:
+            size: 1
+            offset: 38
+        - data_type:
+            size: 2
+            offset: 36
+        - increment_or_decrement:
+            size: 1
+            offset: 35
+        - src0_bank:
+            size: 1
+            offset: 34
+        - cache_by_pass12:
+            size: 1
+            offset: 33
+        - drc_sel:
+            size: 1
+            offset: 32
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - dest_n:
+            size: 7
+            offset: 21
+        - src0_n:
+            size: 7
+            offset: 14
+        - src1_n:
+            size: 7
+            offset: 7
+        - src2_n:
+            size: 7
+            offset: 0

--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -177,11 +177,8 @@ public:
         return m_second_program;
     }
 
-    //
-    // Instructions
-    //
-    bool vmov(
-        ExtPredicate pred,
+    // Instructions start
+    bool vmov(ExtPredicate pred,
         bool skipinv,
         Imm1 test_bit_2,
         Imm1 src0_comp_sel,
@@ -206,8 +203,7 @@ public:
         Imm6 src1_n,
         Imm6 src2_n);
 
-    bool vmad(
-        ExtPredicate pred,
+    bool vmad(ExtPredicate pred,
         Imm1 skipinv,
         Imm1 gpi1_swiz_ext,
         Imm1 opcode2,
@@ -236,8 +232,7 @@ public:
         Imm4 src0_swiz,
         Imm6 src0_n);
 
-    bool vmad2(
-        Imm1 dat_fmt,
+    bool vmad2(Imm1 dat_fmt,
         Imm2 pred,
         Imm1 skipinv,
         Imm1 src0_swiz_bits2,
@@ -262,8 +257,7 @@ public:
         Imm6 src1_n,
         Imm6 src2_n);
 
-    bool vnmad32(
-        ExtPredicate pred,
+    bool vnmad32(ExtPredicate pred,
         bool skipinv,
         Imm2 src1_swiz_10_11,
         bool syncstart,
@@ -286,8 +280,7 @@ public:
         Imm6 src1_n,
         Imm6 src2_n);
 
-    bool vnmad16(
-        ExtPredicate pred,
+    bool vnmad16(ExtPredicate pred,
         bool skipinv,
         Imm2 src1_swiz_10_11,
         bool syncstart,
@@ -310,8 +303,33 @@ public:
         Imm6 src1_n,
         Imm6 src2_n);
 
-    bool sop2(
-        Imm2 pred,
+    bool vpck(ExtPredicate pred,
+        bool skipinv,
+        bool nosched,
+        Imm1 unknown,
+        bool syncstart,
+        Imm1 dest_bank_ext,
+        Imm1 end,
+        Imm1 src1_bank_ext,
+        Imm1 src2_bank_ext,
+        RepeatCount repeat_count,
+        Imm3 src_fmt,
+        Imm3 dest_fmt,
+        Imm4 dest_mask,
+        Imm2 dest_bank_sel,
+        Imm2 src1_bank_sel,
+        Imm2 src2_bank_sel,
+        Imm7 dest_n,
+        Imm2 comp_sel_3,
+        Imm1 scale,
+        Imm2 comp_sel_1,
+        Imm2 comp_sel_2,
+        Imm6 src1_n,
+        Imm1 comp0_sel_bit1,
+        Imm6 src2_n,
+        Imm1 comp_sel_0_bit0);
+
+    bool sop2(Imm2 pred,
         Imm1 cmod1,
         Imm1 skipinv,
         Imm1 nosched,
@@ -339,146 +357,7 @@ public:
         Imm7 src1_n,
         Imm7 src2_n);
 
-    bool vpck(
-        ExtPredicate pred,
-        bool skipinv,
-        bool nosched,
-        Imm1 unknown,
-        bool syncstart,
-        Imm1 dest_bank_ext,
-        Imm1 end,
-        Imm1 src1_bank_ext,
-        Imm1 src2_bank_ext,
-        RepeatCount repeat_count,
-        Imm3 src_fmt,
-        Imm3 dest_fmt,
-        Imm4 dest_mask,
-        Imm2 dest_bank_sel,
-        Imm2 src1_bank_sel,
-        Imm2 src2_bank_sel,
-        Imm7 dest_n,
-        Imm2 comp_sel_3,
-        Imm1 scale,
-        Imm2 comp_sel_1,
-        Imm2 comp_sel_2,
-        Imm6 src1_n,
-        Imm1 comp0_sel_bit1,
-        Imm6 src2_n,
-        Imm1 comp_sel_0_bit0);
-
-    bool vbw(
-        Imm3 op1,
-        ExtPredicate pred,
-        Imm1 skipinv,
-        Imm1 nosched,
-        bool repeat_sel,
-        Imm1 sync_start,
-        Imm1 dest_ext,
-        Imm1 end,
-        Imm1 src1_ext,
-        Imm1 src2_ext,
-        RepeatCount repeat_count,
-        Imm1 src2_invert,
-        Imm5 src2_rot,
-        Imm2 src2_exth,
-        Imm1 op2,
-        Imm1 bitwise_partial,
-        Imm2 dest_bank,
-        Imm2 src1_bank,
-        Imm2 src2_bank,
-        Imm7 dest_n,
-        Imm7 src2_sel,
-        Imm7 src1_n,
-        Imm7 src2_n);
-
-    bool vcomp(
-        ExtPredicate pred,
-        bool skipinv,
-        Imm2 dest_type,
-        bool syncstart,
-        bool dest_bank_ext,
-        bool end,
-        bool src1_bank_ext,
-        RepeatCount repeat_count,
-        bool nosched,
-        Imm2 op2,
-        Imm2 src_type,
-        Imm2 src1_mod,
-        Imm2 src_comp,
-        Imm2 dest_bank,
-        Imm2 src1_bank,
-        Imm7 dest_n,
-        Imm7 src1_n,
-        Imm4 write_mask);
-
-    bool vdp(
-        ExtPredicate pred,
-        Imm1 skipinv,
-        bool clip_plane_enable,
-        Imm1 opcode2,
-        Imm1 dest_use_bank_ext,
-        Imm1 end,
-        Imm1 src0_bank_ext,
-        Imm2 increment_mode,
-        Imm1 gpi0_abs,
-        RepeatCount repeat_count,
-        bool nosched,
-        Imm4 write_mask,
-        Imm1 src0_neg,
-        Imm1 src0_abs,
-        Imm3 clip_plane_n,
-        Imm2 dest_bank,
-        Imm2 src0_bank,
-        Imm2 gpi0_n,
-        Imm6 dest_n,
-        Imm4 gpi0_swiz,
-        Imm3 src0_swiz_w,
-        Imm3 src0_swiz_z,
-        Imm3 src0_swiz_y,
-        Imm3 src0_swiz_x,
-        Imm6 src0_n);
-
-    bool br(
-        ExtPredicate pred,
-        Imm1 syncend,
-        bool exception,
-        bool pwait,
-        Imm1 sync_ext,
-        bool nosched,
-        bool br_monitor,
-        bool save_link,
-        Imm1 br_type,
-        Imm1 any_inst,
-        Imm1 all_inst,
-        std::uint32_t br_off);
-
-    bool smp(
-        ExtPredicate pred,
-        Imm1 skipinv,
-        Imm1 nosched,
-        Imm1 syncstart,
-        Imm1 minpack,
-        Imm1 src0_ext,
-        Imm1 src1_ext,
-        Imm1 src2_ext,
-        Imm2 fconv_type,
-        Imm2 mask_count,
-        Imm2 dim,
-        Imm2 lod_mode,
-        bool dest_use_pa,
-        Imm2 sb_mode,
-        Imm2 src0_type,
-        Imm1 src0_bank,
-        Imm2 drc_sel,
-        Imm2 src1_bank,
-        Imm2 src2_bank,
-        Imm7 dest_n,
-        Imm7 src0_n,
-        Imm7 src1_n,
-        Imm7 src2_n);
-
-    bool vtst(
-        ExtPredicate pred,
+    bool vtst(ExtPredicate pred,
         Imm1 skipinv,
         Imm1 onceonly,
         Imm1 syncstart,
@@ -504,8 +383,7 @@ public:
         Imm7 src1_n,
         Imm7 src2_n);
 
-    bool vtstmsk(
-        Imm3 pred,
+    bool vtstmsk(ExtPredicate pred,
         Imm1 skipinv,
         Imm1 onceonly,
         Imm1 syncstart,
@@ -530,8 +408,86 @@ public:
         Imm7 src1_n,
         Imm7 src2_n);
 
-    bool smlsi(
+    bool vbw(Imm3 op1,
+        ExtPredicate pred,
+        Imm1 skipinv,
         Imm1 nosched,
+        bool repeat_sel,
+        Imm1 sync_start,
+        Imm1 dest_ext,
+        Imm1 end,
+        Imm1 src1_ext,
+        Imm1 src2_ext,
+        RepeatCount repeat_count,
+        Imm1 src2_invert,
+        Imm5 src2_rot,
+        Imm2 src2_exth,
+        Imm1 op2,
+        Imm1 bitwise_partial,
+        Imm2 dest_bank,
+        Imm2 src1_bank,
+        Imm2 src2_bank,
+        Imm7 dest_n,
+        Imm7 src2_sel,
+        Imm7 src1_n,
+        Imm7 src2_n);
+
+    bool phas(Imm1 sprvv,
+        Imm1 end,
+        Imm1 imm,
+        Imm1 src1_bank_ext,
+        Imm1 src2_bank_ext,
+        Imm1 mode,
+        Imm1 rate_hi,
+        Imm1 rate_lo_or_nosched,
+        Imm3 wait_cond,
+        Imm8 temp_count,
+        Imm2 src1_bank,
+        Imm2 src2_bank,
+        Imm6 exe_addr_high,
+        Imm7 src1_n_or_exe_addr_mid,
+        Imm7 src2_n_or_exe_addr_low);
+
+    bool nop();
+
+    bool br(ExtPredicate pred,
+        Imm1 syncend,
+        bool exception,
+        bool pwait,
+        Imm1 sync_ext,
+        bool nosched,
+        bool br_monitor,
+        bool save_link,
+        Imm1 br_type,
+        Imm1 any_inst,
+        Imm1 all_inst,
+        uint32_t br_off);
+
+    bool smp(ExtPredicate pred,
+        Imm1 skipinv,
+        Imm1 nosched,
+        Imm1 syncstart,
+        Imm1 minpack,
+        Imm1 src0_ext,
+        Imm1 src1_ext,
+        Imm1 src2_ext,
+        Imm2 fconv_type,
+        Imm2 mask_count,
+        Imm2 dim,
+        Imm2 lod_mode,
+        bool dest_use_pa,
+        Imm2 sb_mode,
+        Imm2 src0_type,
+        Imm1 src0_bank,
+        Imm2 drc_sel,
+        Imm2 src1_bank,
+        Imm2 src2_bank,
+        Imm7 dest_n,
+        Imm7 src0_n,
+        Imm7 src1_n,
+        Imm7 src2_n);
+
+    bool smlsi(Imm1 nosched,
         Imm4 temp_limit,
         Imm4 pa_limit,
         Imm4 sa_limit,
@@ -544,8 +500,57 @@ public:
         Imm8 src1_inc,
         Imm8 src2_inc);
 
-    bool vdual(
-        Imm1 comp_count_type,
+    bool kill(ShortPredicate pred);
+
+    bool spec(bool special,
+        SpecialCategory category);
+
+    bool vcomp(ExtPredicate pred,
+        bool skipinv,
+        Imm2 dest_type,
+        bool syncstart,
+        bool dest_bank_ext,
+        bool end,
+        bool src1_bank_ext,
+        RepeatCount repeat_count,
+        bool nosched,
+        Imm2 op2,
+        Imm2 src_type,
+        Imm2 src1_mod,
+        Imm2 src_comp,
+        Imm2 dest_bank,
+        Imm2 src1_bank,
+        Imm7 dest_n,
+        Imm7 src1_n,
+        Imm4 write_mask);
+
+    bool vdp(ExtPredicate pred,
+        Imm1 skipinv,
+        bool clip_plane_enable,
+        Imm1 opcode2,
+        Imm1 dest_use_bank_ext,
+        Imm1 end,
+        Imm1 src0_bank_ext,
+        Imm2 increment_mode,
+        Imm1 gpi0_abs,
+        RepeatCount repeat_count,
+        bool nosched,
+        Imm4 write_mask,
+        Imm1 src0_neg,
+        Imm1 src0_abs,
+        Imm3 clip_plane_n,
+        Imm2 dest_bank,
+        Imm2 src0_bank,
+        Imm2 gpi0_n,
+        Imm6 dest_n,
+        Imm4 gpi0_swiz,
+        Imm3 src0_swiz_w,
+        Imm3 src0_swiz_z,
+        Imm3 src0_swiz_y,
+        Imm3 src0_swiz_x,
+        Imm6 src0_n);
+
+    bool vdual(Imm1 comp_count_type,
         Imm1 gpi1_neg,
         Imm2 sv_pred,
         Imm1 skipinv,
@@ -572,8 +577,7 @@ public:
         Imm3 write_mask_non_gpi,
         Imm7 unified_store_slot_num);
 
-    bool vldst(
-        Imm2 op1,
+    bool vldst(Imm2 op1,
         ExtPredicate pred,
         Imm1 skipinv,
         Imm1 nosched,
@@ -599,16 +603,7 @@ public:
         Imm7 src0_n,
         Imm7 src1_n,
         Imm7 src2_n);
-
-    bool nop();
-    bool phas();
-
-    bool spec(
-        bool special,
-        SpecialCategory category);
-
-    bool kill(ShortPredicate pred);
-
+    // Instructions end
 private:
     // SPIR-V emitter
     spv::Builder &m_b;

--- a/vita3k/shader/src/translator/branch_cond.cpp
+++ b/vita3k/shader/src/translator/branch_cond.cpp
@@ -312,7 +312,7 @@ bool USSETranslatorVisitor::vtst(
 }
 
 bool USSETranslatorVisitor::vtstmsk(
-    Imm3 pred,
+    ExtPredicate pred,
     Imm1 skipinv,
     Imm1 onceonly,
     Imm1 syncstart,
@@ -352,7 +352,7 @@ bool USSETranslatorVisitor::br(
     Imm1 br_type,
     Imm1 any_inst,
     Imm1 all_inst,
-    std::uint32_t br_off) {
+    uint32_t br_off) {
     Opcode op = (br_type == 0) ? Opcode::BA : Opcode::BR;
 
     if (op == Opcode::BR && (br_off & (1 << 19))) {

--- a/vita3k/shader/src/translator/special.cpp
+++ b/vita3k/shader/src/translator/special.cpp
@@ -28,7 +28,22 @@
 using namespace shader;
 using namespace usse;
 
-bool USSETranslatorVisitor::phas() {
+bool USSETranslatorVisitor::phas(
+    Imm1 sprvv,
+    Imm1 end,
+    Imm1 imm,
+    Imm1 src1_bank_ext,
+    Imm1 src2_bank_ext,
+    Imm1 mode,
+    Imm1 rate_hi,
+    Imm1 rate_lo_or_nosched,
+    Imm3 wait_cond,
+    Imm8 temp_count,
+    Imm2 src1_bank,
+    Imm2 src2_bank,
+    Imm6 exe_addr_high,
+    Imm7 src1_n_or_exe_addr_mid,
+    Imm7 src2_n_or_exe_addr_low) {
     LOG_DISASM("{:016x}: PHAS", m_instr);
     return true;
 }

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -39,560 +39,558 @@ boost::optional<const USSEMatcher<V> &> DecodeUSSE(uint64_t instruction) {
     static const std::vector<USSEMatcher<V>> table = {
 #define INST(fn, name, bitstring) shader::decoder::detail::detail<USSEMatcher<V>>::GetMatcher(fn, name, bitstring)
         // clang-format off
-
         // Vector move
         /*
-                              00111 = op1
-                                    ppp = pred (3 bits, ExtPredicate)
-                                      s = skipinv (1 bit, bool)
-                                        t = test_bit_2 (1 bit)
-                                        r = src0_comp_sel (1 bit)
-                                          y = syncstart (1 bit, bool)
-                                          d = dest_bank_ext (1 bit)
-                                            e = end_or_src0_bank_ext (1 bit)
-                                            c = src1_bank_ext (1 bit)
-                                              b = src2_bank_ext (1 bit)
-                                              mm = move_type (2 bits, MoveType)
-                                                aa = repeat_count (2 bits, RepeatCount)
-                                                  n = nosched (1 bit, bool)
-                                                    ooo = move_data_type (3 bits, MoveDataType)
-                                                      i = test_bit_1 (1 bit)
-                                                        wwww = src0_swiz (4 bits)
-                                                            k = src0_bank_sel (1 bit)
-                                                            ll = dest_bank_sel (2 bits)
-                                                              ff = src1_bank_sel (2 bits)
-                                                                gg = src2_bank_sel (2 bits)
-                                                                  hhhh = dest_mask (4 bits)
-                                                                      jjjjjj = dest_n (6 bits)
-                                                                            qqqqqq = src0_n (6 bits)
-                                                                                  uuuuuu = src1_n (6 bits)
-                                                                                        vvvvvv = src2_n (6 bits)
+                                   00111 = op1
+                                        ppp = pred (3 bits, ExtPredicate)
+                                           s = skipinv (1 bit, bool)
+                                            t = test_bit_2 (1 bit)
+                                             r = src0_comp_sel (1 bit)
+                                              y = syncstart (1 bit, bool)
+                                               d = dest_bank_ext (1 bit)
+                                                e = end_or_src0_bank_ext (1 bit)
+                                                 c = src1_bank_ext (1 bit)
+                                                  b = src2_bank_ext (1 bit)
+                                                   mm = move_type (2 bits, MoveType)
+                                                     aa = repeat_count (2 bits, RepeatCount)
+                                                       n = nosched (1 bit, bool)
+                                                        ooo = move_data_type (3 bits, DataType)
+                                                           i = test_bit_1 (1 bit)
+                                                            wwww = src0_swiz (4 bits)
+                                                                k = src0_bank_sel (1 bit)
+                                                                 ll = dest_bank_sel (2 bits)
+                                                                   ff = src1_bank_sel (2 bits)
+                                                                     gg = src2_bank_sel (2 bits)
+                                                                       hhhh = dest_mask (4 bits)
+                                                                           jjjjjj = dest_n (6 bits)
+                                                                                 qqqqqq = src0_n (6 bits)
+                                                                                       uuuuuu = src1_n (6 bits)
+                                                                                             vvvvvv = src2_n (6 bits)
         */
         INST(&V::vmov, "VMOV ()", "00111pppstrydecbmmaanoooiwwwwkllffgghhhhjjjjjjqqqqqquuuuuuvvvvvv"),
-
         // Vector multiply-add
         /*
-                               00011 = opcode1
-                                    ppp = pred (3 bits, ExtPredicate)
-                                       s = skipinv (1 bit)
-                                        g = gpi1_swiz_ext (1 bit)
-                                         1 = present_bit_1
-                                          o = opcode2 (1 bit)
-                                           d = dest_use_bank_ext (1 bit)
-                                            e = end (1 bit)
-                                             r = src0_bank_ext (1 bit)
-                                              ii = increment_mode (2 bits)
-                                                a = gpi0_abs (1 bit)
-                                                 tt = repeat_count (2 bits, RepeatCount)
-                                                   n = nosched (1 bit, bool)
-                                                    wwww = write_mask (4 bits)
-                                                        c = src0_neg (1 bit)
-                                                         b = src0_abs (1 bit)
-                                                          f = gpi1_neg (1 bit)
-                                                           h = gpi1_abs (1 bit)
-                                                            z = gpi0_swiz_ext (1 bit)
-                                                             kk = dest_bank (2 bits)
-                                                               jj = src0_bank (2 bits)
-                                                                 ll = gpi0_n (2 bits)
-                                                                   mmmmmm = dest_n (6 bits)
-                                                                         qqqq = gpi0_swiz (4 bits)
-                                                                             uuuu = gpi1_swiz (4 bits)
-                                                                                 vv = gpi1_n (2 bits)
-                                                                                   x = gpi0_neg (1 bit)
-                                                                                    y = src0_swiz_ext (1 bit)
-                                                                                     AAAA = src0_swiz (4 bits)
-                                                                                         BBBBBB = src0_n (6 bits)
+                                   00011 = opcode1
+                                        ppp = pred (3 bits, ExtPredicate)
+                                           s = skipinv (1 bit)
+                                            g = gpi1_swiz_ext (1 bit)
+                                             1 = present_bit_1
+                                              o = opcode2 (1 bit)
+                                               d = dest_use_bank_ext (1 bit)
+                                                e = end (1 bit)
+                                                 r = src0_bank_ext (1 bit)
+                                                  ii = increment_mode (2 bits)
+                                                    a = gpi0_abs (1 bit)
+                                                     tt = repeat_count (2 bits, RepeatCount)
+                                                       n = nosched (1 bit, bool)
+                                                        wwww = write_mask (4 bits)
+                                                            c = src0_neg (1 bit)
+                                                             b = src0_abs (1 bit)
+                                                              f = gpi1_neg (1 bit)
+                                                               h = gpi1_abs (1 bit)
+                                                                z = gpi0_swiz_ext (1 bit)
+                                                                 kk = dest_bank (2 bits)
+                                                                   jj = src0_bank (2 bits)
+                                                                     ll = gpi0_n (2 bits)
+                                                                       mmmmmm = dest_n (6 bits)
+                                                                             qqqq = gpi0_swiz (4 bits)
+                                                                                 uuuu = gpi1_swiz (4 bits)
+                                                                                     vv = gpi1_n (2 bits)
+                                                                                       x = gpi0_neg (1 bit)
+                                                                                        y = src0_swiz_ext (1 bit)
+                                                                                         AAAA = src0_swiz (4 bits)
+                                                                                             BBBBBB = src0_n (6 bits)
         */
         INST(&V::vmad, "VMAD ()", "00011pppsg1oderiiattnwwwwcbfhzkkjjllmmmmmmqqqquuuuvvxyAAAABBBBBB"),
-
         // Vector multiply-add (Normal version)
         /*
-                                00000 = opcode1
-                                      d = dat_fmt (1 bit)
-                                      pp = pred (2 bits)
-                                        s = skipinv (1 bit)
-                                          - = don't care
-                                          r = src0_swiz_bits2 (1 bit)
-                                            y = syncstart (1 bit)
-                                            - = don't care
-                                              c = src0_abs (1 bit)
-                                              b = src1_bank_ext (1 bit)
-                                                a = src2_bank_ext (1 bit)
-                                                www = src2_swiz (3 bits)
-                                                    i = src1_swiz_bit2 (1 bit)
-                                                    n = nosched (1 bit)
-                                                      eeee = dest_mask (4 bits)
-                                                          mm = src1_mod (2 bits)
-                                                            oo = src2_mod (2 bits)
-                                                              k = src0_bank (1 bit)
-                                                              tt = dest_bank (2 bits)
-                                                                ff = src1_bank (2 bits)
-                                                                  gg = src2_bank (2 bits)
-                                                                    hhhhhh = dest_n (6 bits)
-                                                                          zz = src1_swiz_bits01 (2 bits)
-                                                                            jj = src0_swiz_bits01 (2 bits)
-                                                                              llllll = src0_n (6 bits)
-                                                                                    qqqqqq = src1_n (6 bits)
-                                                                                          uuuuuu = src2_n (6 bits)
+                                     00000 = opcode1
+                                          d = dat_fmt (1 bit)
+                                           pp = pred (2 bits)
+                                             s = skipinv (1 bit)
+                                              - = don't care
+                                               r = src0_swiz_bits2 (1 bit)
+                                                y = syncstart (1 bit)
+                                                 - = don't care
+                                                  c = src0_abs (1 bit)
+                                                   b = src1_bank_ext (1 bit)
+                                                    a = src2_bank_ext (1 bit)
+                                                     www = src2_swiz (3 bits)
+                                                        i = src1_swiz_bit2 (1 bit)
+                                                         n = nosched (1 bit)
+                                                          eeee = dest_mask (4 bits)
+                                                              mm = src1_mod (2 bits)
+                                                                oo = src2_mod (2 bits)
+                                                                  k = src0_bank (1 bit)
+                                                                   tt = dest_bank (2 bits)
+                                                                     ff = src1_bank (2 bits)
+                                                                       gg = src2_bank (2 bits)
+                                                                         hhhhhh = dest_n (6 bits)
+                                                                               zz = src1_swiz_bits01 (2 bits)
+                                                                                 jj = src0_swiz_bits01 (2 bits)
+                                                                                   llllll = src0_n (6 bits)
+                                                                                         qqqqqq = src1_n (6 bits)
+                                                                                               uuuuuu = src2_n (6 bits)
         */
         INST(&V::vmad2, "VMAD2 ()", "00000dpps-ry-cbawwwineeeemmookttffgghhhhhhzzjjllllllqqqqqquuuuuu"),
-
         // Vector operations except for MAD (F32)
         /*
-                                     00001 = opcode1
-                                          ppp = pred (3 bits, ExtPredicate)
-                                             s = skipinv (1 bit, bool)
-                                              rr = src1_swiz_10_11 (2 bits)
-                                                y = syncstart (1 bit, bool)
-                                                 d = dest_bank_ext (1 bit)
-                                                  c = src1_swiz_9 (1 bit)
-                                                   b = src1_bank_ext (1 bit)
-                                                    a = src2_bank_ext (1 bit)
-                                                     wwww = src2_swiz (4 bits)
-                                                         n = nosched (1 bit, bool)
-                                                          eeee = dest_mask (4 bits)
-                                                              mm = src1_mod (2 bits)
-                                                                o = src2_mod (1 bit)
-                                                                 ii = src1_swiz_7_8 (2 bits)
-                                                                   tt = dest_bank_sel (2 bits)
-                                                                     kk = src1_bank_sel (2 bits)
-                                                                       ll = src2_bank_sel (2 bits)
-                                                                         ffffff = dest_n (6 bits)
-                                                                               zzzzzzz = src1_swiz_0_6 (7 bits)
-                                                                                      ggg = op2 (3 bits)
-                                                                                         hhhhhh = src1_n (6 bits)
-                                                                                               jjjjjj = src2_n (6 bits)
+                                         00001 = opcode1
+                                              ppp = pred (3 bits, ExtPredicate)
+                                                 s = skipinv (1 bit, bool)
+                                                  rr = src1_swiz_10_11 (2 bits)
+                                                    y = syncstart (1 bit, bool)
+                                                     d = dest_bank_ext (1 bit)
+                                                      c = src1_swiz_9 (1 bit)
+                                                       b = src1_bank_ext (1 bit)
+                                                        a = src2_bank_ext (1 bit)
+                                                         wwww = src2_swiz (4 bits)
+                                                             n = nosched (1 bit, bool)
+                                                              eeee = dest_mask (4 bits)
+                                                                  mm = src1_mod (2 bits)
+                                                                    o = src2_mod (1 bit)
+                                                                     ii = src1_swiz_7_8 (2 bits)
+                                                                       tt = dest_bank_sel (2 bits)
+                                                                         kk = src1_bank_sel (2 bits)
+                                                                           ll = src2_bank_sel (2 bits)
+                                                                             ffffff = dest_n (6 bits)
+                                                                                   zzzzzzz = src1_swiz_0_6 (7 bits)
+                                                                                          ggg = op2 (3 bits)
+                                                                                             hhhhhh = src1_n (6 bits)
+                                                                                                   jjjjjj = src2_n (6 bits)
         */
         INST(&V::vnmad32, "VNMAD32 ()", "00001pppsrrydcbawwwwneeeemmoiittkkllffffffzzzzzzzggghhhhhhjjjjjj"),
-
         // Vector operations except for MAD (F16)
         /*
-                                     00010 = opcode1
-                                          ppp = pred (3 bits, ExtPredicate)
-                                             s = skipinv (1 bit, bool)
-                                              rr = src1_swiz_10_11 (2 bits)
-                                                y = syncstart (1 bit, bool)
-                                                 d = dest_bank_ext (1 bit)
-                                                  c = src1_swiz_9 (1 bit)
-                                                   b = src1_bank_ext (1 bit)
-                                                    a = src2_bank_ext (1 bit)
-                                                     wwww = src2_swiz (4 bits)
-                                                         n = nosched (1 bit, bool)
-                                                          eeee = dest_mask (4 bits)
-                                                              mm = src1_mod (2 bits)
-                                                                o = src2_mod (1 bit)
-                                                                 ii = src1_swiz_7_8 (2 bits)
-                                                                   tt = dest_bank_sel (2 bits)
-                                                                     kk = src1_bank_sel (2 bits)
-                                                                       ll = src2_bank_sel (2 bits)
-                                                                         ffffff = dest_n (6 bits)
-                                                                               zzzzzzz = src1_swiz_0_6 (7 bits)
-                                                                                      ggg = op2 (3 bits)
-                                                                                         hhhhhh = src1_n (6 bits)
-                                                                                               jjjjjj = src2_n (6 bits)
+                                         00010 = opcode1
+                                              ppp = pred (3 bits, ExtPredicate)
+                                                 s = skipinv (1 bit, bool)
+                                                  rr = src1_swiz_10_11 (2 bits)
+                                                    y = syncstart (1 bit, bool)
+                                                     d = dest_bank_ext (1 bit)
+                                                      c = src1_swiz_9 (1 bit)
+                                                       b = src1_bank_ext (1 bit)
+                                                        a = src2_bank_ext (1 bit)
+                                                         wwww = src2_swiz (4 bits)
+                                                             n = nosched (1 bit, bool)
+                                                              eeee = dest_mask (4 bits)
+                                                                  mm = src1_mod (2 bits)
+                                                                    o = src2_mod (1 bit)
+                                                                     ii = src1_swiz_7_8 (2 bits)
+                                                                       tt = dest_bank_sel (2 bits)
+                                                                         kk = src1_bank_sel (2 bits)
+                                                                           ll = src2_bank_sel (2 bits)
+                                                                             ffffff = dest_n (6 bits)
+                                                                                   zzzzzzz = src1_swiz_0_6 (7 bits)
+                                                                                          ggg = op2 (3 bits)
+                                                                                             hhhhhh = src1_n (6 bits)
+                                                                                                   jjjjjj = src2_n (6 bits)
         */
         INST(&V::vnmad16, "VNMAD16 ()", "00010pppsrrydcbawwwwneeeemmoiittkkllffffffzzzzzzzggghhhhhhjjjjjj"),
-
         // Vector pack/unpack
         /*
-                              01000 = op1
-                                    ppp = pred (3 bits, ExtPredicate)
-                                      s = skipinv (1 bit, bool)
-                                        n = nosched (1 bit, bool)
-                                        u = unknown (1 bit)
-                                          y = syncstart (1 bit, bool)
-                                          d = dest_bank_ext (1 bit)
-                                            e = end (1 bit)
-                                            r = src1_bank_ext (1 bit)
-                                              c = src2_bank_ext (1 bit)
-                                              - = don't care
-                                                aaa = repeat_count (3 bits, RepeatCount)
-                                                  fff = src_fmt (3 bits)
-                                                      ttt = dest_fmt (3 bits)
-                                                        mmmm = dest_mask (4 bits)
-                                                            bb = dest_bank_sel (2 bits)
-                                                              kk = src1_bank_sel (2 bits)
-                                                                ll = src2_bank_sel (2 bits)
-                                                                  ggggggg = dest_n (7 bits)
-                                                                          oo = comp_sel_3 (2 bits)
-                                                                            h = scale (1 bit)
-                                                                            ii = comp_sel_1 (2 bits)
-                                                                              jj = comp_sel_2 (2 bits)
-                                                                                qqqqqq = src1_n (6 bits)
-                                                                                      v = comp0_sel_bit1 (1 bit)
-                                                                                        wwwwww = src2_n (6 bits)
-                                                                                              x = comp_sel_0_bit0 (1 bit)
+                                   01000 = op1
+                                        ppp = pred (3 bits, ExtPredicate)
+                                           s = skipinv (1 bit, bool)
+                                            n = nosched (1 bit, bool)
+                                             u = unknown (1 bit)
+                                              y = syncstart (1 bit, bool)
+                                               d = dest_bank_ext (1 bit)
+                                                e = end (1 bit)
+                                                 r = src1_bank_ext (1 bit)
+                                                  c = src2_bank_ext (1 bit)
+                                                   - = don't care
+                                                    aaa = repeat_count (3 bits, RepeatCount)
+                                                       fff = src_fmt (3 bits)
+                                                          ttt = dest_fmt (3 bits)
+                                                             mmmm = dest_mask (4 bits)
+                                                                 bb = dest_bank_sel (2 bits)
+                                                                   kk = src1_bank_sel (2 bits)
+                                                                     ll = src2_bank_sel (2 bits)
+                                                                       ggggggg = dest_n (7 bits)
+                                                                              oo = comp_sel_3 (2 bits)
+                                                                                h = scale (1 bit)
+                                                                                 ii = comp_sel_1 (2 bits)
+                                                                                   jj = comp_sel_2 (2 bits)
+                                                                                     qqqqqq = src1_n (6 bits)
+                                                                                           v = comp0_sel_bit1 (1 bit)
+                                                                                            wwwwww = src2_n (6 bits)
+                                                                                                  x = comp_sel_0_bit0 (1 bit)
         */
         INST(&V::vpck, "VPCK ()", "01000pppsnuyderc-aaaffftttmmmmbbkkllgggggggoohiijjqqqqqqvwwwwwwx"),
-
         // Sum of Products
         /*
-                              10000 = op1
-                                    pp = pred (2 bits)
-                                      c = cmod1 (1 bit)
-                                      s = skipinv (1 bit)
-                                        n = nosched (1 bit)
-                                        aa = asel1 (2 bits)
-                                          d = dest_bank_ext (1 bit)
-                                            e = end (1 bit)
-                                            r = src1_bank_ext (1 bit)
-                                              b = src2_bank_ext (1 bit)
-                                              m = cmod2 (1 bit)
-                                                ooo = count (3 bits)
-                                                  f = amod1 (1 bit)
-                                                    ll = asel2 (2 bits)
-                                                      ggg = csel1 (3 bits)
-                                                        hhh = csel2 (3 bits)
-                                                            i = amod2 (1 bit)
-                                                            tt = dest_bank (2 bits)
-                                                              kk = src1_bank (2 bits)
-                                                                jj = src2_bank (2 bits)
-                                                                  qqqqqqq = dest_n (7 bits)
-                                                                          u = src1_mod (1 bit)
-                                                                          vv = cop (2 bits)
-                                                                            ww = aop (2 bits)
-                                                                              x = asrc1_mod (1 bit)
-                                                                                y = dest_mod (1 bit)
-                                                                                zzzzzzz = src1_n (7 bits)
-                                                                                        AAAAAAA = src2_n (7 bits)
+                                   10000 = op1
+                                        pp = pred (2 bits)
+                                          c = cmod1 (1 bit)
+                                           s = skipinv (1 bit)
+                                            n = nosched (1 bit)
+                                             aa = asel1 (2 bits)
+                                               d = dest_bank_ext (1 bit)
+                                                e = end (1 bit)
+                                                 r = src1_bank_ext (1 bit)
+                                                  b = src2_bank_ext (1 bit)
+                                                   m = cmod2 (1 bit)
+                                                    ooo = count (3 bits)
+                                                       f = amod1 (1 bit)
+                                                        ll = asel2 (2 bits)
+                                                          ggg = csel1 (3 bits)
+                                                             hhh = csel2 (3 bits)
+                                                                i = amod2 (1 bit)
+                                                                 tt = dest_bank (2 bits)
+                                                                   kk = src1_bank (2 bits)
+                                                                     jj = src2_bank (2 bits)
+                                                                       qqqqqqq = dest_n (7 bits)
+                                                                              u = src1_mod (1 bit)
+                                                                               vv = cop (2 bits)
+                                                                                 ww = aop (2 bits)
+                                                                                   x = asrc1_mod (1 bit)
+                                                                                    y = dest_mod (1 bit)
+                                                                                     zzzzzzz = src1_n (7 bits)
+                                                                                            AAAAAAA = src2_n (7 bits)
         */
         INST(&V::sop2, "SOP2 ()", "10000ppcsnaaderbmooofllggghhhittkkjjqqqqqqquvvwwxyzzzzzzzAAAAAAA"),
-
         // Test Instructions
         /*
-                              01001 = op1
-                                    ppp = pred (3 bits)
-                                      s = skipinv (1 bit)
-                                        - = don't care
-                                        o = onceonly (1 bit)
-                                          y = syncstart (1 bit)
-                                          d = dest_ext (1 bit)
-                                            r = src1_neg (1 bit)
-                                            c = src1_ext (1 bit)
-                                              e = src2_ext (1 bit)
-                                              a = prec (1 bit)
-                                                v = src2_vscomp (1 bit)
-                                                tt = rpt_count (2 bits, RepeatCount)
-                                                  ii = sign_test (2 bits)
-                                                    zz = zero_test (2 bits)
-                                                      m = test_crcomb_and (1 bit)
-                                                        hhh = chan_cc (3 bits)
-                                                          nn = pdst_n (2 bits)
-                                                            bb = dest_bank (2 bits)
-                                                              kk = src1_bank (2 bits)
-                                                                ff = src2_bank (2 bits)
-                                                                  ggggggg = dest_n (7 bits)
-                                                                          w = test_wben (1 bit)
-                                                                          ll = alu_sel (2 bits)
-                                                                            uuuu = alu_op (4 bits)
-                                                                                jjjjjjj = src1_n (7 bits)
-                                                                                        qqqqqqq = src2_n (7 bits)
+                                   01001 = op1
+                                        ppp = pred (3 bits, ExtPredicate)
+                                           s = skipinv (1 bit)
+                                            - = don't care
+                                             o = onceonly (1 bit)
+                                              y = syncstart (1 bit)
+                                               d = dest_ext (1 bit)
+                                                r = src1_neg (1 bit)
+                                                 c = src1_ext (1 bit)
+                                                  e = src2_ext (1 bit)
+                                                   a = prec (1 bit)
+                                                    v = src2_vscomp (1 bit)
+                                                     tt = rpt_count (2 bits, RepeatCount)
+                                                       ii = sign_test (2 bits)
+                                                         zz = zero_test (2 bits)
+                                                           m = test_crcomb_and (1 bit)
+                                                            hhh = chan_cc (3 bits)
+                                                               nn = pdst_n (2 bits)
+                                                                 bb = dest_bank (2 bits)
+                                                                   kk = src1_bank (2 bits)
+                                                                     ff = src2_bank (2 bits)
+                                                                       ggggggg = dest_n (7 bits)
+                                                                              w = test_wben (1 bit)
+                                                                               ll = alu_sel (2 bits)
+                                                                                 uuuu = alu_op (4 bits)
+                                                                                     jjjjjjj = src1_n (7 bits)
+                                                                                            qqqqqqq = src2_n (7 bits)
         */
         INST(&V::vtst, "VTST ()", "01001ppps-oydrceavttiizzmhhhnnbbkkffgggggggwlluuuujjjjjjjqqqqqqq"),
-
         // Test mask Instructions
         /*
-                                    01111 = op1
-                                          ppp = pred (3 bits)
-                                            s = skipinv (1 bit)
-                                              - = don't care
-                                              o = onceonly (1 bit)
-                                                y = syncstart (1 bit)
-                                                d = dest_ext (1 bit)
-                                                  t = test_flag_2 (1 bit)
-                                                  r = src1_ext (1 bit)
-                                                    c = src2_ext (1 bit)
-                                                    e = prec (1 bit)
-                                                      v = src2_vscomp (1 bit)
-                                                      uu = rpt_count (2 bits, RepeatCount)
-                                                        ii = sign_test (2 bits)
-                                                          zz = zero_test (2 bits)
-                                                            m = test_crcomb_and (1 bit)
-                                                              - = don't care
-                                                              aa = tst_mask_type (2 bits)
-                                                                -- = don't care
-                                                                  bb = dest_bank (2 bits)
-                                                                    nn = src1_bank (2 bits)
-                                                                      kk = src2_bank (2 bits)
-                                                                        fffffff = dest_n (7 bits)
-                                                                                w = test_wben (1 bit)
-                                                                                ll = alu_sel (2 bits)
-                                                                                  gggg = alu_op (4 bits)
-                                                                                      hhhhhhh = src1_n (7 bits)
-                                                                                              jjjjjjj = src2_n (7 bits)
+                                         01111 = op1
+                                              ppp = pred (3 bits, ExtPredicate)
+                                                 s = skipinv (1 bit)
+                                                  - = don't care
+                                                   o = onceonly (1 bit)
+                                                    y = syncstart (1 bit)
+                                                     d = dest_ext (1 bit)
+                                                      t = test_flag_2 (1 bit)
+                                                       r = src1_ext (1 bit)
+                                                        c = src2_ext (1 bit)
+                                                         e = prec (1 bit)
+                                                          v = src2_vscomp (1 bit)
+                                                           uu = rpt_count (2 bits, RepeatCount)
+                                                             ii = sign_test (2 bits)
+                                                               zz = zero_test (2 bits)
+                                                                 m = test_crcomb_and (1 bit)
+                                                                  - = don't care
+                                                                   aa = tst_mask_type (2 bits)
+                                                                     -- = don't care
+                                                                       bb = dest_bank (2 bits)
+                                                                         nn = src1_bank (2 bits)
+                                                                           kk = src2_bank (2 bits)
+                                                                             fffffff = dest_n (7 bits)
+                                                                                    w = test_wben (1 bit)
+                                                                                     ll = alu_sel (2 bits)
+                                                                                       gggg = alu_op (4 bits)
+                                                                                           hhhhhhh = src1_n (7 bits)
+                                                                                                  jjjjjjj = src2_n (7 bits)
         */
         INST(&V::vtstmsk, "VTSTMSK ()", "01111ppps-oydtrcevuuiizzm-aa--bbnnkkfffffffwllgggghhhhhhhjjjjjjj"),
-
         // Bitwise Instructions
         /*
-                             01 = op1_cnst
-                               ooo = op1 (3 bits)
-                                  ppp = pred (3 bits)
-                                     s = skipinv (1 bit)
-                                      n = nosched (1 bit)
-                                       r = repeat_sel (1 bit)
-                                        y = sync_start (1 bit)
-                                         d = dest_ext (1 bit)
-                                          e = end (1 bit)
-                                           c = src1_ext (1 bit)
-                                            x = src2_ext (1 bit)
-                                             mmmm = repeat_count (4 bits)
-                                                 i = src2_invert (1 bit)
-                                                  ttttt = src2_rot (5 bits)
-                                                       hh = src2_exth (2 bits)
-                                                         a = op2 (1 bit)
-                                                          b = bitwise_partial (1 bit)
-                                                           kk = dest_bank (2 bits)
-                                                             ff = src1_bank (2 bits)
-                                                               gg = src2_bank (2 bits)
-                                                                 jjjjjjj = dest_n (7 bits)
-                                                                        lllllll = src2_sel (7 bits)
-                                                                               qqqqqqq = src1_n (7 bits)
-                                                                                    uuuuuuu = src2_n (7 bits)
+                                 01 = op1_cnst
+                                   ooo = op1 (3 bits)
+                                      ppp = pred (3 bits, ExtPredicate)
+                                         s = skipinv (1 bit)
+                                          n = nosched (1 bit)
+                                           r = repeat_sel (1 bit, bool)
+                                            y = sync_start (1 bit)
+                                             d = dest_ext (1 bit)
+                                              e = end (1 bit)
+                                               c = src1_ext (1 bit)
+                                                x = src2_ext (1 bit)
+                                                 aaaa = repeat_count (4 bits, RepeatCount)
+                                                     i = src2_invert (1 bit)
+                                                      ttttt = src2_rot (5 bits)
+                                                           hh = src2_exth (2 bits)
+                                                             b = op2 (1 bit)
+                                                              w = bitwise_partial (1 bit)
+                                                               kk = dest_bank (2 bits)
+                                                                 ff = src1_bank (2 bits)
+                                                                   gg = src2_bank (2 bits)
+                                                                     jjjjjjj = dest_n (7 bits)
+                                                                            lllllll = src2_sel (7 bits)
+                                                                                   mmmmmmm = src1_n (7 bits)
+                                                                                          qqqqqqq = src2_n (7 bits)
         */
-        INST(&V::vbw, "VBW ()", "01ooopppsnrydecxmmmmittttthhabkkffggjjjjjjjlllllllqqqqqqquuuuuuu"),
-
+        INST(&V::vbw, "VBW ()", "01ooopppsnrydecxaaaaittttthhbwkkffggjjjjjjjlllllllmmmmmmmqqqqqqq"),
         // Phase
         /*
-                               11111 = op1
-                                    ---- = don't care
-                                        100 = phas
-                                           ---------------------------------------------------- = don't care
+                                   11111 = op1
+                                        010 = op2
+                                           s = sprvv (1 bit)
+                                            100 = phas
+                                               e = end (1 bit)
+                                                i = imm (1 bit)
+                                                 r = src1_bank_ext (1 bit)
+                                                  c = src2_bank_ext (1 bit)
+                                                   -- = don't care
+                                                     m = mode (1 bit)
+                                                      a = rate_hi (1 bit)
+                                                       t = rate_lo_or_nosched (1 bit)
+                                                        www = wait_cond (3 bits)
+                                                           pppppppp = temp_count (8 bits)
+                                                                   bb = src1_bank (2 bits)
+                                                                     nn = src2_bank (2 bits)
+                                                                       -------- = don't care
+                                                                               xxxxxx = exe_addr_high (6 bits)
+                                                                                     ooooooo = src1_n_or_exe_addr_mid (7 bits)
+                                                                                            ddddddd = src2_n_or_exe_addr_low (7 bits)
         */
-        INST(&V::phas, "PHAS ()", "11111----100----------------------------------------------------"),
-
+        INST(&V::phas, "PHAS ()", "11111010s100eirc--matwwwppppppppbbnn--------xxxxxxoooooooddddddd"),
         // Nop
         /*
-                            11111 = op1
-                                  ---- = don't care
-                                      0 = opcat_extra
-                                      00 = op2_flow_ctrl
-                                        ----------- = don't care
-                                                    101 = nop
-                                                      -------------------------------------- = don't care
+                                 11111 = op1
+                                      ---- = don't care
+                                          0 = opcat_extra
+                                           00 = op2_flow_ctrl
+                                             ----------- = don't care
+                                                        101 = nop
+                                                           -------------------------------------- = don't care
         */
         INST(&V::nop, "NOP ()", "11111----000-----------101--------------------------------------"),
-
         // Branch
         /*
-                          11111 = op1
-                                ppp = pred (3 bits, ExtPredicate)
-                                  s = syncend (1 bit)
-                                    0 = opcat_extra
-                                    00 = op2_flow_ctrl
-                                      e = exception (1 bit, bool)
-                                        ----- = don't care
-                                            w = pwait (1 bit, bool)
-                                              y = sync_ext (1 bit)
-                                              n = nosched (1 bit, bool)
-                                                b = br_monitor (1 bit, bool)
-                                                a = save_link (1 bit, bool)
-                                                  00 = br_op
-                                                    r = br_type (1 bit)
-                                                    ---------------- = don't care
-                                                                    i = any_inst (1 bit)
-                                                                      l = all_inst (1 bit)
-                                                                      oooooooooooooooooooo = br_off (20 bits)
+                               11111 = op1
+                                    ppp = pred (3 bits, ExtPredicate)
+                                       s = syncend (1 bit)
+                                        0 = opcat_extra
+                                         00 = op2_flow_ctrl
+                                           e = exception (1 bit, bool)
+                                            ----- = don't care
+                                                 w = pwait (1 bit, bool)
+                                                  y = sync_ext (1 bit)
+                                                   n = nosched (1 bit, bool)
+                                                    b = br_monitor (1 bit, bool)
+                                                     a = save_link (1 bit, bool)
+                                                      00 = br_op
+                                                        r = br_type (1 bit)
+                                                         ---------------- = don't care
+                                                                         i = any_inst (1 bit)
+                                                                          l = all_inst (1 bit)
+                                                                           oooooooooooooooooooo = br_off (20 bits, uint32_t)
         */
         INST(&V::br, "BR ()", "11111ppps000e-----wynba00r----------------iloooooooooooooooooooo"),
-
         // Sample Instructions
         /*
-                            11100 = op1
-                                  ppp = pred (3 bits, ExtPredicate)
-                                    s = skipinv (1 bit)
-                                      n = nosched (1 bit)
-                                      - = don't care
-                                        y = syncstart (1 bit)
-                                        m = minpack (1 bit)
-                                          r = src0_ext (1 bit)
-                                          c = src1_ext (1 bit)
-                                            e = src2_ext (1 bit)
-                                            ff = fconv_type (2 bits)
-                                              aa = mask_count (2 bits)
-                                                dd = dim (2 bits)
-                                                  ll = lod_mode (2 bits)
-                                                    t = dest_use_pa (1 bit, bool)
-                                                      bb = sb_mode (2 bits)
-                                                        gg = src0_type (2 bits)
-                                                          k = src0_bank (1 bit)
-                                                          hh = drc_sel (2 bits)
-                                                            ii = src1_bank (2 bits)
-                                                              jj = src2_bank (2 bits)
-                                                                ooooooo = dest_n (7 bits)
-                                                                        qqqqqqq = src0_n (7 bits)
-                                                                              uuuuuuu = src1_n (7 bits)
-                                                                                      vvvvvvv = src2_n (7 bits)
+                                 11100 = op1
+                                      ppp = pred (3 bits, ExtPredicate)
+                                         s = skipinv (1 bit)
+                                          n = nosched (1 bit)
+                                           - = don't care
+                                            y = syncstart (1 bit)
+                                             m = minpack (1 bit)
+                                              r = src0_ext (1 bit)
+                                               c = src1_ext (1 bit)
+                                                e = src2_ext (1 bit)
+                                                 ff = fconv_type (2 bits)
+                                                   aa = mask_count (2 bits)
+                                                     dd = dim (2 bits)
+                                                       ll = lod_mode (2 bits)
+                                                         t = dest_use_pa (1 bit, bool)
+                                                          bb = sb_mode (2 bits)
+                                                            gg = src0_type (2 bits)
+                                                              k = src0_bank (1 bit)
+                                                               hh = drc_sel (2 bits)
+                                                                 ii = src1_bank (2 bits)
+                                                                   jj = src2_bank (2 bits)
+                                                                     ooooooo = dest_n (7 bits)
+                                                                            qqqqqqq = src0_n (7 bits)
+                                                                                   uuuuuuu = src1_n (7 bits)
+                                                                                          vvvvvvv = src2_n (7 bits)
         */
         INST(&V::smp, "SMP ()", "11100pppsn-ymrceffaaddlltbbggkhhiijjoooooooqqqqqqquuuuuuuvvvvvvv"),
-
         // SMLSI control instruction
         /*
-                                11111 = op1
-                                      010 = op2
-                                        -- = don't care
-                                          01 = opcat
-                                            - = don't care
-                                              n = nosched (1 bit)
-                                              -- = don't care
-                                                tttt = temp_limit (4 bits)
-                                                    pppp = pa_limit (4 bits)
-                                                        ssss = sa_limit (4 bits)
-                                                            d = dest_inc_mode (1 bit)
-                                                              r = src0_inc_mode (1 bit)
-                                                              c = src1_inc_mode (1 bit)
-                                                                i = src2_inc_mode (1 bit)
-                                                                eeeeeeee = dest_inc (8 bits)
-                                                                        aaaaaaaa = src0_inc (8 bits)
-                                                                                bbbbbbbb = src1_inc (8 bits)
-                                                                                        ffffffff = src2_inc (8 bits)
+                                     11111 = op1
+                                          010 = op2
+                                             -- = don't care
+                                               01 = opcat
+                                                 - = don't care
+                                                  n = nosched (1 bit)
+                                                   -- = don't care
+                                                     tttt = temp_limit (4 bits)
+                                                         pppp = pa_limit (4 bits)
+                                                             ssss = sa_limit (4 bits)
+                                                                 d = dest_inc_mode (1 bit)
+                                                                  r = src0_inc_mode (1 bit)
+                                                                   c = src1_inc_mode (1 bit)
+                                                                    i = src2_inc_mode (1 bit)
+                                                                     eeeeeeee = dest_inc (8 bits)
+                                                                             aaaaaaaa = src0_inc (8 bits)
+                                                                                     bbbbbbbb = src1_inc (8 bits)
+                                                                                             ffffffff = src2_inc (8 bits)
         */
         INST(&V::smlsi, "SMLSI ()", "11111010--01-n--ttttppppssssdrcieeeeeeeeaaaaaaaabbbbbbbbffffffff"),
         // Kill program
         /*
-                           11111 = op1
-                                001 = op2
-                                   -- = don't care
-                                     11 = opcat
-                                       000000000 = kill
-                                                pp = pred (2 bits, ShortPredicate)
-                                                  00000011011110000000000000000000000000000 = kill2
+                                   11111 = op1
+                                        001 = op2
+                                           -- = don't care
+                                             11 = opcat
+                                               000000000 = kill
+                                                        pp = pred (2 bits, ShortPredicate)
+                                                          0000001101111 = kill2
+                                                                       ---------------------------- = don't care
         */
-        INST(&V::kill, "KILL ()", "11111001--11000000000pp00000011011110000000000000000000000000000"),
+        INST(&V::kill, "KILL ()", "11111001--11000000000pp0000001101111----------------------------"),
         // Special
         /*
-                               11111 = op1
-                                    ---- = don't care
-                                        s = special (1 bit, bool)
-                                         cc = category (2 bits, SpecialCategory)
-                                           ---------------------------------------------------- = don't care
+                                   11111 = op1
+                                        ---- = don't care
+                                            s = special (1 bit, bool)
+                                             cc = category (2 bits, SpecialCategory)
+                                               ---------------------------------------------------- = don't care
         */
         INST(&V::spec, "SPEC ()", "11111----scc----------------------------------------------------"),
-
         // Vector Complex Instructions
         /*
-                                00110 = op1
-                                      ppp = pred (3 bits, ExtPredicate)
-                                        s = skipinv (1 bit, bool)
-                                          dd = dest_type (2 bits)
-                                            y = syncstart (1 bit, bool)
-                                            e = dest_bank_ext (1 bit, bool)
-                                              n = end (1 bit, bool)
-                                              r = src1_bank_ext (1 bit, bool)
-                                                - = don't care
-                                                aaaa = repeat_count (4 bits, RepeatCount)
-                                                    o = nosched (1 bit, bool)
-                                                      bb = op2 (2 bits)
-                                                        cc = src_type (2 bits)
-                                                          mm = src1_mod (2 bits)
-                                                            ff = src_comp (2 bits)
-                                                              - = don't care
-                                                              tt = dest_bank (2 bits)
-                                                                kk = src1_bank (2 bits)
-                                                                  -- = don't care
-                                                                    ggggggg = dest_n (7 bits)
-                                                                            -------- = don't care
-                                                                                    hhhhhhh = src1_n (7 bits)
-                                                                                          --- = don't care
-                                                                                            wwww = write_mask (4 bits)
+                                     00110 = op1
+                                          ppp = pred (3 bits, ExtPredicate)
+                                             s = skipinv (1 bit, bool)
+                                              dd = dest_type (2 bits)
+                                                y = syncstart (1 bit, bool)
+                                                 e = dest_bank_ext (1 bit, bool)
+                                                  n = end (1 bit, bool)
+                                                   r = src1_bank_ext (1 bit, bool)
+                                                    - = don't care
+                                                     aaaa = repeat_count (4 bits, RepeatCount)
+                                                         o = nosched (1 bit, bool)
+                                                          bb = op2 (2 bits)
+                                                            cc = src_type (2 bits)
+                                                              mm = src1_mod (2 bits)
+                                                                ff = src_comp (2 bits)
+                                                                  - = don't care
+                                                                   tt = dest_bank (2 bits)
+                                                                     kk = src1_bank (2 bits)
+                                                                       -- = don't care
+                                                                         ggggggg = dest_n (7 bits)
+                                                                                ------- = don't care
+                                                                                       hhhhhhh = src1_n (7 bits)
+                                                                                              --- = don't care
+                                                                                                 wwww = write_mask (4 bits)
         */
         INST(&V::vcomp, "VCOMP ()", "00110pppsddyenr-aaaaobbccmmff-ttkk--ggggggg-------hhhhhhh---wwww"),
-
         // Vector Dot Product (single issue)
         /*
-                            00011 = opcode1
-                                  ppp = pred (3 bits, ExtPredicate)
-                                    s = skipinv (1 bit)
-                                      c = clip_plane_enable (1 bit, bool)
-                                      0 = present_bit_0
-                                        o = opcode2 (1 bit)
-                                        d = dest_use_bank_ext (1 bit)
-                                          e = end (1 bit)
-                                          r = src0_bank_ext (1 bit)
-                                            ii = increment_mode (2 bits)
-                                              g = gpi0_abs (1 bit)
-                                              aa = repeat_count (2 bits, RepeatCount)
-                                                n = nosched (1 bit, bool)
-                                                  wwww = write_mask (4 bits)
-                                                      b = src0_neg (1 bit)
-                                                      f = src0_abs (1 bit)
-                                                        lll = clip_plane_n (3 bits)
-                                                          tt = dest_bank (2 bits)
-                                                            kk = src0_bank (2 bits)
-                                                              hh = gpi0_n (2 bits)
-                                                                jjjjjj = dest_n (6 bits)
-                                                                      zzzz = gpi0_swiz (4 bits)
-                                                                          mmm = src0_swiz_w (3 bits)
-                                                                              qqq = src0_swiz_z (3 bits)
-                                                                                yyy = src0_swiz_y (3 bits)
-                                                                                    xxx = src0_swiz_x (3 bits)
-                                                                                      uuuuuu = src0_n (6 bits)
+                                 00011 = opcode1
+                                      ppp = pred (3 bits, ExtPredicate)
+                                         s = skipinv (1 bit)
+                                          c = clip_plane_enable (1 bit, bool)
+                                           0 = present_bit_0
+                                            o = opcode2 (1 bit)
+                                             d = dest_use_bank_ext (1 bit)
+                                              e = end (1 bit)
+                                               r = src0_bank_ext (1 bit)
+                                                ii = increment_mode (2 bits)
+                                                  g = gpi0_abs (1 bit)
+                                                   aa = repeat_count (2 bits, RepeatCount)
+                                                     n = nosched (1 bit, bool)
+                                                      wwww = write_mask (4 bits)
+                                                          b = src0_neg (1 bit)
+                                                           f = src0_abs (1 bit)
+                                                            lll = clip_plane_n (3 bits)
+                                                               tt = dest_bank (2 bits)
+                                                                 kk = src0_bank (2 bits)
+                                                                   hh = gpi0_n (2 bits)
+                                                                     jjjjjj = dest_n (6 bits)
+                                                                           zzzz = gpi0_swiz (4 bits)
+                                                                               mmm = src0_swiz_w (3 bits)
+                                                                                  qqq = src0_swiz_z (3 bits)
+                                                                                     yyy = src0_swiz_y (3 bits)
+                                                                                        xxx = src0_swiz_x (3 bits)
+                                                                                           uuuuuu = src0_n (6 bits)
         */
         INST(&V::vdp, "VDP ()", "00011pppsc0oderiigaanwwwwbflllttkkhhjjjjjjzzzzmmmqqqyyyxxxuuuuuu"),
-
         // Dual issue instruction
         /*
-                                 0010 = op1
-                                     c = comp_count_type (1 bit)
-                                      g = gpi1_neg (1 bit)
-                                       ss = sv_pred (2 bits)
-                                         k = skipinv (1 bit)
-                                          d = dual_op1_ext_vec3_or_has_w_vec4 (1 bit)
-                                           t = type_f16 (1 bit, bool)
-                                            p = gpi1_swizz_ext (1 bit)
-                                             uuuu = unified_store_swizz (4 bits)
-                                                 n = unified_store_neg (1 bit)
-                                                  aaa = dual_op1 (3 bits)
-                                                     l = dual_op2_ext (1 bit)
-                                                      r = prim_ustore (1 bit, bool)
-                                                       iiii = gpi0_swizz (4 bits)
-                                                           wwww = gpi1_swizz (4 bits)
-                                                               mm = prim_dest_bank (2 bits)
-                                                                 ff = unified_store_slot_bank (2 bits)
-                                                                   ee = prim_dest_num_gpi_case (2 bits)
-                                                                     bbbbbbb = prim_dest_num (7 bits)
-                                                                            ooo = dual_op2 (3 bits)
-                                                                               hh = src_config (2 bits)
-                                                                                 j = gpi2_slot_num_bit_1 (1 bit)
-                                                                                  q = gpi2_slot_num_bit_0_or_unified_store_abs (1 bit)
-                                                                                   vv = gpi1_slot_num (2 bits)
-                                                                                     xx = gpi0_slot_num (2 bits)
-                                                                                       yyy = write_mask_non_gpi (3 bits)
-                                                                                          zzzzzzz = unified_store_slot_num (7 bits)
+                                     0010 = op1
+                                         c = comp_count_type (1 bit)
+                                          g = gpi1_neg (1 bit)
+                                           ss = sv_pred (2 bits)
+                                             k = skipinv (1 bit)
+                                              d = dual_op1_ext_vec3_or_has_w_vec4 (1 bit)
+                                               t = type_f16 (1 bit, bool)
+                                                p = gpi1_swizz_ext (1 bit)
+                                                 uuuu = unified_store_swizz (4 bits)
+                                                     n = unified_store_neg (1 bit)
+                                                      aaa = dual_op1 (3 bits)
+                                                         l = dual_op2_ext (1 bit)
+                                                          r = prim_ustore (1 bit, bool)
+                                                           iiii = gpi0_swizz (4 bits)
+                                                               wwww = gpi1_swizz (4 bits)
+                                                                   mm = prim_dest_bank (2 bits)
+                                                                     ff = unified_store_slot_bank (2 bits)
+                                                                       ee = prim_dest_num_gpi_case (2 bits)
+                                                                         bbbbbbb = prim_dest_num (7 bits)
+                                                                                ooo = dual_op2 (3 bits)
+                                                                                   hh = src_config (2 bits)
+                                                                                     j = gpi2_slot_num_bit_1 (1 bit)
+                                                                                      q = gpi2_slot_num_bit_0_or_unified_store_abs (1 bit)
+                                                                                       vv = gpi1_slot_num (2 bits)
+                                                                                         xx = gpi0_slot_num (2 bits)
+                                                                                           yyy = write_mask_non_gpi (3 bits)
+                                                                                              zzzzzzz = unified_store_slot_num (7 bits)
         */
         INST(&V::vdual, "VDUAL ()", "0010cgsskdtpuuuunaaalriiiiwwwwmmffeebbbbbbbooohhjqvvxxyyyzzzzzzz"),
-
-      // Load and Store
-      /*
-                                  111 = op1_cnst
-                                      oo = op1 (2 bits)
-                                        ppp = pred (3 bits, ExtPredicate)
-                                          s = skipinv (1 bit)
-                                            n = nosched (1 bit)
-                                            m = moe_expand (1 bit)
-                                              y = sync_start (1 bit)
-                                              c = cache_ext (1 bit)
-                                                r = src0_bank_ext (1 bit)
-                                                b = src1_bank_ext (1 bit)
-                                                  a = src2_bank_ext (1 bit)
-                                                  kkkk = mask_count (4 bits)
-                                                      dd = addr_mode (2 bits)
-                                                        ee = mode (2 bits)
-                                                          t = dest_bank_primattr (1 bit)
-                                                            g = range_enable (1 bit)
-                                                            ff = data_type (2 bits)
-                                                              i = increment_or_decrement (1 bit)
-                                                                h = src0_bank (1 bit)
-                                                                j = cache_by_pass12 (1 bit)
-                                                                  l = drc_sel (1 bit)
-                                                                  qq = src1_bank (2 bits)
-                                                                    uu = src2_bank (2 bits)
-                                                                      vvvvvvv = dest_n (7 bits)
-                                                                              wwwwwww = src0_n (7 bits)
-                                                                                    xxxxxxx = src1_n (7 bits)
-                                                                                            zzzzzzz = src2_n (7 bits)
-      */
-      INST(&V::vldst, "VLDST ()", "111oopppsnmycrbakkkkddeetgffihjlqquuvvvvvvvwwwwwwwxxxxxxxzzzzzzz"),
+        // Load and Store
+        /*
+                                     111 = op1_cnst
+                                        oo = op1 (2 bits)
+                                          ppp = pred (3 bits, ExtPredicate)
+                                             s = skipinv (1 bit)
+                                              n = nosched (1 bit)
+                                               m = moe_expand (1 bit)
+                                                y = sync_start (1 bit)
+                                                 c = cache_ext (1 bit)
+                                                  r = src0_bank_ext (1 bit)
+                                                   b = src1_bank_ext (1 bit)
+                                                    a = src2_bank_ext (1 bit)
+                                                     kkkk = mask_count (4 bits)
+                                                         dd = addr_mode (2 bits)
+                                                           ee = mode (2 bits)
+                                                             t = dest_bank_primattr (1 bit)
+                                                              g = range_enable (1 bit)
+                                                               ff = data_type (2 bits)
+                                                                 i = increment_or_decrement (1 bit)
+                                                                  h = src0_bank (1 bit)
+                                                                   j = cache_by_pass12 (1 bit)
+                                                                    l = drc_sel (1 bit)
+                                                                     qq = src1_bank (2 bits)
+                                                                       uu = src2_bank (2 bits)
+                                                                         vvvvvvv = dest_n (7 bits)
+                                                                                wwwwwww = src0_n (7 bits)
+                                                                                       xxxxxxx = src1_n (7 bits)
+                                                                                              zzzzzzz = src2_n (7 bits)
+        */
+        INST(&V::vldst, "VLDST ()", "111oopppsnmycrbakkkkddeetgffihjlqquuvvvvvvvwwwwwwwxxxxxxxzzzzzzz"),
         // clang-format on
     };
 #undef INST


### PR DESCRIPTION
# About PR

- Move usse-decoder-gen to here
- autogen.py now directly update the actual source code
- Update grammar.yaml to reflect recent changes

# Motivation

It's generally good practice to manage auto-generated code by the tool that generated it. But, another reason is that it's very tiring to edit the bit-field of existing decoder. (after all, the motivation behind usse-decoder-gen was the difficulty of bit-field as I know)

# Words for reviewers

Notice that the function parameters don't change in cpp files (except nop), and the bit fields and the order of matchers don't change in entry.cpp in this PR. 