### PR TITLE
renderer: fix few bugs

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1397,7 +1397,8 @@ struct SceGxmProgramParameter {
         bf_t<uint16_t, 8, 4> component_count; // applicable for constants, not applicable for samplers (select size like float2, float3, float3 ...)
         bf_t<uint16_t, 12, 4> container_index; // applicable for constants, not applicable for samplers (buffer, default, texture)
     };
-    uint16_t semantic; // applicable only for for vertex attributes, for everything else it's 0
+    uint8_t semantic; // applicable only for for vertex attributes, for everything else it's 0
+    uint8_t pad;
     uint32_t array_size;
     int32_t resource_index;
 

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -1009,7 +1009,7 @@ EXPORT(int, sceSaveDataDialogGetResult, Ptr<SceSaveDataDialogResult> result) {
         return RET_ERROR(SCE_COMMON_DIALOG_ERROR_NULL);
     }
 
-    if (host.common_dialog.status != SCE_COMMON_DIALOG_STATUS_FINISHED && host.common_dialog.substatus != SCE_COMMON_DIALOG_STATUS_FINISHED) {
+    if (host.common_dialog.status != SCE_COMMON_DIALOG_STATUS_FINISHED || host.common_dialog.substatus != SCE_COMMON_DIALOG_STATUS_FINISHED) {
         return RET_ERROR(SCE_COMMON_DIALOG_ERROR_NOT_FINISHED);
     }
 

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -103,11 +103,7 @@ static AttributeLocations attribute_locations(const SceGxmProgram &vertex_progra
     for (uint32_t i = 0; i < vertex_program.parameter_count; ++i) {
         const SceGxmProgramParameter &parameter = parameters[i];
         if (parameter.category == SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE) {
-            std::string name = gxp::parameter_name_raw(parameter);
-            const auto struct_idx = name.find('.');
-            const bool is_struct_field = struct_idx != std::string::npos;
-            if (is_struct_field)
-                name.replace(struct_idx, 1, "_"); // GLSL vertex inputs can't be structs, replace them here and in shader translator
+            std::string name = gxp::parameter_name(parameter);
             locations.emplace(parameter.resource_index, name);
         }
     }


### PR DESCRIPTION
# About PR

- Fix the mismatch between vertex attribute name of shader and runtime
- Shrink the size of semantic field of gxm parameter struct

# Why shrink

sceGxmProgramFindParameterBySemantic tried to find parameter with semantic 0x6, but it failed because the desired parameter has semantic 0x0106. 0x01 should be from another field. (I guess it's a flag)

# Related issue

This fixes the black screen render of ingame and title of puyo puyo tetris.
 