### PR TITLE
Random GXM game fixes for the chads

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1165,7 +1165,7 @@ typedef std::array<SceGxmTexture, SCE_GXM_MAX_TEXTURE_UNITS> TextureDatas;
 typedef std::array<Ptr<const void>, SCE_GXM_MAX_VERTEX_STREAMS> StreamDatas;
 
 struct GxmViewport {
-    SceGxmViewportMode enable = SCE_GXM_VIEWPORT_DISABLED;
+    SceGxmViewportMode enable = SCE_GXM_VIEWPORT_ENABLED;
     SceFVector3 offset;
     SceFVector3 scale;
 };

--- a/vita3k/renderer/include/renderer/gl/types.h
+++ b/vita3k/renderer/include/renderer/gl/types.h
@@ -23,6 +23,7 @@
 #include <renderer/types.h>
 
 #include <renderer/texture_cache_state.h>
+#include <shader/usse_program_analyzer.h>
 
 #include <map>
 #include <memory>
@@ -46,7 +47,6 @@ inline bool operator==(const ExcludedUniform &lhs, const ExcludedUniform &rhs) {
     return (lhs.name == rhs.name) && (lhs.program == rhs.program);
 }
 
-typedef std::map<GLuint, std::string> AttributeLocations;
 typedef std::map<std::string, SharedGLObject> ShaderCache;
 typedef std::tuple<std::string, std::string> ProgramHashes;
 typedef std::map<ProgramHashes, SharedGLObject> ProgramCache;
