### PR TITLE
Shader uint register storage

### DIFF
--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -18,7 +18,7 @@ struct SpirvUtilFunctions {
     spv::Function *unpack_fx8{ nullptr };
 };
 
-spv::Id finalize(spv::Builder &b, spv::Id first, spv::Id second, const Swizzle4 swizz, const int offset, const Imm4 dest_mask);
+spv::Id finalize(spv::Builder &b, spv::Id type, spv::Id first, spv::Id second, const Swizzle4 swizz, const int offset, const Imm4 dest_mask);
 spv::Id load(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand op, const Imm4 dest_mask, int shift_offset);
 void store(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand dest, spv::Id source, std::uint8_t dest_mask, int off);
 

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -290,7 +290,7 @@ static spv::Id create_input_variable(spv::Builder &b, SpirvShaderParameters &par
         if (!b.isConstant(var)) {
             var = b.createLoad(var);
             if (total_var_comp > 1)
-                var = utils::finalize(b, var, var, SWIZZLE_CHANNEL_4_DEFAULT, 0, dest_mask);
+                var = utils::finalize(b, b.makeUintType(32), var, var, SWIZZLE_CHANNEL_4_DEFAULT, 0, dest_mask);
         }
 
         utils::store(b, parameters, utils, features, dest, var, dest_mask, 0);
@@ -693,10 +693,10 @@ static void copy_uniform_block_to_register(spv::Builder &builder, spv::Id sa_ban
 }
 
 static spv::Id create_uniform_block(spv::Builder &b, const FeatureState &features, const int base_binding, const int size_vec4_granularity, const bool is_vert) {
-    spv::Id f32_type = b.makeFloatType(32);
+    spv::Id i32_type = b.makeUintType(32);
 
-    spv::Id f32_v4_type = b.makeVectorType(f32_type, 4);
-    spv::Id vec4_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(size_vec4_granularity), 16);
+    spv::Id i32_v4_type = b.makeVectorType(i32_type, 4);
+    spv::Id vec4_arr_type = b.makeArrayType(i32_v4_type, b.makeIntConstant(size_vec4_granularity), 16);
 
     std::string name_type = (is_vert ? "vert" : "frag");
 
@@ -732,16 +732,18 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     // Make array type. TODO: Make length configurable
     spv::Id f32_type = b.makeFloatType(32);
     spv::Id i32_type = b.makeIntType(32);
+    spv::Id ui32_type = b.makeUintType(32);
     spv::Id b_type = b.makeBoolType();
 
     spv::Id f32_v4_type = b.makeVectorType(f32_type, 4);
-    spv::Id pa_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(32), 0);
-    spv::Id sa_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(32), 0);
-    spv::Id i_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(3), 0);
-    spv::Id temp_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(20), 0);
+    spv::Id reg_v4_type = b.makeVectorType(ui32_type, 4);
+    spv::Id pa_arr_type = b.makeArrayType(reg_v4_type, b.makeIntConstant(32), 0);
+    spv::Id sa_arr_type = b.makeArrayType(reg_v4_type, b.makeIntConstant(32), 0);
+    spv::Id i_arr_type = b.makeArrayType(reg_v4_type, b.makeIntConstant(3), 0);
+    spv::Id temp_arr_type = b.makeArrayType(reg_v4_type, b.makeIntConstant(20), 0);
     spv::Id index_arr_type = b.makeArrayType(i32_type, b.makeIntConstant(2), 0);
     spv::Id pred_arr_type = b.makeArrayType(b_type, b.makeIntConstant(4), 0);
-    spv::Id o_arr_type = b.makeArrayType(f32_v4_type, b.makeIntConstant(11), 0);
+    spv::Id o_arr_type = b.makeArrayType(reg_v4_type, b.makeIntConstant(11), 0);
 
     // Create register banks
     spv_params.ins = b.createVariable(spv::StorageClassPrivate, pa_arr_type, "pa");

--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -51,13 +51,13 @@ spv::Id shader::usse::USSETranslatorVisitor::do_fetch_texture(const spv::Id tex,
 
     if (dest_type == DataType::F16) {
         // Pack them
-        spv::Id pack1 = m_b.createOp(spv::OpVectorShuffle, type_f32_v[2], { image_sample, image_sample, 0, 1 });
+        spv::Id pack1 = m_b.createOp(spv::OpVectorShuffle, m_b.makeUintType(32), { image_sample, image_sample, 0, 1 });
         pack1 = utils::pack_one(m_b, m_util_funcs, m_features, pack1, DataType::F16);
 
-        spv::Id pack2 = m_b.createOp(spv::OpVectorShuffle, type_f32_v[2], { image_sample, image_sample, 2, 3 });
+        spv::Id pack2 = m_b.createOp(spv::OpVectorShuffle, m_b.makeUintType(32), { image_sample, image_sample, 2, 3 });
         pack2 = utils::pack_one(m_b, m_util_funcs, m_features, pack2, DataType::F16);
 
-        image_sample = m_b.createCompositeConstruct(type_f32_v[2], { pack1, pack2 });
+        image_sample = m_b.createCompositeConstruct(m_b.makeVectorType(m_b.makeUintType(32), 2), { pack1, pack2 });
     }
 
     return image_sample;


### PR DESCRIPTION
I thought this one is needed for integer uniform buffer. Because some encoding of ints are NaN in float that might mess up things. (https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/intBitsToFloat.xhtml) It turned out this is not needed at all for my gpus (nvidia and amd). I'm just putting this here, hoping it might mitigate some issues later. 