### PR TITLE
firmware install: Add unicode path support.

### DIFF
--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -20,14 +20,15 @@
 #include <gui/functions.h>
 #include <host/functions.h>
 #include <util/log.h>
+#include <util/string_utils.h>
 
 #include <nfd.h>
 
 namespace gui {
 
 std::string fw_version;
-bool delete_fw_file = false;
-nfdchar_t *fw_path = nullptr;
+bool delete_pup_file;
+nfdchar_t *pup_path;
 
 static void get_firmware_version(HostState &host) {
     std::ifstream versionFile(host.pref_path + "/PUP_DEC/PUP/version.txt");
@@ -47,11 +48,11 @@ void draw_firmware_install_dialog(GuiState &gui, HostState &host) {
     static bool draw_file_dialog = true;
 
     if (draw_file_dialog) {
-        result = NFD_OpenDialog("PUP", nullptr, &fw_path);
+        result = NFD_OpenDialog("PUP", nullptr, &pup_path);
         draw_file_dialog = false;
 
         if (result == NFD_OKAY) {
-            install_pup(fw_path, host.pref_path);
+            install_pup(host.pref_path, pup_path);
             get_firmware_version(host);
         } else if (result == NFD_CANCEL) {
             gui.file_menu.firmware_install_dialog = false;
@@ -73,16 +74,16 @@ void draw_firmware_install_dialog(GuiState &gui, HostState &host) {
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
-        ImGui::Checkbox("Delete the firmware installation file?", &delete_fw_file);
+        ImGui::Checkbox("Delete the firmware installation file?", &delete_pup_file);
         ImGui::Spacing();
         ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - 30);
         if (ImGui::Button("OK", BUTTON_SIZE)) {
-            if (delete_fw_file) {
-                fs::remove(fs::path(fw_path));
-                delete_fw_file = false;
+            if (delete_pup_file) {
+                fs::remove(fs::path(string_utils::utf_to_wide(pup_path)));
+                delete_pup_file = false;
             }
             fw_version.clear();
-            fw_path = nullptr;
+            pup_path = nullptr;
             get_modules_list(gui, host);
             gui.file_menu.firmware_install_dialog = false;
             draw_file_dialog = true;

--- a/vita3k/host/include/host/functions.h
+++ b/vita3k/host/include/host/functions.h
@@ -22,7 +22,7 @@
 
 struct SfoFile;
 
-void install_pup(const std::string &pup, const std::string &pref_path);
+void install_pup(const std::string &pref_path, const std::string &pup_path);
 
 namespace sfo {
 bool get_data_by_id(std::string &out_data, SfoFile &file, int id);

--- a/vita3k/host/src/pup.cpp
+++ b/vita3k/host/src/pup.cpp
@@ -21,6 +21,7 @@
 #include <util/fs.h>
 
 #include <fstream>
+#include <util/string_utils.h>
 
 // Credits to TeamMolecule for their original work on this https://github.com/TeamMolecule/sceutils
 
@@ -94,10 +95,10 @@ static std::string make_filename(unsigned char *hdr, int64_t filetype) {
     return fmt::format("unknown-0x{:X}.pkg", filetype);
 }
 
-static void extract_pup_files(const std::string &pup, const std::string &output) {
+static void extract_pup_files(const std::wstring &pup, const std::string &output) {
     constexpr int SCEUF_HEADER_SIZE = 0x80;
     constexpr int SCEUF_FILEREC_SIZE = 0x20;
-    std::ifstream infile(pup, std::ios::binary);
+    fs::ifstream infile(pup, std::ios::binary);
     char header[SCEUF_HEADER_SIZE];
     infile.read(header, SCEUF_HEADER_SIZE);
 
@@ -229,19 +230,19 @@ static void decrypt_pup_packages(const std::string &src, const std::string &dest
     join_files(dest, "sa0-", dest + "/sa0.img");
 }
 
-void install_pup(const std::string &pup, const std::string &pref_path) {
+void install_pup(const std::string &pref_path, const std::string &pup_path) {
     if (fs::exists(pref_path + "/PUP_DEC")) {
         LOG_WARN("Path already exists, deleting it and reinstalling");
         fs::remove_all(pref_path + "/PUP_DEC");
     }
 
-    LOG_INFO("Extracting {} to {}", pup, pref_path + "/PUP_DEC");
+    LOG_INFO("Extracting {} to {}", pup_path, pref_path + "/PUP_DEC");
 
     fs::create_directory(pref_path + "/PUP_DEC");
     const auto pup_dest = fmt::format("{}/PUP", pref_path + "/PUP_DEC");
     fs::create_directory(pup_dest);
 
-    extract_pup_files(pup, pup_dest);
+    extract_pup_files(string_utils::utf_to_wide(pup_path), pup_dest);
 
     const auto pup_dec = fmt::format("{}/PUP_dec", pref_path + "/PUP_DEC");
     fs::create_directory(pup_dec);


### PR DESCRIPTION
split other unicode pr, but this time, using only my proper code writed and thinked alone, after understund how it works.

- Add unciode path support for install pup file (firmware and system data)