### PR TITLE
Complete int load & store, Fix VPCK / VTST

### DIFF
--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -126,7 +126,7 @@ public:
      * 
      * \returns A copy of given operand
     */
-    spv::Id load(Operand op, const Imm4 dest_mask, int shift_offset = 0, bool is_integer = false);
+    spv::Id load(Operand op, const Imm4 dest_mask, int shift_offset = 0);
 
 private:
     //
@@ -158,7 +158,7 @@ private:
         return repeat_increase[op.index][repeat_index];
     }
 
-    void store(Operand dest, spv::Id source, std::uint8_t dest_mask = 0xFF, int shift_offset = 0, bool is_integer = false);
+    void store(Operand dest, spv::Id source, std::uint8_t dest_mask = 0xFF, int shift_offset = 0);
     spv::Id swizzle_to_spv_comp(spv::Id composite, spv::Id type, SwizzleChannel swizzle);
 
     // TODO: Separate file for translator helpers?

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -34,8 +34,8 @@ spv::Id make_vector_or_scalar_type(spv::Builder &b, spv::Id component, int size)
 
 spv::Id unwrap_type(spv::Builder &b, spv::Id type);
 
-spv::Id scale_float_for_u8(spv::Builder &b, spv::Id opr);
-spv::Id unscale_float_for_u8(spv::Builder &b, spv::Id opr);
+spv::Id convert_to_float(spv::Builder &b, spv::Id opr, DataType type, bool normal);
+spv::Id convert_to_int(spv::Builder &b, spv::Id opr, DataType type, bool normal);
 
 template <typename F>
 void make_for_loop(spv::Builder &b, spv::Id iterator, spv::Id initial_value_ite, spv::Id iterator_limit, F body) {

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -616,6 +616,9 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
             target_to_store.bank = RegisterBank::OUTPUT;
             target_to_store.num = 0;
             target_to_store.type = std::get<0>(shader::get_parameter_type_store_and_name(program.get_fragment_output_type()));
+            if (!is_float_data_type(target_to_store.type)) {
+                source = utils::convert_to_int(b, source, target_to_store.type, true);
+            }
 
             utils::store(b, parameters, utils, features, target_to_store, source, 0b1111, 0);
         }
@@ -876,6 +879,9 @@ static spv::Function *make_frag_finalize_function(spv::Builder &b, const SpirvSh
     }
 
     spv::Id color = utils::load(b, parameters, utils, features, color_val_operand, 0xF, reg_off);
