### PR TITLE
renderer/gl: Implement decode E5M9 texture format.

### DIFF
--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -128,6 +128,31 @@ static size_t decompress_compressed_swizz_texture(SceGxmTextureBaseFormat fmt, v
     return 0;
 }
 
+/**
+ * \brief Try to decompress texture to 16-bit RGB floating point color.
+ *
+ * \param fmt    Texture base format.
+ * \param dest   Destination texture data. Size must be sufficient enough of align(width, 4) * height * 4 (bytes).
+ * \param data   Source data to decompress.
+ * \param width  Texture width.
+ * \param height Texture height.
+ *
+ * \return Void.
+ */
+void decompress_packed_float_e5m9m9m9(SceGxmTextureBaseFormat fmt, void *dest, const void *data, const uint32_t width, const uint32_t height) {
+    const uint32_t *in = reinterpret_cast<const uint32_t *>(data);
+    uint16_t *out = reinterpret_cast<uint16_t *>(dest);
+
+    for (uint32_t in_offset = 0, out_offset = 0; in_offset < width * height; ++in_offset) {
+        const uint32_t packed = in[in_offset];
+        const uint16_t exponent = static_cast<uint16_t>(packed >> 17);
+
+        out[out_offset++] = exponent | ((packed & (0x1FF << 18)) >> 17);
+        out[out_offset++] = exponent | ((packed & (0x1FF << 9)) >> 8);
+        out[out_offset++] = exponent | ((packed & 0x1FF) << 1);
+    }
+}
+
 void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem) {
     R_PROFILE(__func__);
 
@@ -192,7 +217,18 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
                 pixels = texture_data_decompressed.data();
             }
 
-            if (!((base_format >= SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP) && (base_format <= SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP))) {
+            switch (base_format) {
+            case SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP:
+            case SCE_GXM_TEXTURE_BASE_FORMAT_PVRT4BPP:
+            case SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII2BPP:
+            case SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP:
+                break;
+            case SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9:
+                texture_data_decompressed.resize(width * height * 6);
+                decompress_packed_float_e5m9m9m9(base_format, texture_data_decompressed.data(), pixels, width, height);
+                pixels = texture_data_decompressed.data();
+                break;
+            default:
                 // Convert data
                 texture_pixels_lineared.resize(width * height * bytes_per_pixel);
 
@@ -207,6 +243,7 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
 
                 if (need_decompress_and_unswizzle_on_cpu)
                     texture_data_decompressed.clear();
+                break;
             }
 
             pixels_per_stride = width;

--- a/vita3k/renderer/src/gl/texture_formats.cpp
+++ b/vita3k/renderer/src/gl/texture_formats.cpp
@@ -220,11 +220,13 @@ GLenum translate_internal_format(SceGxmTextureFormat src) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_U5U6U5:
     case SCE_GXM_TEXTURE_BASE_FORMAT_S5S5U6:
     case SCE_GXM_TEXTURE_BASE_FORMAT_X8S8S8U8:
-    case SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9:
     case SCE_GXM_TEXTURE_BASE_FORMAT_F11F11F10:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8:
     case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8:
         return GL_RGB;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9:
+        return GL_RGB16F;
 
     // 4 components.
     case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
@@ -390,8 +392,8 @@ GLenum translate_type(SceGxmTextureFormat format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_S32:
         return GL_INT;
     case SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9:
-        LOG_WARN("Unhandled base format SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9");
-        return GL_UNSIGNED_INT_5_9_9_9_REV;
+        LOG_WARN("Not perfectly handled base format SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9");
+        return GL_HALF_FLOAT;
     case SCE_GXM_TEXTURE_BASE_FORMAT_F11F11F10:
         LOG_WARN("Unhandled base format SCE_GXM_TEXTURE_BASE_FORMAT_F11F11F10");
         return GL_UNSIGNED_INT_2_10_10_10_REV;


### PR DESCRIPTION
Full based on @kd-11 commit, and fixed one mistake by me
- based on two commit:
https://github.com/kd-11/Vita3K/commit/1aec47263344311ac24ccdf52ebcbd6bceca60ec
https://github.com/kd-11/Vita3K/commit/9b9f2d5266fae68e2f2c76e294f066821ccef2a8

# Todo for futur
- fix color issue
- fix yellow things showed on screen
- fix the transition from one scene to another during the replay/intro

# Current Result:
- intro
![image](https://user-images.githubusercontent.com/5261759/107462009-74296d00-6b5b-11eb-82a6-2880681dff71.png)

- Player view in replay
![image](https://user-images.githubusercontent.com/5261759/107468038-90cba200-6b67-11eb-8505-059780097909.png)
