### PR TITLE
shader: memory load instruction with actual base and float scalar array

### DIFF
--- a/vita3k/shader/include/shader/usse_translator_types.h
+++ b/vita3k/shader/include/shader/usse_translator_types.h
@@ -46,7 +46,8 @@ struct SpirvShaderParameters {
     // Sampler map. Since all banks are a flat array, sampler must be in an explicit bank.
     std::unordered_map<std::uint32_t, spv::Id> samplers;
 
-    std::unordered_map<std::uint32_t, SpirvUniformBuffrerBase> buffers;
+    // Memory that has all uniform buffer data
+    spv::Id memory;
 };
 
 using Coord = std::pair<spv::Id, int>;

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -65,7 +65,7 @@ static constexpr int REG_I_COUNT = 3 * 4;
 static constexpr int REG_TEMP_COUNT = 20 * 4;
 static constexpr int REG_INDEX_COUNT = 2 * 4;
 static constexpr int REG_PRED_COUNT = 4 * 4;
-static constexpr int REG_O_COUNT = 11 * 4;
+static constexpr int REG_O_COUNT = 12 * 4;
 
 // **************
 // * Prototypes *


### PR DESCRIPTION
I observed some shader that actually use some value mutated by alu as base. So current method will fail because it assumes that shader will always use certain registers listed in meta as base.

This pr tries to better emulate uniform buffer part of gpu memory by the following method. 

- Create an array varialbe that is big enough
- Load all uniform buffer data to that variable
- The base will be just index of that array 
- Use float scalar array instead of vector array to ease the implementation difficulty
