### PR TITLE
Support rgba color surface

### DIFF
--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -56,7 +56,7 @@ bool create(std::unique_ptr<VertexProgram> &vp, GLState &state, const SceGxmProg
 bool sync_state(GLContext &context, const GxmContextState &state, const MemState &mem, bool enable_texture_cache, bool hardware_flip, const std::string &base_path, const std::string &title_id);
 void sync_rendertarget(const GLRenderTarget &rt);
 void set_context(GLContext &ctx, GxmContextState &state, const MemState &mem, const GLRenderTarget *rt, const FeatureState &features);
-void get_surface_data(GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, const bool do_flip);
+void get_surface_data(GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, SceGxmColorFormat format, const bool do_flip);
 void draw(GLState &renderer, GLContext &context, GxmContextState &state, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format,
     const void *indices, size_t count, const MemState &mem, const char *base_path, const char *title_id,
     const bool log_active_shaders, const bool log_uniforms, const bool do_hardware_flip, const bool texture_cache);

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -474,7 +474,7 @@ static void flip_vertically(uint32_t *pixels, size_t width, size_t height, size_
     }
 }
 
-void get_surface_data(GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, const bool do_flip) {
+void get_surface_data(GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, SceGxmColorFormat format, const bool do_flip) {
     R_PROFILE(__func__);
 
     if (pixels == nullptr) {
@@ -482,7 +482,21 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
     }
 
     glPixelStorei(GL_PACK_ROW_LENGTH, static_cast<GLint>(stride_in_pixels));
-    glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    if (format == SCE_GXM_COLOR_FORMAT_U8U8U8U8_ABGR) {
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    } else if (format == SCE_GXM_COLOR_FORMAT_U8U8U8U8_RGBA) {
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        for (int i = 0; i < width * height; ++i) {
+            uint8_t *pixel = reinterpret_cast<uint8_t *>(&pixels[i]);
+            std::swap(pixel[0], pixel[3]);
+            std::swap(pixel[1], pixel[2]);
+        }
+    } else {
+        // TODO wise color conversino implementation
+        // maybe we can use PBO?
+        assert(false);
+    }
+
     glPixelStorei(GL_PACK_ROW_LENGTH, 0);
 
     if (do_flip) {

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -65,7 +65,7 @@ COMMAND(handle_sync_surface_data) {
     switch (renderer.current_backend) {
     case Backend::OpenGL: {
         gl::get_surface_data(*reinterpret_cast<gl::GLContext *>(render_context), width, height,
-            stride_in_pixels, pixels, !config.hardware_flip);
+            stride_in_pixels, pixels, state->color_surface.colorFormat, !config.hardware_flip);
 
         break;
     }


### PR DESCRIPTION
# About PR
- Support rgba color surface

# Related issue

Xeodrifter was using color surface data as texture in rgba color format.

Improves rendering of xeodrifter along with https://github.com/Vita3K/Vita3K/pull/828

