### PR TITLE
Gui/themes: some reafctor and add

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -42,8 +42,8 @@
     code(int, "sys-lang", static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US), sys_lang)                 \
     code(bool, "auto-lle", false, auto_lle)                                                             \
     code(std::string, "user-start-background", std::string{}, user_start_background)                    \
-    code(std::string, "start-background",  std::string{}, start_background)                             \
-    code(std::string, "theme-content-id", std::string{}, theme_content_id)                              \
+    code(std::string, "start-background",  std::string{"default"}, start_background)                    \
+    code(std::string, "theme-content-id", std::string{"default"}, theme_content_id)                     \
     code(bool, "use-theme-background", false, use_theme_background)                                     \
     code(int, "delay-background", 4, delay_background)                                                  \
     code(int, "delay-start", 10, delay_start)                                                           \

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -178,6 +178,7 @@ struct GuiState {
     std::uint64_t current_theme_bg;
     std::map<std::string, std::map<std::string, ImGui_Texture>> themes_preview;
     std::vector<ImGui_Texture> theme_backgrounds;
+    std::vector<ImVec4> theme_backgrounds_font_color;
     std::map<std::string, ImGui_Texture> theme_information_bar_notice;
 
     std::map<size_t, bool> notice_info_new;

--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -146,7 +146,7 @@ void draw_app_selector(GuiState &gui, HostState &host) {
     if (!host.display.imgui_render || ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows))
         gui.live_area.information_bar = true;
 
-    if (gui.start_background && !gui.file_menu.pkg_install_dialog) {
+    if (!gui.file_menu.pkg_install_dialog) {
         if (ImGui::IsAnyWindowHovered() || ImGui::IsAnyItemActive() || ImGui::IsAnyItemHovered())
             last_time["start"] = 0;
         else {
@@ -428,6 +428,7 @@ void draw_app_selector(GuiState &gui, HostState &host) {
                 if (!host.cfg.apps_list_grid) {
                     ImGui::NextColumn();
                     ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
+                    ImGui::PushStyleColor(ImGuiCol_Text, !gui.theme_backgrounds_font_color.empty() && host.cfg.use_theme_background ? gui.theme_backgrounds_font_color[gui.current_theme_bg] : GUI_COLOR_TEXT);
                     ImGui::Selectable(app.title_id.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
                     ImGui::NextColumn();
                     ImGui::Selectable(app.app_ver.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
@@ -435,12 +436,13 @@ void draw_app_selector(GuiState &gui, HostState &host) {
                     ImGui::Selectable(app.category.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
                     ImGui::NextColumn();
                     ImGui::Selectable(app.title.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
+                    ImGui::PopStyleColor();
                     ImGui::PopStyleVar();
                     ImGui::NextColumn();
                 } else {
                     ImGui::SetCursorPos(ImVec2(POS_STITLE.x + ((GRID_ICON_SIZE.x / 2.f) - (ImGui::CalcTextSize(app.stitle.c_str(), 0, false, GRID_ICON_SIZE.x).x / 2.f)), POS_STITLE.y));
                     ImGui::PushTextWrapPos(POS_STITLE.x + GRID_ICON_SIZE.x);
-                    ImGui::TextColored(GUI_COLOR_TEXT, "%s", app.stitle.c_str());
+                    ImGui::TextColored(!gui.theme_backgrounds_font_color.empty() && host.cfg.use_theme_background ? gui.theme_backgrounds_font_color[gui.current_theme_bg] : GUI_COLOR_TEXT, "%s", app.stitle.c_str());
                     ImGui::PopTextWrapPos();
                     ImGui::NextColumn();
                 }

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -432,20 +432,13 @@ void init(GuiState &gui, HostState &host) {
     if (!host.cfg.user_backgrounds.empty())
         init_user_backgrounds(gui, host);
 
-    if (!host.cfg.theme_content_id.empty()) {
-        init_theme(gui, host, host.cfg.theme_content_id);
-        init_theme_apps_icon(gui, host, host.cfg.theme_content_id);
-    } else {
-        init_theme(gui, host, "default");
-        init_apps_icon(gui, host, gui.app_selector.sys_apps);
-    }
+    init_theme(gui, host, host.cfg.theme_content_id.empty() ? "default" : host.cfg.theme_content_id);
+    init_theme_apps_icon(gui, host, host.cfg.theme_content_id.empty() ? "default" : host.cfg.theme_content_id);
 
-    if (!host.cfg.start_background.empty()) {
-        if (host.cfg.start_background == "image")
-            init_user_start_background(gui, host.cfg.user_start_background);
-        else
-            init_theme_start_background(gui, host, host.cfg.start_background == "default" ? "default" : host.cfg.theme_content_id);
-    }
+    if (host.cfg.start_background == "image")
+        init_user_start_background(gui, host.cfg.user_start_background);
+    else
+        init_theme_start_background(gui, host, host.cfg.start_background.empty() ? "default" : host.cfg.theme_content_id);
 
     if (!host.cfg.run_title_id && !host.cfg.vpk_path) {
         gui.live_area.information_bar = true;

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -755,8 +755,9 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
     const auto background_size = ImVec2(840.0f * scal.x, 500.0f * scal.y);
 
     if (gui.live_area_contents[title_id].find("livearea-background") != gui.live_area_contents[title_id].end())
-        ImGui::GetWindowDrawList()->AddImage(gui.live_area_contents[title_id]["livearea-background"],
-            pos_bg, ImVec2(pos_bg.x + background_size.x, pos_bg.y + background_size.y));
+        ImGui::GetWindowDrawList()->AddImage(gui.live_area_contents[title_id]["livearea-background"], pos_bg, ImVec2(pos_bg.x + background_size.x, pos_bg.y + background_size.y));
+    else
+        ImGui::GetWindowDrawList()->AddRectFilled(pos_bg, ImVec2(pos_bg.x + background_size.x, pos_bg.y + background_size.y), IM_COL32(148.f, 164.f, 173.f, 255.f), 0.f, ImDrawCornerFlags_All);
 
     for (const auto &frame : frames[title_id]) {
         if (frame.autoflip != 0) {

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -305,37 +305,41 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (title / 2.f));
         ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "Theme & Background");
         ImGui::Spacing();
-        if (!host.cfg.theme_content_id.empty()) {
-            ImGui::TextColored(GUI_COLOR_TEXT, "Current theme content id: %s", host.cfg.theme_content_id.c_str());
+        ImGui::TextColored(GUI_COLOR_TEXT, "Current theme content id: %s", host.cfg.theme_content_id.c_str());
+        if (host.cfg.theme_content_id != "default") {
             ImGui::Spacing();
-            if (ImGui::Button("Reset theme")) {
-                host.cfg.theme_content_id.clear();
-                if (host.cfg.start_background == "theme") {
-                    host.cfg.start_background.clear();
-                    gui.start_background = {};
-                }
-                init_theme(gui, host, "default");
+            if (ImGui::Button("Reset Default Theme")) {
+                host.cfg.theme_content_id = "default";
+                host.cfg.use_theme_background = false;
+                if (init_theme(gui, host, "default"))
+                    host.cfg.use_theme_background = true;
+                host.cfg.user_start_background.clear();
+                host.cfg.start_background = "default";
+                init_theme_start_background(gui, host, "default");
                 init_apps_icon(gui, host, gui.app_selector.sys_apps);
             }
             ImGui::SameLine();
-            if (!gui.theme_backgrounds.empty())
-                ImGui::Checkbox("Using theme background", &host.cfg.use_theme_background);
         }
+        if (!gui.theme_backgrounds.empty())
+            ImGui::Checkbox("Using theme background", &host.cfg.use_theme_background);
+
         if (!gui.user_backgrounds.empty()) {
             ImGui::Spacing();
-            if (ImGui::Button("Reset User Background")) {
-                if (!host.cfg.theme_content_id.empty())
+            if (ImGui::Button("Clean User Backgrounds")) {
+                if (!gui.theme_backgrounds.empty())
                     host.cfg.use_theme_background = true;
                 host.cfg.user_backgrounds.clear();
                 gui.user_backgrounds.clear();
             }
         }
-        if (!host.cfg.start_background.empty()) {
+        ImGui::Spacing();
+        ImGui::TextColored(GUI_COLOR_TEXT, "Current start background: %s", host.cfg.start_background.c_str());
+        if (((host.cfg.theme_content_id == "default") && (host.cfg.start_background != "default")) || ((host.cfg.theme_content_id != "default") && (host.cfg.start_background != "theme"))) {
             ImGui::Spacing();
             if (ImGui::Button("Reset Start Background")) {
                 host.cfg.user_start_background.clear();
-                host.cfg.start_background.clear();
-                gui.start_background = {};
+                init_theme_start_background(gui, host, host.cfg.theme_content_id.empty() ? "default" : host.cfg.theme_content_id);
+                host.cfg.start_background = host.cfg.theme_content_id.empty() || (host.cfg.theme_content_id == "default") ? "default" : "theme";
             }
         }
         if (!gui.theme_backgrounds.empty() || !gui.user_backgrounds.empty()) {
@@ -348,10 +352,8 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
             ImGui::Spacing();
             ImGui::SliderInt("Delay for backgrounds", &host.cfg.delay_background, 4, 32);
         }
-        if (gui.start_background) {
-            ImGui::Spacing();
-            ImGui::SliderInt("Delay for start screen", &host.cfg.delay_start, 10, 60);
-        }
+        ImGui::Spacing();
+        ImGui::SliderInt("Delay for start screen", &host.cfg.delay_start, 10, 60);
         ImGui::EndTabItem();
     } else
         ImGui::PopStyleColor();

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -416,8 +416,7 @@ bool handle_events(HostState &host, GuiState &gui) {
                 // TODO pause app running
                 if (event.key.keysym.scancode == host.cfg.keyboard_button_psbutton) {
                     gui::update_apps_list_opened(gui, host.io.title_id);
-                    if (gui.live_area_contents.find(host.io.title_id) == gui.live_area_contents.end())
-                        gui::init_live_area(gui, host);
+                    gui::init_live_area(gui, host);
                     gui.live_area.information_bar = !gui.live_area.information_bar;
                     gui.live_area.live_area_screen = !gui.live_area.live_area_screen;
                 }


### PR DESCRIPTION
Juste reworks some thinks for can works more like PSVita, particularity for theme and start screen.
Also:
- Add fake background for start screen and for live area if fw is missing.
- Fix issue relate delete user background
- Add font color for different bg if exist on theme.

# Result: 
- Color font for this bg on theme
![image](https://user-images.githubusercontent.com/5261759/91663968-4b04ab00-eaec-11ea-9231-7eddbac48a8c.png)
- on other theme
![image](https://user-images.githubusercontent.com/5261759/91663986-738ca500-eaec-11ea-8542-44bc819419cb.png)

