### PR TITLE
dialog: Disable sceTouch and sceCtrl polling when common dialog is running

### DIFF
--- a/vita3k/modules/SceCtrl/SceCtrl.cpp
+++ b/vita3k/modules/SceCtrl/SceCtrl.cpp
@@ -340,7 +340,7 @@ static int peek_buffer(HostState &host, int port, SceCtrlData *&pad_data, int co
     memset(pad_data, 0, sizeof(*pad_data));
     pad_data->timeStamp = timestamp++; // TODO Use the real time and units.
 
-    if (host.common_dialog.status != SCE_COMMON_DIALOG_STATUS_NONE) {
+    if (host.common_dialog.status == SCE_COMMON_DIALOG_STATUS_RUNNING) {
         return 0;
     }
 

--- a/vita3k/touch/src/touch.cpp
+++ b/vita3k/touch/src/touch.cpp
@@ -108,7 +108,7 @@ int peek_touch(const HostState &host, const SceUInt32 &port, SceTouchData *pData
     memset(pData, 0, sizeof(*pData));
     pData->timeStamp = timestamp++; // TODO Use the real time and units.
 
-    if (host.common_dialog.status != SCE_COMMON_DIALOG_STATUS_NONE) {
+    if (host.common_dialog.status == SCE_COMMON_DIALOG_STATUS_RUNNING) {
         return 0;
     }
 


### PR DESCRIPTION
Slight change from #561 to achieve the same result except this time, having `host.common_dialog.status == SCE_COMMON_DIALOG_STATUS_FINISHED` will not disable polling.

Fix #1094