### PR TITLE
io/SceAppUtil: fix saving

### DIFF
--- a/vita3k/io/src/filesystem.cpp
+++ b/vita3k/io/src/filesystem.cpp
@@ -23,18 +23,15 @@
 const wchar_t *translate_open_mode(const int flags) {
     if (flags & SCE_O_WRONLY) {
         if (flags & SCE_O_RDONLY) {
-            if (flags & SCE_O_CREAT) {
-                if (flags & SCE_O_APPEND) {
-                    return L"ab+";
-                }
-                return L"wb+";
+            if (flags & SCE_O_APPEND) {
+                return L"ab+";
             }
             return L"rb+";
         }
         if (flags & SCE_O_APPEND) {
             return L"ab";
         }
-        return L"wb";
+        return L"rb+";
     }
     return L"rb";
 }
@@ -42,18 +39,15 @@ const wchar_t *translate_open_mode(const int flags) {
 const char *translate_open_mode(const int flags) {
     if (flags & SCE_O_WRONLY) {
         if (flags & SCE_O_RDONLY) {
-            if (flags & SCE_O_CREAT) {
-                if (flags & SCE_O_APPEND) {
-                    return "ab+";
-                }
-                return "wb+";
+            if (flags & SCE_O_APPEND) {
+                return "ab+";
             }
             return "rb+";
         }
         if (flags & SCE_O_APPEND) {
             return "ab";
         }
-        return "wb";
+        return "rb+";
     }
     return "rb";
 }

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -249,6 +249,8 @@ SceUID open_file(IOState &io, const char *path, const int flags, const std::stri
     if (!fs::exists(system_path) && !can_write(flags)) {
         LOG_ERROR("Missing file at {} (target path: {})", system_path.string(), path);
         return IO_ERROR(SCE_ERROR_ERRNO_ENOENT);
+    } else if (!fs::exists(system_path) && (flags & SCE_O_CREAT)) {
+        std::ofstream file(system_path.string());
     }
 
     const auto normalized_path = device::construct_normalized_path(device, translated_path);

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -234,6 +234,12 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
             create_dir(host.io, file_path.c_str(), 0777, host.pref_path, export_name);
             break;
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_FILE_TRUNCATE:
+            if (files[i].buf) {
+                fd = open_file(host.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, host.pref_path, export_name);
+                seek_file(fd, static_cast<int>(files[i].offset), SCE_SEEK_SET, host.io, export_name);
+                write_file(fd, files[i].buf.get(host.mem), files[i].bufSize, host.io, export_name);
+                close_file(host.io, fd, export_name);
+            }
             fd = open_file(host.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_APPEND | SCE_O_TRUNC, host.pref_path, export_name);
             truncate_file(fd, files[i].bufSize + files[i].offset, host.io, export_name);
             close_file(host.io, fd, export_name);
@@ -259,7 +265,7 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
         modified_time.minute = local->tm_min;
         modified_time.second = local->tm_sec;
         slot->slotParam.get(host.mem)->modifiedTime = modified_time;
-        fd = open_file(host.io, construct_slotparam_path(slot->id).c_str(), SCE_O_WRONLY, host.pref_path, export_name);
+        fd = open_file(host.io, construct_slotparam_path(slot->id).c_str(), SCE_O_WRONLY | SCE_O_CREAT, host.pref_path, export_name);
         write_file(fd, slot->slotParam.get(host.mem), sizeof(SceAppUtilSaveDataSlotParam), host.io, export_name);
         close_file(host.io, fd, export_name);
     }
@@ -295,6 +301,7 @@ EXPORT(int, sceAppUtilSaveDataSlotGetParam, unsigned int slotId, SceAppUtilSaveD
         return RET_ERROR(SCE_APPUTIL_ERROR_SAVEDATA_SLOT_NOT_FOUND);
     read_file(param, host.io, fd, sizeof(SceAppUtilSaveDataSlotParam), export_name);
     close_file(host.io, fd, export_name);
+    param->status = 0;
     return 0;
 }
 


### PR DESCRIPTION
- undertale writes its save file in truncate mode, so that's been fixed
- some mages games consider a save file to be corrupt if param-status isn't 0
- SCE_O_WRONLY shouldn't create files, only SCE_O_CREAT can