### PR TITLE
Refactor GXP input parsing

### DIFF
--- a/vita3k/shader/CMakeLists.txt
+++ b/vita3k/shader/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
 	include/shader/usse_translator_entry.h
 	include/shader/usse_translator_types.h
 	include/shader/usse_utilities.h
+	include/shader/gxp_parser.h
 	include/shader/spirv_recompiler.h
 
 	src/translator/alu.cpp
@@ -23,6 +24,7 @@ add_library(
 	src/translator/illegal.cpp
 	src/translator/texture.cpp
 	src/translator/utils.cpp
+	src/gxp_parser.cpp
 	src/usse_disasm.cpp
 	src/usse_program_analyzer.cpp
 	src/usse_decode_helpers.cpp

--- a/vita3k/shader/include/shader/gxp_parser.h
+++ b/vita3k/shader/include/shader/gxp_parser.h
@@ -9,4 +9,5 @@ namespace shader {
 usse::GenericType translate_generic_type(const gxp::GenericParameterType &type);
 std::tuple<usse::DataType, std::string> get_parameter_type_store_and_name(const SceGxmParameterType &type);
 std::vector<usse::UniformBuffer> get_uniform_buffers(const SceGxmProgram &program);
+usse::ProgramInput get_program_input(const SceGxmProgram &program);
 } // namespace shader

--- a/vita3k/shader/include/shader/gxp_parser.h
+++ b/vita3k/shader/include/shader/gxp_parser.h
@@ -6,6 +6,7 @@
 
 namespace shader {
 
+usse::GenericType translate_generic_type(const gxp::GenericParameterType &type);
 std::tuple<usse::DataType, std::string> get_parameter_type_store_and_name(const SceGxmParameterType &type);
 std::vector<usse::UniformBuffer> get_uniform_buffers(const SceGxmProgram &program);
 } // namespace shader

--- a/vita3k/shader/include/shader/gxp_parser.h
+++ b/vita3k/shader/include/shader/gxp_parser.h
@@ -7,5 +7,5 @@
 namespace shader {
 
 std::tuple<usse::DataType, std::string> get_parameter_type_store_and_name(const SceGxmParameterType &type);
-
-}
+std::vector<usse::UniformBuffer> get_uniform_buffers(const SceGxmProgram &program);
+} // namespace shader

--- a/vita3k/shader/include/shader/gxp_parser.h
+++ b/vita3k/shader/include/shader/gxp_parser.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gxm/types.h>
+#include <shader/usse_translator_types.h>
+#include <shader/usse_types.h>
+
+namespace shader {
+
+std::tuple<usse::DataType, std::string> get_parameter_type_store_and_name(const SceGxmParameterType &type);
+
+}

--- a/vita3k/shader/include/shader/usse_program_analyzer.h
+++ b/vita3k/shader/include/shader/usse_program_analyzer.h
@@ -67,12 +67,6 @@ struct USSEBlock {
     }
 };
 
-struct UniformBuffer {
-    int base;
-    int size;
-    int cursor;
-};
-
 using UniformBufferMap = std::map<int, UniformBuffer>;
 
 using USSEOffset = std::uint32_t;

--- a/vita3k/shader/include/shader/usse_program_analyzer.h
+++ b/vita3k/shader/include/shader/usse_program_analyzer.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <map>
 #include <queue>
+#include <shader/usse_types.h>
 #include <tuple>
 
 using UniformBufferSizes = std::array<std::uint32_t, 15>;

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -278,6 +278,9 @@ struct Instruction {
     }
 };
 
