### PR TITLE
gui: move trophy and theme inside app selector

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -43,13 +43,15 @@ void get_themes_list(GuiState &gui, HostState &host);
 void get_trophy_np_com_id_list(GuiState &gui, HostState &host);
 void init(GuiState &gui, HostState &host);
 void init_app_background(GuiState &gui, HostState &host);
-void init_icons(GuiState &gui, HostState &host);
+void init_apps_icon(GuiState &gui, HostState &host, const std::vector<gui::App> &apps_list);
 void init_live_area(GuiState &gui, HostState &host);
 bool init_manual(GuiState &gui, HostState &host);
 bool init_theme(GuiState &gui, HostState &host, std::string &content_id);
 void init_theme_start_background(GuiState &gui, HostState &host, const std::string &content_id);
 bool init_user_start_background(GuiState &gui, const std::string &image_path);
+void load_app(GuiState &gui, HostState &host);
 bool refresh_app_list(GuiState &gui, HostState &host);
+void run_app(GuiState &gui, HostState &host);
 
 void draw_begin(GuiState &gui, HostState &host);
 void draw_end(GuiState &host, SDL_Window *window);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -52,6 +52,7 @@ struct App {
 
 struct AppsSelector {
     std::vector<App> apps;
+    std::vector<App> sys_apps;
     std::map<std::string, ImGui_Texture> icons;
     std::string selected_title_id;
     bool is_app_list_sorted{ false };
@@ -65,15 +66,9 @@ struct AppsSelector {
 struct LiveAreaState {
     bool live_area_screen = false;
     bool manual = false;
-};
-
-struct ThemesState {
-    bool start_screen = false;
     bool theme_background = false;
-};
-
-struct TrophyState {
     bool trophy_collection = false;
+    bool start_screen = false;
 };
 
 struct FileMenuState {
@@ -128,8 +123,6 @@ struct GuiState {
     gui::ControlMenuState controls_menu;
     gui::HelpMenuState help_menu;
     gui::LiveAreaState live_area;
-    gui::ThemesState theme;
-    gui::TrophyState trophy;
     gui::AppsSelector app_selector;
 
     std::string app_ver;

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -19,7 +19,7 @@
 
 #include <gui/functions.h>
 
-#include <io/device.h>
+#include <io/VitaIoDevice.h>
 #include <io/vfs.h>
 #include <util/log.h>
 
@@ -40,7 +40,7 @@ void draw_information_bar(GuiState &gui) {
     ImU32 DEFAUL_BAR_COLOR = 4278190080; // Black
     ImU32 DEFAUL_INDICATOR_COLOR = 4294967295; // White
 
-    const auto is_theme_color = (gui.theme.start_screen || gui.live_area.live_area_screen);
+    const auto is_theme_color = (gui.live_area.start_screen || gui.live_area.live_area_screen);
 
     ImGui::SetNextWindowPos(ImVec2(0.f, 0.f), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, MENUBAR_HEIGHT), ImGuiCond_Always);
@@ -90,6 +90,7 @@ static std::map<std::string, std::map<std::string, uint64_t>> current_item, last
 static std::map<std::string, std::string> type;
 static std::string start;
 static int32_t current_app;
+static std::vector<gui::App> app_type;
 
 void init_live_area(GuiState &gui, HostState &host) {
     std::string user_lang;
@@ -118,22 +119,101 @@ void init_live_area(GuiState &gui, HostState &host) {
     default: break;
     }
 
+    // Init type
+    if (items_pos.empty()) {
+        // A1
+        items_pos["a1"]["gate"]["pos"] = ImVec2(620.f, 364.f);
+        items_pos["a1"]["frame1"]["pos"] = ImVec2(900.f, 415.f);
+        items_pos["a1"]["frame1"]["size"] = ImVec2(260.f, 260.f);
+        items_pos["a1"]["frame2"]["pos"] = ImVec2(320.f, 415.f);
+        items_pos["a1"]["frame2"]["size"] = ImVec2(260.f, 260.f);
+        items_pos["a1"]["frame3"]["pos"] = ImVec2(900.f, 155.f);
+        items_pos["a1"]["frame3"]["size"] = ImVec2(840.f, 150.f);
+        // A2
+        items_pos["a2"]["gate"]["pos"] = ImVec2(620.f, 390.f);
+        items_pos["a2"]["frame1"]["pos"] = ImVec2(900.f, 405.f);
+        items_pos["a2"]["frame1"]["size"] = ImVec2(260.f, 400.f);
+        items_pos["a2"]["frame2"]["pos"] = ImVec2(320.f, 405.f);
+        items_pos["a2"]["frame2"]["size"] = ImVec2(260.f, 400.f);
+        items_pos["a2"]["frame3"]["pos"] = ImVec2(640.f, 205.f);
+        items_pos["a2"]["frame3"]["size"] = ImVec2(320.f, 200.f);
+        // A3
+        items_pos["a3"]["gate"]["pos"] = ImVec2(620.f, 394.f);
+        items_pos["a3"]["frame1"]["pos"] = ImVec2(900.f, 415.f);
+        items_pos["a3"]["frame1"]["size"] = ImVec2(260.f, 200.f);
+        items_pos["a3"]["frame2"]["pos"] = ImVec2(320.f, 415.f);
+        items_pos["a3"]["frame2"]["size"] = ImVec2(260.f, 200.f);
+        items_pos["a3"]["frame3"]["pos"] = ImVec2(900.f, 215.f);
+        items_pos["a3"]["frame3"]["size"] = ImVec2(260.f, 210.f);
+        items_pos["a3"]["frame4"]["pos"] = ImVec2(640.f, 215.f);
+        items_pos["a3"]["frame4"]["size"] = ImVec2(320.f, 210.f);
+        items_pos["a3"]["frame5"]["pos"] = ImVec2(320.f, 215.f);
+        items_pos["a3"]["frame5"]["size"] = ImVec2(260.f, 210.f);
+        // A4
+        items_pos["a4"]["gate"]["pos"] = ImVec2(620.f, 394.f);
+        items_pos["a4"]["frame1"]["pos"] = ImVec2(900.f, 415.f);
+        items_pos["a4"]["frame1"]["size"] = ImVec2(260.f, 200.f);
+        items_pos["a4"]["frame2"]["pos"] = ImVec2(320.f, 415.f);
+        items_pos["a4"]["frame2"]["size"] = ImVec2(260.f, 200.f);
+        items_pos["a4"]["frame3"]["pos"] = ImVec2(900.f, 215.f);
+        items_pos["a4"]["frame3"]["size"] = ImVec2(840.f, 70.f);
+        items_pos["a4"]["frame4"]["pos"] = ImVec2(900.f, 145.f);
+        items_pos["a4"]["frame4"]["size"] = ImVec2(840.f, 70.f);
+        items_pos["a4"]["frame5"]["pos"] = ImVec2(900.f, 75.f);
+        items_pos["a4"]["frame5"]["size"] = ImVec2(840.f, 70.f);
+        // A5
+        items_pos["a5"]["gate"]["pos"] = ImVec2(380.f, 388.f);
+        items_pos["a5"]["frame1"]["pos"] = ImVec2(900.f, 414.f);
+        items_pos["a5"]["frame1"]["size"] = ImVec2(480.f, 68.f);
+        items_pos["a5"]["frame2"]["pos"] = ImVec2(900.f, 345.f);
+        items_pos["a5"]["frame2"]["size"] = ImVec2(480.f, 68.f);
+        items_pos["a5"]["frame3"]["pos"] = ImVec2(900.f, 278.f);
+        items_pos["a5"]["frame3"]["size"] = ImVec2(480.f, 68.f);
+        items_pos["a5"]["frame4"]["pos"] = ImVec2(900.f, 210.f);
+        items_pos["a5"]["frame4"]["size"] = ImVec2(480.f, 68.f);
+        items_pos["a5"]["frame5"]["pos"] = ImVec2(900.f, 142.f);
+        items_pos["a5"]["frame5"]["size"] = ImVec2(480.f, 68.f);
+        items_pos["a5"]["frame6"]["pos"] = ImVec2(900.f, 74.f);
+        items_pos["a5"]["frame6"]["size"] = ImVec2(480.f, 68.f);
+        items_pos["a5"]["frame7"]["pos"] = ImVec2(420.f, 220.f);
+        items_pos["a5"]["frame7"]["size"] = ImVec2(360.f, 210.f);
+        // psmobile
+        items_pos["psmobile"]["gate"]["pos"] = ImVec2(380.f, 339.f);
+        //items_pos["psmobile"]["frame1"]["pos"] = ImVec2(900.f, 414.f);
+        //items_pos["psmobile"]["frame1"]["size"] = ImVec2(480.f, 68.f);
+        items_pos["psmobile"]["frame2"]["pos"] = ImVec2(865.f, 215.f);
+        items_pos["psmobile"]["frame2"]["size"] = ImVec2(440.f, 68.f);
+        items_pos["psmobile"]["frame3"]["pos"] = ImVec2(865.f, 113.f);
+        items_pos["psmobile"]["frame3"]["size"] = ImVec2(440.f, 34.f);
+        items_pos["psmobile"]["frame4"]["pos"] = ImVec2(865.f, 39.f);
+        items_pos["psmobile"]["frame4"]["size"] = ImVec2(440.f, 34.f);
+    }
+
+    const VitaIoDevice app_device = host.io.title_id.find("NPXS") != std::string::npos ? VitaIoDevice::vs0 : VitaIoDevice::ux0;
+    app_type = app_device == VitaIoDevice::ux0 ? gui.app_selector.apps : gui.app_selector.sys_apps;
+
+    const auto app_index = std::find_if(app_type.begin(), app_type.end(), [&](const App &a) {
+        return a.title_id == host.io.title_id;
+    });
+    current_app = int32_t(std::distance(app_type.begin(), app_index));
+
     if (gui.live_area_contents.find(host.io.title_id) == gui.live_area_contents.end()) {
         auto default_contents = false;
         const auto fw_path{ fs::path(host.pref_path) / "vs0" };
         const auto default_fw_contents{ fw_path / "data/internal/livearea/default/sce_sys/livearea/contents/template.xml" };
-        auto template_xml{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id / "sce_sys/livearea/contents/template.xml" };
+        auto template_xml{ fs::path(host.pref_path) / app_device._to_string() / "app" / host.io.title_id / "sce_sys/livearea/contents/template.xml" };
 
         pugi::xml_document doc;
 
         if (!doc.load_file(template_xml.c_str())) {
-            if (host.io.title_id.find("PCS") != std::string::npos)
+            if ((host.io.title_id.find("PCS") != std::string::npos) || (host.io.title_id.find("NPXS") != std::string::npos))
                 LOG_WARN("Live Area Contents is corrupted or missing for title: {} '{}'.", host.io.title_id, host.app_title);
             if (doc.load_file(default_fw_contents.c_str())) {
                 template_xml = default_fw_contents;
                 default_contents = true;
                 LOG_INFO("Using default firmware contents.");
             } else {
+                type[host.io.title_id] = "a1";
                 LOG_ERROR("Default firmware contents is corrupted or missing.");
                 return;
             }
@@ -145,7 +225,7 @@ void init_live_area(GuiState &gui, HostState &host) {
             type[host.io.title_id].clear();
             type[host.io.title_id] = doc.child("livearea").attribute("style").as_string();
 
-            if (doc.child("livearea").child("livearea-background").child("image").child("lang")) {
+            if (!doc.child("livearea").child("livearea-background").child("image").child("lang").text().empty()) {
                 for (const auto &livearea_background : doc.child("livearea").child("livearea-background")) {
                     if (livearea_background.child("lang").text().as_string() == user_lang) {
                         name["livearea-background"] = livearea_background.text().as_string();
@@ -189,15 +269,6 @@ void init_live_area(GuiState &gui, HostState &host) {
                 name["gate"].erase(remove_if(name["gate"].begin(), name["gate"].end(), isspace), name["gate"].end());
             }
 
-            if (fs::exists(fw_path / "vsh/shell/6df5c7c2.png"))
-                name["search"] = "6df5c7c2.png";
-            if (fs::exists(fw_path / "vsh/shell/2f88f589.png"))
-                name["manual"] = "2f88f589.png";
-            /*if (fs::exists(fw_path / "vsh/shell/b4a6dc.png"))
-                name["button"] = "b4a6dc.png";
-            if (fs::exists(fw_path / "vsh/shell/4d4d9ca0.png"))
-                name["refresh"] = "4d4d9ca0.png";*/
-
             if (name["livearea-background"].find('\n') != std::string::npos)
                 name["livearea-background"].erase(remove(name["livearea-background"].begin(), name["livearea-background"].end(), '\n'), name["livearea-background"].end());
             name["livearea-background"].erase(remove_if(name["livearea-background"].begin(), name["livearea-background"].end(), isspace), name["livearea-background"].end());
@@ -209,13 +280,13 @@ void init_live_area(GuiState &gui, HostState &host) {
 
                 if (default_contents)
                     vfs::read_file(VitaIoDevice::vs0, buffer, host.pref_path, "data/internal/livearea/default/sce_sys/livearea/contents/" + contents.second);
-                else if ((contents.first == "search") || (contents.first == "manual") /*|| (contents.first == "button") || (contents.first == "refresh")*/)
-                    vfs::read_file(VitaIoDevice::vs0, buffer, host.pref_path, "vsh/shell/" + contents.second);
+                else if (app_device == VitaIoDevice::vs0)
+                    vfs::read_file(VitaIoDevice::vs0, buffer, host.pref_path, "app/" + host.io.title_id + "/sce_sys/livearea/contents/" + contents.second);
                 else
                     vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/livearea/contents/" + contents.second);
 
                 if (buffer.empty()) {
-                    if (host.io.title_id.find("PCS") != std::string::npos)
+                    if ((host.io.title_id.find("PCS") != std::string::npos) || (host.io.title_id.find("NPXS") != std::string::npos))
                         LOG_WARN("Contents {} '{}' Not found for title {} [{}].", contents.first, contents.second, host.io.title_id, host.app_title);
                     continue;
                 }
@@ -408,10 +479,13 @@ void init_live_area(GuiState &gui, HostState &host) {
                             int32_t height = 0;
                             vfs::FileBuffer buffer;
 
-                            vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/livearea/contents/" + bg_name);
+                            if (app_device == VitaIoDevice::vs0)
+                                vfs::read_file(VitaIoDevice::vs0, buffer, host.pref_path, "app/" + host.io.title_id + "/sce_sys/livearea/contents/" + bg_name);
+                            else
+                                vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/livearea/contents/" + bg_name);
 
                             if (buffer.empty()) {
-                                if (host.io.title_id.find("PCS") != std::string::npos)
+                                if ((host.io.title_id.find("PCS") != std::string::npos) || (host.io.title_id.find("NPXS") != std::string::npos))
                                     LOG_WARN("background, Id: {}, Name: '{}', Not found for title: {} [{}].", item.first, bg_name, host.io.title_id, host.app_title);
                                 continue;
                             }
@@ -443,10 +517,13 @@ void init_live_area(GuiState &gui, HostState &host) {
                             int32_t height = 0;
                             vfs::FileBuffer buffer;
 
-                            vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/livearea/contents/" + img_name);
+                            if (app_device == VitaIoDevice::vs0)
+                                vfs::read_file(VitaIoDevice::vs0, buffer, host.pref_path, "app/" + host.io.title_id + "/sce_sys/livearea/contents/" + img_name);
+                            else
+                                vfs::read_app_file(buffer, host.pref_path, host.io.title_id, "sce_sys/livearea/contents/" + img_name);
 
                             if (buffer.empty()) {
-                                if (host.io.title_id.find("PCS") != std::string::npos)
+                                if ((host.io.title_id.find("PCS") != std::string::npos) || (host.io.title_id.find("NPXS") != std::string::npos))
                                     LOG_WARN("Image, Id: {} Name: '{}', Not found for title {} [{}].", item.first, img_name, host.io.title_id, host.app_title);
                                 continue;
                             }
@@ -465,81 +542,8 @@ void init_live_area(GuiState &gui, HostState &host) {
             }
         }
     }
-
-    // Type Used
-    if (items_pos.empty()) {
-        // A1
-        items_pos["a1"]["gate"]["pos"] = ImVec2(620.f, 364.f);
-        items_pos["a1"]["frame1"]["pos"] = ImVec2(900.f, 415.f);
-        items_pos["a1"]["frame1"]["size"] = ImVec2(260.f, 260.f);
-        items_pos["a1"]["frame2"]["pos"] = ImVec2(320.f, 415.f);
-        items_pos["a1"]["frame2"]["size"] = ImVec2(260.f, 260.f);
-        items_pos["a1"]["frame3"]["pos"] = ImVec2(900.f, 155.f);
-        items_pos["a1"]["frame3"]["size"] = ImVec2(840.f, 150.f);
-        // A2
-        items_pos["a2"]["gate"]["pos"] = ImVec2(620.f, 390.f);
-        items_pos["a2"]["frame1"]["pos"] = ImVec2(900.f, 405.f);
-        items_pos["a2"]["frame1"]["size"] = ImVec2(260.f, 400.f);
-        items_pos["a2"]["frame2"]["pos"] = ImVec2(320.f, 405.f);
-        items_pos["a2"]["frame2"]["size"] = ImVec2(260.f, 400.f);
-        items_pos["a2"]["frame3"]["pos"] = ImVec2(640.f, 205.f);
-        items_pos["a2"]["frame3"]["size"] = ImVec2(320.f, 200.f);
-        // A3
-        items_pos["a3"]["gate"]["pos"] = ImVec2(620.f, 394.f);
-        items_pos["a3"]["frame1"]["pos"] = ImVec2(900.f, 415.f);
-        items_pos["a3"]["frame1"]["size"] = ImVec2(260.f, 200.f);
-        items_pos["a3"]["frame2"]["pos"] = ImVec2(320.f, 415.f);
-        items_pos["a3"]["frame2"]["size"] = ImVec2(260.f, 200.f);
-        items_pos["a3"]["frame3"]["pos"] = ImVec2(900.f, 215.f);
-        items_pos["a3"]["frame3"]["size"] = ImVec2(260.f, 210.f);
-        items_pos["a3"]["frame4"]["pos"] = ImVec2(640.f, 215.f);
-        items_pos["a3"]["frame4"]["size"] = ImVec2(320.f, 210.f);
-        items_pos["a3"]["frame5"]["pos"] = ImVec2(320.f, 215.f);
-        items_pos["a3"]["frame5"]["size"] = ImVec2(260.f, 210.f);
-        // A4
-        items_pos["a4"]["gate"]["pos"] = ImVec2(620.f, 394.f);
-        items_pos["a4"]["frame1"]["pos"] = ImVec2(900.f, 415.f);
-        items_pos["a4"]["frame1"]["size"] = ImVec2(260.f, 200.f);
-        items_pos["a4"]["frame2"]["pos"] = ImVec2(320.f, 415.f);
-        items_pos["a4"]["frame2"]["size"] = ImVec2(260.f, 200.f);
-        items_pos["a4"]["frame3"]["pos"] = ImVec2(900.f, 215.f);
-        items_pos["a4"]["frame3"]["size"] = ImVec2(840.f, 70.f);
-        items_pos["a4"]["frame4"]["pos"] = ImVec2(900.f, 145.f);
-        items_pos["a4"]["frame4"]["size"] = ImVec2(840.f, 70.f);
-        items_pos["a4"]["frame5"]["pos"] = ImVec2(900.f, 75.f);
-        items_pos["a4"]["frame5"]["size"] = ImVec2(840.f, 70.f);
-        // A5
-        items_pos["a5"]["gate"]["pos"] = ImVec2(380.f, 388.f);
-        items_pos["a5"]["frame1"]["pos"] = ImVec2(900.f, 414.f);
-        items_pos["a5"]["frame1"]["size"] = ImVec2(480.f, 68.f);
-        items_pos["a5"]["frame2"]["pos"] = ImVec2(900.f, 345.f);
-        items_pos["a5"]["frame2"]["size"] = ImVec2(480.f, 68.f);
-        items_pos["a5"]["frame3"]["pos"] = ImVec2(900.f, 278.f);
-        items_pos["a5"]["frame3"]["size"] = ImVec2(480.f, 68.f);
-        items_pos["a5"]["frame4"]["pos"] = ImVec2(900.f, 210.f);
-        items_pos["a5"]["frame4"]["size"] = ImVec2(480.f, 68.f);
-        items_pos["a5"]["frame5"]["pos"] = ImVec2(900.f, 142.f);
-        items_pos["a5"]["frame5"]["size"] = ImVec2(480.f, 68.f);
-        items_pos["a5"]["frame6"]["pos"] = ImVec2(900.f, 74.f);
-        items_pos["a5"]["frame6"]["size"] = ImVec2(480.f, 68.f);
-        items_pos["a5"]["frame7"]["pos"] = ImVec2(420.f, 220.f);
-        items_pos["a5"]["frame7"]["size"] = ImVec2(360.f, 210.f);
-        // psmobile
-        items_pos["psmobile"]["gate"]["pos"] = ImVec2(380.f, 339.f);
-        //items_pos["psmobile"]["frame1"]["pos"] = ImVec2(900.f, 414.f);
-        //items_pos["psmobile"]["frame1"]["size"] = ImVec2(480.f, 68.f);
-        items_pos["psmobile"]["frame2"]["pos"] = ImVec2(865.f, 215.f);
-        items_pos["psmobile"]["frame2"]["size"] = ImVec2(440.f, 68.f);
-        items_pos["psmobile"]["frame3"]["pos"] = ImVec2(865.f, 113.f);
-        items_pos["psmobile"]["frame3"]["size"] = ImVec2(440.f, 34.f);
-        items_pos["psmobile"]["frame4"]["pos"] = ImVec2(865.f, 39.f);
-        items_pos["psmobile"]["frame4"]["size"] = ImVec2(440.f, 34.f);
-    }
-
-    const auto app_index = std::find_if(gui.app_selector.apps.begin(), gui.app_selector.apps.end(), [&](const App &g) {
-        return g.title_id == host.io.title_id;
-    });
-    current_app = int32_t(std::distance(gui.app_selector.apps.begin(), app_index));
+    if (type[host.io.title_id].empty())
+        type[host.io.title_id] = "a1";
 }
 
 inline uint64_t current_time() {
@@ -554,6 +558,7 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
 
     const ImVec2 display_size = ImGui::GetIO().DisplaySize;
     const auto scal = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
+    const VitaIoDevice app_device = host.io.title_id.find("NPXS") != std::string::npos ? VitaIoDevice::vs0 : VitaIoDevice::ux0;
 
     ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
@@ -723,20 +728,19 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
         // Text
         for (const auto &str_tag : str[host.io.title_id][frame.id]) {
             if (!str_tag.text.empty()) {
-                std::vector<int> R, G, B;
+                std::vector<ImVec4> str_color;
 
                 if (!str_tag.color.empty()) {
                     int color;
 
-                    if (frame.autoflip != 0) {
+                    if (frame.autoflip != 0)
                         sscanf(str[host.io.title_id][frame.id][current_item[host.io.title_id][frame.id]].color.c_str(), "#%x", &color);
-                    } else
+                    else
                         sscanf(str_tag.color.c_str(), "#%x", &color);
 
-                    R.push_back((color >> 16) & 0xFF);
-                    G.push_back((color >> 8) & 0xFF);
-                    B.push_back((color >> 0) & 0xFF);
-                }
+                    str_color.push_back(ImVec4(float((color >> 16) & 0xFF), float((color >> 8) & 0xFF), float((color >> 0) & 0xFF), 255.f));
+                } else
+                    str_color.push_back(ImVec4(255.f, 255.f, 255.f, 255.f));
 
                 auto str_size = scal_size_frame, text_pos = pos_frame;
 
@@ -930,19 +934,10 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
                     }
                 }
                 ImGui::SetCursorPos(pos_str);
-                if (frame.autoflip > 0) {
-                    if (str[host.io.title_id][frame.id][current_item[host.io.title_id][frame.id]].color.empty())
-                        ImGui::TextColored(ImVec4(255.f, 255.f, 255.f, 255.f),
-                            "%s", str[host.io.title_id][frame.id][current_item[host.io.title_id][frame.id]].text.c_str());
-                    else
-                        ImGui::TextColored(ImVec4(float(R[0]), float(G[0]), float(B[0]), 255),
-                            "%s", str[host.io.title_id][frame.id][current_item[host.io.title_id][frame.id]].text.c_str());
-                } else {
-                    if (str_tag.color.empty())
-                        ImGui::TextColored(ImVec4(255.f, 255.f, 255.f, 255.f), "%s", str_tag.text.c_str());
-                    else
-                        ImGui::TextColored(ImVec4(float(R[0]), float(G[0]), float(B[0]), 255), "%s", str_tag.text.c_str());
-                }
+                if (frame.autoflip > 0)
+                    ImGui::TextColored(str_color[0], "%s", str[host.io.title_id][frame.id][current_item[host.io.title_id][frame.id]].text.c_str());
+                else
+                    ImGui::TextColored(str_color[0], "%s", str_tag.text.c_str());
                 if (liveitem[host.io.title_id][frame.id]["text"]["word-wrap"].second != "off")
                     ImGui::PopTextWrapPos();
                 ImGui::EndChild();
@@ -955,10 +950,13 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
     const auto GATE_POS = ImVec2(display_size.x - (items_pos[type[host.io.title_id]]["gate"]["pos"].x * scal.x), display_size.y - (items_pos[type[host.io.title_id]]["gate"]["pos"].y * scal.y));
     const auto scal_font_size = 25.0f / ImGui::GetFontSize();
     const auto START_SIZE = ImVec2((ImGui::CalcTextSize(start.c_str()).x * scal_font_size), (ImGui::CalcTextSize(start.c_str()).y * scal_font_size));
-    const auto START_BUTTON_SIZE = ImVec2((START_SIZE.x + 30.0f) * scal.x, (START_SIZE.y + 10.0f) * scal.y);
-    const auto POS_BUTTON = ImVec2((GATE_POS.x + (GATE_SIZE.x - START_BUTTON_SIZE.x) / 2.0f), (GATE_POS.y + (GATE_SIZE.y - START_BUTTON_SIZE.y) / 1.06f));
+    const auto START_BUTTON_SIZE = ImVec2((START_SIZE.x + 26.0f) * scal.x, (START_SIZE.y + 5.0f) * scal.y);
+    const auto POS_BUTTON = ImVec2((GATE_POS.x + (GATE_SIZE.x - START_BUTTON_SIZE.x) / 2.0f), (GATE_POS.y + (GATE_SIZE.y - START_BUTTON_SIZE.y) / 1.08f));
     const auto POS_START = ImVec2(POS_BUTTON.x + (START_BUTTON_SIZE.x - (START_SIZE.x * scal.x)) / 2,
         POS_BUTTON.y + (START_BUTTON_SIZE.y - (START_SIZE.y * scal.y)) / 2);
+    const auto SELECT_SIZE = ImVec2(GATE_SIZE.x - (10.f * scal.x), GATE_SIZE.y - (5.f * scal.y));
+    const auto SELECT_POS = ImVec2(GATE_POS.x + (5.f * scal.y), GATE_POS.y + (2.f * scal.y));
+    const auto SIZE_GATE = ImVec2(GATE_POS.x + GATE_SIZE.x, GATE_POS.y + GATE_SIZE.y);
 
     const auto BUTTON_SIZE = ImVec2(76.f * scal.x, 30.f * scal.y);
 
@@ -966,88 +964,60 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
         ImGui::SetCursorPos(GATE_POS);
         ImGui::Image(gui.live_area_contents[host.io.title_id]["gate"], GATE_SIZE);
     }
-    ImGui::SetCursorPos(GATE_POS);
     ImGui::PushID(host.io.title_id.c_str());
-    ImGui::GetWindowDrawList()->AddRectFilled(POS_BUTTON, ImVec2(POS_BUTTON.x + START_BUTTON_SIZE.x, POS_BUTTON.y + START_BUTTON_SIZE.y), IM_COL32(20, 168, 222, 255), 12.0f * scal.x, ImDrawCornerFlags_All);
+    ImGui::GetWindowDrawList()->AddRectFilled(POS_BUTTON, ImVec2(POS_BUTTON.x + START_BUTTON_SIZE.x, POS_BUTTON.y + START_BUTTON_SIZE.y), IM_COL32(20, 168, 222, 255), 10.0f * scal.x, ImDrawCornerFlags_All);
     ImGui::GetWindowDrawList()->AddText(gui.live_area_font, 25.0f * scal.x, POS_START, IM_COL32(255, 255, 255, 255), start.c_str());
-    if (ImGui::Selectable("##gate", ImGuiSelectableFlags_None, false, GATE_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_cross)) {
-        gui.app_selector.selected_title_id = host.io.title_id;
+    ImGui::SetCursorPos(SELECT_POS);
+    if (ImGui::Selectable("##gate", ImGuiSelectableFlags_None, false, SELECT_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_cross)) {
+        run_app(gui, host);
         gui.live_area.live_area_screen = false;
     }
     ImGui::PopID();
-    ImGui::GetWindowDrawList()->AddRect(GATE_POS, ImVec2(GATE_POS.x + GATE_SIZE.x, GATE_POS.y + GATE_SIZE.y), IM_COL32(192, 192, 192, 255), 10.0f, ImDrawCornerFlags_All, 12.0f);
+    ImGui::GetWindowDrawList()->AddRect(GATE_POS, SIZE_GATE, IM_COL32(192, 192, 192, 255), 15.f, ImDrawCornerFlags_All, 12.f);
 
-    const auto widget_scal_size = ImVec2(80.0f * scal.x, 80.f * scal.y);
-    const auto manual_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id / "sce_sys/manual/" };
-    const auto scal_widget_font_size = 23.0f / ImGui::GetFontSize();
+    if (app_device == VitaIoDevice::ux0) {
+        const auto widget_scal_size = ImVec2(80.0f * scal.x, 80.f * scal.y);
+        const auto manual_path{ fs::path(host.pref_path) / "ux0/app" / host.io.title_id / "sce_sys/manual/" };
+        const auto scal_widget_font_size = 23.0f / ImGui::GetFontSize();
 
-    auto search_pos = ImVec2(578.0f * scal.x, 505.0f * scal.y);
-    if (!fs::exists(manual_path) || fs::is_empty(manual_path))
-        search_pos = ImVec2(520.0f * scal.x, 505.0f * scal.y);
+        auto search_pos = ImVec2(578.0f * scal.x, 505.0f * scal.y);
+        if (!fs::exists(manual_path) || fs::is_empty(manual_path))
+            search_pos = ImVec2(520.0f * scal.x, 505.0f * scal.y);
 
-    const auto pos_scal_search = ImVec2(display_size.x - search_pos.x, display_size.y - search_pos.y);
+        const auto pos_scal_search = ImVec2(display_size.x - search_pos.x, display_size.y - search_pos.y);
 
-    if (gui.live_area_contents[host.io.title_id].find("search") != gui.live_area_contents[host.io.title_id].end()) {
-        ImGui::SetCursorPos(pos_scal_search);
-        ImGui::Image(gui.live_area_contents[host.io.title_id]["search"], widget_scal_size);
-    } else {
         const std::string SEARCH = "Search";
         const auto SEARCH_SCAL_SIZE = ImVec2((ImGui::CalcTextSize(SEARCH.c_str()).x * scal_widget_font_size) * scal.x, (ImGui::CalcTextSize(SEARCH.c_str()).y * scal_widget_font_size) * scal.y);
         const auto POS_STR_SEARCH = ImVec2(pos_scal_search.x + ((widget_scal_size.x / 2.f) - (SEARCH_SCAL_SIZE.x / 2.f)),
             pos_scal_search.y + ((widget_scal_size.x / 2.f) - (SEARCH_SCAL_SIZE.y / 2.f)));
         ImGui::GetWindowDrawList()->AddRectFilled(pos_scal_search, ImVec2(pos_scal_search.x + widget_scal_size.x, pos_scal_search.y + widget_scal_size.y), IM_COL32(20, 168, 222, 255), 12.0f * scal.x, ImDrawCornerFlags_All);
         ImGui::GetWindowDrawList()->AddText(gui.live_area_font, 23.0f * scal.x, POS_STR_SEARCH, IM_COL32(255, 255, 255, 255), SEARCH.c_str());
-    }
-    ImGui::SetCursorPos(pos_scal_search);
-    if (ImGui::Selectable("##Search", ImGuiSelectableFlags_None, false, widget_scal_size)) {
-        auto search_url = "http://www.google.com/search?q=" + host.app_title;
-        std::replace(search_url.begin(), search_url.end(), ' ', '+');
-        system((OS_PREFIX + search_url).c_str());
-    }
+        ImGui::SetCursorPos(pos_scal_search);
+        if (ImGui::Selectable("##Search", ImGuiSelectableFlags_None, false, widget_scal_size)) {
+            auto search_url = "http://www.google.com/search?q=" + host.app_title;
+            std::replace(search_url.begin(), search_url.end(), ' ', '+');
+            system((OS_PREFIX + search_url).c_str());
+        }
 
-    if (fs::exists(manual_path) && !fs::is_empty(manual_path)) {
-        const auto manaul_pos = ImVec2(463.0f * scal.x, 505.0f * scal.y);
-        const auto pos_scal_manual = ImVec2(display_size.x - manaul_pos.x, display_size.y - manaul_pos.y);
+        if (fs::exists(manual_path) && !fs::is_empty(manual_path)) {
+            const auto manaul_pos = ImVec2(463.0f * scal.x, 505.0f * scal.y);
+            const auto pos_scal_manual = ImVec2(display_size.x - manaul_pos.x, display_size.y - manaul_pos.y);
 
-        if (gui.live_area_contents[host.io.title_id].find("manual") != gui.live_area_contents[host.io.title_id].end()) {
-            ImGui::SetCursorPos(pos_scal_manual);
-            ImGui::Image(gui.live_area_contents[host.io.title_id]["manual"], widget_scal_size);
-        } else {
             const std::string MANUAL_STR = "Manual";
             const auto MANUAL_STR_SCAL_SIZE = ImVec2((ImGui::CalcTextSize(MANUAL_STR.c_str()).x * scal_widget_font_size) * scal.x, (ImGui::CalcTextSize(MANUAL_STR.c_str()).y * scal_widget_font_size) * scal.y);
             const auto MANUAl_STR_POS = ImVec2(pos_scal_manual.x + ((widget_scal_size.x / 2.f) - (MANUAL_STR_SCAL_SIZE.x / 2.f)),
                 pos_scal_manual.y + ((widget_scal_size.x / 2.f) - (MANUAL_STR_SCAL_SIZE.y / 2.f)));
             ImGui::GetWindowDrawList()->AddRectFilled(pos_scal_manual, ImVec2(pos_scal_manual.x + widget_scal_size.x, pos_scal_manual.y + widget_scal_size.y), IM_COL32(202, 0, 106, 255), 12.0f * scal.x, ImDrawCornerFlags_All);
             ImGui::GetWindowDrawList()->AddText(gui.live_area_font, 23.0f * scal.x, MANUAl_STR_POS, IM_COL32(255, 255, 255, 255), MANUAL_STR.c_str());
-        }
-        ImGui::SetCursorPos(pos_scal_manual);
-        if (ImGui::Selectable("##manual", ImGuiSelectableFlags_None, false, widget_scal_size)) {
-            if (init_manual(gui, host))
-                gui.live_area.manual = true;
-            else
-                LOG_ERROR("Error opening Manual");
+            ImGui::SetCursorPos(pos_scal_manual);
+            if (ImGui::Selectable("##manual", ImGuiSelectableFlags_None, false, widget_scal_size)) {
+                if (init_manual(gui, host))
+                    gui.live_area.manual = true;
+                else
+                    LOG_ERROR("Error opening Manual");
+            }
         }
     }
-
-    /*const auto button_pos = ImVec2(355.0f * scal.x, 505.0f * scal.y);
-    const auto pos_scal_button = ImVec2(display_size.x - button_pos.x, display_size.y - button_pos.y);
-
-    const auto refresh_scal_size = ImVec2(64.0f * scal.x, 64.f * scal.y);
-    const auto refresh_pos = ImVec2(457.0f * scal.x, 501.0f * scal.y);
-    const auto pos_scal_refresh = ImVec2(display_size.x - refresh_pos.x, display_size.y - refresh_pos.y);
-
-    ImGui::SetCursorPos(pos_scal_button);
-    if ((gui.live_area_contents[host.io.title_id].find(BUTTON) != gui.live_area_contents[host.io.title_id].end()) && (gui.live_area_contents[host.io.title_id].find(REFRESH) != gui.live_area_contents[host.io.title_id].end())) {
-        ImGui::Image(gui.live_area_contents[host.io.title_id][BUTTON], widget_scal_size);
-        ImGui::SetCursorPos(pos_scal_refresh);
-        ImGui::Image(gui.live_area_contents[host.io.title_id][REFRESH], refresh_scal_size);
-    } else
-        ImGui::Button("Refresh", BUTTON_SIZE);
-    if (ImGui::IsItemClicked(0)) {
-        gui.live_area_contents.erase(host.io.title_id);
-        gui.live_items.erase(host.io.title_id);
-        init_live_area(gui, host);
-    }*/
 
     if (!gui.live_area.manual) {
         const auto wheel_counter = ImGui::GetIO().MouseWheel;
@@ -1057,22 +1027,22 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
                 if (current_app > 0)
                     --current_app;
                 else
-                    current_app = int(gui.app_selector.apps.size()) - 1;
+                    current_app = int(app_type.size()) - 1;
             } else if (ImGui::IsKeyPressed(host.cfg.keyboard_button_down) || ImGui::IsKeyPressed(host.cfg.keyboard_leftstick_down) || (wheel_counter == -1)) {
-                if (current_app < int(gui.app_selector.apps.size()) - 1)
+                if (current_app < int(app_type.size()) - 1)
                     ++current_app;
                 else
                     current_app = 0;
             }
 
-            if (host.io.title_id != gui.app_selector.apps[current_app].title_id) {
-                host.io.title_id = gui.app_selector.apps[current_app].title_id;
-                host.app_title = gui.app_selector.apps[current_app].title;
+            if (host.io.title_id != app_type[current_app].title_id) {
+                host.io.title_id = app_type[current_app].title_id;
+                host.app_title = app_type[current_app].title;
                 init_live_area(gui, host);
             }
 
             ImGui::SetCursorPos(ImVec2(display_size.x - (60.0f * scal.x), 44.0f * scal.y));
-            ImGui::VSliderInt("##slider_current_app", ImVec2(60.f, 500.f * scal.y), &current_app, int32_t(gui.app_selector.apps.size()) - 1, 0, fmt::format("{}\n_____\n\n{}", current_app + 1, int32_t(gui.app_selector.apps.size())).c_str());
+            ImGui::VSliderInt("##slider_current_app", ImVec2(60.f, 500.f * scal.y), &current_app, int32_t(app_type.size()) - 1, 0, fmt::format("{}\n_____\n\n{}", current_app + 1, int32_t(app_type.size())).c_str());
         }
 
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -45,12 +45,8 @@ static void draw_file_menu(FileMenuState &state, HostState &host) {
 static void draw_emulation_menu(GuiState &gui, HostState &host) {
     if (ImGui::BeginMenu("Emulation")) {
         if (ImGui::MenuItem("Load last App", host.cfg.last_app.c_str(), false, !host.cfg.last_app.empty() && gui.app_selector.selected_title_id.empty())) {
-            if (host.cfg.show_live_area_screen) {
-                host.io.title_id = host.cfg.last_app;
-                init_live_area(gui, host);
-                gui.live_area.live_area_screen = true;
-            } else
-                gui.app_selector.selected_title_id = host.cfg.last_app;
+            host.io.title_id = host.cfg.last_app;
+            load_app(gui, host);
         }
         ImGui::EndMenu();
     }
@@ -75,8 +71,6 @@ static void draw_config_menu(GuiState &gui, HostState &host) {
     if (ImGui::BeginMenu("Configuration")) {
         ImGui::MenuItem("Profiles Manager", nullptr, &gui.configuration_menu.profiles_manager_dialog);
         ImGui::MenuItem("Settings", nullptr, &gui.configuration_menu.settings_dialog);
-        if (ImGui::MenuItem("Theme & Background", nullptr, &gui.theme.theme_background))
-            get_themes_list(gui, host);
         ImGui::EndMenu();
     }
 }
@@ -84,14 +78,6 @@ static void draw_config_menu(GuiState &gui, HostState &host) {
 static void draw_controls_menu(ControlMenuState &state) {
     if (ImGui::BeginMenu("Controls")) {
         ImGui::MenuItem("Keyboard Controls", nullptr, &state.controls_dialog);
-        ImGui::EndMenu();
-    }
-}
-
-static void draw_utilities_menu(GuiState &gui, HostState &host) {
-    if (ImGui::BeginMenu("Utilities")) {
-        if (ImGui::MenuItem("Trophy Collection", nullptr, &gui.trophy.trophy_collection, !gui.trophy.trophy_collection))
-            get_trophy_np_com_id_list(gui, host);
         ImGui::EndMenu();
     }
 }
@@ -111,7 +97,6 @@ void draw_main_menu_bar(GuiState &gui, HostState &host) {
         draw_emulation_menu(gui, host);
         draw_debug_menu(gui.debug_menu);
         draw_config_menu(gui, host);
-        draw_utilities_menu(gui, host);
         draw_controls_menu(gui.controls_menu);
         draw_help_menu(gui.help_menu);
 

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -296,7 +296,12 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
             ImGui::Spacing();
             if (ImGui::Button("Reset theme")) {
                 host.cfg.theme_content_id.clear();
+                if (host.cfg.start_background == "theme") {
+                    host.cfg.start_background.clear();
+                    gui.start_background = {};
+                }
                 gui.theme_backgrounds.clear();
+                init_apps_icon(gui, host, gui.app_selector.sys_apps);
             }
             ImGui::SameLine();
             if (!gui.theme_backgrounds.empty())

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -352,9 +352,7 @@ void get_themes_list(GuiState &gui, HostState &host) {
         return ta.second > tb.second;
     });
 
-    if (fs::exists(fs::path(host.pref_path) / "vs0/app/NPXS10015/sce_sys/pic0.png")) {
-        theme_preview_name["default"]["background"] = "app/NPXS10015/sce_sys/pic0.png";
-
+    if (fs::exists(fw_theme_path) && !fs::is_empty(fw_theme_path)) {
         theme_preview_name["default"]["package"] = "data/internal/theme/theme_defaultImage.png";
 
         theme_preview_name["default"]["home"] = "data/internal/theme/defaultTheme_homeScreen.png";
@@ -415,7 +413,7 @@ void draw_start_screen(GuiState &gui, HostState &host) {
 
     ImGui::SetNextWindowPos(ImVec2(0.f, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
-    ImGui::Begin("##start_screen", &gui.theme.start_screen, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##start_screen", &gui.live_area.start_screen, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
 
     if (gui.start_background)
         ImGui::GetForegroundDrawList()->AddImage(gui.start_background,
@@ -442,7 +440,7 @@ void draw_start_screen(GuiState &gui, HostState &host) {
     ImGui::PopFont();
 
     if (ImGui::IsMouseClicked(0) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle))
-        gui.theme.start_screen = false;
+        gui.live_area.start_screen = false;
 
     ImGui::End();
 }
@@ -471,11 +469,11 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
-    if (gui.themes_preview["default"].find("background") == gui.themes_preview["default"].end())
+    if (gui.apps_background.find(host.io.title_id) == gui.apps_background.end())
         ImGui::SetNextWindowBgAlpha(0.999f);
-    ImGui::Begin("##themes", &gui.theme.theme_background, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
-    if (gui.themes_preview["default"].find("background") != gui.themes_preview["default"].end())
-        ImGui::GetWindowDrawList()->AddImage(gui.themes_preview["default"]["background"], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
+    ImGui::Begin("##themes", &gui.live_area.theme_background, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    if (gui.apps_background.find(host.io.title_id) != gui.apps_background.end())
+        ImGui::GetWindowDrawList()->AddImage(gui.apps_background[host.io.title_id], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
     ImGui::SetWindowFontScale(1.6f * SCAL.x);
     const auto theme_str = ImGui::CalcTextSize(title.c_str(), 0, false, SIZE_LIST.x);
     ImGui::PushTextWrapPos(((display_size.x - SIZE_LIST.x) / 2.f) + SIZE_LIST.x);
@@ -831,7 +829,7 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
             else
                 menu.clear();
         } else
-            gui.theme.theme_background = false;
+            gui.live_area.theme_background = false;
     }
 
     if (!selected.empty() && (selected != "default")) {

--- a/vita3k/gui/src/trophy.cpp
+++ b/vita3k/gui/src/trophy.cpp
@@ -230,20 +230,13 @@ void get_trophy_np_com_id_list(GuiState &gui, HostState &host) {
         }
     }
 
-    const auto trophy_app_bg_path{ fs::path(host.pref_path) / "vs0/app/NPXS10008/sce_sys/pic0.png" };
-    if (fs::exists(trophy_app_bg_path))
-        np_com_id_list_name["bg"]["000"] = "pic0.png";
-
     for (const auto &np_com_id : np_com_id_list_name) {
         for (const auto &group : np_com_id.second) {
             int32_t width = 0;
             int32_t height = 0;
             vfs::FileBuffer buffer;
 
-            if (np_com_id.first == "bg")
-                vfs::read_file(VitaIoDevice::vs0, buffer, host.pref_path, "app/NPXS10008/sce_sys/" + group.second);
-            else
-                vfs::read_file(VitaIoDevice::ux0, buffer, host.pref_path, "user/" + host.io.user_id + "/trophy/conf/" + np_com_id.first + "/" + group.second);
+            vfs::read_file(VitaIoDevice::ux0, buffer, host.pref_path, "user/" + host.io.user_id + "/trophy/conf/" + np_com_id.first + "/" + group.second);
 
             if (buffer.empty()) {
                 LOG_WARN("Icon, Name: '{}', Not found for NPComId: {}.", group.second, np_com_id.first);
@@ -399,11 +392,11 @@ void draw_trophy_collection(GuiState &gui, HostState &host) {
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
-    if (gui.trophy_np_com_id_list["bg"].find("000") != gui.trophy_np_com_id_list["bg"].end())
+    if (gui.apps_background.find(host.io.title_id) == gui.apps_background.end())
         ImGui::SetNextWindowBgAlpha(0.999f);
-    ImGui::Begin("##trophy_collection", &gui.theme.theme_background, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
-    if (gui.trophy_np_com_id_list.find("bg") != gui.trophy_np_com_id_list.end())
-        ImGui::GetWindowDrawList()->AddImage(gui.trophy_np_com_id_list["bg"]["000"], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
+    ImGui::Begin("##trophy_collection", &gui.live_area.theme_background, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    if (gui.apps_background.find(host.io.title_id) != gui.apps_background.end())
+        ImGui::GetWindowDrawList()->AddImage(gui.apps_background[host.io.title_id], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
     if (group_id_selected.empty()) {
         ImGui::SetWindowFontScale(1.4f * SCAL.x);
         if (np_com_id_selected.empty()) {
@@ -715,8 +708,11 @@ void draw_trophy_collection(GuiState &gui, HostState &host) {
                 scroll_type = "np_com";
                 set_scroll_pos = true;
             }
-        } else
-            gui.trophy.trophy_collection = false;
+        } else {
+            gui.live_area.trophy_collection = false;
+            if (host.cfg.show_live_area_screen)
+                gui.live_area.live_area_screen = true;
+        }
     }
 
     if (trophy_id_selected.empty() && !detail_np_com_id && (np_com_id_selected.empty() || !group_id_selected.empty())) {

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -437,8 +437,6 @@ ExitCode load_app(Ptr<const void> &entry_point, HostState &host, GuiState &gui, 
         return ModuleLoadFailed;
     }
 
-    gui::init_app_background(gui, host);
-
     if (!host.cfg.show_gui)
         host.display.imgui_render = false;
 

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -168,11 +168,6 @@ int main(int argc, char *argv[]) {
     if (!gl_renderer.init(host.base_path))
         return RendererInitFailed;
 
-    if (host.cfg.overwrite_config) {
-        host.cfg.last_app = host.io.title_id.c_str();
-        config::serialize_config(host.cfg, host.cfg.config_path);
-    }
-
     while (host.frame_count == 0) {
         // Driver acto!
         renderer::process_batches(*host.renderer.get(), host.renderer->features, host.mem, host.cfg, host.base_path.c_str(),


### PR DESCRIPTION
Split Other pr for get more small to review (theme part for icon only on other pr)

- gui/Apps Selector: Move trophy and themes & background inside Apps Selector
- gui/Apps Selector: fix using short title in grid mode
- gui/app context refactor information and delete pupup
- gui/app context menu: fix using short title
- gui/live area: small clean 

# Result: 
- Grid mode with icon 
![image](https://user-images.githubusercontent.com/5261759/87270237-d6d85e80-c4cf-11ea-9161-35f95fffbd69.png)

- Live area trophy
![image](https://user-images.githubusercontent.com/5261759/87270146-94af1d00-c4cf-11ea-80c0-9904796632b5.png)

- Live Arera theme background (is settings)
![image](https://user-images.githubusercontent.com/5261759/87271994-3b49ec80-c4d5-11ea-86cd-818dabd302dc.png)

- information, change icon size/name position get exactly same psvita
![image](https://user-images.githubusercontent.com/5261759/88239617-2e6f8a80-cc85-11ea-8028-b08eac7876c5.png)

- Content delete popup
![image](https://user-images.githubusercontent.com/5261759/88294642-ceb4c600-ccfc-11ea-8b50-a607ccd60e1a.png)
