### PR TITLE
IO: Handle case-sensitive filesystems + cache

### DIFF
--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -246,6 +246,11 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         ImGui::Checkbox("Enable video playing support", &host.cfg.video_playing);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Uncheck the box to disable video player.\nOn some game, disable it is required for more progress.");
+#ifndef WIN32
+        ImGui::Checkbox("Check to enable case-insensitive path finding on case sensitive filesystems. \nRESETS ON RESTART", &host.io.case_isens_find_enabled);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Allows emulator to attempt searching for files regardless of case on non-windows platforms");
+#endif
         ImGui::Separator();
         ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "Emulated System Storage Folder");
         ImGui::Spacing();

--- a/vita3k/io/include/io/functions.h
+++ b/vita3k/io/include/io/functions.h
@@ -37,6 +37,9 @@ void init_device_paths(IOState &io);
 bool init_savedata_app_path(IOState &io, const fs::path &pref_path);
 bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path, bool redirect_stdout);
 
+bool find_case_isens_path(IOState &io, VitaIoDevice &device, const fs::path &translated_path, const fs::path &system_path);
+fs::path find_in_cache(IOState &io, const std::string &system_path);
+
 std::string expand_path(IOState &io, const char *path, const std::wstring &pref_path);
 std::string translate_path(const char *path, VitaIoDevice &device, const IOState::DevicePaths &device_paths);
 

--- a/vita3k/io/include/io/state.h
+++ b/vita3k/io/include/io/state.h
@@ -117,4 +117,5 @@ struct IOState {
     DirEntries dir_entries;
 
     std::unordered_map<std::string, std::string> cachemap;
+    bool case_isens_find_enabled = false;
 };

--- a/vita3k/io/include/io/state.h
+++ b/vita3k/io/include/io/state.h
@@ -21,6 +21,7 @@
 #include <io/util.h>
 
 #include <map>
+#include <unordered_map>
 
 // Class for all needed information to access files on Vita3K.
 class FileStats : public VitaStats {
@@ -114,4 +115,6 @@ struct IOState {
     TtyFiles tty_files;
     StdFiles std_files;
     DirEntries dir_entries;
+
+    std::unordered_map<std::string, std::string> cachemap;
 };

--- a/vita3k/util/include/util/string_utils.h
+++ b/vita3k/util/include/util/string_utils.h
@@ -15,5 +15,6 @@ std::string remove_special_chars(std::string str);
 void replace(std::string &str, const std::string &in, const std::string &out);
 std::basic_string<uint8_t> string_to_byte_array(std::string string);
 std::string toupper(const std::string &s);
+std::string tolower(const std::string &s);
 
 } // namespace string_utils

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -214,6 +214,13 @@ std::string toupper(const std::string &s) {
     return r;
 }
 
+std::string tolower(const std::string &s) {
+    std::string r = s;
+    std::transform(r.begin(), r.end(), r.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+    return r;
+}
+
 } // namespace string_utils
 
 template <>


### PR DESCRIPTION
Fixes #681, on case-sensitive filesystems some files couldn't be found, code attempts to iterate through game directory and find a file. 

- [x] Fix file open/stat
- [x] Fix open dir 
- [x] Support for addcont 
- [x] Lazy evaluation caching of all paths