### PR TITLE
shader: fix bugs in uniform buffer & improve logging

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1743,12 +1743,9 @@ static void convert_uniform_data(std::vector<std::uint8_t> &converted_data, cons
 
 EXPORT(int, sceGxmSetUniformDataF, void *uniformBuffer, const SceGxmProgramParameter *parameter, uint32_t componentOffset, uint32_t componentCount, const float *sourceData) {
     assert(parameter);
-    assert(parameter->container_index == SCE_GXM_DEFAULT_UNIFORM_BUFFER_CONTAINER_INDEX);
 
     if (!uniformBuffer || !parameter || !sourceData)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
-    if (parameter->container_index != SCE_GXM_DEFAULT_UNIFORM_BUFFER_CONTAINER_INDEX)
-        return RET_ERROR(SCE_GXM_ERROR_INVALID_ALIGNMENT);
 
     size_t size = 0;
     size_t offset = 0;

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -189,19 +189,22 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
 
         const uint32_t offset = base_offset + buffer_info->base_offset;
 
-        const auto buffer = uniform_buffers.at(buffer_info->reside_buffer);
+        const auto buffer = uniform_buffers.find(buffer_info->reside_buffer);
+        // buffer = null seems to happen when there's a leftover uniform buffer (uniform buffer that's not used in shader code)
+        // This case needs more invastigation
+        if (buffer != uniform_buffers.end()) {
+            Input item;
+            item.type = DataType::UINT32;
+            item.offset = offset;
+            item.component_count = 1;
+            item.array_size = 1;
+            UniformBufferInputSource source;
+            source.base = buffer->second.reg_block_size;
+            source.index = buffer->second.index;
+            item.source = source;
 
-        Input item;
-        item.type = DataType::UINT32;
-        item.offset = offset;
-        item.component_count = 1;
-        item.array_size = 1;
-        UniformBufferInputSource source;
-        source.base = buffer.reg_block_size;
-        source.index = buffer.index;
-        item.source = source;
-
-        program_input.inputs.push_back(item);
+            program_input.inputs.push_back(item);
+        }
     }
 
     const SceGxmProgramParameterContainer *container = gxp::get_container_by_index(program, 19);

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -241,9 +241,7 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
         // Alternative is 19, which is DATA
         container = gxp::get_container_by_index(program, 19);
     }
