### PR TITLE
np: set state.inited to false on deinit

### DIFF
--- a/vita3k/np/src/init.cpp
+++ b/vita3k/np/src/init.cpp
@@ -31,6 +31,7 @@ bool init(NpState &state, const np::CommunicationID *comm_id) {
 
 bool deinit(NpState &state) {
     // Reserved
+    state.inited = false;
     return true;
 }
 
@@ -40,5 +41,6 @@ bool init(NpTrophyState &state) {
 }
 
 bool deinit(NpTrophyState &state) {
+    state.inited = false;
     return true;
 }


### PR DESCRIPTION
Otherwise, if you call `sceNpInit` =>`sceNpTerm` => `sceNpInit`, you have a `SCE_NP_ERROR_ALREADY_INITIALIZED` error. Same thing for the trophy functions.