### PR TITLE
gui: support for more than 1 folder inside vpk root

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -201,6 +201,9 @@ bool install_archive(HostState &host, GuiState *gui, const fs::path &archive_pat
         }
 
         std::string m_filename = file_stat.m_filename;
+        if (extra_path.find(m_filename) != std::string::npos) {
+            continue;
+        }
         std::string replace_filename = m_filename.substr(extra_path.size());
         const fs::path file_output = { output_path / replace_filename };
         if (mz_zip_reader_is_file_a_directory(zip.get(), i)) {


### PR DESCRIPTION
Fixes:
* Drag and drop for vpk/zip files
* Some zip/vpk had more than 1 folder depth ("game.zip/foo/bar/eboot.bin") where the game is at, this has now been fixed too