### PR TITLE
vita3k: Some refactor on compiler warnings

### DIFF
--- a/vita3k/gui/src/imgui_impl_sdl.cpp
+++ b/vita3k/gui/src/imgui_impl_sdl.cpp
@@ -176,6 +176,7 @@ IMGUI_API ImTextureID ImGui_ImplSdl_CreateTexture(ImGui_State *state, void *data
 #endif
     default:
         LOG_ERROR("Missing ImGui init for backend {}.", static_cast<int>(state->renderer->current_backend));
+        return (void *)0;
     }
 }
 
@@ -215,6 +216,7 @@ IMGUI_API bool ImGui_ImplSdl_CreateDeviceObjects(ImGui_State *state) {
 #endif
     default:
         LOG_ERROR("Missing ImGui init for backend {}.", static_cast<int>(state->renderer->current_backend));
+        return false;
     }
 }
 

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -454,6 +454,7 @@ bool handle_events(HostState &host, GuiState &gui) {
 
                 SDL_SetWindowFullscreen(host.window.get(), host.display.fullscreen.load() ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
             }
+            break;
 
         case SDL_WINDOWEVENT:
             handle_window_event(host, event.window);

--- a/vita3k/kernel/src/relocation.cpp
+++ b/vita3k/kernel/src/relocation.cpp
@@ -280,7 +280,7 @@ bool relocate(const void *entries, uint32_t size, const SegmentInfosForReloc &se
 
     if (LOG_RELOCATIONS) {
         LOG_DEBUG("Relocating patch of size: {}, # of segments: {}", log_hex(size), segment_count);
-        for (const auto seg : segments)
+        for (const auto &seg : segments)
             LOG_DEBUG("    Segment: {} -> {} (size: {})", seg.first, log_hex(seg.second.addr), seg.second.size);
     }
 
@@ -547,7 +547,7 @@ bool relocate(const void *entries, uint32_t size, const SegmentInfosForReloc &se
             const uint32_t orgval = *Ptr<uint32_t>(patch_seg_start + g_offset).get(mem);
 
             uint32_t segbase = 0;
-            for (const auto seg_ : segments) {
+            for (const auto &seg_ : segments) {
                 const auto seg = seg_.second;
                 if (orgval >= seg.p_vaddr && orgval < seg.p_vaddr + seg.size) {
                     segbase = seg.p_vaddr;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -83,7 +83,8 @@ int main(int argc, char *argv[]) {
     }
 
 #ifdef WIN32
-    CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    auto res = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    LOG_ERROR_IF(res == S_FALSE, "Failed to initialize COM Library");
 #endif
 
     if (cfg.console) {

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -189,7 +189,7 @@ static int init_texture_base(const char *export_name, SceGxmTexture *texture, Pt
     if (texture_type == SCE_GXM_TEXTURE_SWIZZLED) {
         // Find highest set bit of width and height. It's also the 2^? for width and height
         static auto highest_set_bit = [](const int num) -> std::uint32_t {
-            for (std::uint32_t i = 12; i >= 0; i--) {
+            for (std::uint32_t i = 12; i != 0; i--) {
                 if (num & (1 << i)) {
                     return i;
                 }

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -776,7 +776,7 @@ EXPORT(int, sceKernelGetThreadmgrUIDClass) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelGetTimerBaseWide, SceUID timer_handle) {
+EXPORT(uint64_t, sceKernelGetTimerBaseWide, SceUID timer_handle) {
     const TimerPtr timer_info = lock_and_find(timer_handle, host.kernel.timers, host.kernel.mutex);
 
     if (!timer_info)

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -759,7 +759,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         uniform_buffers.emplace(buffer.index, block);
     }
 
-    for (const auto buffer : program_input.uniform_buffers) {
+    for (const auto &buffer : program_input.uniform_buffers) {
         if (buffer.reg_block_size > 0) {
             const uint32_t reg_block_size_in_f32v = (buffer.reg_block_size + 3) / 4;
             const auto spv_buffer = uniform_buffers.at(buffer.index);

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -651,6 +651,7 @@ spv::Id shader::usse::utils::load(spv::Builder &b, const SpirvShaderParameters &
         case DataType::UINT16:
         case DataType::UINT8: {
             op.type = DataType::UINT32;
+            break;
         }
 
         default:


### PR DESCRIPTION
Gets rid of some compiler warnings and corrects type of sceKernelGetTimerBaseWide