### PR TITLE
gui: Small refactor for information bar.

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -42,6 +42,7 @@ size_t get_app_size(HostState &host, const std::string &title_id);
 std::vector<App>::iterator get_app_index(GuiState &gui, const std::string &title_id);
 std::vector<std::string>::iterator get_app_open_list_index(GuiState &gui, const std::string &title_id);
 void get_contents_size(GuiState &gui, HostState &host);
+bool get_live_area_sys_app_state(GuiState &gui);
 void get_modules_list(GuiState &gui, HostState &host);
 void get_themes_list(GuiState &gui, HostState &host);
 void get_trophy_np_com_id_list(GuiState &gui, HostState &host);
@@ -58,8 +59,9 @@ void init_theme_start_background(GuiState &gui, HostState &host, const std::stri
 bool init_user_start_background(GuiState &gui, const std::string &image_path);
 void open_trophy_unlocked(GuiState &gui, HostState &host, const std::string &np_com_id, const std::string &trophy_id);
 void pre_load_app(GuiState &gui, HostState &host, bool live_area);
-void pre_run_app(GuiState &gui, HostState &host);
+void pre_run_app(GuiState &gui, HostState &host, const std::string &title_id);
 bool refresh_app_list(GuiState &gui, HostState &host);
+void update_apps_list_opened(GuiState &gui, const std::string &title_id);
 void update_notice_info(GuiState &gui, HostState &host, const std::string &type);
 
 void draw_begin(GuiState &gui, HostState &host);
@@ -69,8 +71,6 @@ void draw_ui(GuiState &gui, HostState &host);
 
 void draw_app_context_menu(GuiState &gui, HostState &host);
 void draw_common_dialog(GuiState &gui, HostState &host);
-void draw_information_bar(GuiState &gui);
-void draw_notice_info(GuiState &gui, HostState &host);
 void draw_reinstall_dialog(GenericDialogState *status);
 void draw_trophies_unlocked(GuiState &gui, HostState &host);
 void draw_perf_overlay(GuiState &gui, HostState &host);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -73,6 +73,7 @@ struct AppsSelector {
 struct LiveAreaState {
     bool app_selector = false;
     bool content_manager = false;
+    bool information_bar = false;
     bool live_area_screen = false;
     bool manual = false;
     bool theme_background = false;

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -168,6 +168,7 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
                 const auto app_size = get_app_size(host, host.app_title_id);
                 gui.app_selector.app_info.size = app_size;
             }
+            gui.live_area.information_bar = false;
         }
         ImGui::EndPopup();
     }
