### PR TITLE
renderer: reset command list at the end of scene

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -129,9 +129,6 @@ EXPORT(int, sceGxmBeginScene, SceGxmContext *context, unsigned int flags, const 
     // It's legal to set at client.
     host.gxm.is_in_scene = true;
 
-    // Reset command list and finish status
-    renderer::reset_command_list(context->renderer->command_list);
-
     SceGxmColorSurface *color_surface_copy = nullptr;
     SceGxmDepthStencilSurface *depth_stencil_surface_copy = nullptr;
 
@@ -737,6 +734,8 @@ EXPORT(int, sceGxmEndScene, SceGxmContext *context, const SceGxmNotification *ve
     // Submit our command list
     renderer::submit_command_list(*host.renderer, context->renderer.get(), &context->state,
         context->renderer->command_list);
+
+    renderer::reset_command_list(context->renderer->command_list);
 
     host.gxm.is_in_scene = false;
     host.renderer->scene_processed_since_last_frame++;


### PR DESCRIPTION
This pr should fix the crash at p4g shopping street after the mem leak pr. 

The game added some commands outside the scene which added some command to the command list that is already submitted. However, the renderer frees the command list after it processed it. Therefore, commands were added to freed command list, which resulted in undefined behavior. I'm not sure how was it able to function without crash before the mem leak pr. (maybe bigger available memory area give more room?) After all it's all inside undefined world, so it's probably not wise to investigate this seriously.