### PR TITLE
shader: Implement built in VertexID and InstanceID

### DIFF
--- a/vita3k/gxm/src/gxp.cpp
+++ b/vita3k/gxm/src/gxp.cpp
@@ -163,11 +163,11 @@ SceGxmVertexProgramOutputs get_vertex_outputs(const SceGxmProgram &program, SceG
     if (!program.is_vertex())
         return _SCE_GXM_VERTEX_PROGRAM_OUTPUT_INVALID;
 
-    auto vertex_outputs_ptr = reinterpret_cast<const SceGxmProgramVertexOutput *>(
+    auto vertex_varyings_ptr = reinterpret_cast<const SceGxmProgramVertexVaryings *>(
         reinterpret_cast<const std::uint8_t *>(&program.varyings_offset) + program.varyings_offset);
 
-    const std::uint32_t vo1 = vertex_outputs_ptr->vertex_outputs1;
-    const std::uint32_t vo2 = vertex_outputs_ptr->vertex_outputs2;
+    const std::uint32_t vo1 = vertex_varyings_ptr->vertex_outputs1;
+    const std::uint32_t vo2 = vertex_varyings_ptr->vertex_outputs2;
 
     const bool has_fog = vo1 & 0x200;
     const bool has_color = vo1 & 0x800;
@@ -230,9 +230,9 @@ SceGxmFragmentProgramInputs get_fragment_inputs(const SceGxmProgram &program) {
     const auto vo_offset = program.varyings_offset;
     const auto vo_offset_addr = (const std::uint8_t *)&program.varyings_offset;
 
-    const SceGxmProgramVertexOutput *vo_ptr = nullptr;
+    const SceGxmProgramVertexVaryings *vo_ptr = nullptr;
     if (vo_offset)
-        vo_ptr = (const SceGxmProgramVertexOutput *)(vo_offset_addr + vo_offset);
+        vo_ptr = (const SceGxmProgramVertexVaryings *)(vo_offset_addr + vo_offset);
 
     // following code is adapted from decompilation
     const uint8_t *vo_start = nullptr;

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -365,10 +365,12 @@ struct UniformInputSource {
     bool in_mem;
 };
 
-struct AttributeInputSoucre {
+struct AttributeInputSource {
     std::string name;
+
     // resource index
-    uint32_t index;
+    std::uint32_t index;
+    std::uint16_t semantic;
 };
 
 struct LiteralInputSource {
@@ -388,7 +390,7 @@ struct DependentSamplerInputSource {
 };
 
 // Read source field in Input struct
-using InputSource = std::variant<UniformInputSource, UniformBufferInputSource, LiteralInputSource, AttributeInputSoucre, DependentSamplerInputSource>;
+using InputSource = std::variant<UniformInputSource, UniformBufferInputSource, LiteralInputSource, AttributeInputSource, DependentSamplerInputSource>;
 
 /**
  * Input parameters that are usually copied into PA or SA


### PR DESCRIPTION
Fix some games unable to clear. VitaGL clear shader uses gl_VertexID kind of like that.

![image](https://user-images.githubusercontent.com/25717050/107140757-e41ad600-6956-11eb-8d18-c4317a98be73.png)
![image](https://user-images.githubusercontent.com/25717050/107140795-19bfbf00-6957-11eb-89e0-a33ff54e55a0.png)

