### PR TITLE
gxm: Save indicies data in beginscene

### DIFF
--- a/vita3k/gxm/include/gxm/functions.h
+++ b/vita3k/gxm/include/gxm/functions.h
@@ -15,6 +15,7 @@ bool is_block_compressed_format(SceGxmTextureFormat src);
 bool is_paletted_format(SceGxmTextureFormat src);
 bool is_yuv_format(SceGxmTextureFormat src);
 size_t attribute_format_size(SceGxmAttributeFormat format);
+size_t index_element_size(SceGxmIndexFormat format);
 } // namespace gxm
 
 namespace gxp {

--- a/vita3k/gxm/src/attributes.cpp
+++ b/vita3k/gxm/src/attributes.cpp
@@ -22,4 +22,8 @@ size_t attribute_format_size(SceGxmAttributeFormat format) {
         return 4;
     }
 }
+
+size_t index_element_size(SceGxmIndexFormat format) {
+    return (format == SCE_GXM_INDEX_FORMAT_U16) ? 2 : 4;
+}
 } // namespace gxm

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -181,8 +181,12 @@ void draw(GLState &renderer, GLContext &context, GxmContextState &state, const F
     // Upload index data.
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, context.element_buffer[0]);
     const GLsizeiptr index_size = (format == SCE_GXM_INDEX_FORMAT_U16) ? 2 : 4;
+
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, index_size * count, nullptr, GL_DYNAMIC_DRAW);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, index_size * count, indices, GL_DYNAMIC_DRAW);
+
+    const std::uint8_t *indicies_u8 = reinterpret_cast<const std::uint8_t *>(indices);
+    delete indicies_u8;
 
     if (fragment_program_gxp.is_native_color()) {
         if (features.should_use_texture_barrier()) {

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -2,6 +2,8 @@
 #include <renderer/state.h>
 #include <renderer/types.h>
 
+#include <gxm/functions.h>
+
 #include <cstring>
 
 namespace renderer {
@@ -147,9 +149,15 @@ void set_vertex_stream(State &state, Context *ctx, GxmContextState *gxm_context,
 
 void draw(State &state, Context *ctx, GxmContextState *gxm_context, SceGxmPrimitiveType prim_type, SceGxmIndexFormat index_type, const void *index_data, const std::uint32_t index_count) {
     switch (state.current_backend) {
-    default:
-        renderer::add_command(ctx, renderer::CommandOpcode::Draw, nullptr, prim_type, index_type, index_data, index_count);
+    default: {
+        const std::size_t copy_size = gxm::index_element_size(index_type) * index_count;
+        std::uint8_t *a_copy = new std::uint8_t[copy_size];
+
+        std::memcpy(a_copy, index_data, copy_size);
+
+        renderer::add_command(ctx, renderer::CommandOpcode::Draw, nullptr, prim_type, index_type, a_copy, index_count);
         break;
+    }
     }
 }
 


### PR DESCRIPTION
Sometimes game overwrite indicies data when a scene has not been finished by command list. This maybe understandable since there's no vertex sync object, indicies submitting maybe is very fast on vita or copied on vita. 

PR copies indicies data first and delete them later when command list got them. Virtua tennis 4 flickering disappear