### PR TITLE
gui/theme: add unicode support for user background

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,7 +46,7 @@
 	url = https://github.com/jonasmr/microprofile
 [submodule "external/nativefiledialog-cmake"]
 	path = external/nativefiledialog-cmake
-	url = https://github.com/illusionman1212/nativefiledialog-cmake
+	url = https://github.com/Vita3K/nativefiledialog-cmake
 [submodule "external/printf"]
 	path = external/printf
 	url = https://github.com/Vita3K/printf


### PR DESCRIPTION
Small split PR #865 
is my reworks code based on @EXtremeExploit  works for unicode, just here only for theme and particluary for user home background and user start backgfround

- Add unicode support inside themes for user start background and user image background 