### PR TITLE
GUI: Some refactor

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -40,6 +40,7 @@ void delete_app(GuiState &gui, HostState &host);
 void get_app_info(GuiState &gui, HostState &host, const std::string &title_id);
 size_t get_app_size(HostState &host, const std::string &title_id);
 std::vector<App>::iterator get_app_index(GuiState &gui, const std::string &title_id);
+std::vector<std::string>::iterator get_app_open_list_index(GuiState &gui, const std::string &title_id);
 void get_contents_size(GuiState &gui, HostState &host);
 void get_modules_list(GuiState &gui, HostState &host);
 void get_themes_list(GuiState &gui, HostState &host);
@@ -56,7 +57,7 @@ void init_theme_apps_icon(GuiState &gui, HostState &host, const std::string &con
 void init_theme_start_background(GuiState &gui, HostState &host, const std::string &content_id);
 bool init_user_start_background(GuiState &gui, const std::string &image_path);
 void open_trophy_unlocked(GuiState &gui, HostState &host, const std::string &np_com_id, const std::string &trophy_id);
-void pre_load_app(GuiState &gui, HostState &host);
+void pre_load_app(GuiState &gui, HostState &host, bool live_area);
 void pre_run_app(GuiState &gui, HostState &host);
 bool refresh_app_list(GuiState &gui, HostState &host);
 void update_notice_info(GuiState &gui, HostState &host, const std::string &type);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -71,6 +71,7 @@ struct AppsSelector {
 };
 
 struct LiveAreaState {
+    bool app_selector = false;
     bool content_manager = false;
     bool live_area_screen = false;
     bool manual = false;
@@ -169,6 +170,9 @@ struct GuiState {
     GLuint display = 0;
 
     ImGuiTextFilter app_search_bar;
+
+    std::vector<std::string> apps_list_opened;
+    int32_t current_app_selected = -1;
 
     std::uint64_t current_theme_bg;
     std::map<std::string, std::map<std::string, ImGui_Texture>> themes_preview;

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -108,7 +108,7 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
     if (ImGui::BeginPopupContextItem("##app_context_menu")) {
         ImGui::SetWindowFontScale(1.3f);
         if (ImGui::MenuItem("Boot", host.app_short_title.c_str()))
-            pre_run_app(gui, host);
+            pre_load_app(gui, host, false);
         if (host.app_title_id.find("NPXS") == std::string::npos) {
             if (ImGui::MenuItem("Check App Compatibility")) {
                 const std::string compat_url = host.app_title_id.find("PCS") != std::string::npos ? "https://vita3k.org/compatibility?g=" + host.app_title_id : "https://github.com/Vita3K/homebrew-compatibility/issues?q=" + host.app_title;

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -414,6 +414,10 @@ ImTextureID load_image(GuiState &gui, const char *data, const std::uint32_t size
 void init(GuiState &gui, HostState &host) {
     ImGui::CreateContext();
     gui.imgui_state.reset(ImGui_ImplSdl_Init(host.renderer.get(), host.window.get(), host.base_path));
+
+    if (host.cfg.show_gui)
+        host.display.imgui_render = true;
+
     assert(gui.imgui_state);
 
     init_style();
@@ -444,9 +448,13 @@ void init(GuiState &gui, HostState &host) {
             init_user_start_background(gui, host.cfg.user_start_background);
         else
             init_theme_start_background(gui, host, host.cfg.start_background == "default" ? "default" : host.cfg.theme_content_id);
+    }
 
-        if (!host.cfg.run_title_id && !host.cfg.vpk_path && gui.start_background)
+    if (!host.cfg.run_title_id && !host.cfg.vpk_path) {
+        if (gui.start_background)
             gui.live_area.start_screen = true;
+        else
+            gui.live_area.app_selector = true;
     }
 
     // Initialize trophy callback
@@ -474,7 +482,7 @@ void draw_end(GuiState &gui, SDL_Window *window) {
 void draw_live_area(GuiState &gui, HostState &host) {
     ImGui::PushFont(gui.live_area_font);
 
-    if (!gui.live_area.content_manager && !gui.live_area.live_area_screen && !gui.live_area.theme_background && !gui.live_area.trophy_collection && host.io.title_id.empty())
+    if (gui.live_area.app_selector)
         draw_app_selector(gui, host);
 
     if (gui.live_area.live_area_screen)

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -45,8 +45,8 @@ static void draw_file_menu(FileMenuState &state, HostState &host) {
 static void draw_emulation_menu(GuiState &gui, HostState &host) {
     if (ImGui::BeginMenu("Emulation")) {
         if (ImGui::MenuItem("Load last App", host.cfg.last_app.c_str(), false, !host.cfg.last_app.empty() && host.io.title_id.empty())) {
-            host.io.title_id = host.cfg.last_app;
-            pre_load_app(gui, host);
+            host.app_title_id = host.cfg.last_app;
+            pre_load_app(gui, host, host.cfg.show_live_area_screen);
         }
         ImGui::EndMenu();
     }

--- a/vita3k/gui/src/manual.cpp
+++ b/vita3k/gui/src/manual.cpp
@@ -33,7 +33,7 @@ static std::map<std::string, std::pair<bool, bool>> zoom;
 
 bool init_manual(GuiState &gui, HostState &host) {
     current_page = 0;
-    const auto title_id = host.io.title_id.empty() ? host.app_title_id : host.io.title_id;
+    const auto title_id = gui.apps_list_opened[gui.current_app_selected];
     if (gui.manuals.find(title_id) == gui.manuals.end()) {
         std::vector<std::string> manual_page_list;
         const auto app_path{ fs::path(host.pref_path) / "ux0/app" / title_id };
@@ -89,7 +89,7 @@ void draw_manual(GuiState &gui, HostState &host) {
     ImGui::SetNextWindowBgAlpha(0.999f);
     ImGui::Begin("##manual", &gui.live_area.manual, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-    const auto title_id = host.io.title_id.empty() ? host.io.title_id : host.io.title_id;
+    const auto title_id = gui.apps_list_opened[gui.current_app_selected];
     if (zoom[title_id].first && ImGui::IsMouseDoubleClicked(0)) {
         zoom[title_id].second ? size_page[title_id]["current"] = size_page[title_id]["mini"] : size_page[title_id]["current"] = size_page[title_id]["max"];
         zoom[title_id].second = !zoom[title_id].second;
@@ -107,8 +107,10 @@ void draw_manual(GuiState &gui, HostState &host) {
     const auto BUTTON_SIZE = ImVec2(65.f * scal.x, 30.f * scal.y);
 
     ImGui::SetCursorPos(ImVec2(size_child.x - ((!zoom[title_id].second ? 70.0f : 85.f) * scal.x), 10.0f * scal.y));
-    if (!hiden_button && ImGui::Button("Esc", BUTTON_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_psbutton))
+    if (!hiden_button && ImGui::Button("Esc", BUTTON_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_psbutton)) {
         gui.live_area.manual = false;
+        gui.live_area.live_area_screen = true;
+    }
 
     const auto wheel_counter = ImGui::GetIO().MouseWheel;
     if (current_page > 0) {

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -522,8 +522,10 @@ void draw_start_screen(GuiState &gui, HostState &host) {
     ImGui::GetForegroundDrawList()->AddText(gui.live_area_font_large, (124.0f * scal_font_large) * SCAL.x, CLOCK_POS, date_color, fmt::format("{:0>2d}:{:0>2d}", local.tm_hour, local.tm_min).c_str());
     ImGui::PopFont();
 
-    if (ImGui::IsMouseClicked(0) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle))
+    if (ImGui::IsMouseClicked(0) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle)) {
         gui.live_area.start_screen = false;
+        gui.live_area.app_selector = true;
+    }
 
     ImGui::End();
 }
@@ -920,6 +922,12 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
         } else {
             if (gui.live_area.content_manager)
                 host.app_title_id = "NPXS10026";
+            else {
+                if (gui.live_area_contents.find("NPXS10015") != gui.live_area_contents.end())
+                    gui.live_area.live_area_screen = true;
+                else
+                    gui.live_area.app_selector = true;
+            }
             gui.live_area.theme_background = false;
         }
     }

--- a/vita3k/host/include/host/state.h
+++ b/vita3k/host/include/host/state.h
@@ -49,7 +49,7 @@ struct DisplayState {
     std::mutex mutex;
     std::condition_variable condvar;
     std::atomic<bool> abort{ false };
-    std::atomic<bool> imgui_render{ true };
+    std::atomic<bool> imgui_render{ false };
     std::atomic<bool> fullscreen{ false };
 };
 

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -406,13 +406,15 @@ bool handle_events(HostState &host, GuiState &gui) {
                     gui.is_capturing_keys = false;
                 }
             }
-            if (!host.io.title_id.empty()) {
-                // toggle gui state
+            // toggle gui state
+            if (!gui.configuration_menu.profiles_manager_dialog && !gui.configuration_menu.settings_dialog && !gui.captured_key) {
                 if (event.key.keysym.sym == SDLK_g)
                     host.display.imgui_render = !host.display.imgui_render;
+            }
+            if (!host.io.title_id.empty() && !gui.live_area.app_selector && !gui.live_area.manual) {
                 // Show/Hide Live Area during app run
                 // TODO pause app running
-                if (!gui.live_area.manual && (event.key.keysym.scancode == host.cfg.keyboard_button_psbutton)) {
+                if (event.key.keysym.scancode == host.cfg.keyboard_button_psbutton) {
                     if (gui.live_area_contents.find(host.io.title_id) == gui.live_area_contents.end())
                         gui::init_live_area(gui, host);
                     gui.live_area.live_area_screen = !gui.live_area.live_area_screen;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -145,7 +145,8 @@ int main(int argc, char *argv[]) {
                 discord::update_init_status(host.cfg.discord_rich_presence, &discord_rich_presence_old);
 #endif
                 gui::draw_live_area(gui, host);
-                gui::draw_ui(gui, host);
+                if (host.display.imgui_render)
+                    gui::draw_ui(gui, host);
 
                 gui::draw_end(gui, host.window.get());
             } else {
@@ -237,7 +238,7 @@ int main(int argc, char *argv[]) {
         gui::draw_common_dialog(gui, host);
         gui::draw_live_area(gui, host);
 
-        if (host.cfg.performance_overlay)
+        if (host.cfg.performance_overlay && !gui.live_area.app_selector && !gui.live_area.live_area_screen)
             gui::draw_perf_overlay(gui, host);
 
         gui::draw_trophies_unlocked(gui, host);


### PR DESCRIPTION
- gui/main menubar: fix set value.
- gui/app sellector: Add information bar.
- gui: reworks app selector and live area switch game.

# Result:
- Live area app with arrow left/right for switch app opened
![image](https://user-images.githubusercontent.com/5261759/90625656-3980f080-e21a-11ea-95c0-41e175be4aae.png)
 
- App Selector with arrow in left for open it on live area 
![image](https://user-images.githubusercontent.com/5261759/90625818-6fbe7000-e21a-11ea-9c23-6d2db0c0052a.png)

- App running go live area and left for show app selector
(for can go on system app for now, can launch another app in futur like psvita)
![image](https://user-images.githubusercontent.com/5261759/90626503-5669f380-e21b-11ea-8a8a-4a2f85910414.png)