### PR TITLE
renderer: add ability to log active default uniform buffers

### DIFF
--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -46,7 +46,7 @@ std::string load_shader(const SceGxmProgram &program, const FeatureState &featur
 bool set_uniform(GLuint program, const SceGxmProgram &shader_program, GLShaderStatics &statics, const MemState &mem,
     const SceGxmProgramParameter *parameter, const void *data, bool log_uniforms);
 
-bool set_uniform_buffer(GLContext &context, const bool vertex_shader, const int block_num, const int size, const void *data);
+bool set_uniform_buffer(GLContext &context, const bool vertex_shader, const int block_num, const int size, const void *data, bool log_active_shader);
 
 bool create(WindowPtr &window, std::unique_ptr<renderer::State> &state);
 bool create(std::unique_ptr<Context> &context);

--- a/vita3k/renderer/include/renderer/gl/types.h
+++ b/vita3k/renderer/include/renderer/gl/types.h
@@ -70,6 +70,9 @@ struct GLContext : public renderer::Context {
     GLObjectArray<1> element_buffer;
     GLObjectArray<30> uniform_buffer;
     const GLRenderTarget *render_target;
+
+    std::map<int, std::vector<uint8_t>> ubo_data;
+
     GLObjectArray<SCE_GXM_MAX_VERTEX_STREAMS> stream_vertex_buffers;
     GLuint last_draw_program{ 0 };
 

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -7,6 +7,8 @@
 #include <renderer/state.h>
 #include <renderer/types.h>
 
+#include <sstream>
+
 #include <gxm/types.h>
 #include <util/log.h>
 
@@ -74,6 +76,14 @@ void draw(GLState &renderer, GLContext &context, GxmContextState &state, const F
         const std::string hash_text_v = hex_string(state.vertex_program.get(mem)->renderer_data->hash);
 
         LOG_DEBUG("\nVertex  : {}\nFragment: {}", hash_text_v, hash_text_f);
+
+        std::stringstream vert_ub("");
+        dump_hex(context.ubo_data[0], vert_ub);
+        LOG_DEBUG("Vertex default uniform buffer: \n{}", vert_ub.str());
+
+        std::stringstream frag_ub("");
+        dump_hex(context.ubo_data[SCE_GXM_REAL_MAX_UNIFORM_BUFFER], frag_ub);
+        LOG_DEBUG("Fragment default uniform buffer: \n{}", frag_ub.str());
     }
 
     if (!program_id) {

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -77,11 +77,11 @@ void draw(GLState &renderer, GLContext &context, GxmContextState &state, const F
 
         LOG_DEBUG("\nVertex  : {}\nFragment: {}", hash_text_v, hash_text_f);
 
-        std::stringstream vert_ub("");
+        std::stringstream vert_ub;
         dump_hex(context.ubo_data[0], vert_ub);
         LOG_DEBUG("Vertex default uniform buffer: \n{}", vert_ub.str());
 
-        std::stringstream frag_ub("");
+        std::stringstream frag_ub;
         dump_hex(context.ubo_data[SCE_GXM_REAL_MAX_UNIFORM_BUFFER], frag_ub);
         LOG_DEBUG("Fragment default uniform buffer: \n{}", frag_ub.str());
     }

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -433,7 +433,7 @@ void set_context(GLContext &context, GxmContextState &state, const MemState &mem
 
     if (state.fragment_program && state.fragment_program.get(mem)->is_maskupdate) {
         uint8_t mask = state.writing_mask ? 0xFF : 0;
-        set_uniform_buffer(context, false, 14, sizeof(mask), &mask);
+        set_uniform_buffer(context, false, 14, sizeof(mask), &mask, false);
 
         glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->maskbuffer[0]);
     } else {

--- a/vita3k/renderer/src/gl/uniforms.cpp
+++ b/vita3k/renderer/src/gl/uniforms.cpp
@@ -252,7 +252,7 @@ bool set_uniform(GLuint program, const SceGxmProgram &shader_program, GLShaderSt
     return true;
 }
 
-bool set_uniform_buffer(GLContext &context, const bool vertex_shader, const int block_num, const int size, const void *data) {
+bool set_uniform_buffer(GLContext &context, const bool vertex_shader, const int block_num, const int size, const void *data, bool log_active_shader) {
     const int binding_base = vertex_shader ? 0 : SCE_GXM_REAL_MAX_UNIFORM_BUFFER;
     glBindBuffer(GL_UNIFORM_BUFFER, context.uniform_buffer[binding_base + block_num]);
     glBufferData(GL_UNIFORM_BUFFER, size, nullptr, GL_STATIC_DRAW);
@@ -260,6 +260,11 @@ bool set_uniform_buffer(GLContext &context, const bool vertex_shader, const int 
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
     glBindBufferBase(GL_UNIFORM_BUFFER, binding_base + block_num, context.uniform_buffer[binding_base + block_num]);
+
+    if (log_active_shader) {
+        std::vector<uint8_t> my_data((uint8_t *)data, (uint8_t *)data + size);
+        context.ubo_data[binding_base + block_num] = my_data;
+    }
 
     return true;
 }

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -105,7 +105,7 @@ COMMAND_SET_STATE(uniform_buffer) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL: {
-        gl::set_uniform_buffer(*reinterpret_cast<gl::GLContext *>(render_context), is_vertex, block_num, size, data);
+        gl::set_uniform_buffer(*reinterpret_cast<gl::GLContext *>(render_context), is_vertex, block_num, size, data, config.log_active_shaders);
         delete data;
 
         break;

--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -23,6 +23,10 @@
 
 #include <type_traits>
 
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
 namespace logging {
 
 ExitCode init(const Root &root_paths);
@@ -65,3 +69,5 @@ std::string log_hex(T val) {
     using unsigned_type = typename std::make_unsigned<T>::type;
     return fmt::format("0x{:0X}", static_cast<unsigned_type>(val));
 }
+
+void dump_hex(const std::vector<uint8_t> &bytes, std::ostream &stream);

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -278,3 +278,48 @@ std::uint32_t nearest_power_of_two(std::uint32_t num) {
 
     return num;
 }
+
+// based on https://gist.github.com/shreyasbharath/32a8092666303a916e24a81b18af146b
+void dump_hex(const std::vector<uint8_t> &bytes, std::ostream &stream) {
+    char buff[17];
+    size_t i = 0;
+
+    stream << std::hex;
+
+    // Process every byte in the data.
+    for (i = 0; i < bytes.size(); i++) {
+        // Multiple of 16 means new line (with line offset).
+
+        if ((i % 16) == 0) {
+            // Just don't print ASCII for the zeroth line.
+            if (i != 0) {
+                stream << "  " << buff << std::endl;
+            }
+
+            // Output the offset.
+            stream << "  " << std::setw(4) << std::setfill('0') << static_cast<unsigned int>(i);
+        }
+
+        // Now the hex code for the specific character.
+        stream << " " << std::setw(2) << std::setfill('0') << static_cast<unsigned int>(bytes[i]);
+
+        // And store a printable ASCII character for later.
+        if ((bytes[i] < 0x20) || (bytes[i] > 0x7e)) {
+            buff[i % 16] = '.';
+        } else {
+            buff[i % 16] = bytes[i];
+        }
+        buff[(i % 16) + 1] = '\0';
+    }
+
+    stream << std::dec;
+
+    // Pad out last line if not exactly 16 characters.
+    while ((i % 16) != 0) {
+        stream << "   ";
+        i++;
+    }
+
+    // And print the final ASCII bit.
+    stream << "  " << buff << std::endl;
+}


### PR DESCRIPTION
It's useful for debugging shaders. Renderdoc does some dumping, but it's in scientific notation. I found hex more handy.