@@ -254,8 +255,10 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
         ImGui::Begin("##information", &information, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
         ImGui::SetWindowFontScale(1.5f * scal.x);
         ImGui::SetCursorPos(ImVec2(10.0f * scal.x, 10.0f * scal.y));
-        if (ImGui::Button("X", ImVec2(40.f * scal.x, 40.f * scal.y)) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle))
+        if (ImGui::Button("X", ImVec2(40.f * scal.x, 40.f * scal.y)) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle)) {
             information = false;
+            gui.live_area.information_bar = true;
+        }
         if (gui.app_selector.icons.find(host.app_title_id) != gui.app_selector.icons.end()) {
             ImGui::SetCursorPos(ImVec2((display_size.x / 2.f) - (INFO_ICON_SIZE.x / 2.f), 22.f * scal.y));
             ImGui::Image(gui.app_selector.icons[host.app_title_id], INFO_ICON_SIZE);

--- a/vita3k/gui/src/content_manager.cpp
+++ b/vita3k/gui/src/content_manager.cpp
@@ -228,8 +228,6 @@ static float scroll_pos;
 static ImGuiTextFilter search_bar;
 
 void draw_content_manager(GuiState &gui, HostState &host) {
-    draw_information_bar(gui);
-
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto SCAL = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
     const auto MENUBAR_HEIGHT = 32.f * SCAL.y;
@@ -245,7 +243,7 @@ void draw_content_manager(GuiState &gui, HostState &host) {
 
     const auto POPUP_SIZE = ImVec2(756.0f * SCAL.x, 436.0f * SCAL.y);
 
-    const auto is_background = gui.apps_background.find(host.app_title_id) != gui.apps_background.end();
+    const auto is_background = gui.apps_background.find("NPXS10026") != gui.apps_background.end();
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
@@ -254,7 +252,7 @@ void draw_content_manager(GuiState &gui, HostState &host) {
 
     ImGui::Begin("##content_manager", &gui.live_area.content_manager, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
-        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background[host.app_title_id], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
+        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10026"], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
 
     ImGui::SetWindowFontScale(1.5f * SCAL.x);
 
@@ -319,8 +317,9 @@ void draw_content_manager(GuiState &gui, HostState &host) {
         ImGui::Separator();
         ImGui::SetWindowFontScale(1.2f);
         if (ImGui::Selectable("Themes", false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0.f, SIZE_SELECT))) {
-            host.app_title_id = "NPXS10015";
-            pre_run_app(gui, host);
+            host.app_title_id = "NPXS10026";
+            gui.live_area.content_manager = false;
+            pre_run_app(gui, host, "NPXS10015");
         }
         ImGui::NextColumn();
         ImGui::SetWindowFontScale(0.8f);
@@ -542,8 +541,13 @@ void draw_content_manager(GuiState &gui, HostState &host) {
                     set_scroll_pos = true;
                 } else
                     menu.clear();
-            } else
+            } else {
+                if (!gui.apps_list_opened.empty() && gui.apps_list_opened[gui.current_app_selected] == "NPXS10026")
+                    gui.live_area.live_area_screen = true;
+                else
+                    gui.live_area.app_selector = true;
                 gui.live_area.content_manager = false;
+            }
         }
     } else {
         ImGui::SetWindowFontScale(1.5f * SCAL.x);

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -415,9 +415,6 @@ void init(GuiState &gui, HostState &host) {
     ImGui::CreateContext();
     gui.imgui_state.reset(ImGui_ImplSdl_Init(host.renderer.get(), host.window.get(), host.base_path));
 
-    if (host.cfg.show_gui)
-        host.display.imgui_render = true;
-
     assert(gui.imgui_state);
 
     init_style();
@@ -451,6 +448,7 @@ void init(GuiState &gui, HostState &host) {
     }
 
     if (!host.cfg.run_title_id && !host.cfg.vpk_path) {
+        gui.live_area.information_bar = true;
         if (gui.start_background)
             gui.live_area.start_screen = true;
         else
@@ -484,6 +482,9 @@ void draw_live_area(GuiState &gui, HostState &host) {
 
     if (gui.live_area.app_selector)
         draw_app_selector(gui, host);
+
+    if (gui.live_area.information_bar)
+        draw_information_bar(gui, host);
 
     if (gui.live_area.live_area_screen)
         draw_live_area_screen(gui, host);

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -33,51 +33,12 @@
 
 namespace gui {
 
-void draw_information_bar(GuiState &gui) {
-    const auto display_size = ImGui::GetIO().DisplaySize;
-    const auto SCAL = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
-    const auto MENUBAR_HEIGHT = 32.f * SCAL.y;
-    ImU32 DEFAUL_BAR_COLOR = 4278190080; // Black
-    ImU32 DEFAUL_INDICATOR_COLOR = 4294967295; // White
-    const auto is_notif_pos = !gui.live_area.start_screen && (gui.live_area.live_area_screen || gui.live_area.app_selector) ? 78.f * SCAL.x : 0.f;
-
-    const auto is_theme_color = gui.live_area.app_selector || gui.live_area.live_area_screen || gui.live_area.start_screen;
-
-    ImGui::SetNextWindowPos(ImVec2(0.f, 0.f), ImGuiCond_Always);
-    ImGui::SetNextWindowSize(ImVec2(display_size.x, MENUBAR_HEIGHT), ImGuiCond_Always);
-    ImGui::Begin("##information_bar", nullptr, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
-
-    const auto scal_default_font = 19.2f / ImGui::GetFontSize();
-
-    const auto now = std::chrono::system_clock::now();
-    const auto tt = std::chrono::system_clock::to_time_t(now);
-    const auto local = *localtime(&tt);
-
-    const std::string clock_str = fmt::format("{:0>2d}:{:0>2d}", local.tm_hour, local.tm_min);
-
-    ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(0.f, 0.f), ImVec2(display_size.x, MENUBAR_HEIGHT), is_theme_color ? gui.information_bar_color["bar"] : DEFAUL_BAR_COLOR, 0.f, ImDrawCornerFlags_All);
-
-    if (gui.live_area.app_selector || gui.live_area.live_area_screen) {
-        const float decal_icon_pos = 38.f * ((float(gui.apps_list_opened.size()) - 1.f) / 2.f);
-        for (auto a = 0; a < gui.apps_list_opened.size(); a++) {
-            const auto icon_scal_pos = ImVec2((display_size.x / 2.f) - (16.f * SCAL.x) - (decal_icon_pos * SCAL.x) + (a * (38.f * SCAL.x)), display_size.y - (544.f * SCAL.y));
-            const auto icon_scal_size = ImVec2(icon_scal_pos.x + (32.0f * SCAL.x), icon_scal_pos.y + (32.f * SCAL.y));
-            if (gui.app_selector.icons.find(gui.apps_list_opened[a]) != gui.app_selector.icons.end())
-                ImGui::GetForegroundDrawList()->AddImage(gui.app_selector.icons[gui.apps_list_opened[a]], icon_scal_pos, icon_scal_size);
-        }
-    }
-
-    const auto clock_size = ImGui::CalcTextSize(clock_str.c_str());
-
-    ImGui::GetForegroundDrawList()->AddText(gui.live_area_font, (19.2f * scal_default_font) * SCAL.x, ImVec2(display_size.x - (62.f * SCAL.x) - (clock_size.x * SCAL.x) - is_notif_pos, (MENUBAR_HEIGHT / 2.f) - (((clock_size.y * scal_default_font) * SCAL.y) / 2.f)), is_theme_color ? gui.information_bar_color["indicator"] : DEFAUL_INDICATOR_COLOR, clock_str.c_str());
-    ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (54.f * SCAL.x) - is_notif_pos, 12.f * SCAL.y), ImVec2(display_size.x - (50.f * SCAL.x) - is_notif_pos, 20 * SCAL.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 0.f, ImDrawCornerFlags_All);
-    ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (50.f * SCAL.x) - is_notif_pos, 5.f * SCAL.y), ImVec2(display_size.x - (12.f * SCAL.x) - is_notif_pos, 27 * SCAL.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 2.f, ImDrawCornerFlags_All);
-
-    ImGui::End();
+bool get_live_area_sys_app_state(GuiState &gui) {
+    return !gui.live_area.content_manager && !gui.live_area.theme_background && !gui.live_area.trophy_collection && !gui.live_area.manual;
 }
 
 static bool notice_info;
-void draw_notice_info(GuiState &gui, HostState &host) {
+static void draw_notice_info(GuiState &gui, HostState &host) {
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto SCAL = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
     const auto NOTICE_SIZE = gui.notice_info_count_new ? ImVec2(104.0f * SCAL.x, 95.0f * SCAL.y) : ImVec2(90.0f * SCAL.x, 82.0f * SCAL.y);
@@ -88,23 +49,23 @@ void draw_notice_info(GuiState &gui, HostState &host) {
 
     ImGui::SetNextWindowPos(WINDOW_POS, ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 50.f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 50.f * SCAL.x);
     ImGui::Begin("##notice_info", nullptr, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     ImGui::PopStyleVar();
     if (gui.notice_info_count_new) {
         if (gui.theme_information_bar_notice.find("new") != gui.theme_information_bar_notice.end())
             ImGui::GetForegroundDrawList()->AddImage(gui.theme_information_bar_notice["new"], NOTICE_POS, ImVec2(NOTICE_POS.x + NOTICE_SIZE.x, NOTICE_SIZE.y));
         else
-            ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (84.f * SCAL.x), (-40.f * SCAL.y)), ImVec2(display_size.x + (32.f * SCAL.y), 76.f * SCAL.y), IM_COL32(11.f, 90.f, 252.f, 255.f), 50.f, ImDrawCornerFlags_All);
+            ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (84.f * SCAL.x), (-40.f * SCAL.y)), ImVec2(display_size.x + (32.f * SCAL.y), 76.f * SCAL.y), IM_COL32(11.f, 90.f, 252.f, 255.f), 75.f * SCAL.x, ImDrawCornerFlags_All);
         ImGui::GetForegroundDrawList()->AddText(gui.live_area_font, 40.f * SCAL.x, ImVec2(display_size.x - (NOTICE_SIZE.x / 2.f) + (10.f * SCAL.x), (10.f * SCAL.y)), NOTICE_COLOR, std::to_string(gui.notice_info_count_new).c_str());
     } else {
         if (gui.theme_information_bar_notice.find("no") != gui.theme_information_bar_notice.end())
             ImGui::GetForegroundDrawList()->AddImage(gui.theme_information_bar_notice["no"], NOTICE_POS, ImVec2(NOTICE_POS.x + NOTICE_SIZE.x, NOTICE_SIZE.y));
         else
-            ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (70.f * SCAL.x), (-24.f * SCAL.y)), ImVec2(display_size.x + (14.f * SCAL.y), 60.f * SCAL.y), IM_COL32(62.f, 98.f, 160.f, 255.f), 50.f, ImDrawCornerFlags_All);
+            ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (70.f * SCAL.x), (-24.f * SCAL.y)), ImVec2(display_size.x + (14.f * SCAL.y), 60.f * SCAL.y), IM_COL32(62.f, 98.f, 160.f, 255.f), 75.f * SCAL.x, ImDrawCornerFlags_All);
     }
 
-    if (ImGui::IsWindowHovered(ImGuiHoveredFlags_None) && !ImGui::IsAnyItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+    if (ImGui::IsWindowHovered(ImGuiHoveredFlags_RootWindow) && !ImGui::IsAnyItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
         if (notice_info) {
             gui.notice_info_count_new = 0;
             gui.notice_info_new.clear();
@@ -157,18 +118,18 @@ void draw_notice_info(GuiState &gui, HostState &host) {
                     gui.notice_info_count_new = 0;
                     gui.notice_info_new.clear();
                     if (notice.type == "content") {
-                        if (notice.group == "theme")
+                        if (notice.group == "theme") {
                             host.app_title_id = "NPXS10015";
-                        else
+                            pre_load_app(gui, host, false);
+                        } else {
                             host.app_title_id = notice.id;
-                        pre_run_app(gui, host);
+                            pre_load_app(gui, host, host.cfg.show_live_area_screen);
+                        }
                     } else {
                         host.app_title_id = "NPXS10008";
-                        pre_run_app(gui, host);
+                        pre_load_app(gui, host, false);
                         open_trophy_unlocked(gui, host, notice.id, notice.group);
                     }
-                    gui.live_area.app_selector = false;
-                    gui.live_area.live_area_screen = false;
                     notice_info = false;
                 }
                 ImGui::PopStyleColor(3);
@@ -229,6 +190,57 @@ void draw_notice_info(GuiState &gui, HostState &host) {
             ImGui::PopStyleVar();
         }
     }
+    ImGui::End();
+}
+
+void draw_information_bar(GuiState &gui, HostState &host) {
+    const auto display_size = ImGui::GetIO().DisplaySize;
+    const auto SCAL = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
+    const auto MENUBAR_HEIGHT = 32.f * SCAL.y;
+    ImU32 DEFAUL_BAR_COLOR = 4278190080; // Black
+    ImU32 DEFAUL_INDICATOR_COLOR = 4294967295; // White
+    const auto is_notif_pos = !gui.live_area.start_screen && (gui.live_area.live_area_screen || gui.live_area.app_selector) ? 78.f * SCAL.x : 0.f;
+
+    const auto is_theme_color = gui.live_area.app_selector || gui.live_area.live_area_screen || gui.live_area.start_screen;
+
+    ImGui::SetNextWindowPos(ImVec2(0.f, 0.f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(display_size.x, MENUBAR_HEIGHT), ImGuiCond_Always);
+    ImGui::Begin("##information_bar", &gui.live_area.information_bar, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+
+    const auto scal_default_font = 19.2f / ImGui::GetFontSize();
+
+    const auto now = std::chrono::system_clock::now();
+    const auto tt = std::chrono::system_clock::to_time_t(now);
+    const auto local = *localtime(&tt);
+
+    const std::string clock_str = fmt::format("{:0>2d}:{:0>2d}", local.tm_hour, local.tm_min);
+
+    ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(0.f, 0.f), ImVec2(display_size.x, MENUBAR_HEIGHT), is_theme_color ? gui.information_bar_color["bar"] : DEFAUL_BAR_COLOR, 0.f, ImDrawCornerFlags_All);
+
+    if (gui.live_area.app_selector || gui.live_area.live_area_screen) {
+        const float decal_icon_pos = 38.f * ((float(gui.apps_list_opened.size()) - 1.f) / 2.f);
+        for (auto a = 0; a < gui.apps_list_opened.size(); a++) {
+            const auto icon_scal_pos = ImVec2((display_size.x / 2.f) - (16.f * SCAL.x) - (decal_icon_pos * SCAL.x) + (a * (38.f * SCAL.x)), display_size.y - (544.f * SCAL.y));
+            const auto icon_scal_size = ImVec2(icon_scal_pos.x + (32.0f * SCAL.x), icon_scal_pos.y + (32.f * SCAL.y));
+            if (gui.app_selector.icons.find(gui.apps_list_opened[a]) != gui.app_selector.icons.end())
+                ImGui::GetForegroundDrawList()->AddImage(gui.app_selector.icons[gui.apps_list_opened[a]], icon_scal_pos, icon_scal_size);
+            if (gui.apps_list_opened[a] != gui.apps_list_opened[gui.current_app_selected])
+                ImGui::GetForegroundDrawList()->AddRectFilled(icon_scal_pos, icon_scal_size, IM_COL32(0.f, 0.f, 0.f, 140.f), 0.f, ImDrawCornerFlags_All);
+        }
+    }
+
+    const auto clock_size = ImGui::CalcTextSize(clock_str.c_str());
+
+    ImGui::GetForegroundDrawList()->AddText(gui.live_area_font, (19.2f * scal_default_font) * SCAL.x, ImVec2(display_size.x - (62.f * SCAL.x) - ((clock_size.x * scal_default_font) * SCAL.x) - is_notif_pos, (MENUBAR_HEIGHT / 2.f) - (((clock_size.y * scal_default_font) * SCAL.y) / 2.f)), is_theme_color ? gui.information_bar_color["indicator"] : DEFAUL_INDICATOR_COLOR, clock_str.c_str());
+    ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (54.f * SCAL.x) - is_notif_pos, 12.f * SCAL.y), ImVec2(display_size.x - (50.f * SCAL.x) - is_notif_pos, 20 * SCAL.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 0.f, ImDrawCornerFlags_All);
+    ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (50.f * SCAL.x) - is_notif_pos, 5.f * SCAL.y), ImVec2(display_size.x - (12.f * SCAL.x) - is_notif_pos, 27 * SCAL.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 2.f, ImDrawCornerFlags_All);
+
+    if (host.display.imgui_render && !gui.live_area.start_screen && !gui.live_area.live_area_screen && get_live_area_sys_app_state(gui) && ImGui::IsWindowHovered(ImGuiHoveredFlags_None))
+        gui.live_area.information_bar = false;
+
+    if (is_notif_pos)
+        draw_notice_info(gui, host);
+
     ImGui::End();
 }
 
@@ -720,25 +732,25 @@ inline uint64_t current_time() {
 }
 
 void draw_live_area_screen(GuiState &gui, HostState &host) {
-    draw_information_bar(gui);
-    draw_notice_info(gui, host);
-
     const ImVec2 display_size = ImGui::GetIO().DisplaySize;
     const auto scal = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
     const auto MENUBAR_HEIGHT = 32.f * scal.y;
+
     const auto title_id = gui.apps_list_opened[gui.current_app_selected];
     const VitaIoDevice app_device = title_id.find("NPXS") != std::string::npos ? VitaIoDevice::vs0 : VitaIoDevice::ux0;
-    const auto is_background = !gui.theme_backgrounds.empty() || !gui.user_backgrounds.empty();
+    const auto is_background = (host.cfg.use_theme_background && !gui.theme_backgrounds.empty()) || !gui.user_backgrounds.empty();
 
     ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
 
-    ImGui::SetNextWindowBgAlpha(is_background ? 0.5f : 0.999f);
+    ImGui::SetNextWindowBgAlpha(is_background ? 0.5f : 0.f);
     ImGui::Begin("##live_area", &gui.live_area.live_area_screen, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
     if (is_background)
         ImGui::GetBackgroundDrawList()->AddImage((host.cfg.use_theme_background && !gui.theme_backgrounds.empty()) ? gui.theme_backgrounds[gui.current_theme_bg] : gui.user_backgrounds[host.cfg.user_backgrounds[gui.current_user_bg]],
             ImVec2(0.f, 32.f), display_size);
+    else
+        ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, MENUBAR_HEIGHT), display_size, IM_COL32(11.f, 90.f, 252.f, 180.f), 0.f, ImDrawCornerFlags_All);
 
     const auto background_pos = ImVec2(900.0f * scal.x, 500.0f * scal.y);
     const auto pos_bg = ImVec2(display_size.x - background_pos.x, display_size.y - background_pos.y);
@@ -1137,11 +1149,8 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
     ImGui::GetWindowDrawList()->AddRectFilled(POS_BUTTON, ImVec2(POS_BUTTON.x + START_BUTTON_SIZE.x, POS_BUTTON.y + START_BUTTON_SIZE.y), IM_COL32(20, 168, 222, 255), 10.0f * scal.x, ImDrawCornerFlags_All);
     ImGui::GetWindowDrawList()->AddText(gui.live_area_font, 25.0f * scal.x, POS_START, IM_COL32(255, 255, 255, 255), start.c_str());
     ImGui::SetCursorPos(SELECT_POS);
-    if (ImGui::Selectable("##gate", false, ImGuiSelectableFlags_None, SELECT_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_cross)) {
-        if (host.io.title_id.empty() || (title_id.find("NPXS") != std::string::npos))
-            pre_run_app(gui, host);
-        gui.live_area.live_area_screen = false;
-    }
+    if (ImGui::Selectable("##gate", false, ImGuiSelectableFlags_None, SELECT_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_cross))
+        pre_run_app(gui, host, title_id);
     ImGui::PopID();
     ImGui::GetWindowDrawList()->AddRect(GATE_POS, SIZE_GATE, IM_COL32(192, 192, 192, 255), 15.f, ImDrawCornerFlags_All, 12.f);
 
@@ -1182,6 +1191,7 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
             ImGui::SetCursorPos(pos_scal_manual);
             if (ImGui::Selectable("##manual", ImGuiSelectableFlags_None, false, widget_scal_size)) {
                 if (init_manual(gui, host)) {
+                    gui.live_area.information_bar = false;
                     gui.live_area.live_area_screen = false;
                     gui.live_area.manual = true;
                 } else

--- a/vita3k/gui/src/manual.cpp
+++ b/vita3k/gui/src/manual.cpp
@@ -109,6 +109,7 @@ void draw_manual(GuiState &gui, HostState &host) {
     ImGui::SetCursorPos(ImVec2(size_child.x - ((!zoom[title_id].second ? 70.0f : 85.f) * scal.x), 10.0f * scal.y));
     if (!hiden_button && ImGui::Button("Esc", BUTTON_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_psbutton)) {
         gui.live_area.manual = false;
+        gui.live_area.information_bar = true;
         gui.live_area.live_area_screen = true;
     }
 

--- a/vita3k/gui/src/private.h
+++ b/vita3k/gui/src/private.h
@@ -59,6 +59,7 @@ void draw_about_dialog(GuiState &gui);
 
 void draw_app_selector(GuiState &gui, HostState &host);
 void draw_content_manager(GuiState &gui, HostState &host);
+void draw_information_bar(GuiState &gui, HostState &host);
 void draw_live_area_screen(GuiState &gui, HostState &host);
 void draw_manual(GuiState &gui, HostState &host);
 void draw_start_screen(GuiState &gui, HostState &host);

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -486,8 +486,6 @@ static const char *const wday[] = {
 };
 
 void draw_start_screen(GuiState &gui, HostState &host) {
-    draw_information_bar(gui);
-
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto SCAL = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
     const auto MENUBAR_HEIGHT = 32.f * SCAL.y;
@@ -550,9 +548,7 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
     const auto SIZE_MINI_PACKAGE = ImVec2(170.f * SCAL.x, 96.f * SCAL.y);
     const auto POPUP_SIZE = ImVec2(756.0f * SCAL.x, 436.0f * SCAL.y);
 
-    draw_information_bar(gui);
-
-    const auto is_background = gui.apps_background.find(host.app_title_id) != gui.apps_background.end();
+    const auto is_background = gui.apps_background.find("NPXS10015") != gui.apps_background.end();
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
@@ -560,7 +556,7 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
     ImGui::Begin("##themes", &gui.live_area.theme_background, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
-        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background[host.app_title_id], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
+        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10015"], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
     ImGui::SetWindowFontScale(1.6f * SCAL.x);
     const auto theme_str = ImGui::CalcTextSize(title.c_str(), 0, false, SIZE_LIST.x);
     ImGui::PushTextWrapPos(((display_size.x - SIZE_LIST.x) / 2.f) + SIZE_LIST.x);
@@ -920,10 +916,10 @@ void draw_themes_selection(GuiState &gui, HostState &host) {
             else
                 menu.clear();
         } else {
-            if (gui.live_area.content_manager)
-                host.app_title_id = "NPXS10026";
-            else {
-                if (gui.live_area_contents.find("NPXS10015") != gui.live_area_contents.end())
+            if (host.app_title_id == "NPXS10026") {
+                gui.live_area.content_manager = true;
+            } else {
+                if (!gui.apps_list_opened.empty() && gui.apps_list_opened[gui.current_app_selected] == "NPXS10015")
                     gui.live_area.live_area_screen = true;
                 else
                     gui.live_area.app_selector = true;

--- a/vita3k/gui/src/trophy.cpp
+++ b/vita3k/gui/src/trophy.cpp
@@ -394,8 +394,6 @@ void open_trophy_unlocked(GuiState &gui, HostState &host, const std::string &np_
 }
 
 void draw_trophy_collection(GuiState &gui, HostState &host) {
-    draw_information_bar(gui);
-
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto SCAL = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
     const auto MENUBAR_HEIGHT = 32.f * SCAL.y;
@@ -412,7 +410,8 @@ void draw_trophy_collection(GuiState &gui, HostState &host) {
 
     const auto TROPHY_PATH{ fs::path(host.pref_path) / "ux0/user" / host.io.user_id / "trophy" };
     const char progress_dummy[32] = "";
-    const auto is_background = gui.apps_background.find(host.app_title_id) != gui.apps_background.end();
+
+    const auto is_background = gui.apps_background.find("NPXS10008") != gui.apps_background.end();
 
     ImGui::SetNextWindowPos(ImVec2(0, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
@@ -420,7 +419,7 @@ void draw_trophy_collection(GuiState &gui, HostState &host) {
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
     ImGui::Begin("##trophy_collection", &gui.live_area.theme_background, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
-        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background[host.app_title_id], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
+        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10008"], ImVec2(0.f, MENUBAR_HEIGHT), display_size);
     if (group_id_selected.empty()) {
         ImGui::SetWindowFontScale(1.4f * SCAL.x);
         if (np_com_id_selected.empty()) {
@@ -735,9 +734,11 @@ void draw_trophy_collection(GuiState &gui, HostState &host) {
                 set_scroll_pos = true;
             }
         } else {
-            gui.live_area.trophy_collection = false;
-            if (host.cfg.show_live_area_screen)
+            if (!gui.apps_list_opened.empty() && gui.apps_list_opened[gui.current_app_selected] == "NPXS10008")
                 gui.live_area.live_area_screen = true;
+            else
+                gui.live_area.app_selector = true;
+            gui.live_area.trophy_collection = false;
         }
     }
 

--- a/vita3k/host/include/host/state.h
+++ b/vita3k/host/include/host/state.h
@@ -49,7 +49,7 @@ struct DisplayState {
     std::mutex mutex;
     std::condition_variable condvar;
     std::atomic<bool> abort{ false };
-    std::atomic<bool> imgui_render{ false };
+    std::atomic<bool> imgui_render{ true };
     std::atomic<bool> fullscreen{ false };
 };
 

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -407,16 +407,18 @@ bool handle_events(HostState &host, GuiState &gui) {
                 }
             }
             // toggle gui state
-            if (!gui.configuration_menu.profiles_manager_dialog && !gui.configuration_menu.settings_dialog && !gui.captured_key) {
+            if (!host.io.title_id.empty() && !gui.configuration_menu.profiles_manager_dialog && !gui.configuration_menu.settings_dialog && !gui.captured_key) {
                 if (event.key.keysym.sym == SDLK_g)
                     host.display.imgui_render = !host.display.imgui_render;
             }
-            if (!host.io.title_id.empty() && !gui.live_area.app_selector && !gui.live_area.manual) {
+            if (!host.io.title_id.empty() && !gui.live_area.app_selector && gui::get_live_area_sys_app_state(gui)) {
                 // Show/Hide Live Area during app run
                 // TODO pause app running
                 if (event.key.keysym.scancode == host.cfg.keyboard_button_psbutton) {
+                    gui::update_apps_list_opened(gui, host.io.title_id);
                     if (gui.live_area_contents.find(host.io.title_id) == gui.live_area_contents.end())
                         gui::init_live_area(gui, host);
+                    gui.live_area.information_bar = !gui.live_area.information_bar;
                     gui.live_area.live_area_screen = !gui.live_area.live_area_screen;
                 }
             }

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -145,8 +145,7 @@ int main(int argc, char *argv[]) {
                 discord::update_init_status(host.cfg.discord_rich_presence, &discord_rich_presence_old);
 #endif
                 gui::draw_live_area(gui, host);
-                if (host.display.imgui_render)
-                    gui::draw_ui(gui, host);
+                gui::draw_ui(gui, host);
 
                 gui::draw_end(gui, host.window.get());
             } else {
@@ -238,7 +237,7 @@ int main(int argc, char *argv[]) {
         gui::draw_common_dialog(gui, host);
         gui::draw_live_area(gui, host);
 
-        if (host.cfg.performance_overlay && !gui.live_area.app_selector && !gui.live_area.live_area_screen)
+        if (host.cfg.performance_overlay && !gui.live_area.app_selector && !gui.live_area.live_area_screen && gui::get_live_area_sys_app_state(gui))
             gui::draw_perf_overlay(gui, host);
 
         gui::draw_trophies_unlocked(gui, host);


### PR DESCRIPTION
- Reworks Information bar after user and dev ask me
New just need move cursor on information bar for re show menubar, for game run same before, press g for display it, untouched this.
Get so more pratice and userfull, for re show info bar, back cursor on app list or just inside other part window
-  Add alpha transparancy for app icon no currently selected, like on psvita
- Some other fix/improve/refactor
- Add blue font default background

# Result: 
- Current app selected with normal light an,d other more dark/hiden
![image](https://user-images.githubusercontent.com/5261759/90956779-e3b27f80-e489-11ea-879b-fe455e0842e9.png)

- default background
![image](https://cdn.discordapp.com/attachments/498117406162681856/746741663749374052/unknown.png)