### PR TITLE
Fix uint8 in shader

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2382,7 +2382,7 @@ EXPORT(int, sceGxmTextureSetStride, SceGxmTexture *texture, uint32_t byteStride)
 
 EXPORT(int, sceGxmTextureSetUAddrMode, SceGxmTexture *texture, SceGxmTextureAddrMode mode) {
     assert(texture);
-    if (texture)
+    if (!texture)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
 
     if ((texture->type << 29) == SCE_GXM_TEXTURE_CUBE || (texture->type << 29) == SCE_GXM_TEXTURE_CUBE_ARBITRARY) {

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -220,7 +220,7 @@ inline std::size_t get_data_type_size(const DataType type) {
 }
 
 inline bool is_unsigned_integer_data_type(const DataType dtype) {
-    return (dtype == DataType::UINT16) || (dtype == DataType::UINT8) || (dtype == DataType::UINT32);
+    return (dtype == DataType::UINT16) || (dtype == DataType::UINT32);
 }
 
 inline bool is_signed_integer_data_type(const DataType dtype) {

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -33,6 +33,21 @@ enum class ShortPredicate : uint8_t {
     NEGP0,
 };
 
+inline ExtPredicate short_predicate_to_ext(ShortPredicate pred) {
+    switch (pred) {
+    case ShortPredicate::NONE:
+        return ExtPredicate::NONE;
+    case ShortPredicate::P0:
+        return ExtPredicate::P0;
+    case ShortPredicate::P1:
+        return ExtPredicate::P1;
+    case ShortPredicate::NEGP0:
+        return ExtPredicate::NEGP0;
+    default:
+        return ExtPredicate::NONE;
+    }
+}
+
 // NOTE: prepended with "_" to allow for '1' and '2' (so that everything is 1 character long)
 enum class SwizzleChannel {
     _X,

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -220,11 +220,15 @@ inline std::size_t get_data_type_size(const DataType type) {
 }
 
 inline bool is_unsigned_integer_data_type(const DataType dtype) {
-    return (dtype == DataType::UINT16) || (dtype == DataType::UINT32);
+    return (dtype == DataType::UINT16) || (dtype == DataType::UINT32) || (dtype == DataType::UINT8);
 }
 
 inline bool is_signed_integer_data_type(const DataType dtype) {
     return (dtype == DataType::INT16) || (dtype == DataType::INT8) || (dtype == DataType::INT32);
+}
+
+inline bool is_float_data_type(const DataType dtype) {
+    return (dtype == DataType::C10) || (dtype == DataType::F16) || (dtype == DataType::F32);
 }
 
 // TODO: Make this a std::set?

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -16,6 +16,8 @@ struct SpirvUtilFunctions {
     spv::Function *unpack_f16{ nullptr };
     spv::Function *pack_fx8{ nullptr };
     spv::Function *unpack_fx8{ nullptr };
+    spv::Function *pack_u8{ nullptr };
+    spv::Function *unpack_u8{ nullptr };
 };
 
 spv::Id finalize(spv::Builder &b, spv::Id first, spv::Id second, const Swizzle4 swizz, const int offset, const Imm4 dest_mask);
@@ -33,6 +35,10 @@ spv::Id make_uniform_vector_from_type(spv::Builder &b, spv::Id type, int val);
 spv::Id make_vector_or_scalar_type(spv::Builder &b, spv::Id component, int size);
 
 spv::Id unwrap_type(spv::Builder &b, spv::Id type);
+
+spv::Id scale_float_for_u8(spv::Builder &b, spv::Id opr);
+spv::Id unscale_float_for_u8(spv::Builder &b, spv::Id opr);
+
 template <typename F>
 void make_for_loop(spv::Builder &b, spv::Id iterator, spv::Id initial_value_ite, spv::Id iterator_limit, F body) {
     auto blocks = b.makeNewLoop();

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -32,6 +32,7 @@ spv::Id make_uniform_vector_from_type(spv::Builder &b, spv::Id type, int val);
 
 spv::Id make_vector_or_scalar_type(spv::Builder &b, spv::Id component, int size);
 
+spv::Id unwrap_type(spv::Builder &b, spv::Id type);
 template <typename F>
 void make_for_loop(spv::Builder &b, spv::Id iterator, spv::Id initial_value_ite, spv::Id iterator_limit, F body) {
     auto blocks = b.makeNewLoop();

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1053,7 +1053,6 @@ static spv::Function *make_frag_finalize_function(spv::Builder &b, const SpirvSh
 
     spv::Id color = utils::load(b, parameters, utils, features, color_val_operand, 0xF, reg_off);
 
-
     if (program.is_native_color() && features.should_use_shader_interlock()) {
         spv::Id signed_i32 = b.makeIntegerType(32, true);
         spv::Id translated_id = b.createUnaryOp(spv::OpConvertFToS, b.makeVectorType(signed_i32, 4), b.createLoad(translate_state.frag_coord_id));

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -330,6 +330,7 @@ static DataType gxm_parameter_type_to_usse_data_type(const SceGxmParameterType p
         break;
 
     case SCE_GXM_PARAMETER_TYPE_U8:
+        return DataType::C10;
     case SCE_GXM_PARAMETER_TYPE_S8:
         return DataType::C10;
 

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -332,7 +332,7 @@ static DataType gxm_parameter_type_to_usse_data_type(const SceGxmParameterType p
     case SCE_GXM_PARAMETER_TYPE_U8:
         return DataType::UINT8;
     case SCE_GXM_PARAMETER_TYPE_S8:
-        return DataType::C10;
+        return DataType::INT8;
 
     default:
         LOG_WARN("Unsupported output register format {}, default to F16", (int)param_type);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -467,11 +467,31 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             const auto swizzle_texcoord = (descriptor->attribute_info & 0x300);
 
             std::string component_type_str = "????";
-
-            if (component_type == 3) {
-                component_type_str = "float";
-            } else if (component_type == 2) {
+            DataType store_type = DataType::F16;
+            switch (component_type) {
+            case 0: {
+                component_type_str = "uchar";
+                store_type = DataType::UINT8;
+                break;
+            }
+            case 1: {
+                //Maybe char?
+                LOG_WARN("Unsupported texture component: {}", component_type);
+                break;
+            }
+            case 2: {
                 component_type_str = "half";
+                store_type = DataType::F16;
+                break;
+            }
+            case 3: {
+                component_type_str = "float";
+                store_type = DataType::F32;
+                break;
+            }
+            default: {
+                LOG_WARN("Unsupported texture component: {}", component_type);
+            }
             }
 
             std::string swizzle_str = ".xy";
@@ -513,7 +533,7 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             tex_query_var_name += std::to_string(tex_coord_index);
 
             NonDependentTextureQueryCallInfo tex_query_info;
-            tex_query_info.store_type = (component_type == 3) ? static_cast<int>(DataType::F32) : static_cast<int>(DataType::F16);
+            tex_query_info.store_type = static_cast<int>(store_type);
 
             // Size of this extra pa occupied
             // Force this to be PRIVATE

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -628,10 +628,6 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             target_to_store.num = 0;
             target_to_store.type = gxm_parameter_type_to_usse_data_type(program.get_fragment_output_type());
 
-            if (target_to_store.type == DataType::UINT8) {
-                source = utils::scale_float_for_u8(b, source);
-            }
-
             utils::store(b, parameters, utils, features, target_to_store, source, 0b1111, 0);
         }
     }
@@ -1057,9 +1053,6 @@ static spv::Function *make_frag_finalize_function(spv::Builder &b, const SpirvSh
 
     spv::Id color = utils::load(b, parameters, utils, features, color_val_operand, 0xF, reg_off);
 
-    if (param_type == SCE_GXM_PARAMETER_TYPE_U8) {
-        color = utils::unscale_float_for_u8(b, color);
-    }
 
     if (program.is_native_color() && features.should_use_shader_interlock()) {
         spv::Id signed_i32 = b.makeIntegerType(32, true);

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1118,6 +1118,11 @@ bool USSETranslatorVisitor::sop2(
     // Final result. Do binary operation and then store
     store(inst.opr.dest, apply_opcode(color_op, src_color_type, factored_rgb_lhs, factored_rgb_rhs), 0b0111, dest_repeat_offset);
     store(inst.opr.dest, apply_opcode(alpha_op, src_alpha_type, factored_a_lhs, factored_a_rhs), 0b1000, dest_repeat_offset);
+
+    // TODO log correctly
+    LOG_DISASM("{:016x}: {}", m_instr, disasm::opcode_str(color_op));
+    LOG_DISASM("{:016x}: {}", m_instr, disasm::opcode_str(alpha_op));
+
     END_REPEAT()
 
     return true;

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1117,7 +1117,6 @@ bool USSETranslatorVisitor::sop2(
     auto color_res = apply_opcode(color_op, src_color_type, factored_rgb_lhs, factored_rgb_rhs);
     auto alpha_res = apply_opcode(alpha_op, src_alpha_type, factored_a_lhs, factored_a_rhs);
 
-
     // Final result. Do binary operation and then store
     store(inst.opr.dest, color_res, 0b0111, dest_repeat_offset);
     store(inst.opr.dest, alpha_res, 0b1000, dest_repeat_offset);

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1038,16 +1038,20 @@ bool USSETranslatorVisitor::sop2(
             return m_b.createBinOp(spv::OpFSub, type, lhs, rhs);
         }
 
+        case Opcode::FMIN:
         case Opcode::VMIN: {
             return m_b.createBuiltinCall(type, std_builtins, GLSLstd450FMin, { lhs, rhs });
         }
 
+        case Opcode::FMAX:
         case Opcode::VMAX: {
             return m_b.createBuiltinCall(type, std_builtins, GLSLstd450FMax, { lhs, rhs });
         }
 
-        default:
+        default: {
+            LOG_ERROR("Unsuppported sop2 opcode: {}", disasm::opcode_str(op));
             break;
+        }
         }
 
         return spv::NoResult;

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1084,12 +1084,6 @@ bool USSETranslatorVisitor::sop2(
     spv::Id src1_alpha = load(inst.opr.src1, 0b1000, src1_repeat_offset);
     spv::Id src2_alpha = load(inst.opr.src2, 0b1000, src2_repeat_offset);
 
-    // Normalize u8 values
-    src1_color = utils::unscale_float_for_u8(m_b, src1_color);
-    src2_color = utils::unscale_float_for_u8(m_b, src2_color);
-    src1_alpha = utils::unscale_float_for_u8(m_b, src1_alpha);
-    src2_alpha = utils::unscale_float_for_u8(m_b, src2_alpha);
-
     spv::Id src_color_type = m_b.getTypeId(src1_color);
     spv::Id src_alpha_type = m_b.getTypeId(src1_alpha);
 
@@ -1123,9 +1117,6 @@ bool USSETranslatorVisitor::sop2(
     auto color_res = apply_opcode(color_op, src_color_type, factored_rgb_lhs, factored_rgb_rhs);
     auto alpha_res = apply_opcode(alpha_op, src_alpha_type, factored_a_lhs, factored_a_rhs);
 
-    // Undo normalization
-    color_res = utils::scale_float_for_u8(m_b, color_res);
-    alpha_res = utils::scale_float_for_u8(m_b, alpha_res);
 
     // Final result. Do binary operation and then store
     store(inst.opr.dest, color_res, 0b0111, dest_repeat_offset);

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -387,8 +387,8 @@ bool USSETranslatorVisitor::vpck(
             spv::OpAll,
             spv::OpAll,
             spv::OpAll,
-            spv::OpConvertUToF,
-            spv::OpConvertUToF,
+            spv::OpAll,
+            spv::OpAll,
             spv::OpAll },
         { spv::OpAll,
             spv::OpAll,
@@ -422,7 +422,7 @@ bool USSETranslatorVisitor::vpck(
             spv::OpConvertUToF,
             spv::OpConvertUToF,
             spv::OpAll },
-        { spv::OpConvertFToU,
+        { spv::OpAll,
             spv::OpConvertFToS,
             spv::OpAll,
             spv::OpConvertFToU,
@@ -430,7 +430,7 @@ bool USSETranslatorVisitor::vpck(
             spv::OpAll,
             spv::OpAll,
             spv::OpAll },
-        { spv::OpConvertFToU,
+        { spv::OpAll,
             spv::OpConvertFToS,
             spv::OpAll,
             spv::OpConvertFToU,
@@ -578,6 +578,8 @@ bool USSETranslatorVisitor::vpck(
         }
     }
 
+    auto source_type = utils::make_vector_or_scalar_type(m_b, type_f32, m_b.getNumComponents(source));
+
     // When scale, don't do conversion. Reinterpret them.
     if (repack_opcode[dest_fmt][src_fmt] != spv::OpAll && !scale) {
         // Do conversion
@@ -591,6 +593,14 @@ bool USSETranslatorVisitor::vpck(
 
         std::vector<spv::Id> ops{ source };
         source = m_b.createOp(repack_opcode[dest_fmt][src_fmt], m_b.makeVectorType(dest_type, m_b.getNumComponents(source)), ops);
+    }
+
+    if (scale && src_data_type_table[src_fmt] == DataType::UINT8) {
+        source = utils::unscale_float_for_u8(m_b, source);
+    }
+
+    if (scale && dest_data_type_table[dest_fmt] == DataType::UINT8) {
+        source = utils::scale_float_for_u8(m_b, source);
     }
 
     store(inst.opr.dest, source, dest_mask, dest_repeat_offset);

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -595,13 +595,14 @@ bool USSETranslatorVisitor::vpck(
         source = m_b.createOp(repack_opcode[dest_fmt][src_fmt], m_b.makeVectorType(dest_type, m_b.getNumComponents(source)), ops);
     }
 
+    /* we might need to consider this
     if (scale && src_data_type_table[src_fmt] == DataType::UINT8) {
         source = utils::unscale_float_for_u8(m_b, source);
     }
 
     if (scale && dest_data_type_table[dest_fmt] == DataType::UINT8) {
         source = utils::scale_float_for_u8(m_b, source);
-    }
+    }*/
 
     store(inst.opr.dest, source, dest_mask, dest_repeat_offset);
     END_REPEAT()

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -531,12 +531,12 @@ bool USSETranslatorVisitor::vpck(
     GET_REPEAT(inst);
 
     if (src2_mask != 0) {
-        LOG_DISASM("{} {} ({} {})", disasm_str, disasm::operand_to_str(inst.opr.dest, dest_mask, dest_repeat_offset),
+        LOG_DISASM("{} {} ({} {}) [{}]", disasm_str, disasm::operand_to_str(inst.opr.dest, dest_mask, dest_repeat_offset),
             disasm::operand_to_str(inst.opr.src1, src1_mask, src1_repeat_offset),
-            disasm::operand_to_str(inst.opr.src2, src2_mask, src2_repeat_offset));
+            disasm::operand_to_str(inst.opr.src2, src2_mask, src2_repeat_offset), scale ? "scale" : "noscale");
     } else {
-        LOG_DISASM("{} {} {}", disasm_str, disasm::operand_to_str(inst.opr.dest, dest_mask, dest_repeat_offset),
-            disasm::operand_to_str(inst.opr.src1, dest_mask, src1_repeat_offset));
+        LOG_DISASM("{} {} {} [{}]", disasm_str, disasm::operand_to_str(inst.opr.dest, dest_mask, dest_repeat_offset),
+            disasm::operand_to_str(inst.opr.src1, dest_mask, src1_repeat_offset), scale ? "scale" : "noscale");
     }
 
     spv::Id source = load(inst.opr.src1, src1_mask, src1_repeat_offset);

--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -61,6 +61,8 @@ spv::Id shader::usse::USSETranslatorVisitor::do_fetch_texture(const spv::Id tex,
     }
 
     if (dest_type == DataType::UINT8) {
+        // Texel is normalized we have to denormalize it
+        image_sample = utils::scale_float_for_u8(m_b, image_sample);
         image_sample = utils::pack_one(m_b, m_util_funcs, m_features, image_sample, DataType::UINT8);
     }
 

--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -61,8 +61,6 @@ spv::Id shader::usse::USSETranslatorVisitor::do_fetch_texture(const spv::Id tex,
     }
 
     if (dest_type == DataType::UINT8) {
-        // Texel is normalized we have to denormalize it
-        image_sample = utils::scale_float_for_u8(m_b, image_sample);
         image_sample = utils::pack_one(m_b, m_util_funcs, m_features, image_sample, DataType::UINT8);
     }
 

--- a/vita3k/shader/src/usse_program_analyzer.cpp
+++ b/vita3k/shader/src/usse_program_analyzer.cpp
@@ -96,6 +96,11 @@ std::uint8_t get_predicate(const std::uint64_t inst) {
             return 0;
         }
     }
+    // SOP2
+    case 0b10000: {
+        uint8_t predicate = ((inst >> 32) & ~0xF9FFFFFF) >> 25;
+        return static_cast<uint8_t>(short_predicate_to_ext(static_cast<ShortPredicate>(predicate)));
+    }
     case 0b00000:
         return ((inst >> 32) & ~0xFCFFFFFF) >> 24;
 

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -685,13 +685,6 @@ spv::Id shader::usse::utils::load(spv::Builder &b, const SpirvShaderParameters &
     const bool is_unsigned_integer_dtype = is_unsigned_integer_data_type(op.type);
     const bool is_signed_integer_dtype = is_signed_integer_data_type(op.type);
 
-    // Bitcast them to integer. Those flags assuming bits stores on those float registers are actually integer
-    if (is_signed_integer_dtype) {
-        first_pass = b.createUnaryOp(spv::OpBitcast, utils::make_vector_or_scalar_type(b, b.makeIntType(32), static_cast<int>(dest_comp_count)), first_pass);
-    } else if (is_unsigned_integer_dtype) {
-        first_pass = b.createUnaryOp(spv::OpBitcast, utils::make_vector_or_scalar_type(b, b.makeUintType(32), static_cast<int>(dest_comp_count)), first_pass);
-    }
-
     return apply_modifiers(b, op.flags, first_pass);
 }
 
@@ -1015,7 +1008,6 @@ spv::Id shader::usse::utils::scale_float_for_u8(spv::Builder &b, spv::Id opr) {
 
 spv::Id shader::usse::utils::unscale_float_for_u8(spv::Builder &b, spv::Id opr) {
     auto type = unwrap_type(b, b.getTypeId(opr));
-    assert(b.isFloatType(opr));
     spv::Id factor;
     if (b.getScalarTypeWidth(type) == 16)
         factor = b.makeFloat16Constant(MAX_U8);

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -187,8 +187,6 @@ static spv::Function *make_u8_unpack_func(spv::Builder &b, const FeatureState &f
     extracted = b.createUnaryOp(spv::OpBitcast, type_ui32, extracted);
     extracted = b.createBuiltinCall(type_f32_v4, b.import("GLSL.std.450"), GLSLstd450UnpackUnorm4x8, { extracted });
 
-    extracted = shader::usse::utils::scale_float_for_u8(b, extracted);
-
     b.makeReturn(false, extracted);
     b.setBuildPoint(last_build_point);
 
@@ -210,7 +208,6 @@ static spv::Function *make_u8_pack_func(spv::Builder &b, const FeatureState &fea
 
     spv::Id extracted = u8_pack_func->getParamId(0);
 
-    extracted = shader::usse::utils::unscale_float_for_u8(b, extracted);
     extracted = b.createBuiltinCall(type_ui32, b.import("GLSL.std.450"), GLSLstd450PackUnorm4x8, { extracted });
     extracted = b.createUnaryOp(spv::OpBitcast, type_f32, extracted);
 

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -270,7 +270,6 @@ static spv::Function *make_f16_pack_func(spv::Builder &b, const FeatureState &fe
 }
 
 spv::Id shader::usse::utils::unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id scalar, const DataType type) {
-    // TODO: doing this for uint8 is probably not right
     switch (type) {
     case DataType::F16: {
         if (!utils.unpack_f16) {

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -217,6 +217,7 @@ static spv::Function *make_f16_pack_func(spv::Builder &b, const FeatureState &fe
 }
 
 spv::Id shader::usse::utils::unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id scalar, const DataType type) {
+    // TODO: doing this for uint8 is probably not right
     switch (type) {
     case DataType::F16: {
         if (!utils.unpack_f16) {
@@ -225,7 +226,7 @@ spv::Id shader::usse::utils::unpack_one(spv::Builder &b, SpirvUtilFunctions &uti
 
         return b.createFunctionCall(utils.unpack_f16, { scalar });
     }
-
+    case DataType::UINT8:
     // TODO: Not really FX8?
     case DataType::C10: {
         if (!utils.unpack_fx8) {
@@ -234,9 +235,10 @@ spv::Id shader::usse::utils::unpack_one(spv::Builder &b, SpirvUtilFunctions &uti
 
         return b.createFunctionCall(utils.unpack_fx8, { scalar });
     }
-
-    default:
+    default: {
+        LOG_ERROR("Unsupported unpack type: {}", log_hex(type));
         break;
+    }
     }
 
     return spv::NoResult;
@@ -251,7 +253,7 @@ spv::Id shader::usse::utils::pack_one(spv::Builder &b, SpirvUtilFunctions &utils
 
         return b.createFunctionCall(utils.pack_f16, { vec });
     }
-
+    case DataType::UINT8:
     // TODO: Not really FX8?
     case DataType::C10: {
         if (!utils.pack_fx8) {
@@ -261,8 +263,10 @@ spv::Id shader::usse::utils::pack_one(spv::Builder &b, SpirvUtilFunctions &utils
         return b.createFunctionCall(utils.pack_fx8, { vec });
     }
 
-    default:
+    default: {
+        LOG_ERROR("Unsupported pack type: {}", log_hex(source_type));
         break;
+    }
     }
 
     return spv::NoResult;

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -926,3 +926,10 @@ spv::Id shader::usse::utils::make_vector_or_scalar_type(spv::Builder &b, spv::Id
     }
     return b.makeVectorType(component, size);
 }
+
+spv::Id shader::usse::utils::unwrap_type(spv::Builder &b, spv::Id type) {
+    if (b.isVectorType(type)) {
+        return b.getContainedTypeId(type);
+    }
+    return type;
+}

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -801,8 +801,7 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
         break;
     }
 
-    case DataType::INT8:
-    case DataType::UINT8: {
+    case DataType::INT8: {
         dest.type = DataType::C10;
         break;
     }
@@ -810,6 +809,7 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
     case DataType::F32:
     case DataType::F16:
     case DataType::C10:
+    case DataType::UINT8:
         break;
 
     default: {


### PR DESCRIPTION
# About PR
- Fix trivial errors in sop2 implementation
- Implement pack & unpack of uint8
- Handle uint8 (or uchar) sampler
- Handle uint8 output, input and colorattachment
- Update SOP2 to receives and returns uint8 values
- Update VPCK to support uint8

# SOP2

Analyzing shaders using SOP2, I observed four behaviors about sop2.

1. It can use uchar value coming from uniform parameter directly as its sources.
2. The output from one sop2 can be also used directly as sources of another sop2.
3. It can do y = ```(1-x)*color1 + x*color2```. And 1 was immediate value.
4. In 3, x can be 0xff in uint8 bytes.

From 1 and 2, I thought that sop2 actually takes uint8 and returns uint8. Before, we were inputting and outputting fp8 values.

From 3 and 4, I thought that sop2 is actually normalizing the sources internally. I saw so many evidences that uint8 is statically converted to float value (so that 255 -> 255.0 and vice versa) So, if sop2 doesn't normalize sources, in 4 (1-x) would become signed -254, which is really weird if we think that inputs are unsigned values.

# Related issue
- Fixes the yellow screen in xeodrifter with one upcoming PR
- Fixes usampler test shader
- No regression on P4G TV that motivated using fp8 for input and output of sop2 before

