### PR TITLE
gen-modules: remove hardcoded path to db.yml

### DIFF
--- a/tools/gen-modules/gen-modules.cpp
+++ b/tools/gen-modules/gen-modules.cpp
@@ -96,7 +96,7 @@ static void gen_license_comment(std::ostream &dst) {
 }
 
 static void gen_nids_h(const Modules &modules) {
-    std::ofstream out("src/emulator/nids/include/nids/nids.h");
+    std::ofstream out("vita3k/nids/include/nids/nids.h");
     gen_license_comment(out);
 
     for (const Module &module : modules) {
@@ -143,7 +143,7 @@ static void gen_library_h(std::ostream &dst, const Library &library) {
 
 static void gen_module_stubs(const Modules &modules) {
     for (const Module &module : modules) {
-        const std::string module_path = "src/emulator/modules/" + module.first;
+        const std::string module_path = "vita3k/modules/" + module.first;
 
 #ifdef WIN32
         CreateDirectoryA(module_path.c_str(), nullptr);
@@ -164,7 +164,7 @@ static void gen_module_stubs(const Modules &modules) {
 }
 
 static void gen_modules_cmakelists(const Modules &modules) {
-    std::ofstream out("src/emulator/modules/CMakeLists.txt");
+    std::ofstream out("vita3k/modules/CMakeLists.txt");
     out << "add_library(modules STATIC";
 
     for (const Module &module : modules) {

--- a/tools/gen-modules/gen-modules.cpp
+++ b/tools/gen-modules/gen-modules.cpp
@@ -179,7 +179,12 @@ static void gen_modules_cmakelists(const Modules &modules) {
 }
 
 int main(int argc, const char *argv[]) {
-    const Node db = LoadFile("src/external/vita-headers/db.yml");
+    if (argc != 2) {
+        std::cout << "Usage: " << argv[0] << " <path_to_db.yml>" << std::endl;
+        return 0;
+    }
+
+    const Node db = LoadFile(argv[1]);
     const Modules modules = parse_db(db);
 
     gen_nids_h(modules);


### PR DESCRIPTION
With PR #649, vita-headers is not in the repository anymore.