### PR TITLE
Dump shader before crashing

### DIFF
--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -22,7 +22,7 @@ static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 void spirv_disasm_print(const usse::SpirvCode &spirv_binary, std::string *spirv_dump = nullptr);
 
 std::string convert_gxp_to_glsl(const SceGxmProgram &program, const std::string &shader_hash, const FeatureState &features, bool maskupdate = false,
-    bool force_shader_debug = false, std::string *spirv_dump = nullptr, std::string *disasm_dump = nullptr);
+    bool force_shader_debug = false, std::function<bool(const std::string &ext, const std::string &dump)> dumper = nullptr);
 
 void convert_gxp_to_glsl_from_filepath(const std::string &shader_filepath);
 


### PR DESCRIPTION
# About PR
- Dump shader immediate and final forms as soon as it becomes available

# Motivation

If the game crashes because of shader recompiler related issue, gxp and other immediate files are not dumped. This is annoying because they're basis for shader debugging.
