### PR TITLE
kernel: reimplement run_callback

### DIFF
--- a/vita3k/app/include/app/functions.h
+++ b/vita3k/app/include/app/functions.h
@@ -23,6 +23,7 @@ struct Config;
 struct HostState;
 struct SDL_Window;
 struct ImGui_State;
+struct CPUDepInject;
 template <class T>
 class Ptr;
 class Root;
@@ -39,7 +40,7 @@ enum class AppRunType {
     Vpk,
 };
 
-bool init(HostState &state, Config &cfg, const Root &root_paths);
+bool init(HostState &state, Config &cfg, const Root &root_paths, CPUDepInject inject);
 void destroy(HostState &host, ImGui_State *imgui);
 void update_viewport(HostState &state);
 void error_dialog(const std::string &message, SDL_Window *window = nullptr);

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -94,7 +94,7 @@ void update_viewport(HostState &state) {
     }
 }
 
-bool init(HostState &state, Config &cfg, const Root &root_paths) {
+bool init(HostState &state, Config &cfg, const Root &root_paths, CPUDepInject inject) {
     const ResumeAudioThread resume_thread = [&state](SceUID thread_id) {
         const auto thread = lock_and_find(thread_id, state.kernel.threads, state.kernel.mutex);
         const std::lock_guard<std::mutex> lock(thread->mutex);
@@ -176,6 +176,11 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
         discordrpc::update_presence();
     }
 #endif
+
+    for (int i = 0; i < cfg.cpu_pool_size; ++i) {
+        auto item = init_cpu(0, 0, 0, state.mem, inject);
+        state.kernel.cpu_pool.add(std::move(item));
+    }
 
     state.kernel.start_tick = { rtc_base_ticks() };
     state.kernel.base_tick = { rtc_base_ticks() };

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -41,6 +41,7 @@
     code(int, "sys-button", static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS), sys_button)          \
     code(int, "sys-lang", static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US), sys_lang)                 \
     code(bool, "lle-kernel", false, lle_kernel)                                                         \
+    code(int, "cpu-pool-size", 10, cpu_pool_size)                                                       \
     code(bool, "auto-lle", false, auto_lle)                                                             \
     code(int, "delay-background", 4, delay_background)                                                  \
     code(int, "delay-start", 10, delay_start)                                                           \

--- a/vita3k/cpu/include/cpu/functions.h
+++ b/vita3k/cpu/include/cpu/functions.h
@@ -111,6 +111,8 @@ std::stack<StackFrame> get_stack_frames(CPUState &state);
 void push_stack_frame(CPUState &state, StackFrame sf);
 void log_stack_frames(CPUState &cpu);
 bool is_returning(CPUState &cpu);
+void set_thread_id(CPUState &state, SceUID thread_id);
+SceUID get_thread_id(CPUState &state);
 
 void push_lr(CPUState &cpu, Address lr);
 Address pop_lr(CPUState &cpu);

--- a/vita3k/cpu/src/cpu.cpp
+++ b/vita3k/cpu/src/cpu.cpp
@@ -663,3 +663,11 @@ void load_context(CPUState &state, CPUContext &ctx) {
     write_lr(state, ctx.lr);
     write_sp(state, ctx.sp);
 }
+
+void set_thread_id(CPUState &state, SceUID thread_id) {
+    state.thread_id = thread_id;
+}
+
+SceUID get_thread_id(CPUState &state) {
+    return state.thread_id;
+}

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -17,13 +17,13 @@
 
 #pragma once
 
+#include <codec/state.h>
 #include <cpu/functions.h>
 #include <kernel/thread/thread_state.h>
 #include <kernel/types.h>
 #include <mem/ptr.h>
-
-#include <codec/state.h>
 #include <rtc/rtc.h>
+#include <util/pool.h>
 
 #include <atomic>
 #include <map>
@@ -60,6 +60,7 @@ typedef std::map<Address, uint32_t> NidFromExport;
 typedef std::map<Address, uint32_t> NotFoundVars;
 typedef std::map<Address, WatchMemory> WatchMemoryAddrs;
 typedef std::vector<ModuleRegion> ModuleRegions;
