### PR TITLE
io: Fix sceIoRemove and sceIoRmdir return codes on success

### DIFF
--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -503,7 +503,12 @@ int remove_file(IOState &io, const char *file, const std::wstring &pref_path, co
 
     LOG_TRACE("{}: Removing file {} ({})", export_name, file, device::construct_normalized_path(device, translated_path));
 
-    return fs::remove(emulated_path);
+    if (!fs::remove(emulated_path)) {
+        LOG_ERROR("Cannot remove file: {} ({})", file, device::construct_normalized_path(device, translated_path));
+        return IO_ERROR(SCE_ERROR_ERRNO_ENOENT);
+    }
+
+    return 0;
 }
 
 SceUID open_dir(IOState &io, const char *path, const std::wstring &pref_path, const char *export_name) {
@@ -624,5 +629,10 @@ int remove_dir(IOState &io, const char *dir, const std::wstring &pref_path, cons
 
     LOG_TRACE("{}: Removing dir {} ({})", export_name, dir, device::construct_normalized_path(device, translated_path));
 
-    return fs::remove(device::construct_emulated_path(device, translated_path, pref_path, io.redirect_stdio));
+    if (!fs::remove(device::construct_emulated_path(device, translated_path, pref_path, io.redirect_stdio))) {
+        LOG_ERROR("Cannot remove dir: {} ({})", dir, device::construct_normalized_path(device, translated_path));
+        return IO_ERROR(SCE_ERROR_ERRNO_ENOENT);
+    }
+
+    return 0;
 }


### PR DESCRIPTION
`sceIoRemove` and `sceIoRmdir` must return 0 on success which is not the case on master as `remove_file` and `remove_dir` return true (aka 1) on success