### PR TITLE
Stricter last draw program cache validation

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1128,8 +1128,8 @@ struct GxmContextState {
     Ptr<const SceGxmFragmentProgram> fragment_program;
     Ptr<const SceGxmVertexProgram> vertex_program;
 
-    Ptr<const SceGxmFragmentProgram> last_draw_fragment_program;
-    Ptr<const SceGxmVertexProgram> last_draw_vertex_program;
+    std::string last_draw_fragment_program_hash;
+    std::string last_draw_vertex_program_hash;
 
     // Uniforms.
     UniformBuffers fragment_uniform_buffers;


### PR DESCRIPTION
When the app unregisters program, very rarely, the program address can be the same as the previous program. To avoid drawing using incorrect program in this situation, this PR doesn't let it pass even if the program address is the same as before.

The additional cost should be two string comparisons and copying, so I think this PR shouldn't cause drastic performance drop.