### PR TITLE
Fix uchar sampler and sop2

### DIFF
--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -33,6 +33,21 @@ enum class ShortPredicate : uint8_t {
     NEGP0,
 };
 
+inline ExtPredicate short_predicate_to_ext(ShortPredicate pred) {
+    switch (pred) {
+    case ShortPredicate::NONE:
+        return ExtPredicate::NONE;
+    case ShortPredicate::P0:
+        return ExtPredicate::P0;
+    case ShortPredicate::P1:
+        return ExtPredicate::P1;
+    case ShortPredicate::NEGP0:
+        return ExtPredicate::NEGP0;
+    default:
+        return ExtPredicate::NONE;
+    }
+}
+
 // NOTE: prepended with "_" to allow for '1' and '2' (so that everything is 1 character long)
 enum class SwizzleChannel {
     _X,

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -466,11 +466,31 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             const auto swizzle_texcoord = (descriptor->attribute_info & 0x300);
 
             std::string component_type_str = "????";
-
-            if (component_type == 3) {
-                component_type_str = "float";
-            } else if (component_type == 2) {
+            DataType store_type = DataType::F16;
+            switch (component_type) {
+            case 0: {
+                component_type_str = "uchar";
+                store_type = DataType::UINT8;
+                break;
+            }
+            case 1: {
+                //Maybe char?
+                LOG_WARN("Unsupported texture component: {}", component_type);
+                break;
+            }
+            case 2: {
                 component_type_str = "half";
+                store_type = DataType::F16;
+                break;
+            }
+            case 3: {
+                component_type_str = "float";
+                store_type = DataType::F32;
+                break;
+            }
+            default: {
+                LOG_WARN("Unsupported texture component: {}", component_type);
+            }
             }
 
             std::string swizzle_str = ".xy";
@@ -512,7 +532,7 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             tex_query_var_name += std::to_string(tex_coord_index);
 
             NonDependentTextureQueryCallInfo tex_query_info;
-            tex_query_info.store_type = (component_type == 3) ? static_cast<int>(DataType::F32) : static_cast<int>(DataType::F16);
+            tex_query_info.store_type = static_cast<int>(store_type);
 
             // Size of this extra pa occupied
             // Force this to be PRIVATE

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -329,6 +329,7 @@ static DataType gxm_parameter_type_to_usse_data_type(const SceGxmParameterType p
         break;
 
     case SCE_GXM_PARAMETER_TYPE_U8:
+        return DataType::C10;
     case SCE_GXM_PARAMETER_TYPE_S8:
         return DataType::C10;
 

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1118,6 +1118,11 @@ bool USSETranslatorVisitor::sop2(
     // Final result. Do binary operation and then store
     store(inst.opr.dest, apply_opcode(color_op, src_color_type, factored_rgb_lhs, factored_rgb_rhs), 0b0111, dest_repeat_offset);
     store(inst.opr.dest, apply_opcode(alpha_op, src_alpha_type, factored_a_lhs, factored_a_rhs), 0b1000, dest_repeat_offset);
+
+    // TODO log correctly
+    LOG_DISASM("{:016x}: {}", m_instr, disasm::opcode_str(color_op));
+    LOG_DISASM("{:016x}: {}", m_instr, disasm::opcode_str(alpha_op));
+
     END_REPEAT()
 
     return true;

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1038,16 +1038,20 @@ bool USSETranslatorVisitor::sop2(
             return m_b.createBinOp(spv::OpFSub, type, lhs, rhs);
         }
 
+        case Opcode::FMIN:
         case Opcode::VMIN: {
             return m_b.createBuiltinCall(type, std_builtins, GLSLstd450FMin, { lhs, rhs });
         }
 
+        case Opcode::FMAX:
         case Opcode::VMAX: {
             return m_b.createBuiltinCall(type, std_builtins, GLSLstd450FMax, { lhs, rhs });
         }
 
-        default:
+        default: {
+            LOG_ERROR("Unsuppported sop2 opcode: {}", disasm::opcode_str(op));
             break;
+        }
         }
 
         return spv::NoResult;

--- a/vita3k/shader/src/usse_program_analyzer.cpp
+++ b/vita3k/shader/src/usse_program_analyzer.cpp
@@ -96,6 +96,11 @@ std::uint8_t get_predicate(const std::uint64_t inst) {
             return 0;
         }
     }
+    // SOP2
+    case 0b10000: {
+        uint8_t predicate = ((inst >> 32) & ~0xF9FFFFFF) >> 25;
+        return static_cast<uint8_t>(short_predicate_to_ext(static_cast<ShortPredicate>(predicate)));
+    }
     case 0b00000:
         return ((inst >> 32) & ~0xFCFFFFFF) >> 24;
 

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -217,6 +217,7 @@ static spv::Function *make_f16_pack_func(spv::Builder &b, const FeatureState &fe
 }
 
 spv::Id shader::usse::utils::unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id scalar, const DataType type) {
+    // TODO: doing this for uint8 is probably not right
     switch (type) {
     case DataType::F16: {
         if (!utils.unpack_f16) {
@@ -225,7 +226,7 @@ spv::Id shader::usse::utils::unpack_one(spv::Builder &b, SpirvUtilFunctions &uti
 
         return b.createFunctionCall(utils.unpack_f16, { scalar });
     }
-
+    case DataType::UINT8:
     // TODO: Not really FX8?
     case DataType::C10: {
         if (!utils.unpack_fx8) {
@@ -234,9 +235,10 @@ spv::Id shader::usse::utils::unpack_one(spv::Builder &b, SpirvUtilFunctions &uti
 
         return b.createFunctionCall(utils.unpack_fx8, { scalar });
     }
-
-    default:
+    default: {
+        LOG_ERROR("Unsupported unpack type: {}", log_hex(type));
         break;
+    }
     }
 
     return spv::NoResult;
@@ -251,7 +253,7 @@ spv::Id shader::usse::utils::pack_one(spv::Builder &b, SpirvUtilFunctions &utils
 
         return b.createFunctionCall(utils.pack_f16, { vec });
     }
-
+    case DataType::UINT8:
     // TODO: Not really FX8?
     case DataType::C10: {
         if (!utils.pack_fx8) {
@@ -261,8 +263,10 @@ spv::Id shader::usse::utils::pack_one(spv::Builder &b, SpirvUtilFunctions &utils
         return b.createFunctionCall(utils.pack_fx8, { vec });
     }
 
-    default:
+    default: {
+        LOG_ERROR("Unsupported pack type: {}", log_hex(source_type));
         break;
+    }
     }
 
     return spv::NoResult;


### PR DESCRIPTION
# About PR
- Fix some errors in sop2 implementation
- Correctly handle uchar sampler
- Stub uint8 pack & unpack

# Related issue

Half-fixes the yellow screen in xeodrifter
Fixes usampler test shader

# Uint8

I tried unpacking 4-bytes into 4 1-byte uint and static cast to float. (so that 255 becomes 255.0) The unpacked value was used as an operand of sop2. However, we assumed operands of sop2 to be in c10. 

I need to investigate more on sop2. In the meantime, I'm just stubbing uint8 packer & unpacker with c10 implementation to prevent shader crash and see more.

