### PR TITLE
io: Fix get_device work case insensitive, also delete extra device path

### DIFF
--- a/vita3k/io/include/io/device.h
+++ b/vita3k/io/include/io/device.h
@@ -38,7 +38,8 @@ inline VitaIoDevice get_device(const std::string &path) {
     if (colon == std::string::npos)
         return VitaIoDevice::_INVALID;
 
-    const auto p = path.substr(0, colon);
+    auto p = path.substr(0, colon);
+    std::transform(p.begin(), p.end(), p.begin(), tolower);
     if (VitaIoDevice::_is_valid_nocase(p.c_str()))
         return VitaIoDevice::_from_string(p.c_str());
 
@@ -105,6 +106,8 @@ inline std::string remove_duplicate_device(const std::string &path, VitaIoDevice
     auto cur_path = remove_device_from_path(path, device);
     if (get_device(cur_path) != VitaIoDevice::_INVALID) {
         device = get_device(cur_path);
+        if (cur_path.find_first_of(':') != std::string::npos)
+            cur_path = remove_duplicate_device(cur_path, device);
         return cur_path;
     }
 


### PR DESCRIPTION
#### What does this PR do?
Which problem(s) does it fix and how? What does this PR add?
Some games send "app0:APP0" and get_device will fail because of the all caps APP0, this fixes it by making the device part all lowercase and then getting the device

Also deletes extra device paths on path recursively (app0:APP0:/pog/champ.txt => ux0/app/GAMEID/pog/champ.txt)
* Makes PCSG01093 [このすば Attack of the Destroyer] bootable