### PR TITLE
shader: implement i32mad and fix bugs in ub memory 

### DIFF
--- a/tools/usse-decoder-gen/grammar.yaml
+++ b/tools/usse-decoder-gen/grammar.yaml
@@ -788,8 +788,61 @@ I32MAD:
     description: 32-bit Integer multiply-add
     members:
         - opcode1: '10101'
+        - pred:
+            size: 2
+            type: ShortPredicate
+        - src0_high:
+            size: 1
         - DONTCARE:
-            size: 59
+            size: 1
+        - nosched:
+            size: 1
+        - src1_high:
+            size: 1
+        - src2_high:
+            size: 1
+        - dest_bank_ext:
+            size: 1
+            type: bool
+        - end:
+            size: 1
+        - src1_bank_ext:
+            size: 1
+            type: bool
+        - src2_bank_ext:
+            size: 1
+            type: bool
+        - unk0: '0'
+        - repeat_count:
+            size: 3
+            type: RepeatCount
+        - is_signed:
+            size: 1
+            type: bool
+        - is_sat:
+            size: 1
+            type: bool
+        - unk1: '00'
+        - src2_type:
+            size: 2
+        - unk2: '000'
+        - src0_bank:
+            size: 1
+        - dest_bank:
+            size: 2
+        - src1_bank:
+            size: 2
+        - src2_bank:
+            size: 2
+        - dest_n:
+            size: 7
+        - src0_n:
+            size: 7
+        - src1_n:
+            size: 7
+        - src2_n:
+            size: 7
+
 ILLEGAL22:
     description: Illegal instruction
     members:

--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -512,7 +512,27 @@ public:
 
     bool i16mad();
 
-    bool i32mad();
+    bool i32mad(ShortPredicate pred,
+        Imm1 src0_high,
+        Imm1 nosched,
+        Imm1 src1_high,
+        Imm1 src2_high,
+        bool dest_bank_ext,
+        Imm1 end,
+        bool src1_bank_ext,
+        bool src2_bank_ext,
+        RepeatCount repeat_count,
+        bool is_signed,
+        bool is_sat,
+        Imm2 src2_type,
+        Imm1 src0_bank,
+        Imm2 dest_bank,
+        Imm2 src1_bank,
+        Imm2 src2_bank,
+        Imm7 dest_n,
+        Imm7 src0_n,
+        Imm7 src1_n,
+        Imm7 src2_n);
 
     bool illegal22();
 

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -14,6 +14,7 @@ namespace shader::usse::utils {
 struct SpirvUtilFunctions {
     std::map<DataType, spv::Function *> unpack_funcs;
     std::map<DataType, spv::Function *> pack_funcs;
+    spv::Function *fetch_memory{ nullptr };
     spv::Function *pack_fx8{ nullptr };
     spv::Function *unpack_fx8{ nullptr };
 };
@@ -27,6 +28,8 @@ spv::Id unpack(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &f
 
 spv::Id unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id scalar, const DataType type);
 spv::Id pack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id vec, const DataType source_type);
+
+spv::Id fetch_memory(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, spv::Id addr);
 
 spv::Id make_uniform_vector_from_type(spv::Builder &b, spv::Id type, int val);
 

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -748,7 +748,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         }
     }
 
-    spv::Id memory_type = b.makeArrayType(f32_type, b.makeIntConstant(total_buffer_size * 4), 4);
+    spv::Id memory_type = b.makeArrayType(f32_type, b.makeIntConstant(total_buffer_size * 4 + 100), 0);
     spv_params.memory = b.createVariable(spv::StorageClassPrivate, memory_type, "memory");
 
     int last_base = 0;
@@ -764,7 +764,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                 b.createStore(src, dest);
             }
         });
-        buffer_bases.emplace(index, last_base);
+        buffer_bases.emplace(index, last_base * 4);
         last_base += size * 4;
     }
 
@@ -808,7 +808,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                            reg.bank = RegisterBank::SECATTR;
                            reg.num = input.offset;
                            reg.type = DataType::INT32;