@@ -106,7 +106,7 @@ struct GLFragmentProgram : public renderer::FragmentProgram {
 
 struct GLVertexProgram : public renderer::VertexProgram {
     GLShaderStatics statics;
-    AttributeLocations attribute_locations;
+    shader::usse::AttributeInformationMap attribute_infos;
 };
 
 struct GLRenderTarget : public renderer::RenderTarget {

--- a/vita3k/renderer/src/gl/attribute_formats.cpp
+++ b/vita3k/renderer/src/gl/attribute_formats.cpp
@@ -11,6 +11,7 @@ GLenum attribute_format_to_gl_type(SceGxmAttributeFormat format) {
     case SCE_GXM_ATTRIBUTE_FORMAT_U8:
     case SCE_GXM_ATTRIBUTE_FORMAT_U8N:
         return GL_UNSIGNED_BYTE;
+
     case SCE_GXM_ATTRIBUTE_FORMAT_S8:
     case SCE_GXM_ATTRIBUTE_FORMAT_S8N:
         return GL_BYTE;

--- a/vita3k/renderer/src/gl/compile_program.cpp
+++ b/vita3k/renderer/src/gl/compile_program.cpp
@@ -49,14 +49,6 @@ static SharedGLObject compile_glsl(GLenum type, const std::string &source) {
     return shader;
 }
 
-static void bind_attribute_locations(GLuint gl_program, const GLVertexProgram &program) {
-    R_PROFILE(__func__);
-
-    for (const AttributeLocations::value_type &binding : program.attribute_locations) {
-        glBindAttribLocation(gl_program, binding.first / sizeof(uint32_t), binding.second.c_str());
-    }
-}
-
 static void bind_uniform_block_locations(GLuint gl_program, const SceGxmProgram &program) {
     std::string name_type = (program.is_vertex() ? "vert" : "frag");
 
@@ -153,9 +145,6 @@ SharedGLObject compile_program(ProgramCache &program_cache, ShaderCache &vertex_
 
     glAttachShader(program->get(), fragment_shader->get());
     glAttachShader(program->get(), vertex_shader->get());
-
-    bind_attribute_locations(program->get(), vertex_program);
-
     glLinkProgram(program->get());
 
     if (!features.use_shader_binding) {

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -93,22 +93,6 @@ static GLenum translate_blend_factor(SceGxmBlendFactor src) {
     }
 }
 
-static AttributeLocations attribute_locations(const SceGxmProgram &vertex_program) {
-    R_PROFILE(__func__);
-    AttributeLocations locations;
-
-    const SceGxmProgramParameter *const parameters = gxp::program_parameters(vertex_program);
-    for (uint32_t i = 0; i < vertex_program.parameter_count; ++i) {
-        const SceGxmProgramParameter &parameter = parameters[i];
-        if (parameter.category == SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE) {
-            std::string name = gxp::parameter_name(parameter);
-            locations.emplace(parameter.resource_index, name);
-        }
-    }
-
-    return locations;
-}
-
 void bind_fundamental(GLContext &context) {
     // Bind the vertex array and element buffer.
     glBindVertexArray(context.vertex_array[0]);
@@ -408,8 +392,7 @@ bool create(std::unique_ptr<VertexProgram> &vp, GLState &state, const SceGxmProg
     gxp_ptr_map.emplace(hash_bytes_v, &program);
 
     shader::usse::get_uniform_buffer_sizes(program, vp->uniform_buffer_sizes);
-
-    vert_program_gl->attribute_locations = attribute_locations(program);
+    shader::usse::get_attribute_informations(program, vert_program_gl->attribute_infos);
 
     return true;
 }

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -96,7 +96,7 @@ void set_fragment_texture(State &state, Context *ctx, GxmContextState *gxm_conte
 void set_viewport(State &state, Context *ctx, GxmContextState *gxm_context, float xOffset, float yOffset, float zOffset, float xScale, float yScale, float zScale) {
     switch (state.current_backend) {
     default:
-        renderer::add_state_set_command(ctx, renderer::GXMState::Viewport, SCE_GXM_VIEWPORT_ENABLED, true, xOffset, yOffset,
+        renderer::add_state_set_command(ctx, renderer::GXMState::Viewport, true, xOffset, yOffset,
             zOffset, xScale, yScale, zScale);
 
         break;
@@ -106,7 +106,7 @@ void set_viewport(State &state, Context *ctx, GxmContextState *gxm_context, floa
 void set_viewport_enable(State &state, Context *ctx, GxmContextState *gxm_context, SceGxmViewportMode enable) {
     switch (state.current_backend) {
     default:
-        renderer::add_state_set_command(ctx, renderer::GXMState::Viewport, enable, false);
+        renderer::add_state_set_command(ctx, renderer::GXMState::Viewport, false, enable);
         break;
     }
 }

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -127,7 +127,7 @@ COMMAND_SET_STATE(viewport) {
         state->viewport.scale.x = helper.pop<float>();
         state->viewport.scale.y = helper.pop<float>();
         state->viewport.scale.z = helper.pop<float>();
-    } else {    
+    } else {
         state->viewport.enable = helper.pop<SceGxmViewportMode>();
     }
 

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -118,7 +118,6 @@ COMMAND_SET_STATE(uniform_buffer) {
 }
 
 COMMAND_SET_STATE(viewport) {
-    state->viewport.enable = helper.pop<SceGxmViewportMode>();
     const bool set_viewport_param = helper.pop<bool>();
 
     if (set_viewport_param) {
@@ -128,6 +127,8 @@ COMMAND_SET_STATE(viewport) {
         state->viewport.scale.x = helper.pop<float>();
         state->viewport.scale.y = helper.pop<float>();
         state->viewport.scale.z = helper.pop<float>();
+    } else {    
+        state->viewport.enable = helper.pop<SceGxmViewportMode>();
     }
 
     // Sync

--- a/vita3k/shader/include/shader/usse_program_analyzer.h
+++ b/vita3k/shader/include/shader/usse_program_analyzer.h
@@ -68,10 +68,32 @@ struct USSEBlock {
     }
 };
 
+struct AttributeInformation {
+    std::uint32_t info;
+
+    explicit AttributeInformation()
+        : info(0) {
+    }
+
+    explicit AttributeInformation(const std::uint16_t loc, const std::uint16_t gxm_type)
+        : info(loc | (static_cast<std::uint32_t>(gxm_type) << 16)) {
+    }
+
+    std::uint16_t location() const {
+        return static_cast<std::uint16_t>(info);
+    }
+
+    std::uint16_t gxm_type() const {
+        return static_cast<std::uint16_t>(info >> 16);
+    }
+};
+
 using UniformBufferMap = std::map<int, UniformBuffer>;
+using AttributeInformationMap = std::map<int, AttributeInformation>;
 
 using USSEOffset = std::uint32_t;
 
+void get_attribute_informations(const SceGxmProgram &program, AttributeInformationMap &locmap);
 void get_uniform_buffer_sizes(const SceGxmProgram &program, UniformBufferSizes &sizes);
 int match_uniform_buffer_with_buffer_size(const SceGxmProgram &program, const SceGxmProgramParameter &parameter, const shader::usse::UniformBufferMap &buffers);
 

--- a/vita3k/shader/src/usse_program_analyzer.cpp
+++ b/vita3k/shader/src/usse_program_analyzer.cpp
@@ -166,4 +166,17 @@ void get_uniform_buffer_sizes(const SceGxmProgram &program, UniformBufferSizes &
         sizes[index] = buffer.size;
     }
 }
+
+void get_attribute_informations(const SceGxmProgram &program, AttributeInformationMap &locmap) {
+    const SceGxmProgramParameter *const gxp_parameters = gxp::program_parameters(program);
+    std::uint32_t fcount_allocated = 0;
+
+    for (size_t i = 0; i < program.parameter_count; ++i) {
+        const SceGxmProgramParameter &parameter = gxp_parameters[i];
+        if (parameter.category == SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE) {
+            locmap.emplace(parameter.resource_index, AttributeInformation(fcount_allocated / 4, parameter.type));
+            fcount_allocated += ((parameter.array_size * parameter.component_count + 3) / 4) * 4;
+        }
+    }
+}
 } // namespace shader::usse


### PR DESCRIPTION
- Enable viewport by default (I have noticed a bunch of games don't set viewport mode at all)
- Only set viewport mode to enable/disable when in function sceGxmSetViewportEnable. We overwritten the viewport setting in sceGxmBeginScene, if this is set outside. Fix Haiyore rendering
- Allocate each input attribute in shader a location
    * Previously we manually queried them. I don't know if this break homebrew hand-written shader.
- Calculate attribute location using linear allocation, not by dividing register index.
    * There are some cases when the input variable in shader are not aligned by 4 floats, so for example half4 a, half4 b will have the same attribute location (0/4 and 2/4 = 0), if we use old method
    * Old method results in some attributes being disabled and overwritten.
    * => Should fix Berserk rendering