### PR TITLE
Fix cpu state corruption when calling guest callback function

### DIFF
--- a/vita3k/cpu/include/cpu/functions.h
+++ b/vita3k/cpu/include/cpu/functions.h
@@ -26,8 +26,10 @@
 
 struct CPUState;
 struct MemState;
+struct uc_context;
 
 struct CPUContext {
+    uc_context *context;
     uint32_t cpu_registers[16];
     uint32_t sp;
     uint32_t pc;

--- a/vita3k/cpu/src/cpu.cpp
+++ b/vita3k/cpu/src/cpu.cpp
@@ -614,6 +614,10 @@ static void delete_cpu_context(CPUContext *ctx) {
 }
 
 void save_context(CPUState &state, CPUContext &ctx) {
+    auto err = uc_context_alloc(state.uc.get(), &ctx.context);
+    assert(err == UC_ERR_OK);
+    err = uc_context_save(state.uc.get(), ctx.context);
+    assert(err == UC_ERR_OK);
     for (auto i = 0; i < 16; i++) {
         ctx.cpu_registers[i] = read_reg(state, i);
     }
@@ -636,4 +640,6 @@ void load_context(CPUState &state, CPUContext &ctx) {
     write_pc(state, ctx.pc);
     write_lr(state, ctx.lr);
     write_sp(state, ctx.sp);
+    auto err = uc_context_restore(state.uc.get(), ctx.context);
+    assert(err == UC_ERR_OK);
 }

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -485,12 +485,11 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
 
         LOG_DEBUG("Running module_start of library: {} at address {}", module_name, log_hex(module_start.address()));
 
-        auto argp = Ptr<void>();
         auto inject = create_cpu_dep_inject(host);
         const SceUID module_thread_id = create_thread(module_start, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT),
             inject, nullptr);
         const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
-        const auto ret = run_on_current(*module_thread, module_start, 0, argp);
+        const auto ret = run_on_current(*module_thread, module_start, { 0, 0 });
         module_thread->to_do = ThreadToDo::exit;
         module_thread->something_to_do.notify_all(); // TODO Should this be notify_one()?
         host.kernel.running_threads.erase(module_thread_id);

--- a/vita3k/kernel/include/kernel/thread/thread_functions.h
+++ b/vita3k/kernel/include/kernel/thread/thread_functions.h
@@ -19,9 +19,11 @@
 
 #include <kernel/state.h>
 #include <mem/ptr.h>
+#include <vector>
 //#include <psp2/types.h>
 
 #include <functional>
+#include <list>
 #include <memory>
 
 struct CPUState;
@@ -37,5 +39,5 @@ int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const 
 Ptr<void> copy_stack(SceUID thid, SceUID thread_id, const Ptr<void> &argp, KernelState &kernel, MemState &mem);
 bool run_thread(ThreadState &thread, bool callback);
 bool run_callback(ThreadState &thread, Address &pc, Address &data);
-uint32_t run_on_current(ThreadState &thread, const Ptr<const void> entry_point, SceSize arglen, Ptr<void> &argp, bool callback = false);
+uint32_t run_on_current(ThreadState &thread, const Ptr<const void> entry_point, const std::list<uint32_t> &args);
 void raise_waiting_threads(ThreadState *thread);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -1250,7 +1250,7 @@ EXPORT(int, sceKernelLoadModule, char *path, int flags, SceKernelLMOption *optio
     return mod_id;
 }
 
-EXPORT(int, sceKernelLoadStartModule, char *path, SceSize args, Ptr<void> argp, int flags, SceKernelLMOption *option, int *status) {
+EXPORT(int, sceKernelLoadStartModule, char *path, SceSize args, Address argp, int flags, SceKernelLMOption *option, int *status) {
     SceUID mod_id;
     Ptr<const void> entry_point;
     SceKernelModuleInfoPtr module;
@@ -1265,7 +1265,7 @@ EXPORT(int, sceKernelLoadStartModule, char *path, SceSize args, Ptr<void> argp, 
 
     const ThreadStatePtr thread = lock_and_find(thid, host.kernel.threads, host.kernel.mutex);
 
-    uint32_t result = run_on_current(*thread, entry_point, args, argp);
+    uint32_t result = run_on_current(*thread, entry_point, { static_cast<uint32_t>(args), argp });
     char *module_name = module->module_name;
 
     LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(result));

--- a/vita3k/modules/SceNetCtl/SceNetCtl.cpp
+++ b/vita3k/modules/SceNetCtl/SceNetCtl.cpp
@@ -20,6 +20,8 @@
 #include <kernel/thread/thread_functions.h>
 #include <util/lock_and_find.h>
 
+#include <kernel/functions.h>
+
 #define SCE_NETCTL_INFO_SSID_LEN_MAX 32
 #define SCE_NETCTL_INFO_CONFIG_NAME_LEN_MAX 64
 
@@ -115,9 +117,9 @@ EXPORT(int, sceNetCtlCheckCallback) {
     host.net.state = 0;
 
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
-    for (auto &callback : host.net.cbs) {
-        Ptr<void> argp = Ptr<void>(callback.second.data);
-        run_on_current(*thread, Ptr<void>(callback.second.pc), host.net.state, argp);
+    auto cbs = host.net.cbs;
+    for (auto &callback : cbs) {
+        run_on_current(*thread, Ptr<void>(callback.second.pc), { 1, callback.second.data });
     }
     return STUBBED("Stub");
 }

--- a/vita3k/modules/SceNpManager/SceNpManager.cpp
+++ b/vita3k/modules/SceNpManager/SceNpManager.cpp
@@ -60,10 +60,8 @@ EXPORT(int, sceNpCheckCallback) {
 
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
     for (auto &callback : host.np.cbs) {
-        Ptr<void> argp = Ptr<void>(callback.second.data);
-        run_on_current(*thread, Ptr<void>(callback.second.pc), host.np.state, argp);
+        run_on_current(*thread, Ptr<void>(callback.second.pc), { static_cast<uint32_t>(host.np.state), 0, callback.second.data });
     }
-
     return STUBBED("Stub");
 }
 

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -185,12 +185,11 @@ bool load_module(HostState &host, SceSysmoduleModuleId module_id) {
             if (lib_entry_point) {
                 LOG_DEBUG("Running module_start of module: {}", module_name);
 
-                Ptr<void> argp = Ptr<void>();
                 auto inject = create_cpu_dep_inject(host);
                 const SceUID module_thread_id = create_thread(lib_entry_point, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER,
                     static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), inject, nullptr);
                 const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
-                const auto ret = run_on_current(*module_thread, lib_entry_point, 0, argp);
+                const auto ret = run_on_current(*module_thread, lib_entry_point, { 0, 0 });
 
                 module_thread->to_do = ThreadToDo::exit;
                 module_thread->something_to_do.notify_all(); // TODO Should this be notify_one()?


### PR DESCRIPTION
# About PR

- Fix cpu state corruption when calling guest callback function

# Context saving

Our previous context saving was not enough for unicorn to continue the emulation normally. It turned out unicorn relied on some internal states that could've changed as it runs the code. (which caused the crash after restoring context) Fortunately, unicorn provides its own context saving api that also deal with internal states. I used it in this PR.

# Some words

run_on_current still just continues the main emulation without going back to the caller. Notice that run_thread(thread, false) will not stop until the current thread dies. So, we can't use this function to use random guest function and multiple netctl callbacks are not working. (after processing one callback it immediately returns to the guest)

I'm searching for clean way to solve this problem.
  
