### PR TITLE
gui: fix clock/date pos if missing fw font.

### DIFF
--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -157,6 +157,7 @@ void draw_app_selector(GuiState &gui, HostState &host) {
                 last_time["start"] += host.cfg.delay_start;
                 last_time["home"] = 0;
                 gui.live_area.app_selector = false;
+                gui.live_area.information_bar = true;
                 gui.live_area.start_screen = true;
             }
         }

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -133,11 +133,15 @@ static void init_font(GuiState &gui, HostState &host) {
 static void init_live_area_font(GuiState &gui, HostState &host) {
     const auto font_path{ fs::path(host.pref_path) / "sa0/data/font/pvf/jpn0.pvf" };
 
+    ImGuiIO &io = ImGui::GetIO();
+    ImFontConfig font_config{};
+    static const ImWchar large_font_chars[] = { L'0', L'1', L'2', L'3', L'4', L'5', L'6', L'7', L'8', L'9', L':', L';', L'<', L'=', L'>' };
+
     // check existence of font file
     if (!fs::exists(font_path)) {
         LOG_WARN("Could not find firmware font file at \"{}\", using defaut vita3k font.", font_path.string());
         gui.live_area_font = gui.normal_font;
-        gui.live_area_font_large = gui.normal_font;
+        gui.live_area_font_large = io.Fonts->AddFontFromMemoryTTF(gui.font_data.data(), static_cast<int>(gui.font_data.size()), 124.f, &font_config, large_font_chars);
         return;
     }
 
@@ -147,11 +151,7 @@ static void init_live_area_font(GuiState &gui, HostState &host) {
     std::ifstream font_stream(font_path.string().c_str(), std::ios::in | std::ios::binary);
     font_stream.read(gui.live_area_font_data.data(), font_file_size);
 
-    static const ImWchar large_font_chars[] = { L'0', L'1', L'2', L'3', L'4', L'5', L'6', L'7', L'8', L'9', L':', L';', L'<', L'=', L'>' };
-
     // add it to imgui
-    ImGuiIO &io = ImGui::GetIO();
-    ImFontConfig font_config{};
     gui.live_area_font = io.Fonts->AddFontFromMemoryTTF(gui.live_area_font_data.data(), static_cast<int>(font_file_size), 19.2f, &font_config, io.Fonts->GetGlyphRangesJapanese());
     gui.live_area_font_large = io.Fonts->AddFontFromMemoryTTF(gui.live_area_font_data.data(), static_cast<int>(font_file_size), 124.f, &font_config, large_font_chars);
 }

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -207,8 +207,6 @@ void draw_information_bar(GuiState &gui, HostState &host) {
     ImGui::SetNextWindowSize(ImVec2(display_size.x, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::Begin("##information_bar", &gui.live_area.information_bar, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
 
-    const auto scal_default_font = 19.2f / ImGui::GetFontSize();
-
     const auto now = std::chrono::system_clock::now();
     const auto tt = std::chrono::system_clock::to_time_t(now);
     const auto local = *localtime(&tt);
@@ -229,9 +227,11 @@ void draw_information_bar(GuiState &gui, HostState &host) {
         }
     }
 
+    const auto scal_default_font = 19.2f * (19.2f / ImGui::GetFontSize());
+    const auto scal_font_size = scal_default_font / ImGui::GetFontSize();
     const auto clock_size = ImGui::CalcTextSize(clock_str.c_str());
 
-    ImGui::GetForegroundDrawList()->AddText(gui.live_area_font, (19.2f * scal_default_font) * SCAL.x, ImVec2(display_size.x - (62.f * SCAL.x) - ((clock_size.x * scal_default_font) * SCAL.x) - is_notif_pos, (MENUBAR_HEIGHT / 2.f) - (((clock_size.y * scal_default_font) * SCAL.y) / 2.f)), is_theme_color ? gui.information_bar_color["indicator"] : DEFAUL_INDICATOR_COLOR, clock_str.c_str());
+    ImGui::GetForegroundDrawList()->AddText(gui.live_area_font, scal_default_font * SCAL.x, ImVec2(display_size.x - (62.f * SCAL.x) - ((clock_size.x * scal_font_size) * SCAL.x) - is_notif_pos, (MENUBAR_HEIGHT / 2.f) - (((clock_size.y * scal_font_size) * SCAL.y) / 2.f)), is_theme_color ? gui.information_bar_color["indicator"] : DEFAUL_INDICATOR_COLOR, clock_str.c_str());
     ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (54.f * SCAL.x) - is_notif_pos, 12.f * SCAL.y), ImVec2(display_size.x - (50.f * SCAL.x) - is_notif_pos, 20 * SCAL.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 0.f, ImDrawCornerFlags_All);
     ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (50.f * SCAL.x) - is_notif_pos, 5.f * SCAL.y), ImVec2(display_size.x - (12.f * SCAL.x) - is_notif_pos, 27 * SCAL.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 2.f, ImDrawCornerFlags_All);
 
@@ -272,32 +272,32 @@ static std::map<std::string, std::map<std::string, std::map<std::string, ImVec2>
 static std::map<std::string, std::map<std::string, std::string>> target;
 static std::map<std::string, std::map<std::string, uint64_t>> current_item, last_time;
 static std::map<std::string, std::string> type;
-static std::string start;
+static std::string start, resume;
 
 void init_live_area(GuiState &gui, HostState &host) {
     std::string user_lang;
     const auto sys_lang = static_cast<SceSystemParamLang>(host.cfg.sys_lang);
     switch (sys_lang) {
-    case SCE_SYSTEM_PARAM_LANG_JAPANESE: user_lang = "ja", start = u8"はじめる"; break;
-    case SCE_SYSTEM_PARAM_LANG_ENGLISH_US: user_lang = "en", start = "Start"; break;
-    case SCE_SYSTEM_PARAM_LANG_FRENCH: user_lang = "fr", start = "Demarrer"; break;
-    case SCE_SYSTEM_PARAM_LANG_SPANISH: user_lang = "es", start = "Iniciar"; break;
-    case SCE_SYSTEM_PARAM_LANG_GERMAN: user_lang = "de", start = "Starten"; break;
-    case SCE_SYSTEM_PARAM_LANG_ITALIAN: user_lang = "it", start = "Avvia"; break;
-    case SCE_SYSTEM_PARAM_LANG_DUTCH: user_lang = "nl", start = "Starten"; break;
-    case SCE_SYSTEM_PARAM_LANG_PORTUGUESE_PT: user_lang = "pt", start = "Iniciar"; break;
-    case SCE_SYSTEM_PARAM_LANG_RUSSIAN: user_lang = "ru", start = u8"Запуск"; break;
-    case SCE_SYSTEM_PARAM_LANG_KOREAN: user_lang = "ko", start = u8"시작"; break;
-    case SCE_SYSTEM_PARAM_LANG_CHINESE_T: user_lang = "ch", start = u8"开始"; break;
-    case SCE_SYSTEM_PARAM_LANG_CHINESE_S: user_lang = "zh", start = u8"啟動"; break;
-    case SCE_SYSTEM_PARAM_LANG_FINNISH: user_lang = "fi", start = "Rozpocznij"; break;
-    case SCE_SYSTEM_PARAM_LANG_SWEDISH: user_lang = "sv", start = "Starta"; break;
-    case SCE_SYSTEM_PARAM_LANG_DANISH: user_lang = "da", start = "Start"; break;
-    case SCE_SYSTEM_PARAM_LANG_NORWEGIAN: user_lang = "no", start = "Start"; break;
-    case SCE_SYSTEM_PARAM_LANG_POLISH: user_lang = "pl", start = "Rozpocznij"; break;
-    case SCE_SYSTEM_PARAM_LANG_PORTUGUESE_BR: user_lang = "pt-br", start = "Iniciar"; break;
-    case SCE_SYSTEM_PARAM_LANG_ENGLISH_GB: user_lang = "en-gb", start = "Start"; break;
-    case SCE_SYSTEM_PARAM_LANG_TURKISH: user_lang = "tr", start = u8"Başlat"; break;
+    case SCE_SYSTEM_PARAM_LANG_JAPANESE: user_lang = "ja", start = u8"はじめる", resume = u8"つづける"; break;
+    case SCE_SYSTEM_PARAM_LANG_ENGLISH_US: user_lang = "en", start = u8"Start", resume = u8"Continue"; break;
+    case SCE_SYSTEM_PARAM_LANG_FRENCH: user_lang = "fr", start = u8"Démarrer", resume = u8"Continuer"; break;
+    case SCE_SYSTEM_PARAM_LANG_SPANISH: user_lang = "es", start = u8"Iniciar", resume = u8"Continuar"; break;
+    case SCE_SYSTEM_PARAM_LANG_GERMAN: user_lang = "de", start = u8"Starten", resume = u8"Fortfahren"; break;
+    case SCE_SYSTEM_PARAM_LANG_ITALIAN: user_lang = "it", start = u8"Avvia", resume = u8"Continua"; break;
+    case SCE_SYSTEM_PARAM_LANG_DUTCH: user_lang = "nl", start = u8"Starten", resume = u8"Doorgaan"; break;
+    case SCE_SYSTEM_PARAM_LANG_PORTUGUESE_PT: user_lang = "pt", start = u8"Iniciar", resume = u8"Continuar"; break;
+    case SCE_SYSTEM_PARAM_LANG_RUSSIAN: user_lang = "ru", start = u8"Запуск", resume = u8"Продолжить"; break;
+    case SCE_SYSTEM_PARAM_LANG_KOREAN: user_lang = "ko", start = u8"시작", resume = u8"계속"; break;
+    case SCE_SYSTEM_PARAM_LANG_CHINESE_T: user_lang = "ch", start = u8"开始", resume = u8"繼續"; break;
+    case SCE_SYSTEM_PARAM_LANG_CHINESE_S: user_lang = "zh", start = u8"啟動", resume = u8"继续"; break;
+    case SCE_SYSTEM_PARAM_LANG_FINNISH: user_lang = "fi", start = u8"Rozpocznij", resume = u8"Jatka"; break;
+    case SCE_SYSTEM_PARAM_LANG_SWEDISH: user_lang = "sv", start = u8"Starta", resume = u8"Fortsätt"; break;
+    case SCE_SYSTEM_PARAM_LANG_DANISH: user_lang = "da", start = u8"Start", resume = u8"Fortsæt"; break;
+    case SCE_SYSTEM_PARAM_LANG_NORWEGIAN: user_lang = "no", start = u8"Start", resume = u8"Fortsett"; break;
+    case SCE_SYSTEM_PARAM_LANG_POLISH: user_lang = "pl", start = u8"Rozpocznij", resume = u8"Kontynuuj"; break;
+    case SCE_SYSTEM_PARAM_LANG_PORTUGUESE_BR: user_lang = "pt-br", start = u8"Iniciar", resume = u8"Continuar"; break;
+    case SCE_SYSTEM_PARAM_LANG_ENGLISH_GB: user_lang = "en-gb", start = u8"Start", resume = u8"Continue"; break;
+    case SCE_SYSTEM_PARAM_LANG_TURKISH: user_lang = "tr", start = u8"Başlat", resume = u8"Devam"; break;
     default: break;
     }
 
@@ -1127,10 +1127,13 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
         }
     }
 
+    const auto scal_default_font = 25.f * (19.2f / ImGui::GetFontSize());
+    const auto scal_font_size = scal_default_font / ImGui::GetFontSize();
+
+    const std::string BUTTON_STR = title_id == host.io.title_id ? resume : start;
     const auto GATE_SIZE = ImVec2(280.0f * scal.x, 158.0f * scal.y);
     const auto GATE_POS = ImVec2(display_size.x - (items_pos[type[title_id]]["gate"]["pos"].x * scal.x), display_size.y - (items_pos[type[title_id]]["gate"]["pos"].y * scal.y));
-    const auto scal_font_size = 25.0f / ImGui::GetFontSize();
-    const auto START_SIZE = ImVec2((ImGui::CalcTextSize(start.c_str()).x * scal_font_size), (ImGui::CalcTextSize(start.c_str()).y * scal_font_size));
+    const auto START_SIZE = ImVec2((ImGui::CalcTextSize(BUTTON_STR.c_str()).x * scal_font_size), (ImGui::CalcTextSize(BUTTON_STR.c_str()).y * scal_font_size));
     const auto START_BUTTON_SIZE = ImVec2((START_SIZE.x + 26.0f) * scal.x, (START_SIZE.y + 5.0f) * scal.y);
     const auto POS_BUTTON = ImVec2((GATE_POS.x + (GATE_SIZE.x - START_BUTTON_SIZE.x) / 2.0f), (GATE_POS.y + (GATE_SIZE.y - START_BUTTON_SIZE.y) / 1.08f));
     const auto POS_START = ImVec2(POS_BUTTON.x + (START_BUTTON_SIZE.x - (START_SIZE.x * scal.x)) / 2,
@@ -1147,7 +1150,7 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
     }
     ImGui::PushID(title_id.c_str());
     ImGui::GetWindowDrawList()->AddRectFilled(POS_BUTTON, ImVec2(POS_BUTTON.x + START_BUTTON_SIZE.x, POS_BUTTON.y + START_BUTTON_SIZE.y), IM_COL32(20, 168, 222, 255), 10.0f * scal.x, ImDrawCornerFlags_All);
-    ImGui::GetWindowDrawList()->AddText(gui.live_area_font, 25.0f * scal.x, POS_START, IM_COL32(255, 255, 255, 255), start.c_str());
+    ImGui::GetWindowDrawList()->AddText(gui.live_area_font, scal_default_font * scal.x, POS_START, IM_COL32(255, 255, 255, 255), BUTTON_STR.c_str());
     ImGui::SetCursorPos(SELECT_POS);
     if (ImGui::Selectable("##gate", false, ImGuiSelectableFlags_None, SELECT_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_cross))
         pre_run_app(gui, host, title_id);

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -47,6 +47,7 @@ static void draw_emulation_menu(GuiState &gui, HostState &host) {
         if (ImGui::MenuItem("Load last App", host.cfg.last_app.c_str(), false, !host.cfg.last_app.empty() && host.io.title_id.empty())) {
             host.app_title_id = host.cfg.last_app;
             pre_load_app(gui, host, host.cfg.show_live_area_screen);
+            gui.live_area.information_bar = true;
         }
         ImGui::EndMenu();
     }

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -137,7 +137,7 @@ void init_theme_start_background(GuiState &gui, HostState &host, const std::stri
             break;
         case 2:
             date["date"].x = 50.f;
-            date["clock"].x = 424.f;
+            date["clock"].x = 50.f;
             break;
         default:
             LOG_WARN("Date layout is unknown : {}", start_param["dateLayout"]);
@@ -420,7 +420,7 @@ void get_themes_list(GuiState &gui, HostState &host) {
                 const auto updated = fs::last_write_time(theme_path / content_id);
                 const auto updated_date = std::localtime(&updated);
 
-                themes_info[content_id].updated = fmt::format("{}/{}/{}  {:0>2d}:{:0>2d}", updated_date->tm_mday, updated_date->tm_mon + 1, updated_date->tm_year + 1900, updated_date->tm_hour, updated_date->tm_min).c_str();
+                themes_info[content_id].updated = fmt::format("{}/{}/{}  {:0>2d}:{:0>2d}", updated_date->tm_mday, updated_date->tm_mon + 1, updated_date->tm_year + 1900, updated_date->tm_hour, updated_date->tm_min);
 
                 themes_info[content_id].size = theme_size / KB(1);
                 themes_info[content_id].version = infomation.child("m_contentVer").text().as_string();
@@ -490,7 +490,7 @@ void draw_start_screen(GuiState &gui, HostState &host) {
     const auto SCAL = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
     const auto MENUBAR_HEIGHT = 32.f * SCAL.y;
     auto DATE_POS = ImVec2(display_size.x - (date["date"].x * SCAL.x), display_size.y - (date["date"].y * SCAL.y));
-    const auto CLOCK_POS = ImVec2(display_size.x - (date["clock"].x * SCAL.x), display_size.y - (date["clock"].y * SCAL.y));
+    auto CLOCK_POS = ImVec2(display_size.x - (date["clock"].x * SCAL.x), display_size.y - (date["clock"].y * SCAL.y));
 
     ImGui::SetNextWindowPos(ImVec2(0.f, MENUBAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
@@ -505,19 +505,27 @@ void draw_start_screen(GuiState &gui, HostState &host) {
     const auto now = std::chrono::system_clock::now();
     const auto tt = std::chrono::system_clock::to_time_t(now);
     const auto local = *localtime(&tt);
-    const auto scal_font = 19.2f / ImGui::GetFontSize();
+
+    const auto scal_default_font = 19.2f / ImGui::GetFontSize();
+    const auto scal_date_font_size = 34.f * scal_default_font;
+    const auto scal_data_font = scal_date_font_size / ImGui::GetFontSize();
+
+    const auto scal_clock_font_size = 124.f * scal_default_font;
+    const auto scal_clock_font = scal_clock_font_size / ImGui::GetFontSize();
 
     const auto DATE_STR = fmt::format("{} {} ({})", local.tm_mday, wmonth[local.tm_mon], wday[local.tm_wday]);
+    const auto CLOCK_STR = fmt::format("{:0>2d}:{:0>2d}", local.tm_hour, local.tm_min);
+
     if (start_param["dateLayout"] == "2") {
-        const auto scal_date_font_size = 34.f / ImGui::GetFontSize();
-        const auto DATE_SIZE = (ImGui::CalcTextSize(DATE_STR.c_str()).x * scal_font) * scal_date_font_size;
+        const auto DATE_SIZE = ImGui::CalcTextSize(DATE_STR.c_str()).x * scal_data_font;
+        const auto CLOCK_SIZE = ImGui::CalcTextSize(CLOCK_STR.c_str()).x * scal_clock_font;
         DATE_POS.x -= DATE_SIZE * SCAL.x;
+        CLOCK_POS.x -= CLOCK_SIZE * SCAL.x;
     }
 
-    ImGui::GetForegroundDrawList()->AddText(gui.live_area_font, (34.0f * scal_font) * SCAL.x, DATE_POS, date_color, DATE_STR.c_str());
+    ImGui::GetForegroundDrawList()->AddText(gui.live_area_font, scal_date_font_size * SCAL.x, DATE_POS, date_color, DATE_STR.c_str());
     ImGui::PushFont(gui.live_area_font_large);
-    const auto scal_font_large = 124.f / ImGui::GetFontSize();
-    ImGui::GetForegroundDrawList()->AddText(gui.live_area_font_large, (124.0f * scal_font_large) * SCAL.x, CLOCK_POS, date_color, fmt::format("{:0>2d}:{:0>2d}", local.tm_hour, local.tm_min).c_str());
+    ImGui::GetForegroundDrawList()->AddText(gui.live_area_font_large, scal_clock_font_size * SCAL.x, CLOCK_POS, date_color, CLOCK_STR.c_str());
     ImGui::PopFont();
 
     if (ImGui::IsMouseClicked(0) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle)) {


### PR DESCRIPTION
- Fix start in french
- fix dispear info bar on  live area if usiing load last app
- same for open start screen if before you have go to menu bar
- Add resume name for all language, name change relate if you run app or not, like psvita, run app, press PS get live area with it show Continue on gate.

all after is for missing fw font
- FIx large font
- fix position for clock in info bar, and fix missing clock in start screen 
# Result:
Without fw font
- Master
![image](https://user-images.githubusercontent.com/5261759/90983541-46ca1200-e56f-11ea-9cfe-64c05e8d230f.png)

- PR
![image](https://user-images.githubusercontent.com/5261759/90983028-7d9e2900-e56b-11ea-8fdc-4e0c3f569030.png)

- Fix french name on start
![image](https://user-images.githubusercontent.com/5261759/90991681-60894a80-e5ab-11ea-82a7-b3639f11f945.png)
- Add continue if this game game running (other app open in list keep start)
![image](https://user-images.githubusercontent.com/5261759/90991708-8c0c3500-e5ab-11ea-80f4-63fc76594ff1.png)

