### PR TITLE
Rework uniform buffers

### DIFF
--- a/vita3k/shader/include/shader/gxp_parser.h
+++ b/vita3k/shader/include/shader/gxp_parser.h
@@ -8,6 +8,5 @@ namespace shader {
 
 usse::GenericType translate_generic_type(const gxp::GenericParameterType &type);
 std::tuple<usse::DataType, std::string> get_parameter_type_store_and_name(const SceGxmParameterType &type);
-std::vector<usse::UniformBuffer> get_uniform_buffers(const SceGxmProgram &program);
 usse::ProgramInput get_program_input(const SceGxmProgram &program);
 } // namespace shader

--- a/vita3k/shader/include/shader/usse_program_analyzer.h
+++ b/vita3k/shader/include/shader/usse_program_analyzer.h
@@ -75,22 +75,6 @@ using USSEOffset = std::uint32_t;
 void get_uniform_buffer_sizes(const SceGxmProgram &program, UniformBufferSizes &sizes);
 int match_uniform_buffer_with_buffer_size(const SceGxmProgram &program, const SceGxmProgramParameter &parameter, const shader::usse::UniformBufferMap &buffers);
 
-template <typename F>
-void data_analyze(USSEOffset end_offset, F read_func, UniformBufferMap &buffer_map) {
-    int base = 0;
-    int cursor = 0;
-    int offset = 0;
-    int size = 0;
-
-    for (USSEOffset i = 0; i < end_offset; i++) {
-        // Analyze for any existing memory uniform buffer
-        if (is_buffer_fetch_or_store(read_func(i), base, cursor, offset, size)) {
-            buffer_map[base].base = base;
-            buffer_map[base].size = std::max<int>(buffer_map[base].size, offset + (size + 3) / 4);
-        }
-    }
-}
-
 template <typename F, typename H>
 void analyze(USSEOffset end_offset, F read_func, H handler_func) {
     std::queue<USSEBlock *> blocks_queue;

--- a/vita3k/shader/include/shader/usse_translator_types.h
+++ b/vita3k/shader/include/shader/usse_translator_types.h
@@ -13,6 +13,7 @@ namespace shader::usse {
 
 using SpirvCode = std::vector<uint32_t>;
 using SpirvVarRegBank = spv::Id;
+using SpirvUniformBuffrerBase = std::tuple<uint32_t, spv::Id>;
 
 struct SpirvShaderParameters {
     // Mapped to 'pa' (primary attribute) USSE registers
@@ -45,7 +46,7 @@ struct SpirvShaderParameters {
     // Sampler map. Since all banks are a flat array, sampler must be in an explicit bank.
     std::unordered_map<std::uint32_t, spv::Id> samplers;
 
-    std::unordered_map<std::uint32_t, spv::Id> buffers;
+    std::unordered_map<std::uint32_t, SpirvUniformBuffrerBase> buffers;
 };
 
 using Coord = std::pair<spv::Id, int>;

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -304,24 +304,18 @@ struct Sampler {
  * Uniform buffers that are attached to gxp shader program
  */
 struct UniformBuffer {
-    int base;
-    int size;
-    int index;
-    bool rw; // TODO confirm this
-    bool reg; // register buffer TODO confirm this
-};
-
-// TODO do we need this
-struct UniformBlock {
-    int block_num;
-    uint32_t offset;
+    uint32_t index;
     uint32_t size;
+    uint32_t reg_start_offset;
+    uint32_t reg_block_size;
+    bool rw; // TODO confirm this
 };
 
 struct UniformInputSource {
     std::string name;
     // resource index
     uint32_t index;
+    bool in_mem;
 };
 
 struct AttributeInputSoucre {
@@ -335,8 +329,14 @@ struct LiteralInputSource {
     float data;
 };
 
+struct UniformBufferInputSource {
+    uint32_t base;
+    // resource index
+    uint32_t index;
+};
+
 // Read source field in Input struct
-using InputSource = std::variant<UniformInputSource, LiteralInputSource, AttributeInputSoucre>;
+using InputSource = std::variant<UniformInputSource, UniformBufferInputSource, LiteralInputSource, AttributeInputSoucre>;
 
 /**
  * Input parameters that are usually copied into PA or SA
@@ -365,7 +365,6 @@ struct ProgramInput {
     std::vector<Input> inputs;
     std::vector<Sampler> samplers;
     std::vector<UniformBuffer> uniform_buffers;
-    std::unordered_map<int, UniformBlock> uniform_blocks;
 };
 
 enum class ShaderPhase {

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -164,6 +164,19 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
             break;
         }
         case SCE_GXM_PARAMETER_CATEGORY_UNIFORM_BUFFER: {
+            if (uniform_buffers.find(parameter.resource_index) == uniform_buffers.end()) {
+                UniformBuffer buffer;
+                buffer.index = (parameter.resource_index + 1) % SCE_GXM_REAL_MAX_UNIFORM_BUFFER;
+                buffer.reg_block_size = 0;
+                buffer.rw = false;
+                buffer.reg_start_offset = 0;
+                buffer.size = (parameter.array_size + 3) / 4;
+                uniform_buffers.emplace(parameter.resource_index, buffer);
+            } else {
+                auto &buffer = uniform_buffers.at(parameter.resource_index);
+                buffer.size = std::max((parameter.array_size + 3) / 4, buffer.size);
+            }
+            break;
         }
         default: {
             LOG_CRITICAL("Unknown parameter type used in shader.");

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -135,13 +135,13 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
                     buffer.index = (parameter.container_index + 1) % SCE_GXM_REAL_MAX_UNIFORM_BUFFER;
                     buffer.reg_block_size = reg_block_size;
                     buffer.rw = false;
-                    buffer.reg_start_offset = parameter.resource_index;
+                    buffer.reg_start_offset = offset;
                     buffer.size = parameter.resource_index + parameter_size_in_f32;
                     uniform_buffers.emplace(parameter.container_index, buffer);
                 } else {
                     auto &buffer = uniform_buffers.at(parameter.container_index);
                     buffer.size = std::max(parameter.resource_index + parameter_size_in_f32, buffer.size);
-                    buffer.reg_start_offset = std::min(buffer.reg_start_offset, static_cast<uint32_t>(parameter.resource_index));
+                    buffer.reg_start_offset = std::min(buffer.reg_start_offset, static_cast<uint32_t>(offset));
                 }
             }
 

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -60,7 +60,7 @@ namespace shader {
 // **************
 
 static constexpr int REG_PA_COUNT = 32 * 4;
-static constexpr int REG_SA_COUNT = 40 * 4;
+static constexpr int REG_SA_COUNT = 32 * 4;
 static constexpr int REG_I_COUNT = 3 * 4;
 static constexpr int REG_TEMP_COUNT = 20 * 4;
 static constexpr int REG_INDEX_COUNT = 2 * 4;

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -573,7 +573,7 @@ bool USSETranslatorVisitor::vldst(
     to_store.type = DataType::F32;
 
     SpirvUniformBuffrerBase buffer_and_base = m_spirv_params.buffers.at(src0_n);
-    const uint32_t buffer_base = std::get<0>(buffer_and_base);
+    const uint32_t buffer_base = std::get<0>(buffer_and_base) + src1_n;
     const spv::Id buffer = std::get<1>(buffer_and_base);
     const bool is_load = true;
     spv::Id previous = spv::NoResult;


### PR DESCRIPTION
# About PR
- Don't analyze shader instructions to find out the size of uniform buffers
- Deal with half register half memory uniform buffer

# Related issue

Fixes p4g sunny character rendering.

# Description 

We used to analyze the program to determine the size of memory uniform buffer. However, this method will require tons of works when dealing with ldr with temporary register for base field. (this can happen)

From my observation, uniform parameters of memory uniform buffer are not stripped away. Utilizing this, I tried to determine uniform buffer size from uniform parameters. I also observed half register half memory uniform buffer. (this seems to happen in large default uniform buffer) In this case the size_in_f32 is less than the total size of uniform buffer, and the ldr instruction will be used to access fields not available in register. Also, the base of ldr instruction should start from the end of "register block " of uniform buffer. I updated recompiler to consider this information.