### PR TITLE
gxm: Optimize graphics hashing with XXH3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,3 +81,6 @@
 [submodule "external/psvpfstools"]
 	path = external/psvpfstools
 	url = https://github.com/Vita3K/psvpfstools.git
+[submodule "external/xxHash"]
+	path = external/xxHash
+	url = https://github.com/Cyan4973/xxHash

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <mutex>
 #include <queue>
+#include <unordered_map>
 #include <vector>
 
 struct ThreadState;
@@ -54,7 +55,7 @@ typedef std::shared_ptr<SDL_Thread> ThreadPtr;
 typedef std::map<SceUID, ThreadPtr> ThreadPtrs;
 typedef std::shared_ptr<SceKernelModuleInfo> SceKernelModuleInfoPtr;
 typedef std::map<SceUID, SceKernelModuleInfoPtr> SceKernelModuleInfoPtrs;
-typedef std::map<uint32_t, Address> ExportNids;
+typedef std::unordered_map<uint32_t, Address> ExportNids;
 typedef std::map<Address, uint32_t> NidFromExport;
 typedef std::map<Address, uint32_t> NotFoundVars;
 typedef std::map<Address, WatchMemory> WatchMemoryAddrs;

--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -6,6 +6,7 @@
 #include <mem/ptr.h>
 #include <util/log.h>
 
+#include "../xxHash/xxh3.h"
 #include <algorithm> // find
 #include <cstring> // memcmp
 #include <numeric> // accumulate, reduce
@@ -17,14 +18,8 @@ namespace renderer {
 namespace texture {
 
 static TextureCacheHash hash_data(const void *data, size_t size) {
-    const uint8_t *const begin = static_cast<const uint8_t *>(data);
-    const uint8_t *const end = begin + size;
-
-#ifdef WIN32
-    return std::reduce(std::execution::par_unseq, begin, end, TextureCacheHash(0));
-#else
-    return std::accumulate(begin, end, TextureCacheHash(0));
-#endif
+    auto hash = XXH_INLINE_XXH3_64bits(data, size);
+    return TextureCacheHash(hash);
 }
 
 static TextureCacheHash hash_palette_data(const SceGxmTexture &texture, size_t count, const MemState &mem) {


### PR DESCRIPTION
* XXH3 is faster than accumulate and SHA256
* Also optimize nids find inside resolve_export function
# Testing
Since my PC is not that great i am unable to detect any performance boost with this, but technically it should, if someone could do some benchmarking justo to get some numbers would be great