### PR TITLE
modules/SceGxm: Stub TextureInitCube.

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2663,11 +2663,14 @@ EXPORT(uint32_t, sceGxmTextureGetWidth, const SceGxmTexture *texture) {
     return static_cast<uint32_t>(gxm::get_width(texture));
 }
 
-EXPORT(int, sceGxmTextureInitCube, SceGxmTexture *texture, const void *data, SceGxmTextureFormat texFormat, uint32_t width, uint32_t height, uint32_t mipCount) {
+EXPORT(int, sceGxmTextureInitCube, SceGxmTexture *texture, Ptr<const void> data, SceGxmTextureFormat texFormat, uint32_t width, uint32_t height, uint32_t mipCount) {
     if (!texture) {
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
     }
-    return UNIMPLEMENTED();
+    STUBBED("Stub InitCube");
+    const int result = init_texture_base(export_name, texture, data, texFormat, width, height, mipCount, SCE_GXM_TEXTURE_CUBE);
+
+    return result;
 }
 
 EXPORT(int, sceGxmTextureInitCubeArbitrary, SceGxmTexture *texture, const void *data, SceGxmTextureFormat texFormat, uint32_t width, uint32_t height, uint32_t mipCount) {


### PR DESCRIPTION
- get improvement status on very some game request this function, can move some game to nothing to ingame or menu/intro etc 

# Exemple: 
- Secret of mana move from nothing to menu
![image](https://user-images.githubusercontent.com/5261759/108607874-64175600-73c3-11eb-8ccb-dbafea73d6e2.png)