+typedef Pool<CPUState> CPUPool;
 
 struct WaitingThreadData {
     ThreadStatePtr thread;
@@ -322,6 +323,7 @@ struct KernelState {
     NotFoundVars not_found_vars;
     WatchMemoryAddrs watch_memory_addrs;
     ModuleRegions module_regions;
+    CPUPool cpu_pool;
 
     InitialFibers initial_fibers;
     SceRtcTick start_tick;

--- a/vita3k/kernel/include/kernel/thread/thread_functions.h
+++ b/vita3k/kernel/include/kernel/thread/thread_functions.h
@@ -23,6 +23,7 @@
 
 #include <functional>
 #include <memory>
+#include <vector>
 
 struct CPUState;
 struct ThreadState;
@@ -36,6 +37,6 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
 int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const Ptr<void> &argp);
 Ptr<void> copy_stack(SceUID thid, SceUID thread_id, const Ptr<void> &argp, KernelState &kernel, MemState &mem);
 bool run_thread(ThreadState &thread, bool callback);
-bool run_callback(ThreadState &thread, Address &pc, Address &data);
+int run_callback(KernelState &kernel, ThreadState &thread, const SceUID &thid, Address callback_address, const std::vector<uint32_t> &args);
 uint32_t run_on_current(ThreadState &thread, const Ptr<const void> entry_point, SceSize arglen, const Ptr<void> &argp, bool callback = false);
 void raise_waiting_threads(ThreadState *thread);

--- a/vita3k/kernel/src/thread/thread.cpp
+++ b/vita3k/kernel/src/thread/thread.cpp
@@ -78,17 +78,6 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
         free(mem, stack);
     };
 
-    const CallSVC call_svc = [inject, thid, &mem](CPUState &cpu, uint32_t imm, Address pc) {
-        uint32_t nid;
-        if (is_returning(cpu)) {
-            nid = *Ptr<uint32_t>(pc).get(mem);
-        } else {
-            nid = *Ptr<uint32_t>(pc + 4).get(mem);
-        }
-        inject.call_import(cpu, nid, thid);
-    };
-    inject.call_svc = call_svc;
-
     const ThreadStatePtr thread = std::make_shared<ThreadState>();
     thread->name = name;
     thread->entry_point = entry_point.address();

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -25,6 +25,7 @@
 #include <gui/state.h>
 #include <host/pkg.h>
 #include <host/state.h>
+#include <modules/module_parent.h>
 #include <renderer/functions.h>
 #include <shader/spirv_recompiler.h>
 #include <util/log.h>
@@ -127,7 +128,8 @@ int main(int argc, char *argv[]) {
         vpk_path_wide = string_utils::utf_to_wide(*cfg.run_title_id);
     }
 
-    if (!app::init(host, cfg, root_paths)) {
+    auto inject = create_cpu_dep_inject(host);
+    if (!app::init(host, cfg, root_paths, inject)) {
         app::error_dialog("Host initialization failed.", host.window.get());
         return HostInitFailed;
     }

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1064,7 +1064,7 @@ static int SDLCALL thread_function(void *data) {
                 break;
         }
         const ThreadStatePtr display_thread = util::find(params.thid, params.kernel->threads);
-        run_callback(*display_thread, display_callback->pc, display_callback->data);
+        run_callback(*params.kernel, *display_thread, params.thid, display_callback->pc, { display_callback->data });
 
         free(*params.mem, display_callback->data);
 

--- a/vita3k/modules/SceNetCtl/SceNetCtl.cpp
+++ b/vita3k/modules/SceNetCtl/SceNetCtl.cpp
@@ -117,8 +117,7 @@ EXPORT(int, sceNetCtlCheckCallback) {
 
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
     for (auto &callback : host.net.cbs) {
-        Ptr<void> argp = Ptr<void>(callback.second.data);
-        run_on_current(*thread, Ptr<void>(callback.second.pc), 1, argp);
+        run_callback(host.kernel, *thread, thread_id, callback.second.pc, { 1, callback.second.data });
     }
     return STUBBED("Stub");
 }

--- a/vita3k/modules/SceNpManager/SceNpManager.cpp
+++ b/vita3k/modules/SceNpManager/SceNpManager.cpp
@@ -47,8 +47,7 @@ EXPORT(int, sceNpCheckCallback) {
 
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
     for (auto &callback : host.np.cbs) {
-        Ptr<void> argp = Ptr<void>(callback.second.data);
-        run_on_current(*thread, Ptr<void>(callback.second.pc), host.np.state, argp);
+        run_callback(host.kernel, *thread, thread_id, callback.second.pc, { (uint32_t)host.np.state, callback.second.data });
     }
 
     return STUBBED("Stub");

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -239,5 +239,15 @@ CPUDepInject create_cpu_dep_inject(HostState &host) {
     inject.trace_stack = host.cfg.stack_traceback;
     inject.get_watch_memory_addr = get_watch_memory_addr;
     inject.module_regions = host.kernel.module_regions;
+    const CallSVC call_svc = [inject, &host](CPUState &cpu, uint32_t imm, Address pc) {
+        uint32_t nid;
+        if (is_returning(cpu)) {
+            nid = *Ptr<uint32_t>(pc).get(host.mem);
+        } else {
+            nid = *Ptr<uint32_t>(pc + 4).get(host.mem);
+        }
+        inject.call_import(cpu, nid, get_thread_id(cpu));
+    };
+    inject.call_svc = call_svc;
     return inject;
 }

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -161,9 +161,7 @@ void call_import(HostState &host, CPUState &cpu, uint32_t nid, SceUID thread_id)
 
         const std::unordered_set<uint32_t> lle_nid_blacklist = {};
         log_import_call('L', nid, thread_id, lle_nid_blacklist, pc);
-        const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
-        const std::lock_guard<std::mutex> lock(thread->mutex);
-        write_pc(*thread->cpu, export_pc);
+        write_pc(cpu, export_pc);
     }
 }
 

