### PR TITLE
Fix kiil and vtest instruction + v_Position

### DIFF
--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -394,6 +394,11 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             const auto pa_iter_size = num_comp * 4;
             const auto pa_iter_var = b.createVariable(spv::StorageClassInput, pa_iter_type, pa_name.c_str());
 
+            // TODO how about centroid?
+            if (input_id == 0xD000) {
+                b.addDecoration(pa_iter_var, spv::DecorationBuiltIn, spv::BuiltInFragCoord);
+            }
+
             translation_state.pa_vars.push_back(
                 { pa_iter_var,
                     pa_offset,

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -468,6 +468,12 @@ spv::Id USSETranslatorVisitor::do_alu_op(Instruction &inst, const Imm4 dest_mask
         break;
     }
 
+    case Opcode::ISUBU32:
+    case Opcode::ISUB32: {
+        result = m_b.createBinOp(spv::OpISub, source_type, vsrc1, vsrc2);
+        break;
+    }
+
     default: {
         LOG_ERROR("Unimplemented ALU opcode instruction: {}", disasm::opcode_str(inst.opcode));
         break;

--- a/vita3k/shader/src/translator/branch_cond.cpp
+++ b/vita3k/shader/src/translator/branch_cond.cpp
@@ -96,8 +96,8 @@ static Opcode decode_test_inst(const Imm2 alu_sel, const Imm4 alu_op, const Imm1
             Opcode::IMULU16,
             Opcode::IADD32,
             Opcode::IADDU32,
-            Opcode::INVALID,
-            Opcode::INVALID },
+            Opcode::ISUB32,
+            Opcode::ISUBU32 },
         { Opcode::IADD8,
             Opcode::ISUB8,
             Opcode::IADDU8,
@@ -148,6 +148,10 @@ static Opcode decode_test_inst(const Imm2 alu_sel, const Imm4 alu_op, const Imm1
         }
     }
 
+    if (alu_sel == 1) {
+        filled_dt = DataType::INT32;
+    }
+
     if (alu_sel == 3) {
         filled_dt = DataType::UINT32;
     }
@@ -188,6 +192,7 @@ bool USSETranslatorVisitor::vtst(
     Opcode test_op = decode_test_inst(alu_sel, alu_op, prec, load_data_type);
 
     if (test_op == Opcode::INVALID) {
+        LOG_ERROR("Unsupported comparision: {} {}", alu_sel, alu_op);
         return false;
     }
 
@@ -211,9 +216,11 @@ bool USSETranslatorVisitor::vtst(
 
     const Imm4 load_mask = tb_decode_load_mask[chan_cc];
 
+    bool use_double_reg = alu_sel == 0;
+
     // Build up source
-    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_ext, true, 8, m_second_program);
-    inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank, src2_ext, true, 8, m_second_program);
+    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_ext, use_double_reg, 8, m_second_program);
+    inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank, src2_ext, use_double_reg, 8, m_second_program);
 
     inst.opr.src1.type = load_data_type;
     inst.opr.src2.type = load_data_type;

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -458,7 +458,7 @@ boost::optional<const USSEMatcher<V> &> DecodeUSSE(uint64_t instruction) {
                                                 pp = pred (2 bits, ShortPredicate)
                                                   00000011011110000000000000000000000000000 = kill2
         */
-        INST(&V::kill, "KILL ()", "11111001--11000000000pp00000011011110000000000000000000000000000"),
+        INST(&V::kill, "KILL ()", "11111001--11000000000pp0000001101111----------------------------"),
         // Special
         /*
                                11111 = op1


### PR DESCRIPTION
# About PR
- Implement int32 subs in vtest
- Correct register type in vtest (no double regs)
- Match more kill instructions
- Map gl_fragcoord to v_Position in fragment input 

# v_Position

This is equivalent to WPOS. So, we can just give gl_fragcoord to it.

# Related issues

With updated vtest & v_Position, vitagl texture sample is now working correctly.

Updated v_Position fixes a compile error of one fragment shader in LBP.

