### PR TITLE
shader: convert position in screen space

### DIFF
--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -164,6 +164,17 @@ void draw(GLState &renderer, GLContext &context, GxmContextState &state, const F
         }
     }
 
+    const auto set_uniform_if_exists = [&](const std::string &name, float val) {
+        GLuint loc = glGetUniformLocation(program_id, name.c_str());
+        if (loc != -1) {
+            glUniform1f(loc, val);
+        }
+    };
+
+    set_uniform_if_exists("viewport_flag", state.viewport.enable == SCE_GXM_VIEWPORT_ENABLED ? 1.0f : 0.0f);
+    set_uniform_if_exists("screen_width", state.color_surface.width);
+    set_uniform_if_exists("screen_height", state.color_surface.height);
+
     context.vertex_set_requests.clear();
     context.fragment_set_requests.clear();
 

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -280,6 +280,12 @@ void sync_texture(GLContext &context, const GxmContextState &state, const MemSta
         return;
     }
 
+    const SceGxmTextureFormat format = gxm::get_format(&texture);
+    if (gxm::is_paletted_format(format) && texture.palette_addr == 0) {
+        LOG_WARN("Ignoring null palette texture");
+        return;
+    }
+
     glActiveTexture(static_cast<GLenum>(static_cast<std::size_t>(GL_TEXTURE0) + index));
 
     if (enable_texture_cache) {


### PR DESCRIPTION
# Description

When viewport is disabled, the shader output should be in screen space, but opengl expects gl_Position to be in ndc. This pr add appropriate conversion that is done in vertex opengl shader.

# Related issue

Gets blazblue ingame.