### PR TITLE
themes: some improvement

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -58,6 +58,7 @@ void draw_ui(GuiState &gui, HostState &host);
 
 void draw_app_context_menu(GuiState &gui, HostState &host);
 void draw_common_dialog(GuiState &gui, HostState &host);
+void draw_information_bar(GuiState &gui);
 void draw_reinstall_dialog(GenericDialogState *status);
 void draw_trophies_unlocked(GuiState &gui, HostState &host);
 void draw_perf_overlay(GuiState &gui, HostState &host);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -173,6 +173,8 @@ struct GuiState {
 
     std::map<std::string, ImGui_Texture> apps_background;
 
+    std::map<std::string, ImU32> information_bar_color;
+
     std::map<std::string, std::map<std::string, ImGui_Texture>> live_area_contents;
     std::map<std::string, std::map<std::string, std::map<std::string, std::vector<ImGui_Texture>>>> live_items;
 

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -195,6 +195,7 @@ struct GuiState {
     ImFont *normal_font{};
     ImFont *monospaced_font{};
     ImFont *live_area_font{};
+    ImFont *live_area_font_large{};
     std::vector<char> font_data;
     std::vector<char> live_area_font_data;
 };

--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -89,12 +89,13 @@ void draw_app_selector(GuiState &gui, HostState &host) {
 
             while (last_time["start"] + host.cfg.delay_start < current_time()) {
                 last_time["start"] += host.cfg.delay_start;
+                last_time["home"] = 0;
                 gui.theme.start_screen = true;
             }
         }
     }
 
-    if ((!gui.theme_backgrounds.empty() || !gui.user_backgrounds.empty()) && ImGui::IsWindowHovered()) {
+    if (!gui.theme.start_screen && (!gui.theme_backgrounds.empty() || !gui.user_backgrounds.empty())) {
         if (last_time["home"] == 0)
             last_time["home"] = current_time();
 

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -136,6 +136,7 @@ static void init_live_area_font(GuiState &gui, HostState &host) {
     if (!fs::exists(font_path)) {
         LOG_WARN("Could not find firmware font file at \"{}\", using defaut vita3k font.", font_path.string());
         gui.live_area_font = gui.normal_font;
+        gui.live_area_font_large = gui.normal_font;
         return;
     }
 
@@ -145,10 +146,13 @@ static void init_live_area_font(GuiState &gui, HostState &host) {
     std::ifstream font_stream(font_path.string().c_str(), std::ios::in | std::ios::binary);
     font_stream.read(gui.live_area_font_data.data(), font_file_size);
 
+    static const ImWchar large_font_chars[] = { L'0', L'1', L'2', L'3', L'4', L'5', L'6', L'7', L'8', L'9', L':', L';', L'<', L'=', L'>' };
+
     // add it to imgui
     ImGuiIO &io = ImGui::GetIO();
     ImFontConfig font_config{};
     gui.live_area_font = io.Fonts->AddFontFromMemoryTTF(gui.live_area_font_data.data(), static_cast<int>(font_file_size), 19.2f, &font_config, io.Fonts->GetGlyphRangesJapanese());
+    gui.live_area_font_large = io.Fonts->AddFontFromMemoryTTF(gui.live_area_font_data.data(), static_cast<int>(font_file_size), 124.f, &font_config, large_font_chars);
 }
 
 static void init_user_backgrounds(GuiState &gui, HostState &host) {


### PR DESCRIPTION
- improve date position for start screen with using calc text size for template 2.
- fix line position on start screen
- fix small things relate switch bg broken after outside start screen.
- fix size text more close psvita
- create information bar like on psvita, with show clock and batteries level (totaly fake here lol)
- fix quality on big text size for clock, thx to @VelocityRa  for code and help 
also thx to @1whatleytay for color code :)
- Add info bar on live area screen/theme/screen start

# Result : 
- Master
![image](https://user-images.githubusercontent.com/5261759/86525774-c13db600-be8b-11ea-8e4f-248bcd9eb0d8.png)

- PR
![image](https://user-images.githubusercontent.com/5261759/86751435-f1798600-c03e-11ea-8cc2-c836a83594ff.png)

- fix position for title name and separator
![image](https://user-images.githubusercontent.com/5261759/86777141-13800200-c059-11ea-80cd-a05f2b2a5754.png)

- add space for themes list and on information
![image](https://user-images.githubusercontent.com/5261759/86777191-1e3a9700-c059-11ea-95d1-4c38240a690b.png)
![image](https://user-images.githubusercontent.com/5261759/86777247-2db9e000-c059-11ea-85cb-4bf8d1e6379d.png)

- Add also info bar on live area screen
![image](https://user-images.githubusercontent.com/5261759/86866939-34386e00-c0d2-11ea-8242-1cb49009e7b1.png)

- Information bar Indicator color (clock only here) 
![image](https://cdn.discordapp.com/attachments/442344583293304833/730574718997889056/unknown.png)