### PR TITLE
GitHub Actions: Replace deprecated add-path and set-env

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -41,20 +41,20 @@ jobs:
       - name: Set up build environment (macos-latest)
         run: |
           brew install ccache boost
-          echo "::add-path::/usr/local/opt/ccache/libexec"
-          echo "::set-env name=CCACHE_DIR::/tmp/ccache"
+          echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+          echo "CCACHE_DIR=/tmp/ccache" >> $GITHUB_ENV
         if: matrix.os == 'macos-latest'
 
       - name: Set up build environment (ubuntu-latest)
         run: |
           sudo apt-get update
           sudo apt-get -y install ccache libboost-filesystem-dev libboost-program-options-dev libboost-system-dev libgtk-3-dev libsdl2-dev
-          echo "::set-env name=CCACHE_DIR::/tmp/ccache"
+          echo "CCACHE_DIR=/tmp/ccache" >> $GITHUB_ENV
         if: matrix.os == 'ubuntu-latest'
 
       - name: Set up build environment (windows-latest)
-        run: |
-          echo "::set-env name=BOOST_ROOT::$env:BOOST_ROOT_1_72_0"
+        shell: bash
+        run: echo "BOOST_ROOT=$BOOST_ROOT_1_72_0" >> $GITHUB_ENV
         if: matrix.os == 'windows-latest'
 
       - uses: actions/cache@v1


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

> Action and workflow authors who are setting environment variables via stdout should update any usage of the set-env and add-path workflow commands to use the new environment files.