### PR TITLE
Adjust pa offset in non native color

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1226,7 +1226,9 @@ using SceGxmVertexOutputTexCoordInfos = std::array<uint8_t, 10>;
 
 #pragma pack(push, 1)
 struct SceGxmProgramVertexOutput {
-    std::uint8_t unk0[10];
+    std::uint8_t unk0[8];
+    std::uint8_t fragment_output_start; // this might be wrong
+    std::uint8_t unk1;
     std::uint8_t output_param_type;
     std::uint8_t output_comp_count;
 
@@ -1293,9 +1295,7 @@ struct SceGxmProgram {
     std::uint8_t unk12;
     std::uint8_t unk13;
 
-private:
     std::uint8_t type{ 0 }; // shader profile, seems to contain more info in bits after the first(bitfield?)
-public:
     std::uint8_t unk15;
     std::uint8_t unk16;
     std::uint8_t unk17;


### PR DESCRIPTION
# About PR

- Adjust pa offset in non native color fragment shader

# Dangerous

This can break a lot of games potentially. Needs to be tested in as many games as possible.

# Related issues

In some non-native color fragment shader, the output was present in pa2 not pa0. We need to adjust this value. Reversing gxm, I found this promising field in SceGxmProgramVertexOutput. But, I'm not 100% sure because related code was really complicated.

Fixes yellow video in saenai game.

Fixes test shader below.
```
usampler2D test_sampler;
unsigned char4 main(half2 coord : TEXCOORD0): COLOR0 {     
    return tex2D<unsigned char4>(test_sampler, coord); 
}
```