### PR TITLE
Limit Framerate when selecting applications

### DIFF
--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -136,8 +136,24 @@ int main(int argc, char *argv[]) {
         auto discord_rich_presence_old = host.cfg.discord_rich_presence;
 #endif
 
+        std::chrono::system_clock::time_point present = std::chrono::system_clock::now();
+        std::chrono::system_clock::time_point later = std::chrono::system_clock::now();
+        const double frame_time = 1000.0 / 60.0;
         // Application not provided via argument, show game selector
         while (run_type == app::AppRunType::Unknown) {
+            // get the current time & get the time we worked for
+            present = std::chrono::system_clock::now();
+            std::chrono::duration<double, std::milli> work_time = present - later;
+            // check if we are running faster than ~60fps (16.67ms)
+            if (work_time.count() < frame_time) {
+                // sleep for delta time.
+                std::chrono::duration<double, std::milli> delta_ms(frame_time - work_time.count());
+                auto delta_ms_duration = std::chrono::duration_cast<std::chrono::milliseconds>(delta_ms);
+                std::this_thread::sleep_for(std::chrono::milliseconds(delta_ms_duration.count()));
+            }
+            // save the later time
+            later = std::chrono::system_clock::now();
+
             if (handle_events(host, gui)) {
                 gui::draw_begin(gui, host);
 


### PR DESCRIPTION
Small fix to prevent high CPU usage when selecting applications. Turns out we are running too fast.

Current limit is 60fps, though feel free to tweak.

After tweak: 
![image](https://user-images.githubusercontent.com/7894419/92511306-b31b6580-f23f-11ea-89a3-6ecebe634d16.png)  
Current Master:  
![image](https://user-images.githubusercontent.com/7894419/92511370-c8908f80-f23f-11ea-8373-4ccdd4b0461f.png)
