### PR TITLE
gxm/kernel: Add missing checks in draw precomputed and lock lw mutex

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -817,8 +817,10 @@ EXPORT(int, sceGxmDrawPrecomputed, SceGxmContext *context, SceGxmPrecomputedDraw
     SceGxmPrecomputedVertexState *vertex_state = context->state.precomputed_vertex_state.cast<SceGxmPrecomputedVertexState>().get(host.mem);
     SceGxmPrecomputedFragmentState *fragment_state = context->state.precomputed_fragment_state.cast<SceGxmPrecomputedFragmentState>().get(host.mem);
 
-    assert(vertex_state);
-    assert(fragment_state);
+    if (!vertex_state)
+        return RET_ERROR(SCE_GXM_ERROR_INVALID_PRECOMPUTED_VERTEX_STATE);
+    if (!fragment_state)
+        return RET_ERROR(SCE_GXM_ERROR_INVALID_PRECOMPUTED_FRAGMENT_STATE);
 
     // not sure if precomputed uses current program... maybe it does?
     // anyway states have to be made on a program to program basis so this should be safe

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -297,6 +297,9 @@ EXPORT(int, _sceKernelGetTimerTime) {
 }
 
 EXPORT(int, _sceKernelLockLwMutex, Ptr<SceKernelLwMutexWork> workarea, int lock_count, unsigned int *ptimeout) {
+    if (!workarea)
+        return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
+
     const auto lwmutexid = workarea.get(host.mem)->uid;
     return mutex_lock(host.kernel, host.mem, export_name, thread_id, lwmutexid, lock_count, ptimeout, SyncWeight::Light);
 }


### PR DESCRIPTION
#### What does this PR do?

Adds 3 missing checks:
Draw precomputed: vertex_state and fragment_state
kernelLwLockMutex: workarea