### PR TITLE
SceLibKernel: check if a thread is valid in sceKernelWaitThreadEnd/sceKernelWaitThreadEndCB before to lock

### DIFF
--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -1580,6 +1580,10 @@ int wait_thread_end(HostState &host, SceUID thread_id, SceUID thid, int *stat) {
 
     {
         const ThreadStatePtr thread = lock_and_find(thid, host.kernel.threads, host.kernel.mutex);
+        if (!thread) {
+            return SCE_KERNEL_ERROR_UNKNOWN_THREAD_ID;
+        }
+
         const std::lock_guard<std::mutex> thread_lock(thread->mutex);
 
         if (thread->to_do == ThreadToDo::exit) {


### PR DESCRIPTION
[1001 Spikes [PCSE00349]](https://github.com/Vita3K/compatibility/issues/186): Bootable/Menu => Ingame