### PR TITLE
Continuous tag is release

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -99,7 +99,7 @@ jobs:
         uses: Xotl/cool-github-releases@v1
         with:
           mode: update
-          isPrerelease: true
+          isPrerelease: false
           tag_name: continous
           release_name: "Automatic CI builds"
           body_mrkdwn: |


### PR DESCRIPTION
Prerelease doesn't show up in github main page because we already have releases.