### PR TITLE
trophy: some fix/improvement

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -55,6 +55,7 @@ bool init_theme(GuiState &gui, HostState &host, const std::string &content_id);
 void init_theme_apps_icon(GuiState &gui, HostState &host, const std::string &content_id);
 void init_theme_start_background(GuiState &gui, HostState &host, const std::string &content_id);
 bool init_user_start_background(GuiState &gui, const std::string &image_path);
+void open_trophy_unlocked(GuiState &gui, HostState &host, const std::string &np_com_id, const std::string &trophy_id);
 void pre_load_app(GuiState &gui, HostState &host);
 void pre_run_app(GuiState &gui, HostState &host);
 bool refresh_app_list(GuiState &gui, HostState &host);

--- a/vita3k/gui/src/trophy_unlocked.cpp
+++ b/vita3k/gui/src/trophy_unlocked.cpp
@@ -9,9 +9,9 @@
 namespace gui {
 
 static constexpr float TROPHY_MOVE_DELTA = 12.0f;
-static constexpr float TROPHY_WINDOW_ICON_SIZE = 60.0f;
-static constexpr float TROPHY_WINDOW_MARGIN_PADDING = 10.0f;
-static const ImVec2 TROPHY_WINDOW_SIZE = ImVec2(360, TROPHY_WINDOW_ICON_SIZE + TROPHY_WINDOW_MARGIN_PADDING * 2);
+static constexpr float TROPHY_WINDOW_ICON_SIZE = 48.0f;
+static constexpr float TROPHY_WINDOW_MARGIN_PADDING = 6.0f;
+static const ImVec2 TROPHY_WINDOW_SIZE = ImVec2(400.f, TROPHY_WINDOW_ICON_SIZE + TROPHY_WINDOW_MARGIN_PADDING * 2);
 static constexpr int TROPHY_WINDOW_STATIC_FRAME_COUNT = 250;
 static constexpr float TROPHY_WINDOW_Y_POS = 20.0f;
 
@@ -47,18 +47,15 @@ static void draw_trophy_unlocked(GuiState &gui, HostState &host, NpTrophyUnlockC
     ImGui::SetNextWindowBgAlpha(0.9f);
     ImGui::SetNextWindowPos(gui.trophy_window_pos);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 10.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 15.0f);
     ImGui::PushStyleColor(ImGuiCol_WindowBg, GUI_SMOOTH_GRAY);
     ImGui::SetNextWindowSize(TROPHY_WINDOW_SIZE);
-    ImGui::Begin("##NoName", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize);
+    ImGui::Begin("##NoName", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
 
-    ImGui::SetWindowFontScale(1.3f);
     ImGui::SetCursorPos(ImVec2(TROPHY_WINDOW_MARGIN_PADDING, TROPHY_WINDOW_MARGIN_PADDING));
     ImGui::Columns(2, nullptr, false);
     ImGui::SetColumnWidth(0, TROPHY_WINDOW_ICON_SIZE + TROPHY_WINDOW_MARGIN_PADDING * 2);
     ImGui::Image((ImTextureID)gui.trophy_window_icon, ImVec2(TROPHY_WINDOW_ICON_SIZE, TROPHY_WINDOW_ICON_SIZE));
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.24f, 0.24f, 0.24f, 1.0f));
-    ImGui::SetColumnWidth(1, ImGui::GetIO().DisplaySize.x - ImGui::GetCursorPosX() - TROPHY_WINDOW_MARGIN_PADDING);
     ImGui::NextColumn();
 
     std::string trophy_kind_s = "?";
@@ -88,16 +85,15 @@ static void draw_trophy_unlocked(GuiState &gui, HostState &host, NpTrophyUnlockC
         break;
     }
 
-    ImGui::TextWrapped("%s (%s)", callback_data.trophy_name.c_str(), trophy_kind_s.c_str());
+    ImGui::SetWindowFontScale(1.4f);
+    ImGui::SetCursorPosY(TROPHY_WINDOW_MARGIN_PADDING);
+    ImGui::TextColored(ImVec4(0.24f, 0.24f, 0.24f, 1.0f), "(%s) %s", trophy_kind_s.c_str(), callback_data.trophy_name.c_str());
 
     ImGui::SetWindowFontScale(1.2f);
-    ImGui::TextWrapped("%s", callback_data.description.c_str());
-
-    ImGui::PopStyleColor();
+    ImGui::TextColored(ImVec4(0.24f, 0.24f, 0.24f, 1.0f), "You have earned a trophy!");
     ImGui::End();
     ImGui::PopStyleColor();
