### PR TITLE
Make lle mp4 and avplayer bootable

### DIFF
--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -39,10 +39,13 @@ struct WatchMemory;
 
 struct InitialFiber;
 
+struct CodecEngineBlock;
+
 typedef std::vector<InitialFiber> InitialFibers;
 
 typedef std::shared_ptr<SceKernelMemBlockInfo> SceKernelMemBlockInfoPtr;
 typedef std::map<SceUID, SceKernelMemBlockInfoPtr> Blocks;
+typedef std::map<SceUID, CodecEngineBlock> CodecEngineBlocks;
 typedef std::map<SceUID, Ptr<Ptr<void>>> SlotToAddress;
 typedef std::map<SceUID, SlotToAddress> ThreadToSlotToAddress;
 typedef std::shared_ptr<ThreadState> ThreadStatePtr;
@@ -203,6 +206,17 @@ struct PlayerInfoState {
 typedef std::shared_ptr<PlayerInfoState> PlayerPtr;
 typedef std::map<SceUID, PlayerPtr> PlayerStates;
 
+struct MJpegState {
+    bool initialized = false;
+
+    AVCodecContext *decoder{};
+};
+
+struct CodecEngineBlock {
+    uint32_t size;
+    int32_t vaddr;
+};
+
 struct TimerState {
     std::string name;
 
@@ -253,6 +267,7 @@ struct KernelState {
     std::mutex mutex;
     Blocks blocks;
     Blocks vm_blocks;
+    CodecEngineBlocks codec_blocks;
     ThreadToSlotToAddress tls;
     Ptr<const void> tls_address;
     unsigned int tls_psize;

--- a/vita3k/mem/include/mem/ptr.h
+++ b/vita3k/mem/include/mem/ptr.h
@@ -39,7 +39,11 @@ public:
     template <class U>
     Ptr(U *pointer, const MemState &mem) {
         const uint8_t *const pointer_bytes = reinterpret_cast<const uint8_t *>(pointer);
-        addr = static_cast<Address>(pointer_bytes - &mem.memory[0]);
+        if (pointer_bytes == 0) {
+            addr = 0;
+        } else {
+            addr = static_cast<Address>(pointer_bytes - &mem.memory[0]);
+        }
     }
 
     Address address() const {

--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
@@ -164,7 +164,8 @@ EXPORT(int, sceAudiodecDeleteDecoderResident) {
 }
 
 EXPORT(int, sceAudiodecGetContextSize) {
-    return UNIMPLEMENTED();
+    STUBBED("fake size");
+    return 53;
 }
 
 EXPORT(int, sceAudiodecGetInternalError) {

--- a/vita3k/modules/SceCodecEngine/SceCodecEngineUser.h
+++ b/vita3k/modules/SceCodecEngine/SceCodecEngineUser.h
@@ -19,6 +19,13 @@
 
 #include <module/module.h>
 
+enum SceCodecEngineErrorCode {
+    SCE_CODECENGINE_ERROR_INVALID_POINTER = 0x80600000,
+    SCE_CODECENGINE_ERROR_INVALID_SIZE = 0x80600001,
+    SCE_CODECENGINE_ERROR_INVALID_HEAP = 0x80600005,
+    SCE_CODECENGINE_ERROR_INVALID_VALUE = 0x80600009
+};
+
 BRIDGE_DECL(sceCodecEngineAllocMemoryFromUnmapMemBlock)
 BRIDGE_DECL(sceCodecEngineCloseUnmapMemBlock)
 BRIDGE_DECL(sceCodecEngineFreeMemoryFromUnmapMemBlock)

--- a/vita3k/modules/SceSysmem/SceSysmem.h
+++ b/vita3k/modules/SceSysmem/SceSysmem.h
@@ -19,6 +19,10 @@
 
 #include <module/module.h>
 
+// TODO use macro
+EXPORT(SceUID, sceKernelFindMemBlockByAddr, Address addr, uint32_t size);
+EXPORT(int, sceKernelFreeMemBlock, SceUID uid);
+
 BRIDGE_DECL(sceKernelAllocMemBlock)
 BRIDGE_DECL(sceKernelAllocMemBlockForVM)
 BRIDGE_DECL(sceKernelAllocUnmapMemBlock)

--- a/vita3k/modules/SceVideodec/SceVideodecUser.cpp
+++ b/vita3k/modules/SceVideodec/SceVideodecUser.cpp
@@ -357,7 +357,8 @@ EXPORT(int, sceM4vdecDeleteDecoder) {
 }
 
 EXPORT(int, sceM4vdecQueryDecoderMemSize) {
-    return UNIMPLEMENTED();
+    STUBBED("fake size");
+    return 53;
 }
 
 EXPORT(int, sceM4vdecQueryDecoderMemSizeInternal) {
@@ -393,7 +394,8 @@ EXPORT(int, sceVideodecQueryInstanceNongameapp) {
 }
 
 EXPORT(int, sceVideodecQueryMemSize) {
-    return UNIMPLEMENTED();
+    STUBBED("fake size");
+    return 53;
 }
 
 EXPORT(int, sceVideodecQueryMemSizeInternal) {


### PR DESCRIPTION
# About Pr
- Fix some issues regarding full mspace
- Stub codecengine
- Stub avcdec memsize functions

# About codecengine

It's used to give work memory for codec library. But, codecengine apparently allocates it at separate hardware unit. So, if lle mp4 and avplayer turned out to use this worker memory directly, it can be quite troublesome. I just stubbed it for the moment, but if some of those lle functions are not working correctly, we might look at codecengine again.

# Further works

Video is now working in many games with this. But, it randomly got stuck or crash in the middle of video. This is maybe related to sync primitives which we need to investigate on. Also, audio is not working correctly because of incomplete audiodec. ngs pr (https://github.com/Vita3K/Vita3K/pull/657) improves the situation, but we also need to implement decoders for more codecs. (e.g. AAC)
