### PR TITLE
shader: Add sb_mode 0

### DIFF
--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -181,6 +181,7 @@ bool USSETranslatorVisitor::smp(
     spv::Id result = do_fetch_texture(sampler, { coord, static_cast<int>(DataType::F32) }, DataType::F32);
 
     switch (sb_mode) {
+    case 0:
     case 1: {
         store(inst.opr.dest, result, 0b1111);
         break;
@@ -194,6 +195,7 @@ bool USSETranslatorVisitor::smp(
         store(inst.opr.dest, result, 0b1111);
         break;
     }
+
     default: {
         LOG_ERROR("Unsupported sb_mode: {}", sb_mode);
     }


### PR DESCRIPTION
Sb_mode is sample bypassing mode. It's to decide which sample values to gather during the smp call. [Docs](http://cdn.imgtec.com/sdk-documentation/PowerVR+Instruction+Set+Reference.pdf) here talks a bit about it.

From @sunho work:
- mode 3 has some extra info (4 components), and mode 1 is just normal sample result.
- Based on the docs there, I assume mode 0 is default mode, same as mode 1.
- Mode 2 is info mode (contains sample info, i dont know what it contains yet, need hardware test. I guess it has mipmap level maybe).
- Mode 3 is both, since 4 latter components are sample data, 4 beginning components should be info mode

Add mode 0 fix rainy texture in menu of Virtua Tennis 4. All results gather here are likely correct.

![a](https://cdn.discordapp.com/attachments/534180053865725962/793016061674127361/unknown.png)