-    if (!container) {
-        LOG_WARN("Container for literal not found, skipping creating literals!");
-    } else {
+    if (container) {
         for (std::uint32_t i = 0; i < program.literals_count * 2; i += 2) {
             auto literal_offset = container->base_sa_offset + literals[i];
             auto literal_data = *reinterpret_cast<const float *>(&literals[i + 1]);
@@ -261,8 +259,6 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
             item.source = source;
 
             program_input.inputs.push_back(item);
-
-            LOG_TRACE("[LITERAL + {}] sa{} = {} (0x{:X})", literals[i], literal_offset, literal_data, literals[i + 1]);
         }
     }
 

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -191,7 +191,7 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
 
         const auto buffer = uniform_buffers.find(buffer_info->reside_buffer);
         // buffer = null seems to happen when there's a leftover uniform buffer (uniform buffer that's not used in shader code)
-        // This case needs more invastigation
+        // This case needs more investigation
         if (buffer != uniform_buffers.end()) {
             Input item;
             item.type = DataType::UINT32;

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1215,7 +1215,7 @@ static SpirvCode convert_gxp_to_spirv(const SceGxmProgram &program, const std::s
     return spirv;
 }
 
-static std::string convert_spirv_to_glsl(SpirvCode spirv_binary, const FeatureState &features, TranslationState &translation_state) {
+static std::string convert_spirv_to_glsl(std::string shader_name, SpirvCode spirv_binary, const FeatureState &features, TranslationState &translation_state) {
     spirv_cross::CompilerGLSL glsl(std::move(spirv_binary));
 
     spirv_cross::CompilerGLSL::Options options;
@@ -1231,6 +1231,7 @@ static std::string convert_spirv_to_glsl(SpirvCode spirv_binary, const FeatureSt
     //options.vertex.flip_vert_y = true;
 
     glsl.set_common_options(options);
+    glsl.add_header_line("// Shader Name: " + shader_name);
 
     if (!features.direct_pack_unpack_half) {
         if (features.pack_unpack_half_through_ext) {
@@ -1384,7 +1385,7 @@ std::string convert_gxp_to_glsl(const SceGxmProgram &program, const std::string 
     translation_state.is_maskupdate = maskupdate;
     std::vector<uint32_t> spirv_binary = convert_gxp_to_spirv(program, shader_name, features, translation_state, force_shader_debug, dumper);
 
-    const auto source = convert_spirv_to_glsl(spirv_binary, features, translation_state);
+    const auto source = convert_spirv_to_glsl(shader_name, spirv_binary, features, translation_state);
 
     if (LOG_SHADER_CODE || force_shader_debug)
         LOG_DEBUG("Generated GLSL:\n{}", source);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1215,7 +1215,7 @@ static SpirvCode convert_gxp_to_spirv(const SceGxmProgram &program, const std::s
     return spirv;
 }
 
-static std::string convert_spirv_to_glsl(std::string shader_name, SpirvCode spirv_binary, const FeatureState &features, TranslationState &translation_state) {
+static std::string convert_spirv_to_glsl(const std::string &shader_name, SpirvCode spirv_binary, const FeatureState &features, TranslationState &translation_state) {
     spirv_cross::CompilerGLSL glsl(std::move(spirv_binary));
 
     spirv_cross::CompilerGLSL::Options options;

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -592,6 +592,8 @@ bool USSETranslatorVisitor::vldst(
     spv::Id source_1 = load(inst.opr.src1, 0b1, 0);
     spv::Id source_2 = load(inst.opr.src2, 0b1, 0);
 
+    source_1 = m_b.createBinOp(spv::OpIMul, m_b.makeIntType(32), source_1, m_b.makeIntConstant(4));
+
     spv::Id base = m_b.createBinOp(spv::OpIAdd, m_b.makeIntType(32), source_0, source_1);
     base = m_b.createBinOp(spv::OpIAdd, m_b.makeIntType(32), base, source_2);
 

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -535,6 +535,7 @@ bool USSETranslatorVisitor::vldst(
     // - Post or pre or any increment mode.
 
     Instruction inst;
+    inst.opcode = Opcode::LDR;
 
     DataType type_to_ldst = DataType::UNK;
 
@@ -580,6 +581,11 @@ bool USSETranslatorVisitor::vldst(
     inst.opr.src0.type = DataType::INT32;
     inst.opr.src1.type = DataType::INT32;
     inst.opr.src2.type = DataType::INT32;
+
+    std::string disasm_str = fmt::format("{:016x}: {}{}", m_instr, disasm::e_predicate_str(pred), disasm::opcode_str(inst.opcode));
+    LOG_DISASM("{} {} ({} + {} + {}) [{} bytes]", disasm_str, disasm::operand_to_str(to_store, 0b1, 0),
+        disasm::operand_to_str(inst.opr.src0, 0b1, 0),
+        disasm::operand_to_str(inst.opr.src1, 0b1, 0), disasm::operand_to_str(inst.opr.src2, 0b1, 0), total_bytes_fo_fetch);
 
     // TODO: is source_2 in word or byte?
     spv::Id source_0 = load(inst.opr.src0, 0b1, 0);

--- a/vita3k/shader/src/translator/ialu.cpp
+++ b/vita3k/shader/src/translator/ialu.cpp
@@ -73,7 +73,7 @@ bool USSETranslatorVisitor::vbw(
     BEGIN_REPEAT(repeat_count)
     GET_REPEAT(inst, RepeatMode::SLMSI);
 
-    spv::Id src1 = load(inst.opr.src1, 0b0001, src1_repeat_offset);
+    spv::Id src1 = load(inst.opr.src1, 0b0001, src1_repeat_offset / 2);
     spv::Id src2 = 0;
 
     if (src1 == spv::NoResult) {
@@ -92,7 +92,7 @@ bool USSETranslatorVisitor::vbw(
         value = src2_n | (static_cast<uint32_t>(src2_sel) << 7) | (static_cast<uint32_t>(src2_exth) << 14);
         src2 = m_b.makeUintConstant(src2_invert ? ~value : value);
     } else {
-        src2 = load(inst.opr.src2, 0b0001, src2_repeat_offset);
+        src2 = load(inst.opr.src2, 0b0001, src2_repeat_offset / 2);
 
         if (src2 == spv::NoResult) {
             LOG_ERROR("Source 2 not loaded");
@@ -125,11 +125,11 @@ bool USSETranslatorVisitor::vbw(
         result = m_b.createUnaryOp(spv::Op::OpBitcast, type_f32, src2);
     }
 
-    store(inst.opr.dest, result, 0b0001, dest_repeat_offset);
+    store(inst.opr.dest, result, 0b0001, dest_repeat_offset / 2);
 
     LOG_DISASM("{:016x}: {}{} {} {} {}", m_instr, disasm::e_predicate_str(pred), disasm::opcode_str(inst.opcode),
-        disasm::operand_to_str(inst.opr.dest, 0b0001, dest_repeat_offset), disasm::operand_to_str(inst.opr.src1, 0b0001, src1_repeat_offset),
-        immediate ? log_hex(value) : disasm::operand_to_str(inst.opr.src2, 0b0001, src2_repeat_offset));
+        disasm::operand_to_str(inst.opr.dest, 0b0001, dest_repeat_offset / 2), disasm::operand_to_str(inst.opr.src1, 0b0001, src1_repeat_offset / 2),
+        immediate ? log_hex(value) : disasm::operand_to_str(inst.opr.src2, 0b0001, src2_repeat_offset / 2));
 
     END_REPEAT()
 

--- a/vita3k/shader/src/usse_disasm.cpp
+++ b/vita3k/shader/src/usse_disasm.cpp
@@ -159,7 +159,7 @@ std::string operand_to_str(Operand op, Imm4 write_mask, int32_t shift) {
     std::string opstr = reg_to_str(op.bank, op.num + shift);
 
     if (op.bank == RegisterBank::IMMEDIATE) {
-        return "0x" + opstr;
+        return opstr;
     }
 
     if (write_mask != 0) {


### PR DESCRIPTION
# About PR

- Correct the unit of src1 in ldr (it was in words instead of bytes)
- Correct repeat offset of vbw (it needed /2)
- Adjust null checks 
- Improve logging

# Related issue

Fixes regression in BlazBlue.