### PR TITLE
Add console mode

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -180,24 +180,26 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
     state.kernel.start_tick = { rtc_base_ticks() };
     state.kernel.base_tick = { rtc_base_ticks() };
 
-    if (renderer::init(state.window, state.renderer, backend)) {
-        update_viewport(state);
-        return true;
-    } else {
-        switch (backend) {
-        case renderer::Backend::OpenGL:
-            error_dialog("Could not create OpenGL context!\nDoes your GPU at least support OpenGL 4.1?", nullptr);
-            break;
+    if (!cfg.console) {
+        if (renderer::init(state.window, state.renderer, backend)) {
+            update_viewport(state);
+            return true;
+        } else {
+            switch (backend) {
+            case renderer::Backend::OpenGL:
+                error_dialog("Could not create OpenGL context!\nDoes your GPU at least support OpenGL 4.1?", nullptr);
+                break;
 #ifdef USE_VULKAN
-        case renderer::Backend::Vulkan:
-            error_dialog("Could not create Vulkan context!");
-            break;
+            case renderer::Backend::Vulkan:
+                error_dialog("Could not create Vulkan context!");
+                break;
 #endif
-        default:
-            error_dialog(fmt::format("Unknown backend render: {}.", state.cfg.backend_renderer));
-            break;
+            default:
+                error_dialog(fmt::format("Unknown backend render: {}.", state.cfg.backend_renderer));
+                break;
+            }
+            return false;
         }
-        return false;
     }
 
     return true;

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -160,7 +160,7 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
         LOG_WARN("Failed to init audio! Audio will not work.");
     }
 
-    if (!init(state.io, state.base_path, state.pref_path)) {
+    if (!init(state.io, state.base_path, state.pref_path, cfg.console)) {
         LOG_ERROR("Failed to initialize file system for the emulator!");
         return false;
     }

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -74,6 +74,7 @@ private:
         overwrite_config = rhs.overwrite_config;
         load_config = rhs.load_config;
         fullscreen = rhs.fullscreen;
+        console = rhs.console;
     }
 
 public:
@@ -90,6 +91,7 @@ public:
     bool overwrite_config = true;
     bool load_config = false;
     bool fullscreen = false;
+    bool console = false;
 
     Config() {
         update_yaml();

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -75,6 +75,7 @@ private:
         load_config = rhs.load_config;
         fullscreen = rhs.fullscreen;
         console = rhs.console;
+        console_arguments = rhs.console_arguments;
     }
 
 public:
@@ -88,6 +89,7 @@ public:
 
     // Setting not present in the YAML file
     fs::path config_path = {};
+    std::string console_arguments;
     bool overwrite_config = true;
     bool load_config = false;
     bool fullscreen = false;

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -141,6 +141,8 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
 
     // Grouped options
     auto input = app.add_option_group("Input", "Special options for Vita3K");
+    input->add_option("--console,-z", command_line.console, "Starts the emulator in fullscreen mode.")
+       ->default_val(false)->group("Input");
     input->add_option("--installed-id,-r", command_line.run_title_id, "Title ID of installed app to run")
         ->default_str({})->check(CLI::IsMember(get_file_set(fs::path(cfg.pref_path) / "ux0/app")))->group("Input");
     input->add_option("--recompile-shader,-s", command_line.recompile_shader_path, "Recompile the given PS Vita shader (GXP format) to SPIR_V / GLSL and quit")

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -142,6 +142,8 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
     auto input = app.add_option_group("Input", "Special options for Vita3K");
     input->add_option("--console,-z", command_line.console, "Starts the emulator in fullscreen mode.")
        ->default_val(false)->group("Input");
+    input->add_option("--console-arguments,-Z", command_line.console_arguments, "Starts the emulator in fullscreen mode.")
+        ->default_str("")->group("Input");
     input->add_option("--installed-id,-r", command_line.run_title_id, "Title ID of installed app to run")
         ->default_str({})->check(CLI::IsMember(get_file_set(fs::path(cfg.pref_path) / "ux0/app")))->group("Input");
     input->add_option("--recompile-shader,-s", command_line.recompile_shader_path, "Recompile the given PS Vita shader (GXP format) to SPIR_V / GLSL and quit")

--- a/vita3k/gui/src/archive_install_dialog.cpp
+++ b/vita3k/gui/src/archive_install_dialog.cpp
@@ -38,7 +38,7 @@ void draw_archive_install_dialog(GuiState &gui, HostState &host) {
         draw_file_dialog = false;
 
         if (result == NFD_OKAY) {
-            if (install_archive(host, gui, static_cast<fs::path>(archive_path)))
+            if (install_archive(host, &gui, static_cast<fs::path>(archive_path)))
                 content_install_confirm = true;
             else if (!gui.content_reinstall_confirm)
                 ImGui::OpenPopup("Content installation failed");
@@ -64,7 +64,7 @@ void draw_archive_install_dialog(GuiState &gui, HostState &host) {
         ImGui::Spacing();
         ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 65);
         if (ImGui::Button("Yes", BUTTON_SIZE))
-            if (install_archive(host, gui, static_cast<fs::path>(archive_path))) {
+            if (install_archive(host, &gui, static_cast<fs::path>(archive_path))) {
                 gui.content_reinstall_confirm = false;
                 content_install_confirm = true;
             }

--- a/vita3k/host/include/host/state.h
+++ b/vita3k/host/include/host/state.h
@@ -63,6 +63,7 @@ struct HostState {
     std::string default_path;
     std::string pref_path;
     Config cfg;
+    SceUID main_thread_id;
     size_t frame_count = 0;
     uint32_t sdl_ticks = 0;
     uint32_t fps = 0;

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -500,6 +500,8 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
         LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(ret));
     }
 
+    host.main_thread_id = main_thread_id;
+
     if (start_thread(host.kernel, main_thread_id, 0, Ptr<void>()) < 0) {
         app::error_dialog("Failed to run main thread.", host.window.get());
         return RunThreadFailed;

--- a/vita3k/interface.h
+++ b/vita3k/interface.h
@@ -36,6 +36,6 @@ inline void delete_zip(mz_zip_archive *zip) {
 
 bool handle_events(HostState &host, GuiState &gui);
 
-bool install_archive(HostState &host, GuiState &gui, const fs::path &path);
-ExitCode load_app(Ptr<const void> &entry_point, HostState &host, GuiState &gui, const std::wstring &path, app::AppRunType run_type);
+bool install_archive(HostState &host, GuiState *gui, const fs::path &path);
+ExitCode load_app(Ptr<const void> &entry_point, HostState &host, const std::wstring &path, app::AppRunType run_type);
 ExitCode run_app(HostState &host, Ptr<const void> &entry_point);

--- a/vita3k/io/include/io/device.h
+++ b/vita3k/io/include/io/device.h
@@ -119,7 +119,10 @@ inline std::string remove_duplicate_device(const std::string &path, VitaIoDevice
   * \param ext The extension of the file (optional).
   * \return A complete Boost.Filesystem path normalized.
   */
-inline fs::path construct_emulated_path(const VitaIoDevice dev, const fs::path &path, const std::string &base_path, const std::string &ext = "") {
+inline fs::path construct_emulated_path(const VitaIoDevice dev, const fs::path &path, const std::string &base_path, const bool redirect_pwd = false, const std::string &ext = "") {
+    if (redirect_pwd && dev == +VitaIoDevice::host0) {
+        return fs::current_path() / path;
+    }
     return fs_utils::construct_file_name(base_path, get_device_string(dev, false), path, ext);
 }
 } // namespace device

--- a/vita3k/io/include/io/functions.h
+++ b/vita3k/io/include/io/functions.h
@@ -35,7 +35,7 @@ inline SceUID invalid_fd = -1;
 
 void init_device_paths(IOState &io);
 bool init_savedata_game_path(IOState &io, const fs::path &pref_path);
-bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path);
+bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path, bool redirect_stdout);
 
 std::string expand_path(IOState &io, const char *path, const std::string &pref_path);
 std::string translate_path(const char *path, VitaIoDevice &device, const IOState::DevicePaths &device_paths);

--- a/vita3k/io/include/io/state.h
+++ b/vita3k/io/include/io/state.h
@@ -107,6 +107,8 @@ struct IOState {
 
     std::string user_id;
 
+    bool redirect_stdio;
+
     SceUID next_fd = 0;
     TtyFiles tty_files;
     StdFiles std_files;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -78,7 +78,6 @@ int main(int argc, char *argv[]) {
         return InitConfigFailed;
     }
 
-
 #ifdef WIN32
     CoInitializeEx(NULL, COINIT_MULTITHREADED);
 #endif

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -179,6 +179,16 @@ int main(int argc, char *argv[]) {
     if (const auto err = run_app(host, entry_point) != Success)
         return err;
 
+    if (cfg.console) {
+        auto main_thread = host.kernel.threads.at(host.main_thread_id);
+        auto lock = std::unique_lock<std::mutex>(main_thread->mutex);
+        main_thread->something_to_do.wait(lock, [&]() {
+            return main_thread->to_do == ThreadToDo::exit;
+        });
+        return Success;
+    } else {
+        gui.imgui_state->do_clear_screen = false;
+    }
 
     app::gl_screen_renderer gl_renderer;
 

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
     if (!fs::exists(root_paths.get_pref_path()))
         fs::create_directories(root_paths.get_pref_path());
 
-    if (logging::init(root_paths) != Success)
+    if (logging::init(root_paths, true) != Success)
         return InitConfigFailed;
 
     Config cfg{};

--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -25,7 +25,7 @@
 
 namespace logging {
 
-ExitCode init(const Root &root_paths);
+ExitCode init(const Root &root_paths, bool use_stdout);
 void set_level(spdlog::level::level_enum log_level);
 ExitCode add_sink(const fs::path &log_path);
 

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -42,8 +42,10 @@ static const fs::path &LOG_FILE_NAME = "vita3k.log";
 static const char *LOG_PATTERN = "%^[%H:%M:%S.%e] |%L| [%!]: %v%$";
 std::vector<spdlog::sink_ptr> sinks;
 
-ExitCode init(const Root &root_paths) {
-    sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+ExitCode init(const Root &root_paths, bool use_stdout) {
+    sinks.clear();
+    if (use_stdout)
+        sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
 
     if (add_sink(root_paths.get_base_path_string() / LOG_FILE_NAME) != Success)
         return InitConfigFailed;


### PR DESCRIPTION
# Motive

With this, we can conveniently run cli vita apps. This would come handy for building up testing infrastructure.

# Usage

It redirects stdout, argc, and argv. If the app printf it will printf in the vita3k as well, and the arguments given to vita3k will be also available to the app. host0 io device is redirected to pwd. By writing to and reading from "host0:/hello.txt," you can read and write from the hello.txt in the working directory.

e.g.
```
Vita3k -z true -Z "this is argument" hello_world.vpk
```

# Sample cli program

```c
#include <psp2/kernel/processmgr.h>
#include <stdio.h>

int main(int argc, char *argv[]) {
	printf("argc: %d argv[1]: %s\n", argc, argv[1]);
	FILE* fp = fopen("host0:/hello", "w");
	fprintf(fp, "Argument: %s\n", argv[1]);
	fclose(fp);
	printf("Hello world\n");
	sceKernelExitProcess(0);
	return 0;
}
 
```