-    ImGui::PopStyleVar();
-    ImGui::PopStyleVar();
+    ImGui::PopStyleVar(2);
 
     if (gui.trophy_window_frame_stage == TrophyAnimationStage::STATIC) {
         gui.trophy_window_frame_count++;

--- a/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
+++ b/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
@@ -180,7 +180,6 @@ EXPORT(int, sceNpTrophyTerm) {
 
 static void trophy_unlocked(const NpTrophyUnlockCallbackData &callback_data, const SceNpTrophyID trophy_id) {
     LOG_TRACE("Trophy unlocked: {}, id = {}", callback_data.trophy_name, trophy_id);
-    LOG_TRACE("Detail: {}", callback_data.description);
 }
 
 static int do_trophy_callback(HostState &host, np::trophy::Context *context, SceNpTrophyID trophy_id) {
@@ -191,8 +190,10 @@ static int do_trophy_callback(HostState &host, np::trophy::Context *context, Sce
         return SCE_NP_TROPHY_ERROR_INVALID_TROPHY_ID;
     }
 
+    callback_data.np_com_id = fmt::format("{}_{:0>2d}", context->comm_id.data, context->comm_id.num);
+    callback_data.trophy_id = fmt::format("{:0>3d}", trophy_id);
     callback_data.trophy_kind = context->trophy_kinds[trophy_id];
-    if (!context->get_trophy_description(trophy_id, callback_data.trophy_name, callback_data.description)) {
+    if (!context->get_trophy_name(trophy_id, callback_data.trophy_name)) {
         return SCE_NP_TROPHY_ERROR_UNSUPPORTED_TROPHY_CONF;
     }
 

--- a/vita3k/np/include/np/state.h
+++ b/vita3k/np/include/np/state.h
@@ -34,8 +34,9 @@ struct SceNpServiceStateCallback {
 typedef std::map<int, SceNpServiceStateCallback> np_callbacks;
 
 struct NpTrophyUnlockCallbackData {
+    std::string np_com_id;
+    std::string trophy_id;
     std::string trophy_name;
-    std::string description;
     np::trophy::SceNpTrophyGrade trophy_kind;
     std::vector<std::uint8_t> icon_buf;
 };

--- a/vita3k/np/include/np/trophy/context.h
+++ b/vita3k/np/include/np/trophy/context.h
@@ -84,7 +84,7 @@ struct Context {
 
     const bool is_trophy_unlocked(const uint32_t &trophy_index);
     const int total_trophy_unlocked();
-    bool get_trophy_description(const std::int32_t id, std::string &name, std::string &detail);
+    bool get_trophy_name(const std::int32_t id, std::string &name);
 
     explicit Context(const CommunicationID &comm_id, IOState *io, const SceUID trophy_stream,
         const std::string &output_progress_path);

--- a/vita3k/np/src/trophy/context.cpp
+++ b/vita3k/np/src/trophy/context.cpp
@@ -273,7 +273,7 @@ const int Context::total_trophy_unlocked() {
     return total;
 }
 
-bool Context::get_trophy_description(const std::int32_t id, std::string &name, std::string &detail) {
+bool Context::get_trophy_name(const std::int32_t id, std::string &name) {
     if (id < 0 || id >= MAX_TROPHIES) {
         return false;
     }
@@ -297,16 +297,15 @@ bool Context::get_trophy_description(const std::int32_t id, std::string &name, s
     }
 
     // Try to find the description for the id
-    for (auto trop : doc.child("trophyconf")) {
-        if ((strncmp(trop.name(), "trophy", 6) == 0) && (trop.attribute("id").as_uint() == id)) {
+    for (const auto &trop : doc.child("trophyconf")) {
+        if ((trop.name() == std::string("trophy")) && (trop.attribute("id").as_uint() == id)) {
             name = trop.child("name").text().as_string();
-            detail = trop.child("detail").text().as_string();
 
-            return true;
+            break;
         }
     }
 
-    return false;
+    return !name.empty();
 }
 
 int Context::install_trophy_conf(IOState *io, const std::string &pref_path, const std::string np_com_id) {


### PR DESCRIPTION
This pr for split my other pr, with so here only change and fix relate trophy.
- trophy: fix get trophy name for showed on popup notif
- trophy collection: improve gui and add open trophy id for notice info.

# Result: 
- set margin left for trophy icon like on psvita (in center pos compare mp com id icon.
![image](https://user-images.githubusercontent.com/5261759/90012189-367a8300-dca3-11ea-994f-27205a9fd42f.png)
- small fix margin left also for group (is same in finnaly for both)
![image](https://user-images.githubusercontent.com/5261759/90012251-55791500-dca3-11ea-9e95-bf7e3919fd7e.png)

- Fix trophy display name missing for some game and reworks gui like on psvita
![image](https://user-images.githubusercontent.com/5261759/90012393-9709c000-dca3-11ea-83a1-5d88a35118cd.png)