+/**
+ * Container type for gxp parameters
+ */
 enum class GenericType {
     SCALER,
     VECTOR,
@@ -285,18 +288,24 @@ enum class GenericType {
     INVALID
 };
 
+/**
+ * Samplers that are attached to gxp shader program
+ */
 struct Sampler {
     std::string name;
     bool dependent;
-    uint32_t index;
+    uint32_t index; // resource index
     uint32_t offset; // SA offset for dependent sampler
 };
 
+/**
+ * Uniform buffers that are attached to gxp shader program
+ */
 struct UniformBuffer {
     int base;
     int size;
-    bool rw;
-    bool reg;
+    bool rw; // TODO confirm this
+    bool reg; // register buffer TODO confirm this
 };
 
 // TODO do we need this
@@ -308,30 +317,47 @@ struct UniformBlock {
 
 struct UniformInputSource {
     std::string name;
+    // resource index
     uint32_t index;
 };
 
 struct AttributeInputSoucre {
     std::string name;
+    // resource index
     uint32_t index;
 };
 
 struct LiteralInputSource {
+    // The constant data
     float data;
 };
 
+// Read source field in Input struct
 using InputSource = std::variant<UniformInputSource, LiteralInputSource, AttributeInputSoucre>;
 
+/**
+ * Input parameters that are usually copied into PA or SA
+ * registers before shader program starts.
+ */
 struct Input {
+    // Destination reigster bank
     RegisterBank bank;
+    // The type of parameter
     DataType type;
+    // The container type of parameter
     GenericType generic_type;
+    // Offset of destination register
     uint32_t offset;
-    uint32_t component_count;
-    uint32_t array_size;
+    uint32_t component_count
+        uint32_t array_size;
+    // The source where shader fetches the data
+    // e.g. vertex attributes
     InputSource source;
 };
 
+/**
+ * Contains the metadata of various input data of gxp shader program
+ */
 struct ProgramInput {
     std::vector<Input> inputs;
     std::vector<Sampler> samplers;

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -4,6 +4,8 @@
 
 #include <array>
 #include <functional>
+#include <string>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -348,8 +350,8 @@ struct Input {
     GenericType generic_type;
     // Offset of destination register
     uint32_t offset;
-    uint32_t component_count
-        uint32_t array_size;
+    uint32_t component_count;
+    uint32_t array_size;
     // The source where shader fetches the data
     // e.g. vertex attributes
     InputSource source;
@@ -361,6 +363,7 @@ struct Input {
 struct ProgramInput {
     std::vector<Input> inputs;
     std::vector<Sampler> samplers;
+    std::vector<UniformBuffer> uniform_buffers;
     std::unordered_map<int, UniformBlock> uniform_blocks;
 };
 

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -277,6 +277,12 @@ struct Instruction {
     }
 };
 
+struct UniformBuffer {
+    int base;
+    int size;
+    bool rw;
+};
+
 enum class ShaderPhase {
     SampleRate, // Secondary phase
     Pixel, // Primary phase

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <functional>
+#include <variant>
 #include <vector>
 
 namespace shader {
@@ -275,6 +276,13 @@ struct Instruction {
         , flags(0)
         , dest_mask(0) {
     }
+};
+
+enum class GenericType {
+    SCALER,
+    VECTOR,
+    ARRAY,
+    INVALID
 };
 
 struct UniformBuffer {

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -285,10 +285,57 @@ enum class GenericType {
     INVALID
 };
 
+struct Sampler {
+    std::string name;
+    bool dependent;
+    uint32_t index;
+    uint32_t offset; // SA offset for dependent sampler
+};
+
 struct UniformBuffer {
     int base;
     int size;
     bool rw;
+    bool reg;
+};
+
+// TODO do we need this
+struct UniformBlock {
+    int block_num;
+    uint32_t offset;
+    uint32_t size;
+};
+
+struct UniformInputSource {
+    std::string name;
+    uint32_t index;
+};
+
+struct AttributeInputSoucre {
+    std::string name;
+    uint32_t index;
+};
+
+struct LiteralInputSource {
+    float data;
+};
+
+using InputSource = std::variant<UniformInputSource, LiteralInputSource, AttributeInputSoucre>;
+
+struct Input {
+    RegisterBank bank;
+    DataType type;
+    GenericType generic_type;
+    uint32_t offset;
+    uint32_t component_count;
+    uint32_t array_size;
+    InputSource source;
+};
+
+struct ProgramInput {
+    std::vector<Input> inputs;
+    std::vector<Sampler> samplers;
+    std::unordered_map<int, UniformBlock> uniform_blocks;
 };
 
 enum class ShaderPhase {

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -1,0 +1,37 @@
+#include <shader/gxp_parser.h>
+
+using namespace shader::usse;
+
+std::tuple<DataType, std::string> shader::get_parameter_type_store_and_name(const SceGxmParameterType &type) {
+    switch (type) {
+    case SCE_GXM_PARAMETER_TYPE_F16: {
+        return std::make_tuple(DataType::F16, "half");
+    }
+
+    case SCE_GXM_PARAMETER_TYPE_U16: {
+        return std::make_tuple(DataType::UINT16, "ushort");
+    }
+
+    case SCE_GXM_PARAMETER_TYPE_S16: {
+        return std::make_tuple(DataType::INT16, "ishort");
+    }
+
+    case SCE_GXM_PARAMETER_TYPE_U8: {
+        return std::make_tuple(DataType::UINT8, "uchar");
+    }
+
+    case SCE_GXM_PARAMETER_TYPE_S8: {
+        return std::make_tuple(DataType::INT8, "ichar");
+    }
+
+    case SCE_GXM_PARAMETER_TYPE_U32: {
+        return std::make_tuple(DataType::UINT32, "uint");
+    }
+    case SCE_GXM_PARAMETER_TYPE_S32: {
+        return std::make_tuple(DataType::INT32, "int");
+    }
+
+    default:
+        break;
+    }
+}

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -1,5 +1,5 @@
-#include <shader/gxp_parser.h>
 #include <gxm/functions.h>
+#include <shader/gxp_parser.h>
 #include <shader/usse_program_analyzer.h>
 #include <util/log.h>
 
@@ -82,18 +82,11 @@ std::vector<UniformBuffer> shader::get_uniform_buffers(const SceGxmProgram &prog
         },
         buffer_size_map);
 
-    std::array<const SceGxmProgramParameterContainer *, SCE_GXM_REAL_MAX_UNIFORM_BUFFER> all_buffers_in_register;
-
-    // Empty them out
-    for (auto &buffer : all_buffers_in_register) {
-        buffer = nullptr;
-    }
-
     // move into load buffers function now?
-    const auto *buffer_info = reinterpret_cast<const SceGxmUniformBufferInfo *>(
+    const auto buffer_info = reinterpret_cast<const SceGxmUniformBufferInfo *>(
         reinterpret_cast<const std::uint8_t *>(&program.uniform_buffer_offset) + program.uniform_buffer_offset);
 
-    auto *buffer_container = gxp::get_container_by_index(program, 19);
+    auto buffer_container = gxp::get_container_by_index(program, 19);
     uint32_t buffer_base = buffer_container ? buffer_container->base_sa_offset : 0;
 
     for (size_t i = 0; i < program.uniform_buffer_count; ++i) {
@@ -130,4 +123,152 @@ std::vector<UniformBuffer> shader::get_uniform_buffers(const SceGxmProgram &prog
         output_buffers.push_back(item);
     }
     return output_buffers;
+}
+
+ProgramInput shader::get_program_input(const SceGxmProgram &program) {
+    ProgramInput program_input;
+    const SceGxmProgramParameter *const gxp_parameters = gxp::program_parameters(program);
+
+    for (size_t i = 0; i < program.parameter_count; ++i) {
+        const SceGxmProgramParameter &parameter = gxp_parameters[i];
+
+        bool is_uniform = false;
+        uint16_t curi = parameter.category;
+
+        switch (parameter.category) {
+        case SCE_GXM_PARAMETER_CATEGORY_UNIFORM:
+            is_uniform = true;
+            [[fallthrough]];
+
+        // fallthrough
+        case SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE: {
+            std::string var_name = gxp::parameter_name(parameter);
+
+            auto container = gxp::get_container_by_index(program, parameter.container_index);
+            std::uint32_t offset = parameter.resource_index;
+
+            if (container && parameter.resource_index < container->size_in_f32) {
+                offset = container->base_sa_offset + parameter.resource_index;
+            }
+
+            if (container && container->size_in_f32 > 0) {
+                UniformBlock block;
+                block.block_num = (container->container_index + 1) % SCE_GXM_REAL_MAX_UNIFORM_BUFFER;
+                block.offset = container->base_sa_offset;
+                block.size = container->size_in_f32;
+                program_input.uniform_blocks.emplace(container->container_index, block);
+            }
+
+            const auto parameter_type = gxp::parameter_type(parameter);
+            const auto [store_type, param_type_name] = shader::get_parameter_type_store_and_name(parameter_type);
+
+            // Make the type
+            std::string param_log = fmt::format("[{} + {}] {}a{} = ({}{}) {}",
+                gxp::get_container_name(parameter.container_index), parameter.resource_index,
+                is_uniform ? "s" : "p", offset, param_type_name, parameter.component_count, var_name);
+
+            if (parameter.array_size > 1) {
+                param_log += fmt::format("[{}]", parameter.array_size);
+            }
+
+            LOG_DEBUG(param_log);
+
+            Input item;
+            item.type = store_type;
+            item.offset = offset;
+            item.component_count = parameter.component_count;
+            item.array_size = parameter.array_size;
+            gxp::GenericParameterType param_type = gxp::parameter_generic_type(parameter);
+            item.generic_type = translate_generic_type(param_type);
+            item.bank = is_uniform ? RegisterBank::SECATTR : RegisterBank::PRIMATTR;
+            if (!is_uniform) {
+                AttributeInputSoucre source;
+                source.name = var_name;
+                source.index = parameter.resource_index;
+                item.source = source;
+            } else {
+                UniformInputSource source;
+                source.name = var_name;
+                source.index = parameter.resource_index;
+                item.source = source;
+            }
+
+            program_input.inputs.push_back(item);
+            break;
+        }
+
+        case SCE_GXM_PARAMETER_CATEGORY_SAMPLER: {
+            const std::string name = gxp::parameter_name(parameter);
+            Sampler sampler;
+            sampler.name = name;
+            sampler.dependent = false;
+            sampler.index = parameter.resource_index;
+            program_input.samplers.push_back(sampler);
+            break;
+        }
+        case SCE_GXM_PARAMETER_CATEGORY_AUXILIARY_SURFACE: {
+            assert(parameter.component_count == 0);
+            LOG_CRITICAL("auxiliary_surface used in shader");
+            break;
+        }
+        default: {
+            LOG_CRITICAL("Unknown parameter type used in shader.");
+            break;
+        }
+        }
+    }
+
+    const SceGxmProgramParameterContainer *container = gxp::get_container_by_index(program, 19);
+
+    if (container) {
+        // Create dependent sampler
+        const SceGxmDependentSampler *dependent_samplers = reinterpret_cast<const SceGxmDependentSampler *>(reinterpret_cast<const std::uint8_t *>(&program.dependent_sampler_offset)
+            + program.dependent_sampler_offset);
+
+        for (std::uint32_t i = 0; i < program.dependent_sampler_count; i++) {
+            const std::uint32_t rsc_index = dependent_samplers[i].resource_index_layout_offset / 4;
+
+            const auto sampler = std::find_if(program_input.samplers.begin(), program_input.samplers.end(), [=](auto x) { return x.index == rsc_index; });
+            sampler->dependent = true;
+            sampler->offset = container->base_sa_offset + dependent_samplers[i].sa_offset;
+        }
+    }
+
+    const std::uint32_t *literals = reinterpret_cast<const std::uint32_t *>(reinterpret_cast<const std::uint8_t *>(&program.literals_offset)
+        + program.literals_offset);
+
+    // Get base SA offset for literal
+    // The container index of those literals are 16
+    container = gxp::get_container_by_index(program, 16);
+
+    if (!container) {
+        // Alternative is 19, which is DATA
+        container = gxp::get_container_by_index(program, 19);
+    }
+    if (!container) {
+        LOG_WARN("Container for literal not found, skipping creating literals!");
+    } else {
+        for (std::uint32_t i = 0; i < program.literals_count * 2; i += 2) {
+            auto literal_offset = container->base_sa_offset + literals[i];
+            auto literal_data = *reinterpret_cast<const float *>(&literals[i + 1]);
+
+            LiteralInputSource source;
+            source.data = literal_data;
+
+            Input item;
+            item.component_count = 1;
+            item.type = DataType::F32;
+            item.bank = RegisterBank::SECATTR;
+            item.offset = literal_offset;
+            item.array_size = 1;
+            item.generic_type = GenericType::SCALER;
+            item.source = source;
+
+            program_input.inputs.push_back(item);
+
+            LOG_TRACE("[LITERAL + {}] sa{} = {} (0x{:X})", literals[i], literal_offset, literal_data, literals[i + 1]);
+        }
+    }
+
+    return program_input;
 }

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -5,6 +5,19 @@
 
 using namespace shader::usse;
 
+GenericType shader::translate_generic_type(const gxp::GenericParameterType &type) {
+    switch (type) {
+    case gxp::GenericParameterType::Scalar:
+        return GenericType::SCALER;
+    case gxp::GenericParameterType::Vector:
+        return GenericType::VECTOR;
+    case gxp::GenericParameterType::Array:
+        return GenericType::ARRAY;
+    default:
+        return GenericType::INVALID;
+    }
+}
+
 std::tuple<DataType, std::string> shader::get_parameter_type_store_and_name(const SceGxmParameterType &type) {
     switch (type) {
     case SCE_GXM_PARAMETER_TYPE_F16: {

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -20,6 +20,10 @@ GenericType shader::translate_generic_type(const gxp::GenericParameterType &type
 
 std::tuple<DataType, std::string> shader::get_parameter_type_store_and_name(const SceGxmParameterType &type) {
     switch (type) {
+    case SCE_GXM_PARAMETER_TYPE_F32: {
+        return std::make_tuple(DataType::F32, "float");
+    }
+
     case SCE_GXM_PARAMETER_TYPE_F16: {
         return std::make_tuple(DataType::F16, "half");
     }

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -127,6 +127,9 @@ std::vector<UniformBuffer> shader::get_uniform_buffers(const SceGxmProgram &prog
 
 ProgramInput shader::get_program_input(const SceGxmProgram &program) {
     ProgramInput program_input;
+    program_input.uniform_buffers = get_uniform_buffers(program);
+
+    // TODO split these to functions (e.g. get_literals, get_paramters)
     const SceGxmProgramParameter *const gxp_parameters = gxp::program_parameters(program);
 
     for (size_t i = 0; i < program.parameter_count; ++i) {

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -1,4 +1,7 @@
 #include <shader/gxp_parser.h>
+#include <gxm/functions.h>
+#include <shader/usse_program_analyzer.h>
+#include <util/log.h>
 
 using namespace shader::usse;
 
@@ -34,4 +37,80 @@ std::tuple<DataType, std::string> shader::get_parameter_type_store_and_name(cons
     default:
         break;
     }
+}
+
+std::vector<UniformBuffer> shader::get_uniform_buffers(const SceGxmProgram &program) {
+    std::vector<UniformBuffer> output_buffers;
+
+    const std::uint64_t *secondary_program_insts = reinterpret_cast<const std::uint64_t *>(
+        reinterpret_cast<const std::uint8_t *>(&program.secondary_program_offset) + program.secondary_program_offset);
+
+    const std::uint64_t *primary_program_insts = program.primary_program_start();
+
+    UniformBufferMap buffer_size_map;
+    // Analyze the shader to get maximum uniform buffer data
+    // Analyze secondary program
+    data_analyze(
+        static_cast<shader::usse::USSEOffset>((program.secondary_program_offset_end + 4 - program.secondary_program_offset)) / 8,
+        [&](USSEOffset off) -> std::uint64_t {
+            return secondary_program_insts[off];
+        },
+        buffer_size_map);
+
+    // Analyze primary program
+    data_analyze(
+        static_cast<shader::usse::USSEOffset>(program.primary_program_instr_count),
+        [&](USSEOffset off) -> std::uint64_t {
+            return primary_program_insts[off];
+        },
+        buffer_size_map);
+
+    std::array<const SceGxmProgramParameterContainer *, SCE_GXM_REAL_MAX_UNIFORM_BUFFER> all_buffers_in_register;
+
+    // Empty them out
+    for (auto &buffer : all_buffers_in_register) {
+        buffer = nullptr;
+    }
+
+    // move into load buffers function now?
+    const auto *buffer_info = reinterpret_cast<const SceGxmUniformBufferInfo *>(
+        reinterpret_cast<const std::uint8_t *>(&program.uniform_buffer_offset) + program.uniform_buffer_offset);
+
+    auto *buffer_container = gxp::get_container_by_index(program, 19);
+    uint32_t buffer_base = buffer_container ? buffer_container->base_sa_offset : 0;
+
+    for (size_t i = 0; i < program.uniform_buffer_count; ++i) {
+        //const SceGxmProgramParameter &parameter = gxp_parameters[i];
+        const SceGxmUniformBufferInfo *buffer = &buffer_info[i];
+        //const SceGxmProgramParameter *parameter = nullptr;
+
+        //for (uint32_t a = 0; a < program.parameter_count; a++) {
+        //    if (gxp_parameters[a].resource_index == buffer->reside_buffer) {
+        //        parameter = &gxp_parameters[a];
+        //        break;
+        //    }
+        //}
+
+        uint32_t this_buffer_base = buffer_base + buffer->base_offset;
+
+        auto buffer_info = buffer_size_map.find(this_buffer_base);
+        if (buffer_info == buffer_size_map.end()) {
+            LOG_WARN("Cannot find buffer at index {} and base {}, skipping.", i, this_buffer_base);
+            continue;
+        }
+
+        uint32_t buffer_size = buffer_info->second.size;
+
+        if (buffer_size == -1) {
+            LOG_WARN("Could not analyze buffer size at index {} and base {}, skipping.", i, this_buffer_base);
+            continue;
+        }
+
+        UniformBuffer item;
+        item.base = this_buffer_base;
+        item.rw = ((buffer->reside_buffer + 1) % SCE_GXM_REAL_MAX_UNIFORM_BUFFER) == 0; // TODO: confirm this
+        item.size = buffer_size;
+        output_buffers.push_back(item);
+    }
+    return output_buffers;
 }

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -81,6 +81,7 @@ struct StructDeclContext {
     void clear() { *this = {}; }
 };
 
+// TODO do we need this? This is made to avoid spir-v validation error regarding interface variables
 struct VarToReg {
     spv::Id var;
     bool pa; // otherwise sa
@@ -738,7 +739,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                            std::sort(literal_pairs.begin(), literal_pairs.end());
                        },
                        [&](const UniformInputSource &s) {
-                           // In ubo mode we copy
+                           // In ubo mode we copy using default uniform buffer
                            if (!features.use_ubo) {
                                add_var_to_reg(input, s.name, false);
                            }
@@ -760,6 +761,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         }
     }
 
+    // This one usually copies default uniform buffer to SA registers
     if (features.use_ubo) {
         for (const auto [_, block] : program_input.uniform_blocks) {
             const int total_vec4 = static_cast<int>((block.size + 3) / 4);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -29,6 +29,7 @@
 #include <shader/usse_utilities.h>
 #include <util/fs.h>
 #include <util/log.h>
+#include <shader/gxp_parser.h>
 
 #include <SPIRV/SpvBuilder.h>
 #include <SPIRV/disassemble.h>
@@ -320,28 +321,6 @@ static spv::Id create_builtin_sampler(spv::Builder &b, const FeatureState &featu
     return sampler;
 }
 
-static DataType gxm_parameter_type_to_usse_data_type(const SceGxmParameterType param_type) {
-    switch (param_type) {
-    case SCE_GXM_PARAMETER_TYPE_F16:
-        return DataType::F16;
-
-    case SCE_GXM_PARAMETER_TYPE_F32:
-        return DataType::F32;
-        break;
-
-    case SCE_GXM_PARAMETER_TYPE_U8:
-        return DataType::UINT8;
-    case SCE_GXM_PARAMETER_TYPE_S8:
-        return DataType::INT8;
-
-    default:
-        LOG_WARN("Unsupported output register format {}, default to F16", (int)param_type);
-        break;
-    }
-
-    return DataType::F16;
-}
-
 static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &parameters, utils::SpirvUtilFunctions &utils, const FeatureState &features, TranslationState &translation_state, NonDependentTextureQueryCallInfos &tex_query_infos, SamplerMap &samplers,
     const SceGxmProgram &program) {
     static const std::unordered_map<std::uint32_t, std::string> name_map = {
@@ -626,59 +605,10 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
 
             target_to_store.bank = RegisterBank::OUTPUT;
             target_to_store.num = 0;
-            target_to_store.type = gxm_parameter_type_to_usse_data_type(program.get_fragment_output_type());
+            target_to_store.type = std::get<0>(shader::get_parameter_type_store_and_name(program.get_fragment_output_type()));
 
             utils::store(b, parameters, utils, features, target_to_store, source, 0b1111, 0);
         }
-    }
-}
-
-static void get_parameter_type_store_and_name(const SceGxmProgramParameter &parameter, DataType &store_type, const char *&param_type_name) {
-    switch (parameter.type) {
-    case SCE_GXM_PARAMETER_TYPE_F16: {
-        param_type_name = "half";
-        store_type = DataType::F16;
-        break;
-    }
-
-    case SCE_GXM_PARAMETER_TYPE_U16: {
-        param_type_name = "ushort";
-        store_type = DataType::UINT16;
-        break;
-    }
-
-    case SCE_GXM_PARAMETER_TYPE_S16: {
-        param_type_name = "ishort";
-        store_type = DataType::INT16;
-        break;
-    }
-
-    case SCE_GXM_PARAMETER_TYPE_U8: {
-        param_type_name = "uchar";
-        store_type = DataType::UINT8;
-        break;
-    }
-
-    case SCE_GXM_PARAMETER_TYPE_S8: {
-        param_type_name = "ichar";
-        store_type = DataType::INT8;
-        break;
-    }
-
-    case SCE_GXM_PARAMETER_TYPE_U32: {
-        param_type_name = "uint";
-        store_type = DataType::UINT32;
-        break;
-    }
-
-    case SCE_GXM_PARAMETER_TYPE_S32: {
-        param_type_name = "int";
-        store_type = DataType::INT32;
-        break;
-    }
-
-    default:
-        break;
     }
 }
 
@@ -875,10 +805,8 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
 
             all_buffers_in_register[parameter.container_index] = container;
 
-            auto param_type_name = "float";
-            DataType store_type = DataType::F32;
-
-            get_parameter_type_store_and_name(parameter, store_type, param_type_name);
+            const auto parameter_type = gxp::parameter_type(parameter);
+            const auto [store_type, param_type_name] = shader::get_parameter_type_store_and_name(parameter_type);
 
             // Make the type
             std::string param_log = fmt::format("[{} + {}] {}a{} = ({}{}) {}",
@@ -892,7 +820,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
             LOG_DEBUG(param_log);
 
             if (!is_uniform || !features.use_ubo) {
-                int type_size = gxp::get_parameter_type_size(static_cast<SceGxmParameterType>((uint16_t)parameter.type));
+                int type_size = gxp::get_parameter_type_size(parameter_type);
                 spv::Id var = b.createVariable(spv::StorageClassInput, param_type, var_name.c_str());
                 translation_state.interfaces.push_back(var);
                 translation_state.pa_vars.push_back(
@@ -1062,7 +990,7 @@ static spv::Function *make_frag_finalize_function(spv::Builder &b, const SpirvSh
     color_val_operand.bank = program.is_native_color() ? RegisterBank::OUTPUT : RegisterBank::PRIMATTR;
     color_val_operand.num = 0;
     color_val_operand.swizzle = SWIZZLE_CHANNEL_4_DEFAULT;
-    color_val_operand.type = gxm_parameter_type_to_usse_data_type(param_type);
+    color_val_operand.type = std::get<0>(shader::get_parameter_type_store_and_name(param_type));
 
     auto vertex_outputs_ptr = reinterpret_cast<const SceGxmProgramVertexOutput *>(
         reinterpret_cast<const std::uint8_t *>(&program.varyings_offset) + program.varyings_offset);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -23,13 +23,14 @@
 
 #include <gxm/functions.h>
 #include <gxm/types.h>
+#include <shader/gxp_parser.h>
 #include <shader/profile.h>
 #include <shader/usse_translator_entry.h>
 #include <shader/usse_translator_types.h>
 #include <shader/usse_utilities.h>
 #include <util/fs.h>
 #include <util/log.h>
-#include <shader/gxp_parser.h>
+#include <util/overloaded.h>
 
 #include <SPIRV/SpvBuilder.h>
 #include <SPIRV/disassemble.h>
@@ -117,11 +118,11 @@ using VertexProgramOutputPropertiesMap = std::map<SceGxmVertexProgramOutputs, Ve
 // * Functions (implementation) *
 // ******************************
 
-static spv::Id create_array_if_needed(spv::Builder &b, const spv::Id param_id, const SceGxmProgramParameter &parameter, const uint32_t explicit_array_size = 0) {
+static spv::Id create_array_if_needed(spv::Builder &b, const spv::Id param_id, const Input &input, const uint32_t explicit_array_size = 0) {
     // disabled
     return param_id;
 
-    const auto array_size = explicit_array_size == 0 ? parameter.array_size : explicit_array_size;
+    const auto array_size = explicit_array_size == 0 ? input.array_size : explicit_array_size;
     if (array_size > 1) {
         const auto array_size_id = b.makeUintConstant(array_size);
         return b.makeArrayType(param_id, array_size_id, 0);
@@ -129,28 +130,26 @@ static spv::Id create_array_if_needed(spv::Builder &b, const spv::Id param_id, c
     return param_id;
 }
 
-static spv::Id get_type_basic(spv::Builder &b, const SceGxmProgramParameter &parameter) {
-    SceGxmParameterType type = gxp::parameter_type(parameter);
-
-    switch (type) {
+static spv::Id get_type_basic(spv::Builder &b, const Input &input) {
+    switch (input.type) {
     // clang-format off
-    case SCE_GXM_PARAMETER_TYPE_F16:
-    case SCE_GXM_PARAMETER_TYPE_F32:
+    case DataType::F16:
+    case DataType::F32:
          return b.makeFloatType(32);
 
-    case SCE_GXM_PARAMETER_TYPE_U8:
-    case SCE_GXM_PARAMETER_TYPE_U16:
-    case SCE_GXM_PARAMETER_TYPE_U32:
+    case DataType::UINT8:
+    case DataType::UINT16:
+    case DataType::UINT32:
         return b.makeUintType(32);
 
-    case SCE_GXM_PARAMETER_TYPE_S8:
-    case SCE_GXM_PARAMETER_TYPE_S16:
-    case SCE_GXM_PARAMETER_TYPE_S32:
+    case DataType::INT8:
+    case DataType::INT16:
+    case DataType::INT32:
         return b.makeIntType(32);
 
     // clang-format on
     default: {
-        LOG_ERROR("Unsupported parameter type {} used in shader.", log_hex(type));
+        LOG_ERROR("Unsupported parameter type {} used in shader.", log_hex(input.type));
         return get_type_fallback(b);
     }
     }
@@ -160,44 +159,42 @@ static spv::Id get_type_fallback(spv::Builder &b) {
     return b.makeFloatType(32);
 }
 
-static spv::Id get_type_scalar(spv::Builder &b, const SceGxmProgramParameter &parameter) {
-    spv::Id param_id = get_type_basic(b, parameter);
-    param_id = create_array_if_needed(b, param_id, parameter);
+static spv::Id get_type_scalar(spv::Builder &b, const Input &input) {
+    spv::Id param_id = get_type_basic(b, input);
+    param_id = create_array_if_needed(b, param_id, input);
     return param_id;
 }
 
-static spv::Id get_type_vector(spv::Builder &b, const SceGxmProgramParameter &parameter) {
-    if (parameter.component_count == 1) {
-        return get_type_scalar(b, parameter);
+static spv::Id get_type_vector(spv::Builder &b, const Input &input) {
+    if (input.component_count == 1) {
+        return get_type_scalar(b, input);
     }
-    spv::Id param_id = get_type_basic(b, parameter);
-    param_id = b.makeVectorType(param_id, parameter.component_count);
+    spv::Id param_id = get_type_basic(b, input);
+    param_id = b.makeVectorType(param_id, input.component_count);
 
     return param_id;
 }
 
-static spv::Id get_type_array(spv::Builder &b, const SceGxmProgramParameter &parameter) {
-    spv::Id param_id = get_type_basic(b, parameter);
-    if (parameter.component_count > 1) {
-        param_id = b.makeVectorType(param_id, parameter.component_count);
+static spv::Id get_type_array(spv::Builder &b, const Input &input) {
+    spv::Id param_id = get_type_basic(b, input);
+    if (input.component_count > 1) {
+        param_id = b.makeVectorType(param_id, input.component_count);
     }
 
     // TODO: Stride
-    param_id = b.makeArrayType(param_id, b.makeUintConstant(parameter.array_size), 1);
+    param_id = b.makeArrayType(param_id, b.makeUintConstant(input.array_size), 1);
 
     return param_id;
 }
 
-static spv::Id get_param_type(spv::Builder &b, const SceGxmProgramParameter &parameter) {
-    gxp::GenericParameterType param_type = gxp::parameter_generic_type(parameter);
-
-    switch (param_type) {
-    case gxp::GenericParameterType::Scalar:
-        return get_type_scalar(b, parameter);
-    case gxp::GenericParameterType::Vector:
-        return get_type_vector(b, parameter);
-    case gxp::GenericParameterType::Array:
-        return get_type_array(b, parameter);
+static spv::Id get_param_type(spv::Builder &b, const Input &input) {
+    switch (input.generic_type) {
+    case GenericType::SCALER:
+        return get_type_scalar(b, input);
+    case GenericType::VECTOR:
+        return get_type_vector(b, input);
+    case GenericType::ARRAY:
+        return get_type_array(b, input);
     default:
         return get_type_fallback(b);
     }
@@ -234,12 +231,10 @@ spv::StorageClass reg_type_to_spv_storage_class(usse::RegisterBank reg_type) {
     return spv::StorageClassMax;
 }
 
-static spv::Id create_param_sampler(spv::Builder &b, const SceGxmProgramParameter &parameter) {
+static spv::Id create_param_sampler(spv::Builder &b, const std::string &name) {
     spv::Id sampled_type = b.makeFloatType(32);
     spv::Id image_type = b.makeImageType(sampled_type, spv::Dim2D, false, false, false, 1, spv::ImageFormatUnknown);
     spv::Id sampled_image_type = b.makeSampledImageType(image_type);
-    std::string name = gxp::parameter_name(parameter);
-
     return b.createVariable(spv::StorageClassUniformConstant, sampled_image_type, name.c_str());
 }
 
@@ -711,148 +706,71 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     }
 
     SamplerMap samplers;
- 
-    spv::Id ite_copy = b.createVariable(spv::StorageClassFunction, i32_type, "i");
-    std::array<const SceGxmProgramParameterContainer *, SCE_GXM_REAL_MAX_UNIFORM_BUFFER> all_buffers_in_register;
 
-    // Empty them out
-    for (auto &buffer : all_buffers_in_register) {
-        buffer = nullptr;
+    spv::Id ite_copy = b.createVariable(spv::StorageClassFunction, i32_type, "i");
+
+    using literal_pair = std::pair<std::uint32_t, spv::Id>;
+
+    std::vector<literal_pair> literal_pairs;
+
+    const auto program_input = shader::get_program_input(program);
+
+    for (const auto &input : program_input.inputs) {
+        std::visit(
+            overloaded{
+                [&](const LiteralInputSource &s) {
+                    literal_pairs.emplace_back(input.offset, b.makeFloatConstant(s.data));
+                    // Pair sort automatically sort offset for us
+                    std::sort(literal_pairs.begin(), literal_pairs.end());
+                },
+                [&](const UniformInputSource &s) {
+                    if (!features.use_ubo) {
+                        const spv::Id param_type = get_param_type(b, input);
+                        int type_size = get_data_type_size(input.type);
+                        spv::Id var = b.createVariable(spv::StorageClassInput, param_type, s.name.c_str());
+                        translation_state.interfaces.push_back(var);
+                        translation_state.pa_vars.push_back(
+                            { var,
+                                input.offset,
+                                input.array_size * input.component_count * 4,
+                                input.type });
+                    }
+                },
+                [&](const AttributeInputSoucre &s) {
+                    const spv::Id param_type = get_param_type(b, input);
+                    int type_size = get_data_type_size(input.type);
+                    spv::Id var = b.createVariable(spv::StorageClassInput, param_type, s.name.c_str());
+                    translation_state.interfaces.push_back(var);
+                    translation_state.pa_vars.push_back(
+                        { var,
+                            input.offset,
+                            input.array_size * input.component_count * 4,
+                            input.type });
+                } },
+            input.source);
     }
 
-    for (size_t i = 0; i < program.parameter_count; ++i) {
-        const SceGxmProgramParameter &parameter = gxp_parameters[i];
 
-        usse::RegisterBank param_reg_type = usse::RegisterBank::PRIMATTR;
-        uint16_t curi = parameter.category;
-
-        switch (parameter.category) {
-        case SCE_GXM_PARAMETER_CATEGORY_UNIFORM:
-            param_reg_type = usse::RegisterBank::SECATTR;
-            [[fallthrough]];
-
-        // fallthrough
-        case SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE: {
-            spv::Id param_type = get_param_type(b, parameter);
-
-            const bool is_uniform = param_reg_type == usse::RegisterBank::SECATTR;
-
-            std::string var_name = gxp::parameter_name(parameter);
-
-            auto container = gxp::get_container_by_index(program, parameter.container_index);
-            std::uint32_t offset = parameter.resource_index;
-
-            if (container && parameter.resource_index < container->size_in_f32) {
-                offset = container->base_sa_offset + parameter.resource_index;
-            }
-
-            all_buffers_in_register[parameter.container_index] = container;
-
-            const auto parameter_type = gxp::parameter_type(parameter);
-            const auto [store_type, param_type_name] = shader::get_parameter_type_store_and_name(parameter_type);
-
-            // Make the type
-            std::string param_log = fmt::format("[{} + {}] {}a{} = ({}{}) {}",
-                gxp::get_container_name(parameter.container_index), parameter.resource_index,
-                is_uniform ? "s" : "p", offset, param_type_name, parameter.component_count, var_name);
-
-            if (parameter.array_size > 1) {
-                param_log += fmt::format("[{}]", parameter.array_size);
-            }
-
-            LOG_DEBUG(param_log);
-
-            if (!is_uniform || !features.use_ubo) {
-                int type_size = gxp::get_parameter_type_size(parameter_type);
-                spv::Id var = b.createVariable(spv::StorageClassInput, param_type, var_name.c_str());
-                translation_state.interfaces.push_back(var);
-                translation_state.pa_vars.push_back(
-                    { var,
-                        offset,
-                        parameter.array_size * parameter.component_count * 4,
-                        store_type });
-            }
-
-            break;
+    for (const auto &sampler : program_input.samplers) {
+        const auto sampler_spv_var = create_param_sampler(b, sampler.name);
+        samplers.emplace(sampler.index, sampler_spv_var);
+        if (features.use_shader_binding) {
+            b.addDecoration(sampler_spv_var, spv::DecorationBinding, sampler.index);
         }
-
-        case SCE_GXM_PARAMETER_CATEGORY_SAMPLER: {
-            const auto sampler_spv_var = create_param_sampler(b, parameter);
-            samplers.emplace(parameter.resource_index, sampler_spv_var);
-            if (features.use_shader_binding)
-                b.addDecoration(sampler_spv_var, spv::DecorationBinding, parameter.resource_index);
-
-            break;
-        }
-        case SCE_GXM_PARAMETER_CATEGORY_AUXILIARY_SURFACE: {
-            assert(parameter.component_count == 0);
-            LOG_CRITICAL("auxiliary_surface used in shader");
-            break;
-        }
-        default: {
-            LOG_CRITICAL("Unknown parameter type used in shader.");
-            break;
-        }
+        if (sampler.dependent) {
+            spv_params.samplers.emplace(sampler.offset, sampler_spv_var);
         }
     }
 
     if (features.use_ubo) {
-        for (const auto &buffer_in_register : all_buffers_in_register) {
-            if (buffer_in_register && buffer_in_register->size_in_f32 != 0) {
-                // Create an array of vec4
-                const int buffer_block_num = (buffer_in_register->container_index + 1) % SCE_GXM_REAL_MAX_UNIFORM_BUFFER;
-                const int total_vec4 = static_cast<int>((buffer_in_register->size_in_f32 + 3) / 4);
-                spv::Id default_buffer = create_uniform_block(b, features, buffer_block_num, total_vec4, !program.is_fragment());
-                copy_uniform_block_to_register(b, spv_params.uniforms, default_buffer, ite_copy, buffer_in_register->base_sa_offset / 4, total_vec4);
-            }
+        for (const auto [_, block] : program_input.uniform_blocks) {
+            const int total_vec4 = static_cast<int>((block.size + 3) / 4);
+            spv::Id default_buffer = create_uniform_block(b, features, block.block_num, total_vec4, !program.is_fragment());
+            copy_uniform_block_to_register(b, spv_params.uniforms, default_buffer, ite_copy, block.offset / 4, total_vec4);
         }
     }
 
-    const SceGxmProgramParameterContainer *container = gxp::get_container_by_index(program, 19);
-
-    if (container) {
-        // Create dependent sampler
-        const SceGxmDependentSampler *dependent_samplers = reinterpret_cast<const SceGxmDependentSampler *>(reinterpret_cast<const std::uint8_t *>(&program.dependent_sampler_offset)
-            + program.dependent_sampler_offset);
-
-        for (std::uint32_t i = 0; i < program.dependent_sampler_count; i++) {
-            const std::uint32_t rsc_index = dependent_samplers[i].resource_index_layout_offset / 4;
-            spv_params.samplers.emplace(container->base_sa_offset + dependent_samplers[i].sa_offset, samplers[rsc_index]);
-        }
-    }
-
-    const std::uint32_t *literals = reinterpret_cast<const std::uint32_t *>(reinterpret_cast<const std::uint8_t *>(&program.literals_offset)
-        + program.literals_offset);
-
-    // Get base SA offset for literal
-    // The container index of those literals are 16
-    container = gxp::get_container_by_index(program, 16);
-
-    if (!container) {
-        // Alternative is 19, which is DATA
-        container = gxp::get_container_by_index(program, 19);
-    }
-
-    if (!container) {
-        LOG_WARN("Container for literal not found, skipping creating literals!");
-    } else if (program.literals_count != 0) {
-        spv::Id f32_type = b.makeFloatType(32);
-        using literal_pair = std::pair<std::uint32_t, spv::Id>;
-
-        std::vector<literal_pair> literal_pairs;
-
-        for (std::uint32_t i = 0; i < program.literals_count * 2; i += 2) {
-            auto literal_offset = container->base_sa_offset + literals[i];
-            auto literal_data = *reinterpret_cast<const float *>(&literals[i + 1]);
-
-            literal_pairs.emplace_back(literal_offset, b.makeFloatConstant(literal_data));
-
-            // Pair sort automatically sort offset for us
-            std::sort(literal_pairs.begin(), literal_pairs.end());
-
-            LOG_TRACE("[LITERAL + {}] sa{} = {} (0x{:X})", literals[i], literal_offset, literal_data, literals[i + 1]);
-        }
-
+    if (literal_pairs.size() != 0) {
         std::uint32_t composite_base = literal_pairs[0].first;
 
         // We should avoid ugly and long GLSL code generated. Also, inefficient SPIR-V code.

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -702,12 +702,6 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     spv_params.indexes = b.createVariable(spv::StorageClassPrivate, index_arr_type, "idx");
     spv_params.outs = b.createVariable(spv::StorageClassPrivate, o_arr_type, "outs");
 
-    const auto buffers = shader::get_uniform_buffers(program);
-    for (const auto &buffer : buffers) {
-        spv::Id block = create_uniform_block(b, features, buffer.rw, buffer.size, !program.is_fragment());
-        spv_params.buffers.emplace(buffer.base, block);
-    }
-
     SamplerMap samplers;
 
     spv::Id ite_copy = b.createVariable(spv::StorageClassFunction, i32_type, "i");
@@ -717,6 +711,11 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     std::vector<literal_pair> literal_pairs;
 
     const auto program_input = shader::get_program_input(program);
+    for (const auto &buffer : program_input.uniform_buffers) {
+        spv::Id block = create_uniform_block(b, features, buffer.rw, buffer.size, !program.is_fragment());
+        spv_params.buffers.emplace(buffer.base, block);
+    }
+
     const auto add_var_to_reg = [&](const Input &input, const std::string &name, bool pa) {
         const spv::Id param_type = get_param_type(b, input);
         int type_size = get_data_type_size(input.type);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -81,11 +81,12 @@ struct StructDeclContext {
     void clear() { *this = {}; }
 };
 
-struct PAVar {
+struct VarToReg {
     spv::Id var;
-    uint32_t pa_offset;
-    uint32_t pa_size;
-    DataType pa_dtype;
+    bool pa; // otherwise sa
+    uint32_t offset;
+    uint32_t size;
+    DataType dtype;
 };
 
 struct TranslationState {
@@ -95,7 +96,7 @@ struct TranslationState {
     spv::Id mask_id = spv::NoResult;
     spv::Id frag_coord_id = spv::NoResult; ///< gl_FragCoord, not built-in in SPIR-V.
     spv::Id flip_vec_id = spv::NoResult;
-    std::vector<PAVar> pa_vars;
+    std::vector<VarToReg> var_to_regs;
     std::vector<spv::Id> interfaces;
     bool is_maskupdate;
 };
@@ -397,8 +398,9 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
                 b.addDecoration(pa_iter_var, spv::DecorationBuiltIn, spv::BuiltInFragCoord);
             }
 
-            translation_state.pa_vars.push_back(
+            translation_state.var_to_regs.push_back(
                 { pa_iter_var,
+                    true,
                     pa_offset,
                     pa_iter_size,
                     pa_dtype });
@@ -714,42 +716,38 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     std::vector<literal_pair> literal_pairs;
 
     const auto program_input = shader::get_program_input(program);
+    const auto add_var_to_reg = [&](const Input &input, const std::string &name, bool pa) {
+        const spv::Id param_type = get_param_type(b, input);
+        int type_size = get_data_type_size(input.type);
+        spv::Id var = b.createVariable(spv::StorageClassInput, param_type, name.c_str());
+        translation_state.interfaces.push_back(var);
+        VarToReg var_to_reg;
+        var_to_reg.var = var;
+        var_to_reg.pa = pa;
+        var_to_reg.offset = input.offset;
+        var_to_reg.size = input.array_size * input.component_count * 4;
+        var_to_reg.dtype = input.type;
+        translation_state.var_to_regs.push_back(var_to_reg);
+    };
 
     for (const auto &input : program_input.inputs) {
-        std::visit(
-            overloaded{
-                [&](const LiteralInputSource &s) {
-                    literal_pairs.emplace_back(input.offset, b.makeFloatConstant(s.data));
-                    // Pair sort automatically sort offset for us
-                    std::sort(literal_pairs.begin(), literal_pairs.end());
-                },
-                [&](const UniformInputSource &s) {
-                    if (!features.use_ubo) {
-                        const spv::Id param_type = get_param_type(b, input);
-                        int type_size = get_data_type_size(input.type);
-                        spv::Id var = b.createVariable(spv::StorageClassInput, param_type, s.name.c_str());
-                        translation_state.interfaces.push_back(var);
-                        translation_state.pa_vars.push_back(
-                            { var,
-                                input.offset,
-                                input.array_size * input.component_count * 4,
-                                input.type });
-                    }
-                },
-                [&](const AttributeInputSoucre &s) {
-                    const spv::Id param_type = get_param_type(b, input);
-                    int type_size = get_data_type_size(input.type);
-                    spv::Id var = b.createVariable(spv::StorageClassInput, param_type, s.name.c_str());
-                    translation_state.interfaces.push_back(var);
-                    translation_state.pa_vars.push_back(
-                        { var,
-                            input.offset,
-                            input.array_size * input.component_count * 4,
-                            input.type });
-                } },
+        std::visit(overloaded{
+                       [&](const LiteralInputSource &s) {
+                           literal_pairs.emplace_back(input.offset, b.makeFloatConstant(s.data));
+                           // Pair sort automatically sort offset for us
+                           std::sort(literal_pairs.begin(), literal_pairs.end());
+                       },
+                       [&](const UniformInputSource &s) {
+                           // In ubo mode we copy
+                           if (!features.use_ubo) {
+                               add_var_to_reg(input, s.name, false);
+                           }
+                       },
+                       [&](const AttributeInputSoucre &s) {
+                           add_var_to_reg(input, s.name, true);
+                       } },
             input.source);
     }
-
 
     for (const auto &sampler : program_input.samplers) {
         const auto sampler_spv_var = create_param_sampler(b, sampler.name);
@@ -770,11 +768,11 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         }
     }
 
+    // We should avoid ugly and long GLSL code generated. Also, inefficient SPIR-V code.
+    // Packing literals into vector may help solving this.
     if (literal_pairs.size() != 0) {
         std::uint32_t composite_base = literal_pairs[0].first;
 
-        // We should avoid ugly and long GLSL code generated. Also, inefficient SPIR-V code.
-        // Packing literals into vector may help solving this.
         std::vector<spv::Id> constituents;
         constituents.push_back(literal_pairs[0].second);
 
@@ -1082,9 +1080,9 @@ static SpirvCode convert_gxp_to_spirv(const SceGxmProgram &program, const std::s
         end_hook_func = make_vert_finalize_function(b, parameters, program, utils, features, translation_state);
     }
 
-    for (auto &pa_var : translation_state.pa_vars) {
-        create_input_variable(b, parameters, utils, features, "", RegisterBank::PRIMATTR,
-            pa_var.pa_offset, spv::NoResult, pa_var.pa_size, pa_var.var, pa_var.pa_dtype);
+    for (auto &var_to_reg : translation_state.var_to_regs) {
+        create_input_variable(b, parameters, utils, features, "", var_to_reg.pa ? RegisterBank::PRIMATTR : RegisterBank::SECATTR,
+            var_to_reg.offset, spv::NoResult, var_to_reg.size, var_to_reg.var, var_to_reg.dtype);
     }
 
     generate_shader_body(b, parameters, program, features, utils, end_hook_func, texture_queries);

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -556,27 +556,7 @@ bool USSETranslatorVisitor::v32nmad(
 
     const auto src1_swizzle_enc = src1_swiz_0_6 | src1_swiz_7_8 << 7 | src1_swiz_9 << 9 | src1_swiz_10_11 << 10;
     inst.opr.src1.swizzle = decode_swizzle4(src1_swizzle_enc);
-
-    static const Swizzle4 tb_decode_src2_swizzle[] = {
-        SWIZZLE_CHANNEL_4(X, X, X, X),
-        SWIZZLE_CHANNEL_4(Y, Y, Y, Y),
-        SWIZZLE_CHANNEL_4(Z, Z, Z, Z),
-        SWIZZLE_CHANNEL_4(W, W, W, W),
-        SWIZZLE_CHANNEL_4(X, Y, Z, W),
-        SWIZZLE_CHANNEL_4(Y, Z, W, W),
-        SWIZZLE_CHANNEL_4(X, Y, Z, Z),
-        SWIZZLE_CHANNEL_4(X, X, Y, Z),
-        SWIZZLE_CHANNEL_4(X, Y, X, Y),
-        SWIZZLE_CHANNEL_4(X, Y, W, Z),
-        SWIZZLE_CHANNEL_4(Z, X, Y, W),
-        SWIZZLE_CHANNEL_4(Z, W, Z, W),
-        SWIZZLE_CHANNEL_4(Y, Z, X, Z),
-        SWIZZLE_CHANNEL_4(X, X, Y, Y),
-        SWIZZLE_CHANNEL_4(X, Z, W, W),
-        SWIZZLE_CHANNEL_4(X, Y, Z, 1),
-    };
-
-    inst.opr.src2.swizzle = tb_decode_src2_swizzle[src2_swiz];
+    inst.opr.src2.swizzle = decode_vec34_swizzle(src2_swiz, false, 2);
 
     // TODO: source modifiers
 

--- a/vita3k/util/CMakeLists.txt
+++ b/vita3k/util/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
     util
     STATIC
+    include/util/overloaded.h
     include/util/align.h
     include/util/bytes.h
     include/util/exit_code.h

--- a/vita3k/util/include/util/overloaded.h
+++ b/vita3k/util/include/util/overloaded.h
@@ -1,0 +1,4 @@
+template <class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+template <class... Ts>
+overloaded(Ts...)->overloaded<Ts...>;


### PR DESCRIPTION
# About PR

- Separate gxp input parsing part from spirv recompiler
- Fix non-ubo mode uniform bug
- Refactor various utility functions
- Refactor create_parameters of spirv_recompiler.cpp

# Motivation

GXP input parsing part can be reused for many purposes (fuzzing/debugging/optimizing/etc) But, we had it inside private recompiler function that also deals with spir-v setting up, hiding useful parsed information.

With this PR, now we can get almost all information about input data of gxp shader program using code like below. 
```cpp
const auto prgoram_input = shader::get_program_input(program);
```