-                           const auto base = buffer_bases.at(s.index) + s.base;
+                           const auto base = buffer_bases.at(s.index) + 4 * s.base;
                            utils::store(b, spv_params, utils, features, reg, b.makeIntConstant(base), 0b1, 0);
                        },
                        [&](const DependentSamplerInputSource &s) {

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -748,7 +748,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         }
     }
 
-    spv::Id memory_type = b.makeArrayType(f32_type, b.makeIntConstant(total_buffer_size * 4 + 100), 0);
+    spv::Id memory_type = b.makeArrayType(f32_type, b.makeIntConstant(total_buffer_size * 4 + 1), 0);
     spv_params.memory = b.createVariable(spv::StorageClassPrivate, memory_type, "memory");
 
     int last_base = 0;

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -581,6 +581,7 @@ bool USSETranslatorVisitor::vldst(
     inst.opr.src1.type = DataType::INT32;
     inst.opr.src2.type = DataType::INT32;
 
+    // TODO: is source_2 in word or byte?
     spv::Id source_0 = load(inst.opr.src0, 0b1, 0);
     spv::Id source_1 = load(inst.opr.src1, 0b1, 0);
     spv::Id source_2 = load(inst.opr.src2, 0b1, 0);
@@ -589,9 +590,9 @@ bool USSETranslatorVisitor::vldst(
     base = m_b.createBinOp(spv::OpIAdd, m_b.makeIntType(32), base, source_2);
 
     for (int i = 0; i < total_bytes_fo_fetch / 4; ++i) {
-        spv::Id offset = m_b.createBinOp(spv::OpIAdd, m_b.makeIntType(32), base, m_b.makeIntConstant(i));
-        spv::Id src = m_b.createAccessChain(spv::StorageClassPrivate, m_spirv_params.memory, { offset });
-        store(to_store, m_b.createLoad(src), 0b1);
+        spv::Id offset = m_b.createBinOp(spv::OpIAdd, m_b.makeIntType(32), base, m_b.makeIntConstant(4 * i));
+        spv::Id src = utils::fetch_memory(m_b, m_spirv_params, m_util_funcs, offset);
+        store(to_store, src, 0b1);
         to_store.num += 1;
     }
 

--- a/vita3k/shader/src/translator/ialu.cpp
+++ b/vita3k/shader/src/translator/ialu.cpp
@@ -173,7 +173,34 @@ bool USSETranslatorVisitor::i32mad(
     Imm7 src0_n,
     Imm7 src1_n,
     Imm7 src2_n) {
-    LOG_DISASM("Unimplmenet Opcode: i32mad");
+    Instruction inst;
+    inst.opcode = Opcode::IMAD;
+
+    inst.opr.dest = decode_dest(inst.opr.dest, dest_n, dest_bank, dest_bank_ext, false, 7, m_second_program);
+    inst.opr.src0 = decode_src0(inst.opr.src0, src0_n, src0_bank, false, false, 7, m_second_program);
+    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_bank_ext, false, 7, m_second_program);
+    inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank, src2_bank_ext, false, 7, m_second_program);
+
+    const DataType inst_dt = is_signed ? DataType::INT32 : DataType::UINT32;
+
+    inst.opr.dest.type = inst_dt;
+    inst.opr.src0.type = inst_dt;
+    inst.opr.src1.type = inst_dt;
+    inst.opr.src2.type = inst_dt;
+
+    spv::Id vsrc0 = load(inst.opr.src0, 0b1, 0);
+    spv::Id vsrc1 = load(inst.opr.src1, 0b1, 0);
+    spv::Id vsrc2 = load(inst.opr.src2, 0b1, 0);
+
+    auto mul_result = m_b.createBinOp(spv::OpIMul, m_b.getTypeId(vsrc0), vsrc0, vsrc1);
+    auto add_result = m_b.createBinOp(spv::OpIAdd, m_b.getTypeId(mul_result), mul_result, vsrc2);
+
+    if (add_result != spv::NoResult) {
+        store(inst.opr.dest, add_result, 0b1, 0);
+    }
+
+    LOG_DISASM("{:016x}: {}{} {} {} {} {}", m_instr, disasm::s_predicate_str(pred), "IMAD", disasm::operand_to_str(inst.opr.dest, 0b1),
+        disasm::operand_to_str(inst.opr.src0, 0b1), disasm::operand_to_str(inst.opr.src1, 0b1), disasm::operand_to_str(inst.opr.src2, 0b1));
     return true;
 }
 