+    if (!is_float_data_type(color_val_operand.type)) {
+        color = utils::convert_to_float(b, color, color_val_operand.type, true);
+    }
 
     if (program.is_native_color() && features.should_use_shader_interlock()) {
         spv::Id signed_i32 = b.makeIntegerType(32, true);

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -470,7 +470,7 @@ spv::Id USSETranslatorVisitor::do_alu_op(Instruction &inst, const Imm4 dest_mask
 
     case Opcode::ISUBU32:
     case Opcode::ISUB32: {
-        result = m_b.createBinOp(spv::OpISub, source_type, vsrc1, vsrc2);
+        result = m_b.createBinOp(spv::OpISub, m_b.makeIntType(32), vsrc1, vsrc2);
         break;
     }
 

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -957,6 +957,11 @@ bool USSETranslatorVisitor::sop(
     spv::Id src1_alpha = load(inst.opr.src1, 0b1000, src1_repeat_offset);
     spv::Id src2_alpha = load(inst.opr.src2, 0b1000, src2_repeat_offset);
 
+    src1_color = utils::convert_to_float(m_b, src1_color, DataType::UINT8, true);
+    src2_color = utils::convert_to_float(m_b, src2_color, DataType::UINT8, true);
+    src1_alpha = utils::convert_to_float(m_b, src1_alpha, DataType::UINT8, true);
+    src2_alpha = utils::convert_to_float(m_b, src2_alpha, DataType::UINT8, true);
+
     spv::Id src_color_type = m_b.getTypeId(src1_color);
     spv::Id src_alpha_type = m_b.getTypeId(src1_alpha);
 
@@ -989,6 +994,9 @@ bool USSETranslatorVisitor::sop(
 
     auto color_res = apply_opcode(color_op, src_color_type, factored_rgb_lhs, factored_rgb_rhs);
     auto alpha_res = apply_opcode(alpha_op, src_alpha_type, factored_a_lhs, factored_a_rhs);
+
+    color_res = utils::convert_to_int(m_b, color_res, DataType::UINT8, true);
+    alpha_res = utils::convert_to_int(m_b, alpha_res, DataType::UINT8, true);
 
     // Final result. Do binary operation and then store
     store(inst.opr.dest, color_res, 0b0111, dest_repeat_offset);

--- a/vita3k/shader/src/translator/branch_cond.cpp
+++ b/vita3k/shader/src/translator/branch_cond.cpp
@@ -148,15 +148,50 @@ static Opcode decode_test_inst(const Imm2 alu_sel, const Imm4 alu_op, const Imm1
         }
     }
 
-    if (alu_sel == 1) {
+    const auto test_op = test_ops[alu_sel][alu_op];
+
+    switch (test_op) {
+    case Opcode::IADDU32:
+    case Opcode::ISUBU32: {
+        filled_dt = DataType::UINT32;
+        break;
+    }
+    case Opcode::ISUB32:
+    case Opcode::IADD32: {
         filled_dt = DataType::INT32;
+        break;
+    }
+    case Opcode::IADD16:
+    case Opcode::ISUB16:
+    case Opcode::IMUL16: {
+        filled_dt = DataType::INT16;
+        break;
+    }
+    case Opcode::IADDU16:
+    case Opcode::ISUBU16:
+    case Opcode::IMULU16: {
+        filled_dt = DataType::UINT16;
+        break;
+    }
+    case Opcode::IADD8:
+    case Opcode::ISUB8:
+    case Opcode::IMUL8: {
+        filled_dt = DataType::INT8;
+        break;
+    }
+    case Opcode::IADDU8:
+    case Opcode::ISUBU8:
+    case Opcode::IMULU8: {
+        filled_dt = DataType::UINT8;
+        break;
+    }
     }
 
     if (alu_sel == 3) {
         filled_dt = DataType::UINT32;
     }
 
-    return test_ops[alu_sel][alu_op];
+    return test_op;
 }
 
 bool USSETranslatorVisitor::vtst(

--- a/vita3k/shader/src/translator/ialu.cpp
+++ b/vita3k/shader/src/translator/ialu.cpp
@@ -199,15 +199,15 @@ bool USSETranslatorVisitor::i32mad2(
         inst.opr.src2.flags |= RegisterFlags::Negative;
     }
 
-    spv::Id vsrc0 = load(inst.opr.src0, 0b1, 0, true);
-    spv::Id vsrc1 = load(inst.opr.src0, 0b1, 0, true);
-    spv::Id vsrc2 = load(inst.opr.src0, 0b1, 0, true);
+    spv::Id vsrc0 = load(inst.opr.src0, 0b1, 0);
+    spv::Id vsrc1 = load(inst.opr.src0, 0b1, 0);
+    spv::Id vsrc2 = load(inst.opr.src0, 0b1, 0);
 
     auto mul_result = m_b.createBinOp(spv::OpIMul, m_b.getTypeId(vsrc0), vsrc0, vsrc1);
     auto add_result = m_b.createBinOp(spv::OpIAdd, m_b.getTypeId(mul_result), mul_result, vsrc2);
 
     if (add_result != spv::NoResult) {
-        store(inst.opr.dest, add_result, 0b1, 0, true);
+        store(inst.opr.dest, add_result, 0b1, 0);
     }
 
     // TODO not sure about sn

--- a/vita3k/shader/src/translator/ialu.cpp
+++ b/vita3k/shader/src/translator/ialu.cpp
@@ -68,6 +68,7 @@ bool USSETranslatorVisitor::vbw(
 
     inst.opr.src1.type = DataType::UINT32;
     inst.opr.src2.type = DataType::UINT32;
+    inst.opr.dest.type = DataType::UINT32;
 
     BEGIN_REPEAT(repeat_count, 1)
     GET_REPEAT(inst);

--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -61,6 +61,7 @@ spv::Id shader::usse::USSETranslatorVisitor::do_fetch_texture(const spv::Id tex,
     }
 
     if (dest_type == DataType::UINT8) {
+        image_sample = utils::convert_to_int(m_b, image_sample, DataType::UINT8, true);
         image_sample = utils::pack_one(m_b, m_util_funcs, m_features, image_sample, DataType::UINT8);
     }
 

--- a/vita3k/shader/src/translator/utils.cpp
+++ b/vita3k/shader/src/translator/utils.cpp
@@ -33,46 +33,11 @@
 using namespace shader;
 using namespace usse;
 
-static spv::Id get_int_max_value_constant(spv::Builder &b, DataType type) {
-    int max_value;
-    switch (type) {
-    case DataType::UINT8:
-        max_value = 0xFF;
-        break;
-    case DataType::INT8:
-        max_value = 0x7F;
-        break;
-    case DataType::UINT16:
-        max_value = 0xFFFF;
-        break;
-    case DataType::INT16:
-        max_value = 0x7FFF;
-        break;
-    case DataType::UINT32:
-        max_value = 0xFFFFFFFF;
-        break;
-    case DataType::INT32:
-        max_value = 0x7FFFFFFF;
-        break;
-    }
-    return b.makeIntConstant(max_value);
+spv::Id USSETranslatorVisitor::load(Operand op, const Imm4 dest_mask, const int shift_offset) {
+    return utils::load(m_b, m_spirv_params, m_util_funcs, m_features, op, dest_mask, shift_offset);
 }
 
-spv::Id USSETranslatorVisitor::load(Operand op, const Imm4 dest_mask, const int shift_offset, bool is_integer) {
-    spv::Id out = utils::load(m_b, m_spirv_params, m_util_funcs, m_features, op, dest_mask, shift_offset);
-    if (is_integer) {
-        out = m_b.createBinOp(spv::OpFMul, type_f32_v[4], out, get_int_max_value_constant(m_b, op.type));
-        spv::Id out_type = m_b.makeVectorType(type_ui32, 4);
-        out = m_b.createUnaryOp(spv::OpConvertSToF, out_type, out);
-    }
-    return out;
-}
-
-void USSETranslatorVisitor::store(Operand dest, spv::Id source, std::uint8_t dest_mask, int shift_offset, bool is_integer) {
-    if (is_integer) {
-        source = m_b.createUnaryOp(spv::OpConvertSToF, type_f32_v[4], source);
-        source = m_b.createBinOp(spv::OpFDiv, type_f32_v[4], source, get_int_max_value_constant(m_b, dest.type));
-    }
+void USSETranslatorVisitor::store(Operand dest, spv::Id source, std::uint8_t dest_mask, int shift_offset) {
     utils::store(m_b, m_spirv_params, m_util_funcs, m_features, dest, source, dest_mask, shift_offset);
 }
 

--- a/vita3k/shader/src/translator/utils.cpp
+++ b/vita3k/shader/src/translator/utils.cpp
@@ -64,6 +64,5 @@ spv::Id USSETranslatorVisitor::swizzle_to_spv_comp(spv::Id composite, spv::Id ty
 size_t USSETranslatorVisitor::dest_mask_to_comp_count(Imm4 dest_mask) {
     std::bitset<4> bs(dest_mask);
     const auto bit_count = bs.count();
-    assert(bit_count <= 4 && bit_count > 0);
     return bit_count;
 }


### PR DESCRIPTION
# About PR
- Make load of int value outputs ivec or uvec always
- Make store of int value takes ivec or uvec always
- Non-built in int pack & unpack function that uses ivec or uvec (built in ones output normalized float)
- Adjust some instructions using int values
- Correct vpck with two f32 sources
- Complete vpck with int values
- Fix vtst

# Related issue

With https://github.com/Vita3K/Vita3K/pull/942, this fixes vitagl and vitaquake3.

# Preparing for int instructions

With this pr, every int load & store should work correctly, and store & load function with int values becomes more intuitive. (less side effect) There are more description inside commits, reviewer or future contributor can read it to understand the motivation more deeply.