### PR TITLE
Add multi thread for content manager

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -36,7 +36,7 @@ enum GenericDialogState {
     CANCEL_STATE
 };
 
-void delete_app(GuiState &gui, HostState &host, const std::string &app_path);
+void delete_apps(GuiState &gui, HostState &host, const std::vector<std::string> &app_list);
 void get_app_info(GuiState &gui, HostState &host, const std::string &app_path);
 size_t get_app_size(GuiState &gui, HostState &host, const std::string &app_path);
 std::vector<App>::const_iterator get_app_index(GuiState &gui, const std::string &app_path);
@@ -45,6 +45,7 @@ std::vector<std::string>::iterator get_app_open_list_index(GuiState &gui, const 
 std::map<std::string, std::string> get_date_time(GuiState &gui, HostState &host, const tm &date_time);
 bool get_live_area_sys_app_state(GuiState &gui);
 void get_modules_list(GuiState &gui, HostState &host);
+void get_themes_size(GuiState &gui, HostState &host);
 std::string get_unit_size(const size_t &size);
 void get_user_app_params(GuiState &gui, HostState &host, const std::string &app_path);
 void get_user_apps_title(GuiState &gui, HostState &host);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -82,6 +82,7 @@ struct LiveAreaState {
     bool start_screen = false;
     bool trophy_collection = false;
     bool user_management = false;
+    bool waiting_popup = false;
 };
 
 struct FileMenuState {

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -26,24 +26,11 @@
 
 namespace gui {
 
-void delete_app(GuiState &gui, HostState &host, const std::string &app_path) {
-    const fs::path APP_PATH{ fs::path(host.pref_path) / "ux0/app" / app_path };
-    const auto APP_INDEX = get_app_index(gui, app_path);
-
-    LOG_INFO_IF(fs::remove_all(APP_PATH), "Application successfully deleted '{} [{}]'.", APP_INDEX->title_id, APP_INDEX->title);
-
-    if (!fs::exists(app_path)) {
-        gui.delete_app_icon = true;
-        gui.app_selector.user_apps.erase(APP_INDEX);
-    } else
-        LOG_ERROR("Failed to delete '{} [{}]'.", APP_INDEX->title_id, APP_INDEX->title);
-}
-
 static std::map<double, std::string> update_history_infos;
 
-static bool get_update_history(GuiState &gui, HostState &host, const std::string &title_id) {
+static bool get_update_history(GuiState &gui, HostState &host, const std::string &app_path) {
     update_history_infos.clear();
-    const auto change_info_path{ fs::path(host.pref_path) / "ux0/app" / title_id / "sce_sys/changeinfo/" };
+    const auto change_info_path{ fs::path(host.pref_path) / "ux0/app" / app_path / "sce_sys/changeinfo/" };
 
     std::string fname = fs::exists(change_info_path / fmt::format("changeinfo_{:0>2d}.xml", host.cfg.sys_lang)) ? fmt::format("changeinfo_{:0>2d}.xml", host.cfg.sys_lang) : "changeinfo.xml";
 
@@ -241,12 +228,10 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
         }
         if (ImGui::Button("Ok", BUTTON_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_cross)) {
             if (context_dialog == "app") {
-                fs::remove_all(DLC_PATH);
-                fs::remove_all(SAVE_DATA_PATH);
-                fs::remove_all(SHADER_LOG_PATH);
-                delete_app(gui, host, app_path);
-            } else if (context_dialog == "save")
-                fs::remove_all(SAVE_DATA_PATH);
+                delete_apps(gui, host, { app_path });
+                gui.delete_app_icon = true;
+            }
+            fs::remove_all(SAVE_DATA_PATH);
             context_dialog.clear();
         }
         ImGui::PopStyleVar();

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -560,6 +560,9 @@ void draw_live_area(GuiState &gui, HostState &host) {
     if (!gui.trophy_unlock_display_requests.empty())
         gui::draw_trophies_unlocked(gui, host);
 
+    if (gui.live_area.waiting_popup)
+        draw_waiting_popup(gui, host);
+
     // System App
     if (gui.live_area.content_manager)
         draw_content_manager(gui, host);

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -233,6 +233,26 @@ void init_lang(GuiState &gui, HostState &host) {
     }
 }
 
+void draw_waiting_popup(GuiState &gui, HostState &host) {
+    const auto display_size = ImGui::GetIO().DisplaySize;
+    const auto SCAL = ImVec2(display_size.x / 960.0f, display_size.y / 544.0f);
+    const auto WAITING_WINDOW = ImVec2(520.f * SCAL.x, 120.f * SCAL.y);
+
+    ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
+    ImGui::Begin("##delete_dialog", nullptr, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f);
+    ImGui::BeginChild("##delete_dialog_child", WAITING_WINDOW, true, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::SetWindowFontScale(1.2f);
+    const auto calc_text = ImGui::CalcTextSize("Please wait...");
+    ImGui::SetCursorPos(ImVec2((WAITING_WINDOW.x / 2.f) - (calc_text.x / 2.f), (WAITING_WINDOW.y / 2.f) - (calc_text.y / 2.f)));
+    ImGui::TextColored(GUI_COLOR_TEXT, "Please wait...");
+    ImGui::EndChild();
+    ImGui::PopStyleVar();
+    ImGui::End();
+}
+
 bool get_live_area_sys_app_state(GuiState &gui) {
     return !gui.live_area.content_manager && !gui.live_area.settings && !gui.live_area.trophy_collection && !gui.live_area.manual && !gui.live_area.user_management;
 }

--- a/vita3k/gui/src/private.h
+++ b/vita3k/gui/src/private.h
@@ -67,6 +67,7 @@ void draw_settings(GuiState &gui, HostState &host);
 void draw_start_screen(GuiState &gui, HostState &host);
 void draw_trophy_collection(GuiState &gui, HostState &host);
 void draw_user_management(GuiState &gui, HostState &host);
+void draw_waiting_popup(GuiState &gui, HostState &host);
 
 void reevaluate_code(GuiState &gui, HostState &host);
 

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -1172,6 +1172,7 @@ void draw_settings(GuiState &gui, HostState &host) {
                 settings_menu.clear();
         } else {
             if (host.app_title_id == "NPXS10026") {
+                get_themes_size(gui, host);
                 gui.live_area.content_manager = true;
             } else {
                 if (!gui.apps_list_opened.empty() && gui.apps_list_opened[gui.current_app_selected] == "NPXS10015")


### PR DESCRIPTION
- content manager: add multi thread support for get size. (fix freeze on open app)
- gui: fix crash if data font is missing.
- reworks delete app for can using same function inside context menu/content manager.

# Result : 
 - Delete on content manager.
![image](https://user-images.githubusercontent.com/5261759/93693764-6cadec80-fb04-11ea-9905-786a4ba717ef.png)

- On App selector.
![image](https://user-images.githubusercontent.com/5261759/93693775-98c96d80-fb04-11ea-8a8f-c41f80250d2c.png)