--- a/vita3k/shader/src/translator/ialu.cpp
+++ b/vita3k/shader/src/translator/ialu.cpp
@@ -151,7 +151,28 @@ bool USSETranslatorVisitor::i16mad() {
     return true;
 }
 
-bool USSETranslatorVisitor::i32mad() {
+bool USSETranslatorVisitor::i32mad(
+    ShortPredicate pred,
+    Imm1 src0_high,
+    Imm1 nosched,
+    Imm1 src1_high,
+    Imm1 src2_high,
+    bool dest_bank_ext,
+    Imm1 end,
+    bool src1_bank_ext,
+    bool src2_bank_ext,
+    RepeatCount repeat_count,
+    bool is_signed,
+    bool is_sat,
+    Imm2 src2_type,
+    Imm1 src0_bank,
+    Imm2 dest_bank,
+    Imm2 src1_bank,
+    Imm2 src2_bank,
+    Imm7 dest_n,
+    Imm7 src0_n,
+    Imm7 src1_n,
+    Imm7 src2_n) {
     LOG_DISASM("Unimplmenet Opcode: i32mad");
     return true;
 }

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -458,9 +458,33 @@ boost::optional<const USSEMatcher<V> &> DecodeUSSE(uint64_t instruction) {
         // 32-bit Integer multiply-add
         /*
                                        10101 = opcode1
-                                            ----------------------------------------------------------- = don't care
+                                            pp = pred (2 bits, ShortPredicate)
+                                              s = src0_high (1 bit)
+                                               - = don't care
+                                                n = nosched (1 bit)
+                                                 r = src1_high (1 bit)
+                                                  c = src2_high (1 bit)
+                                                   d = dest_bank_ext (1 bit, bool)
+                                                    e = end (1 bit)
+                                                     b = src1_bank_ext (1 bit, bool)
+                                                      a = src2_bank_ext (1 bit, bool)
+                                                       0 = unk0
+                                                        ttt = repeat_count (3 bits, RepeatCount)
+                                                           i = is_signed (1 bit, bool)
+                                                            f = is_sat (1 bit, bool)
+                                                             00 = unk1
+                                                               yy = src2_type (2 bits)
+                                                                 000 = unk2
+                                                                    k = src0_bank (1 bit)
+                                                                     gg = dest_bank (2 bits)
+                                                                       hh = src1_bank (2 bits)
+                                                                         jj = src2_bank (2 bits)
+                                                                           lllllll = dest_n (7 bits)
+                                                                                  mmmmmmm = src0_n (7 bits)
+                                                                                         ooooooo = src1_n (7 bits)
+                                                                                                qqqqqqq = src2_n (7 bits)
         */
-        INST(&V::i32mad, "I32MAD ()", "10101-----------------------------------------------------------"),
+        INST(&V::i32mad, "I32MAD ()", "10101pps-nrcdeba0tttif00yy000kgghhjjlllllllmmmmmmmoooooooqqqqqqq"),
         // Illegal instruction
         /*
                                              10110 = opcode1


### PR DESCRIPTION
# About PR
- Implement i32mad
- Better stub for sn argument of i32mad2
- Memory address in bytes (it was in words before)

# Description

This pr tries to better support memory uniform buffer which is usually used in big vertex shader programs. i32mad and i32mad2 were used to manipulate the pointer (memory address) to uniform buffer.

# Related issue

Fixes mesh rendering of adventure of mana.
