### PR TITLE
Add color format for Wipeout 2048 and fix color for racer

### DIFF
--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -480,8 +480,10 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
     // TODO Need more check into this
     switch (format) {
     case SCE_GXM_COLOR_FORMAT_U8U8U8U8_ABGR:
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, pixels);
+        break;
     case SCE_GXM_COLOR_FORMAT_U8U8U8U8_ARGB:
-        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_U8U8U8U8_RGBA:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_BYTE, pixels);
@@ -499,6 +501,9 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
         break;
     case SCE_GXM_COLOR_FORMAT_U8_R:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RED, GL_UNSIGNED_BYTE, pixels);
+        break;
+    case SCE_GXM_COLOR_FORMAT_U2F10F10F10_ABGR:
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_INT_2_10_10_10_REV, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_F16_R:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RED, GL_HALF_FLOAT, pixels);


### PR DESCRIPTION
works little inspired on @kd-11 works
- fix color one racer in Wipeout 2048
- fix caracterestique racer missing

# Result:  
- master
![image](https://user-images.githubusercontent.com/5261759/107229027-9c12b680-6a1d-11eb-9f5a-677330ce3fc1.png)
- pr 
![image](https://user-images.githubusercontent.com/5261759/107163235-bb233100-69a8-11eb-85e2-d380919321cd.png)
- master
![image](https://user-images.githubusercontent.com/5261759/107229213-cc5a5500-6a1d-11eb-93e2-e017809be143.png)
- pr
![image](https://user-images.githubusercontent.com/5261759/107163256-e6a61b80-69a8-11eb-906c-916e306bf807.png)
- master
![image](https://user-images.githubusercontent.com/5261759/107229277-e5fb9c80-6a1d-11eb-8f72-adabbb3ef01f.png)
- pr
![image](https://user-images.githubusercontent.com/5261759/107163264-ee65c000-69a8-11eb-91b4-5d34b1a12176.png)