### PR TITLE
gxm: fix is_sampler_cube method

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1435,7 +1435,7 @@ struct SceGxmProgramParameter {
     int32_t resource_index;
 
     bool is_sampler_cube() const {
-        return (semantic >> 12) & 1;
+        return (semantic_index >> 4) & 1;
     }
 };
 


### PR DESCRIPTION
Previously, we had:
```
uint16_t semantic;
[...]
bool is_sampler_cube() const {
    return (semantic >> 12) & 1;
}
```
then the `semantic` variable split into two uint8_t:
```
uint8_t semantic;
uint8_t semantic_index;
```
so I believe the `is_sampler_cube` method needs an update. Also, it makes no sense to shift an uint8_t to the right by 12 bits