--- a/vita3k/util/CMakeLists.txt
+++ b/vita3k/util/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
     include/util/lock_and_find.h
     include/util/log.h
     include/util/preprocessor.h
+    include/util/pool.h
     include/util/resource.h
     include/util/string_utils.h
     include/util/system.h

--- a/vita3k/util/include/util/pool.h
+++ b/vita3k/util/include/util/pool.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <set>
+#include <vector>
+
+template <typename T>
+class PoolItem;
+
+// Pool class for public static resources
+template <typename T>
+class Pool {
+public:
+    typedef std::unique_ptr<T, std::function<void(T *)>> Ptr;
+    Pool() {
+    }
+
+    void add(Ptr item) {
+        free_ids.insert(items.size());
+        items.push_back(std::move(item));
+    }
+
+    int available() {
+        std::unique_lock<std::mutex> lock(mutex);
+        return free_ids.size();
+    }
+
+    // borrow returns PoolItem instance wrapping one of available resources in the pool
+    // if there's no available resource, the thread will wait until resources are returned to the pool
+    // if PoolItem instance is destroyed, the corresponding resource is considerd to be returned to the pool
+    PoolItem<T> borrow();
+
+private:
+    void release(int id) {
+        std::unique_lock<std::mutex> lock(mutex);
+        free_ids.insert(id);
+        cond.notify_one();
+    }
+
+    Pool(const Pool &);
+    const Pool &operator=(const Pool &);
+
+    std::mutex mutex;
+    std::condition_variable cond;
+    std::vector<Ptr> items;
+    std::set<int> free_ids;
+
+    friend class PoolItem<T>;
+};
+
+template <typename T>
+class PoolItem {
+public:
+    PoolItem(Pool<T> *parent, T *item, int id)
+        : parent(parent)
+        , item(item)
+        , id(id) {
+    }
+
+    T *get() {
+        return item;
+    }
+
+    ~PoolItem() {
+        parent->release(id);
+    }
+
+private:
+    PoolItem(const PoolItem &);
+    const PoolItem &operator=(const PoolItem &);
+
+    Pool<T> *parent;
+    int id;
+    T *item;
+};
+
+template <typename T>
+PoolItem<T> Pool<T>::borrow() {
+    std::unique_lock<std::mutex> lock(mutex);
+    cond.wait(lock, [&] { return !free_ids.empty(); });
+    auto it = free_ids.begin();
+    int id = *it;
+    free_ids.erase(it);
+    return PoolItem<T>(this, items[id].get(), id);
+}


### PR DESCRIPTION
This should be without erratic bug when calling lle callback function (after running one callback function it will go outside the interrupt handler) 

I used cpu instance pool to solve the problem. It grabs one cpu instance from the pool, execute the lle code on it, and return instance to the pool. If service call is made inside lle callback code, it should work fine, since it's brand new cpu instance separate from the original cpu instance of the thread (the one called something like sceNpCheckCallback) The cursed nested loop like service call -> callback -> service call -> callback -> service call also work fine. But, if the depth is higher than the volume of cpu pool, it would break. I set it to 10 for now. I think it should work fine as long as there's no infinite recursion or something.

The reason for pooling is because of unicorn instance tlb cache. The instance holds its own jit cache, and the overhead for translation is quite high. Pooling can help this. However, since we almost randomly draw an instance from the pool, the instance might not have helpful jit cache. Solving this problem is interesting further work. We can try using thread_id to draw more appropriate instance. (e.g. this instance was used by thread 3 before, so it should have jit cache helpful for lle callback execed from thread 3) 

