### PR TITLE
Small fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ endif()
 enable_testing()
 
 macro(pre_configure_boost)
-	find_package(Boost COMPONENTS filesystem system QUIET)
+	set (Boost_USE_STATIC_LIBS ON)
+	find_package(Boost COMPONENTS filesystem system program_options QUIET)
 
 	if (Boost_FOUND)
 		set(BOOST_INCLUDEDIR ${Boost_INCLUDE_DIRS})

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -377,6 +377,10 @@ SceOff tell_file(IOState &io, const SceUID fd, const char *export_name) {
 
     const auto std_file = io.std_files.find(fd);
 
+    if (std_file == io.std_files.end()) {
+        return IO_ERROR(SCE_ERROR_ERRNO_EBADFD);
+    }
+
     return std_file->second.tell();
 }
 

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -43,9 +43,7 @@ Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID th
 
     const Ptr<Ptr<void>> address(tls);
 
-    if (!kernel.tls_address) {
-        return address;
-    } else {
+    if (kernel.tls_address) {
         auto alloc_name = fmt::format("TLS for thread #{} {}", thread_id, key);
         // TODO Use a finer-grained allocator.
         // TODO This is a memory leak.
@@ -55,8 +53,9 @@ Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID th
 
         *address.get(mem) = new_tls;
         slot_to_address.insert(SlotToAddress::value_type(key, address));
-        return address;
     }
+    *(address.get(mem)) = 0;
+    return address;
 }
 
 void stop_all_threads(KernelState &kernel) {

--- a/vita3k/kernel/src/thread/thread.cpp
+++ b/vita3k/kernel/src/thread/thread.cpp
@@ -131,6 +131,12 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
 
     write_tpidruro(*thread->cpu, tls_address);
 
+    Ptr<void> tls_address_ptr(tls_address);
+    memset(tls_address_ptr.get(mem), 0, 0x800);
+    if (kernel.tls_address) {
+        assert(kernel.tls_psize <= 0x800 / 4);
+        memcpy(tls_address_ptr.get(mem), kernel.tls_address.get(mem), 4 * kernel.tls_psize);
+    }
     WaitingThreadState waiting{ name };
 
     const std::unique_lock<std::mutex> lock(kernel.mutex);

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -267,7 +267,7 @@ EXPORT(int, _sceKernelGetThreadInfo, SceUID thid, SceKernelThreadInfo *info) {
     const ThreadStatePtr thread = lock_and_find(thid ? thid : thread_id, host.kernel.threads, host.kernel.mutex);
 
     strncpy(info->name, thread->name.c_str(), 0x1f);
-    info->stack = Ptr<void>(thread->stack->get());
+    info->stack = Ptr<void>(thread->stack.get(), host.mem);
     info->stackSize = thread->stack_size;
     info->initPriority = thread->priority;
     info->currentPriority = thread->priority;


### PR DESCRIPTION
Different small fixes.
cmake: improved boost search  - fix #1037 can't be checked by CI. need manual check on linux and macos
kernel: Clear TLS on first get - not a good fix, all TLS shoul be rewritten, but now it make possible to run libUlt.suprx used in some games
modules/sceLibKernel: _sceKernelGetThreadInfo. fix stack pointer - looks like misprint, and also fix libUlt.suprx

Mostly help to run "Ar nosurge Plus - Ode to an Unborn Star" [PCSE00707] 
