### PR TITLE
gui/themes: some fix and refactor.

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -39,7 +39,8 @@ enum GenericDialogState {
 void delete_app(GuiState &gui, HostState &host);
 void get_app_info(GuiState &gui, HostState &host, const std::string &title_id);
 size_t get_app_size(HostState &host, const std::string &title_id);
-std::vector<App>::iterator get_app_index(GuiState &gui, const std::string &title_id);
+std::vector<App>::const_iterator get_app_index(GuiState &gui, const std::string &title_id);
+std::map<std::string, ImGui_Texture>::const_iterator get_app_icon(GuiState &gui, const std::string &title_id);
 std::vector<std::string>::iterator get_app_open_list_index(GuiState &gui, const std::string &title_id);
 void get_contents_size(GuiState &gui, HostState &host);
 bool get_live_area_sys_app_state(GuiState &gui);
@@ -54,7 +55,6 @@ void init_apps_icon(GuiState &gui, HostState &host, const std::vector<gui::App> 
 void init_live_area(GuiState &gui, HostState &host);
 bool init_manual(GuiState &gui, HostState &host);
 bool init_theme(GuiState &gui, HostState &host, const std::string &content_id);
-void init_theme_apps_icon(GuiState &gui, HostState &host, const std::string &content_id);
 void init_theme_start_background(GuiState &gui, HostState &host, const std::string &content_id);
 bool init_user_start_background(GuiState &gui, const std::string &image_path);
 void open_trophy_unlocked(GuiState &gui, HostState &host, const std::string &np_com_id, const std::string &trophy_id);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -58,10 +58,11 @@ struct AppInfo {
 };
 
 struct AppsSelector {
-    std::vector<App> user_apps;
     std::vector<App> sys_apps;
+    std::vector<App> user_apps;
     AppInfo app_info;
-    std::map<std::string, ImGui_Texture> icons;
+    std::map<std::string, ImGui_Texture> sys_apps_icon;
+    std::map<std::string, ImGui_Texture> user_apps_icon;
     bool is_app_list_sorted{ false };
     SortState title_id_sort_state = NOT_SORTED;
     SortState app_ver_sort_state = NOT_SORTED;

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -105,7 +105,7 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
     // App Context Menu
     if (ImGui::BeginPopupContextItem("##app_context_menu")) {
         ImGui::SetWindowFontScale(1.3f);
-        if (ImGui::MenuItem("Boot", host.app_short_title.c_str()))
+        if (ImGui::MenuItem("Boot"))
             pre_load_app(gui, host, false);
         if (host.app_title_id.find("NPXS") == std::string::npos) {
             if (ImGui::MenuItem("Check App Compatibility")) {
@@ -183,16 +183,16 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
     if (!context_dialog.empty()) {
         ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
         ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
-        ImGui::Begin("##context_dialog", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+        ImGui::Begin("##context_dialog", nullptr, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
         ImGui::SetNextWindowBgAlpha(0.999f);
         ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
         ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f);
-        ImGui::BeginChild("##context_dialog_child", WINDOW_SIZE, true, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+        ImGui::BeginChild("##context_dialog_child", WINDOW_SIZE, true, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f);
         // Update History
         if (context_dialog == "history") {
             ImGui::SetNextWindowPos(ImVec2(ImGui::GetWindowPos().x + 20.f * scal.x, ImGui::GetWindowPos().y + BUTTON_SIZE.y));
-            ImGui::BeginChild("##info_update_list", ImVec2(WINDOW_SIZE.x - (30.f * scal.x), WINDOW_SIZE.y - (BUTTON_SIZE.y * 2.f) - (25.f * scal.y)), false, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+            ImGui::BeginChild("##info_update_list", ImVec2(WINDOW_SIZE.x - (30.f * scal.x), WINDOW_SIZE.y - (BUTTON_SIZE.y * 2.f) - (25.f * scal.y)), false, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings);
             for (const auto &update : update_history_infos) {
                 ImGui::SetWindowFontScale(1.4f);
                 ImGui::TextColored(GUI_COLOR_TEXT, "Version %.2f", update.first);
@@ -207,9 +207,9 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
             ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (BUTTON_SIZE.x / 2.f), WINDOW_SIZE.y - BUTTON_SIZE.y - (22.f * scal.y)));
         } else {
             // Delete Data
-            if (gui.app_selector.icons.find(host.app_title_id) != gui.app_selector.icons.end()) {
+            if (gui.app_selector.user_apps_icon.find(host.app_title_id) != gui.app_selector.user_apps_icon.end()) {
                 ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (PUPOP_ICON_SIZE.x / 2.f), 24.f * scal.y));
-                ImGui::Image(gui.app_selector.icons[host.app_title_id], PUPOP_ICON_SIZE);
+                ImGui::Image(gui.app_selector.user_apps_icon[host.app_title_id], PUPOP_ICON_SIZE);
             }
             ImGui::SetWindowFontScale(1.6f * scal.x);
             ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(host.app_short_title.c_str()).x / 2.f));
@@ -250,16 +250,16 @@ void draw_app_context_menu(GuiState &gui, HostState &host) {
     if (information) {
         ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
         ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
-        ImGui::Begin("##information", &information, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+        ImGui::Begin("##information", &information, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
         ImGui::SetWindowFontScale(1.5f * scal.x);
         ImGui::SetCursorPos(ImVec2(10.0f * scal.x, 10.0f * scal.y));
         if (ImGui::Button("X", ImVec2(40.f * scal.x, 40.f * scal.y)) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle)) {
             information = false;
             gui.live_area.information_bar = true;
         }
-        if (gui.app_selector.icons.find(host.app_title_id) != gui.app_selector.icons.end()) {
+        if (get_app_icon(gui, host.app_title_id)->first == host.app_title_id) {
             ImGui::SetCursorPos(ImVec2((display_size.x / 2.f) - (INFO_ICON_SIZE.x / 2.f), 22.f * scal.y));
-            ImGui::Image(gui.app_selector.icons[host.app_title_id], INFO_ICON_SIZE);
+            ImGui::Image(get_app_icon(gui, host.app_title_id)->second, INFO_ICON_SIZE);
         }
         ImGui::SetCursorPos(ImVec2((display_size.x / 2.f) - ImGui::CalcTextSize("Name  ").x, INFO_ICON_SIZE.y + (50.f * scal.y)));
         ImGui::TextColored(GUI_COLOR_TEXT, "Name ");

--- a/vita3k/gui/src/content_manager.cpp
+++ b/vita3k/gui/src/content_manager.cpp
@@ -258,7 +258,7 @@ void draw_content_manager(GuiState &gui, HostState &host) {
 
     if (menu == "info") {
         ImGui::SetCursorPos(ImVec2(90.f * SCAL.x, 10.f * SCAL.y));
-        ImGui::Image(gui.app_selector.icons[app_selected], SIZE_ICON_DETAIL);
+        ImGui::Image(gui.app_selector.user_apps_icon[app_selected], SIZE_ICON_DETAIL);
         const auto CALC_NAME = ImGui::CalcTextSize(get_app_index(gui, app_selected)->title.c_str(), nullptr, false, SIZE_INFO.x - SIZE_ICON_DETAIL.x).y / 2.f;
         ImGui::SetCursorPos(ImVec2((110.f * SCAL.x) + SIZE_ICON_DETAIL.x, (SIZE_ICON_DETAIL.y / 2.f) - CALC_NAME + (10.f * SCAL.y)));
         ImGui::PushTextWrapPos(SIZE_INFO.x);
@@ -344,19 +344,13 @@ void draw_content_manager(GuiState &gui, HostState &host) {
             for (const auto &content : contents_selected) {
                 if (content.second) {
                     if (menu == "app") {
-                        const auto APP_PATH{ fs::path(host.pref_path) / "ux0/app" / content.first };
-                        if (fs::exists(APP_PATH) && !fs::is_empty(APP_PATH))
-                            fs::remove_all(APP_PATH);
-                        const auto DLC_PATH{ fs::path(host.pref_path) / "ux0/addcont" / content.first };
-                        if (fs::exists(DLC_PATH) && !fs::is_empty(DLC_PATH))
-                            fs::remove_all(DLC_PATH);
-
+                        fs::remove_all(fs::path(host.pref_path) / "ux0/app" / content.first);
+                        fs::remove_all(fs::path(host.pref_path) / "ux0/addcont" / content.first);
                         gui.app_selector.user_apps.erase(get_app_index(gui, content.first));
-                        gui.app_selector.icons.erase(content.first);
+                        gui.app_selector.user_apps_icon.erase(content.first);
                     }
                     const auto SAVE_PATH{ fs::path(host.pref_path) / "ux0/user" / host.io.user_id / "savedata" / content.first };
-                    if (fs::exists(SAVE_PATH) && !fs::is_empty(SAVE_PATH))
-                        fs::remove_all(SAVE_PATH);
+                    fs::remove_all(SAVE_PATH);
                 }
             }
             get_contents_size(gui, host);
@@ -421,7 +415,7 @@ void draw_content_manager(GuiState &gui, HostState &host) {
                     ImGui::Checkbox("##selected", &contents_selected[app.title_id]);
                     ImGui::NextColumn();
                     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (8.f * SCAL.y));
-                    ImGui::Image(gui.app_selector.icons[app.title_id], SIZE_ICON_LIST);
+                    ImGui::Image(gui.app_selector.user_apps_icon[app.title_id], SIZE_ICON_LIST);
                     ImGui::NextColumn();
                     const auto Title_POS = ImGui::GetCursorPosY();
                     ImGui::SetWindowFontScale(1.1f);
@@ -469,7 +463,7 @@ void draw_content_manager(GuiState &gui, HostState &host) {
                     ImGui::Checkbox("##selected", &contents_selected[save.title_id]);
                     ImGui::NextColumn();
                     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (8.f * SCAL.y));
-                    ImGui::Image(gui.app_selector.icons[save.title_id], SIZE_ICON_LIST);
+                    ImGui::Image(gui.app_selector.user_apps_icon[save.title_id], SIZE_ICON_LIST);
                     ImGui::NextColumn();
                     const auto Title_POS = ImGui::GetCursorPosY();
                     ImGui::SetWindowFontScale(1.1f);

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -218,8 +218,10 @@ void draw_information_bar(GuiState &gui, HostState &host) {
         for (auto a = 0; a < gui.apps_list_opened.size(); a++) {
             const auto icon_scal_pos = ImVec2((display_size.x / 2.f) - (16.f * SCAL.x) - (decal_icon_pos * SCAL.x) + (a * (38.f * SCAL.x)), display_size.y - (544.f * SCAL.y));
             const auto icon_scal_size = ImVec2(icon_scal_pos.x + (32.0f * SCAL.x), icon_scal_pos.y + (32.f * SCAL.y));
-            if (gui.app_selector.icons.find(gui.apps_list_opened[a]) != gui.app_selector.icons.end())
-                ImGui::GetForegroundDrawList()->AddImage(gui.app_selector.icons[gui.apps_list_opened[a]], icon_scal_pos, icon_scal_size);
+            if (get_app_icon(gui, gui.apps_list_opened[a])->first == gui.apps_list_opened[a])
+                ImGui::GetForegroundDrawList()->AddImage(get_app_icon(gui, gui.apps_list_opened[a])->second, icon_scal_pos, icon_scal_size);
+            else
+                ImGui::GetForegroundDrawList()->AddRectFilled(icon_scal_pos, icon_scal_size, IM_COL32_WHITE, 0.f, ImDrawCornerFlags_All);
             if (gui.apps_list_opened[a] != gui.apps_list_opened[gui.current_app_selected])
                 ImGui::GetForegroundDrawList()->AddRectFilled(icon_scal_pos, icon_scal_size, IM_COL32(0.f, 0.f, 0.f, 140.f), 0.f, ImDrawCornerFlags_All);
         }

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -47,7 +47,6 @@ static void draw_emulation_menu(GuiState &gui, HostState &host) {
         if (ImGui::MenuItem("Load last App", host.cfg.last_app.c_str(), false, !host.cfg.last_app.empty() && host.io.title_id.empty())) {
             host.app_title_id = host.cfg.last_app;
             pre_load_app(gui, host, host.cfg.show_live_area_screen);
-            gui.live_area.information_bar = true;
         }
         ImGui::EndMenu();
     }

--- a/vita3k/gui/src/trophy.cpp
+++ b/vita3k/gui/src/trophy.cpp
@@ -434,7 +434,7 @@ void draw_trophy_collection(GuiState &gui, HostState &host) {
         ImGui::SetWindowFontScale(1.f);
     }
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, (!trophy_id_selected.empty() || detail_np_com_id ? 48.0f : 90.f) * SCAL.y), ImGuiCond_Always, ImVec2(0.5f, 0.f));
-    ImGui::BeginChild("##trophy_collection_child", !trophy_id_selected.empty() || detail_np_com_id ? SIZE_INFO : SIZE_LIST, false, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::BeginChild("##trophy_collection_child", !trophy_id_selected.empty() || detail_np_com_id ? SIZE_INFO : SIZE_LIST, false, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings);
 
     // Trophy Collection
     if (np_com_id_list.empty()) {
@@ -709,7 +709,7 @@ void draw_trophy_collection(GuiState &gui, HostState &host) {
     ImGui::EndChild();
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f);
-    ImGui::SetCursorPos(ImVec2(6.f, display_size.y - (84.f * SCAL.y)));
+    ImGui::SetCursorPos(ImVec2(8.f, display_size.y - (84.f * SCAL.y)));
     if (ImGui::Button("Back", ImVec2(64.f * SCAL.x, 40.f * SCAL.y))) {
         if (!np_com_id_selected.empty()) {
             if (detail_np_com_id) {


### PR DESCRIPTION
Fix some things
- Reworks delete theme and Fix if delete theme actually set.
- hide Select button if is already it currently set for start/theme. 
- Small improvement on grid mode for app title, more close psvita.
- Refactor app icon for split user app and sys app
- Restore scrollbar for app selector and add it for trophy list, theme list.
- fix mistake on themes code for start background