### PR TITLE
fix log name for archive log.

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -305,9 +305,10 @@ static ExitCode load_app_impl(Ptr<const void> &entry_point, HostState &host, con
     if (host.cfg.archive_log) {
         const fs::path log_directory{ host.base_path + "/logs" };
         fs::create_directory(log_directory);
-        const auto log_name{ log_directory / (string_utils::remove_special_chars(host.current_app_title) + " - [" + host.io.title_id + "].log") };
-        if (logging::add_sink(log_name) != Success)
+        const auto log_path{ log_directory / string_utils::utf_to_wide(host.io.title_id + " - [" + string_utils::remove_special_chars(host.current_app_title) + "].log") };
+        if (logging::add_sink(log_path) != Success)
             return InitConfigFailed;
+        logging::set_level(static_cast<spdlog::level::level_enum>(host.cfg.log_level));
     }
 
     LOG_INFO("ngs experimental state: {}", !host.cfg.disable_ngs);


### PR DESCRIPTION
- fix log name for special character with enable archive log for jap/etc...
- inverse order titile / id for more easy order in log list 
- fix log level choice if archive log enable

# Result
- master
![image](https://user-images.githubusercontent.com/5261759/108238978-ba796000-7149-11eb-848c-d3a3af115f36.png)

- pr
![image](https://user-images.githubusercontent.com/5261759/108259353-46e34d00-7161-11eb-9356-4d7ba226d876.png)

- real name
![image](https://user-images.githubusercontent.com/5261759/108241666-5b691a80-714c-11eb-9551-5c3259df8cb1.png)

