### PR TITLE
use USE_DISCORD_RICH_PRESENCE to prevent building discord sdk

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -169,37 +169,39 @@ file(DOWNLOAD https://dl-game-sdk.discordapp.net/2.5.6/discord_game_sdk.zip
 	"${CMAKE_BINARY_DIR}/external/discord_game_sdk.zip" SHOW_PROGRESS)
 endif()
 
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
-file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
-execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/external/discord_game_sdk.zip"
-	WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
-file(RENAME "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.so"
-	"${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so")
-endif()
+if(USE_DISCORD_RICH_PRESENCE)
+  if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/external/discord_game_sdk.zip"
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
+    file(RENAME "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.so"
+      "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so")
+  endif()
 
-add_library(discord-rpc STATIC 
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/achievement_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/activity_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/application_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/core.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/image_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/lobby_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/network_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/overlay_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/relationship_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/storage_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/store_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/types.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/user_manager.cpp
-${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/voice_manager.cpp)
-if(APPLE)
-	target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dylib")
-elseif(WIN32)
-	target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dll.lib")
-elseif(UNIX)
-	target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so")
+  add_library(discord-rpc STATIC
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/achievement_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/activity_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/application_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/core.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/image_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/lobby_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/network_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/overlay_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/relationship_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/storage_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/store_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/types.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/user_manager.cpp
+    ${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/voice_manager.cpp)
+  if(APPLE)
+    target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dylib")
+  elseif(WIN32)
+    target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dll.lib")
+  elseif(UNIX)
+    target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so")
+  endif()
+  target_include_directories(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp")
 endif()
-target_include_directories(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp")
 
 option(BUILD_EXTERNAL "Build external dependencies in /External" OFF)
 option(SKIP_GLSLANG_INSTALL "Skip installation" ON)

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -93,7 +93,10 @@ endif()
 
 add_executable(vita3k MACOSX_BUNDLE main.cpp interface.cpp interface.h performance.cpp)
 
-target_link_libraries(vita3k PRIVATE app discord-rpc gui modules)
+target_link_libraries(vita3k PRIVATE app gui modules)
+if(USE_DISCORD_RICH_PRESENCE)
+	target_link_libraries(vita3k PRIVATE discord-rpc)
+endif()
 if(LINUX)
 	target_link_libraries(vita3k PRIVATE stdc++fs)
 endif()
@@ -127,8 +130,13 @@ if(APPLE)
 		POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../data" "$<TARGET_FILE_DIR:vita3k>/../Resources/data"
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin/" "$<TARGET_FILE_DIR:vita3k>/../Resources/shaders-builtin"
-		COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/external/sdl/macos/SDL2.framework" "$<TARGET_FILE_DIR:vita3k>/../Frameworks/SDL2.framework"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dylib" "$<TARGET_FILE_DIR:vita3k>/../Resources")
+		COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/external/sdl/macos/SDL2.framework" "$<TARGET_FILE_DIR:vita3k>/../Frameworks/SDL2.framework")
+  if(USE_DISCORD_RICH_PRESENCE)
+    add_custom_command(
+      TARGET vita3k
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dylib" "$<TARGET_FILE_DIR:vita3k>/../Resources")
+  endif()
 	set_target_properties(vita3k PROPERTIES LINK_FLAGS "-rpath @loader_path/../Frameworks/ -rpath @loader_path/../Resources/")
 	target_sources(vita3k PRIVATE Vita3K.icns)
 	set(MACOSX_BUNDLE_ICON_FILE Vita3K.icns)
@@ -140,8 +148,13 @@ elseif(LINUX)
 		TARGET vita3k
 		POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../data" "$<TARGET_FILE_DIR:vita3k>/data"
-		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "$<TARGET_FILE_DIR:vita3k>/shaders-builtin"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so" "$<TARGET_FILE_DIR:vita3k>")
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "$<TARGET_FILE_DIR:vita3k>/shaders-builtin")
+  if(USE_DISCORD_RICH_PRESENCE)
+    add_custom_command(
+      TARGET vita3k
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so" "$<TARGET_FILE_DIR:vita3k>")
+  endif()
 elseif(WIN32)
 	target_sources(vita3k PRIVATE resource.h Vita3K.ico Vita3K.rc)
 	set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT vita3k)
@@ -152,8 +165,13 @@ elseif(WIN32)
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../data" "$<TARGET_FILE_DIR:vita3k>/data"
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "$<TARGET_FILE_DIR:vita3k>/shaders-builtin"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/external/sdl/windows/lib/x64/SDL2.dll" "$<TARGET_FILE_DIR:vita3k>"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dll" "$<TARGET_FILE_DIR:vita3k>"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/unicorn.dll" "$<TARGET_FILE_DIR:vita3k>"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/libgcc_s_seh-1.dll" "$<TARGET_FILE_DIR:vita3k>"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/libwinpthread-1.dll" "$<TARGET_FILE_DIR:vita3k>")
+  if(USE_DISCORD_RICH_PRESENCE)
+    add_custom_command(
+      TARGET vita3k
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dll" "$<TARGET_FILE_DIR:vita3k>")
+  endif()
 endif()

--- a/vita3k/app/CMakeLists.txt
+++ b/vita3k/app/CMakeLists.txt
@@ -11,5 +11,8 @@ add_library(
 )
 
 target_include_directories(app PUBLIC include)
-target_link_libraries(app PUBLIC discord-rpc host)
+target_link_libraries(app PUBLIC host)
+if(USE_DISCORD_RICH_PRESENCE)
+  target_link_libraries(app PUBLIC discord-rpc)
+endif()
 target_link_libraries(app PRIVATE gui)


### PR DESCRIPTION
it needs some more testing.

I'm on linux but discord sdk wouldn't build I tried to desactivate it with the `USE_DISCORD_RICH_PRESENCE` flag but it doesn't do much (still linked to the library, built it and copy it)

so it needs to be tested on mac, linux and windows with the flag enabled
