### PR TITLE
external: use unicorn built with mingw for windows executable

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -119,10 +119,34 @@ if(WIN32)
 	target_link_libraries(winsock INTERFACE WSOCK32 WS2_32 IPHLPAPI)
 endif()
 
-option(UNICORN_BUILD_SHARED "Build shared instead of static library" OFF)
-set(UNICORN_ARCH "arm")
-add_subdirectory(unicorn)
-target_include_directories(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn/include")
+if(WIN32)
+	set(UNICORN_VER "4b52942b")
+
+	set(UNICORN_PREFIX "${CMAKE_BINARY_DIR}/external/unicorn")
+	if (NOT EXISTS "${UNICORN_PREFIX}")
+		message(STATUS "Downloading unicorn...")
+
+		file(DOWNLOAD
+			https://github.com/Vita3K/unicorn/releases/download/${UNICORN_VER}/vita3k-unicorn.zip
+			"${CMAKE_BINARY_DIR}/external/unicorn.zip" SHOW_PROGRESS)
+		execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/external/unicorn.zip"
+			WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external")
+	endif()
+	message(STATUS "Using bundled binaries at ${UNICORN_PREFIX}")
+
+	set(LIBUNICORN_INCLUDE_DIR "${UNICORN_PREFIX}/include" CACHE PATH "Path to Unicorn headers" FORCE)
+	set(LIBUNICORN_LIBRARY "${UNICORN_PREFIX}/lib/unicorn.lib" CACHE PATH "Path to Unicorn library" FORCE)
+	set(UNICORN_DLL_DIR "${UNICORN_PREFIX}/lib" CACHE PATH "Path to unicorn.dll" FORCE)
+
+	add_library(unicorn INTERFACE)
+	target_link_libraries(unicorn INTERFACE "${LIBUNICORN_LIBRARY}")
+	target_include_directories(unicorn INTERFACE "${LIBUNICORN_INCLUDE_DIR}")
+else()
+	option(UNICORN_BUILD_SHARED "Build shared instead of static library" OFF)
+	set(UNICORN_ARCH "arm")
+	add_subdirectory(unicorn)
+	target_include_directories(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn/include")
+endif()
 
 add_library(vita-toolchain INTERFACE)
 target_include_directories(vita-toolchain INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/vita-toolchain/src")

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -150,5 +150,8 @@ elseif(WIN32)
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../data" "$<TARGET_FILE_DIR:vita3k>/data"
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "$<TARGET_FILE_DIR:vita3k>/shaders-builtin"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/external/sdl/windows/lib/x64/SDL2.dll" "$<TARGET_FILE_DIR:vita3k>"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dll" "$<TARGET_FILE_DIR:vita3k>")
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dll" "$<TARGET_FILE_DIR:vita3k>"
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/unicorn.dll" "$<TARGET_FILE_DIR:vita3k>"
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/libgcc_s_seh-1.dll" "$<TARGET_FILE_DIR:vita3k>"
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/libwinpthread-1.dll" "$<TARGET_FILE_DIR:vita3k>")
 endif()


### PR DESCRIPTION
For some reason, mingw unicorn outperforms msvc unicorn. (2 fps vs 15 fps in p4g) For this reason, this pr tries to use the mingw unicorn automatically built by github ci in vita3k unicorn repository. (https://github.com/Vita3K/unicorn/releases/tag/4b52942b)

Ideally, we should spot out some subtlety in msvc version of unicorn and remove bottlenecks at some moment. Because msvc version is a lot better in term of debugging experience. (i.e. we can breakpoint at unicorn source code)