### PR TITLE
Use threadsafe versions of std::localtime and std::gmtime

### DIFF
--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -77,8 +77,7 @@ struct WaitingThreadData {
             int32_t wait;
             int32_t flags;
         };
-        struct { // condvar
-        };
+        // struct { }; // condvar
     };
 
     bool operator>(const WaitingThreadData &rhs) const {

--- a/vita3k/modules/SceRtc/SceRtc.cpp
+++ b/vita3k/modules/SceRtc/SceRtc.cpp
@@ -19,6 +19,8 @@
 
 #include <rtc/rtc.h>
 
+#include <util/safe_time.h>
+
 #include <chrono>
 #include <ctime>
 
@@ -29,8 +31,15 @@ EXPORT(int, _sceRtcConvertLocalTimeToUtc, const SceRtcTick *pLocalTime, SceRtcTi
         return RET_ERROR(SCE_RTC_ERROR_INVALID_POINTER);
     }
     std::time_t t = std::time(nullptr);
-    std::time_t local = std::mktime(std::localtime(&t));
-    std::time_t gmt = std::mktime(std::gmtime(&t));
+
+    tm local_tm = {};
+    tm gmt_tm = {};
+
+    SAFE_LOCALTIME(&t, &local_tm);
+    SAFE_GMTIME(&t, &gmt_tm);
+
+    std::time_t local = std::mktime(&local_tm);
+    std::time_t gmt = std::mktime(&gmt_tm);
     pUtc->tick = pLocalTime->tick - (local - gmt) * VITA_CLOCKS_PER_SEC;
 
     return 0;
@@ -42,8 +51,15 @@ EXPORT(int, _sceRtcConvertUtcToLocalTime, const SceRtcTick *pUtc, SceRtcTick *pL
     }
 
     std::time_t t = std::time(nullptr);
-    std::time_t local = std::mktime(std::localtime(&t));
-    std::time_t gmt = std::mktime(std::gmtime(&t));
+
+    tm local_tm = {};
+    tm gmt_tm = {};
+
+    SAFE_LOCALTIME(&t, &local_tm);
+    SAFE_GMTIME(&t, &gmt_tm);
+
+    std::time_t local = std::mktime(&local_tm);
+    std::time_t gmt = std::mktime(&gmt_tm);
     pLocalTime->tick = pUtc->tick + (local - gmt) * VITA_CLOCKS_PER_SEC;
     return 0;
 }
@@ -85,8 +101,15 @@ EXPORT(int, _sceRtcGetCurrentClockLocalTime, SceDateTime *datePtr) {
     }
 
     std::time_t t = std::time(nullptr);
-    std::time_t local = std::mktime(std::localtime(&t));
-    std::time_t gmt = std::mktime(std::gmtime(&t));
+
+    tm local_tm = {};
+    tm gmt_tm = {};
+
+    SAFE_LOCALTIME(&t, &local_tm);
+    SAFE_GMTIME(&t, &gmt_tm);
+
+    std::time_t local = std::mktime(&local_tm);
+    std::time_t gmt = std::mktime(&gmt_tm);
     uint64_t tick = rtc_get_ticks(host.kernel.base_tick.tick) + (local - gmt) * VITA_CLOCKS_PER_SEC;
     __RtcTicksToPspTime(datePtr, tick);
     return 0;

--- a/vita3k/util/CMakeLists.txt
+++ b/vita3k/util/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(
     include/util/overloaded.h
     include/util/align.h
     include/util/bytes.h
+    include/util/safe_time.h
     include/util/exit_code.h
     include/util/exec.h
     include/util/find.h

--- a/vita3k/util/include/util/safe_time.h
+++ b/vita3k/util/include/util/safe_time.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <ctime>
+
+#ifdef WIN32
+#define SAFE_GMTIME(time, result) gmtime_s(result, time)
+#define SAFE_LOCALTIME(time, result) localtime_s(result, time)
+#else
+#define SAFE_GMTIME(time, result) gmtime_r(time, result)
+#define SAFE_LOCALTIME(time, result) localtime_r(time, result)
+#endif


### PR DESCRIPTION
`std::localtime` and `std::gmtime` use static state by default, meaning they aren't especially threadsafe. Platform specific methods fix this by letting you allocate your own `tm` structure that won't be overwritten by a rogue function call.

I don't think this is a priority, I just want something simple to go through right now, and CodeQL has some simple warnings that are easy to resolve. Will probably be going through more until #1079 gets merged.