### PR TITLE
gui: Add missing PopStyleColor

### DIFF
--- a/vita3k/gui/src/common_dialog.cpp
+++ b/vita3k/gui/src/common_dialog.cpp
@@ -104,6 +104,7 @@ static void draw_message_dialog(DialogState &common_dialog) {
         ImGui::EndGroup();
     }
     ImGui::End();
+    ImGui::PopStyleColor();
 }
 
 static void draw_trophy_setup_dialog(DialogState &common_dialog) {


### PR DESCRIPTION
To match with: https://github.com/Vita3K/Vita3K/blob/8369d0287bb0e525b77a7488edad4c9d59390fc3/vita3k/gui/src/common_dialog.cpp#L69