### PR TITLE
gxm: Implement untype attribute format

### DIFF
--- a/vita3k/gxm/src/attributes.cpp
+++ b/vita3k/gxm/src/attributes.cpp
@@ -17,6 +17,8 @@ size_t attribute_format_size(SceGxmAttributeFormat format) {
         return 2;
     case SCE_GXM_ATTRIBUTE_FORMAT_F32:
         return 4;
+    case SCE_GXM_ATTRIBUTE_FORMAT_UNTYPED:
+        return 4;
     default:
         LOG_ERROR("Unsupported attribute format {}", log_hex(format));
         return 4;

--- a/vita3k/renderer/src/gl/attribute_formats.cpp
+++ b/vita3k/renderer/src/gl/attribute_formats.cpp
@@ -26,8 +26,7 @@ GLenum attribute_format_to_gl_type(SceGxmAttributeFormat format) {
     case SCE_GXM_ATTRIBUTE_FORMAT_F32:
         return GL_FLOAT;
     case SCE_GXM_ATTRIBUTE_FORMAT_UNTYPED:
-        LOG_WARN("Unsupported attribute format SCE_GXM_ATTRIBUTE_FORMAT_UNTYPED");
-        return GL_UNSIGNED_BYTE;
+        return GL_INT;
     }
 
     LOG_ERROR("Unsupported attribute format {}", log_hex(format));

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -374,14 +374,13 @@ void sync_vertex_attributes(GLContext &context, const GxmContextState &state, co
             case SCE_GXM_PARAMETER_TYPE_S32:
                 upload_integral = true;
                 break;
-
             default:
                 break;
             }
 
             glBindBuffer(GL_ARRAY_BUFFER, context.stream_vertex_buffers[attribute.streamIndex]);
 
-            if (upload_integral) {
+            if (upload_integral || type == SCE_GXM_ATTRIBUTE_FORMAT_UNTYPED) {
                 glVertexAttribIPointer(attrib_location, attribute.componentCount, type, stream.stride, reinterpret_cast<const GLvoid *>(attribute.offset));
             } else {
                 glVertexAttribPointer(attrib_location, attribute.componentCount, type, normalised, stream.stride, reinterpret_cast<const GLvoid *>(attribute.offset));


### PR DESCRIPTION
untyped attribute formats are simply 32 bit untyped data, GL_INT is 32 bit so it is ok to use it here