### PR TITLE
gui: Refactor get user app info.

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -46,12 +46,14 @@ std::map<std::string, std::string> get_date_time(GuiState &gui, HostState &host,
 bool get_live_area_sys_app_state(GuiState &gui);
 void get_modules_list(GuiState &gui, HostState &host);
 std::string get_unit_size(const size_t &size);
+void get_user_app_params(GuiState &gui, HostState &host, const std::string &title_id);
 void get_user_apps_title(GuiState &gui, HostState &host);
 void get_sys_apps_title(GuiState &gui, HostState &host);
 void init(GuiState &gui, HostState &host);
 void init_app_background(GuiState &gui, HostState &host, const std::string &title_id);
 void init_apps_icon(GuiState &gui, HostState &host, const std::vector<gui::App> &apps_list);
 void init_content_manager(GuiState &gui, HostState &host);
+void init_home(GuiState &gui, HostState &host);
 void init_lang(GuiState &gui, HostState &host);
 void init_live_area(GuiState &gui, HostState &host);
 bool init_manual(GuiState &gui, HostState &host);
@@ -79,7 +81,7 @@ void draw_ui(GuiState &gui, HostState &host);
 
 void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &title_id);
 void draw_common_dialog(GuiState &gui, HostState &host);
-void draw_reinstall_dialog(GenericDialogState *status);
+void draw_reinstall_dialog(GenericDialogState *status, HostState &host);
 void draw_trophies_unlocked(GuiState &gui, HostState &host);
 void draw_perf_overlay(GuiState &gui, HostState &host);
 

--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -93,13 +93,11 @@ void pre_load_app(GuiState &gui, HostState &host, bool live_area, const std::str
 void pre_run_app(GuiState &gui, HostState &host, const std::string &title_id) {
     gui.live_area.live_area_screen = false;
     if (title_id.find("NPXS") == std::string::npos) {
-        if (host.io.title_id != title_id) {
-            host.io.title_id = title_id;
-
-            if (host.cfg.overwrite_config) {
-                host.cfg.last_app = title_id;
-                config::serialize_config(host.cfg, host.cfg.config_path);
-            }
+        get_user_app_params(gui, host, title_id);
+        host.io.title_id = host.app_title_id;
+        if (host.cfg.overwrite_config && (host.cfg.last_app != host.io.title_id)) {
+            host.cfg.last_app = title_id;
+            config::serialize_config(host.cfg, host.cfg.config_path);
         }
         gui.live_area.information_bar = false;
     } else {

--- a/vita3k/gui/src/perf_overlay.cpp
+++ b/vita3k/gui/src/perf_overlay.cpp
@@ -23,7 +23,6 @@
 
 namespace gui {
 static const ImVec2 PERF_OVERLAY_POS = ImVec2(10.0f, 10.0f);
-static const ImVec2 PERF_OVERLAY_WINDOW_SIZE = ImVec2(40.0f, 15.0f);
 static const ImVec4 PERF_OVERLAY_BG_COLOR = ImVec4(0.282f, 0.239f, 0.545f, 1.0f);
 
 void draw_perf_overlay(GuiState &gui, HostState &host) {
@@ -31,7 +30,7 @@ void draw_perf_overlay(GuiState &gui, HostState &host) {
     ImGui::SetNextWindowBgAlpha(0.8f);
     ImGui::PushStyleColor(ImGuiCol_WindowBg, PERF_OVERLAY_BG_COLOR);
 
-    ImGui::Begin("##performance", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar);
+    ImGui::Begin("##performance", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     ImGui::Text("FPS: %d", host.fps);
     ImGui::End();
 

--- a/vita3k/gui/src/reinstall.cpp
+++ b/vita3k/gui/src/reinstall.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2018 Vita3K team
+// Copyright (C) 2021 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,17 +15,21 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include "private.h"
 #include <gui/functions.h>
 
 #include <imgui.h>
 
 namespace gui {
 
-void draw_reinstall_dialog(GenericDialogState *status) {
+void draw_reinstall_dialog(GenericDialogState *status, HostState &host) {
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f, ImGui::GetIO().DisplaySize.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(0, 0));
-    ImGui::Begin("Reinstall this application?");
-    ImGui::Text("This application is already installed.");
+    ImGui::Begin("Reinstall this content?");
+    ImGui::Text("This content is already installed.");
+    ImGui::Spacing();
+    ImGui::Text("Title: %s.\nTitle ID: %s.\nVersion: %s.", host.app_title.c_str(), host.app_title_id.c_str(), host.app_version.c_str());
+    ImGui::Spacing();
     ImGui::Text("Do you want to reinstall it and overwrite existing data?");
     if (ImGui::Button("Yes")) {
         *status = CONFIRM_STATE;

--- a/vita3k/interface.h
+++ b/vita3k/interface.h
@@ -37,5 +37,5 @@ inline void delete_zip(mz_zip_archive *zip) {
 bool handle_events(HostState &host, GuiState &gui);
 
 bool install_archive(HostState &host, GuiState *gui, const fs::path &path, const std::function<void(float)> &progress_callback = nullptr);
-ExitCode load_app(Ptr<const void> &entry_point, HostState &host, const std::wstring &path, app::AppRunType run_type);
+ExitCode load_app(Ptr<const void> &entry_point, HostState &host, const std::wstring &path);
 ExitCode run_app(HostState &host, Ptr<const void> &entry_point);


### PR DESCRIPTION
# About this PR
- for can fix app icon missing if return on live area in commend line run idn, fix also get good name after launch and remove double code no needed anymore 
- refactor main for get app id and fix vpk drop, and stop using vpk path wide for app id, no have sense, more smart without repeat code
- change code for can open home and no boot  content if is no app. 
- remove also old code no used anymore.
- add drop file possible for can install content and refactor reinstall dialog for can show what app you try reinstall.