### PR TITLE
common dialog: add lang support for (trophy/save data) dialog

### DIFF
--- a/lang/en.xml
+++ b/lang/en.xml
@@ -36,6 +36,43 @@
 	<version>Version</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>Preparing to start the application...</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>Do you want to cancel deleting?</cancel_deleting> 
+			<deletion_complete>Deletion complete.</deletion_complete> 
+			<delete_saved_data>Do you want to delete this saved data?</delete_saved_data> 
+		</delete>
+		<info>
+			<details>Details</details>
+			<updated>Updated</updated>
+		</info>
+		<load name="Load">
+			<cancel_loading>Do you want to cancel loading?</cancel_loading>
+			<no_saved_data>There is no saved data.</no_saved_data>
+			<load_complete>Loading complete.</load_complete>
+			<loading>Loading...</loading>
+			<load_saved_data>Do you want to load this saved data?</load_saved_data>
+		</load>
+		<save name="Save">
+			<cancel_saving>Do you want to cancel saving?</cancel_saving>
+			<could_not_save>Could not save the file.
+There is not enough free space on the memory card.</could_not_save>
+			<not_free_space>There is not enough free space on the memory card.</not_free_space>
+			<new_saved_data>New Saved Data</new_saved_data>
+			<saving_complete>Saving complete.</saving_complete>
+			<save_the_data>Do you want to save the data?</save_the_data>
+			<saving>Saving...</saving>
+			<warning_saving>Saving...
+Do not power off the system or close the application.</warning_saving>
+			<overwrite_saved_data>Do you want to overwrite this saved data?</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>The application has been added to the home screen.</app_added_home>
 	<delete_all>Delete All</delete_all>

--- a/lang/es.xml
+++ b/lang/es.xml
@@ -36,6 +36,43 @@
 	<version>Versión</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>Preparándose para iniciar la aplicación...</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>¿Quieres cancelar la eliminación?</cancel_deleting> 
+			<deletion_complete>Eliminación completada.</deletion_complete> 
+			<delete_saved_data>¿Quieres eliminar estos datos guardados?</delete_saved_data> 
+		</delete>
+		<info>
+			<details>Detalles</details>
+			<updated>Actualizado</updated>
+		</info>
+		<load name="Cargar">
+			<cancel_loading>¿Quieres cancelar la carga?</cancel_loading>
+			<no_saved_data>No hay datos guardados.</no_saved_data>
+			<load_complete>Carga completada.</load_complete>
+			<loading>Cargando...</loading>
+			<load_saved_data>¿Quieres cargar estos datos guardados?</load_saved_data>
+		</load>
+		<save name="Guardar">
+			<cancel_saving>¿Quieres cancelar el guardado?</cancel_saving>
+			<could_not_save>No se ha podido guardar el archivo.
+No hay suficiente espacio libre en la tarjeta de memoria.</could_not_save>
+			<not_free_space>No hay suficiente espacio libre en la tarjeta de memoria.</not_free_space>
+			<new_saved_data>Nuevos datos guardados</new_saved_data>
+			<saving_complete>Guardado.</saving_complete>
+			<save_the_data>¿Quieres guardar los datos?</save_the_data>
+			<saving>Guardando...</saving>
+			<warning_saving>Guardando...
+No apagues el sistema ni cierres la aplicación.</warning_saving>
+			<overwrite_saved_data>¿Quieres sobrescribir estos datos guardados?</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>La aplicación se ha agregado a la pantalla de inicio.</app_added_home>
 	<delete_all>Eliminar todo</delete_all>

--- a/lang/fr.xml
+++ b/lang/fr.xml
@@ -36,6 +36,43 @@
 	<version>Version</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>Préparation au lancement de l'application...</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>Annuler la suppression ?</cancel_deleting> 
+			<deletion_complete>Suppression terminée.</deletion_complete> 
+			<delete_saved_data>Supprimer ces données sauvegardées ?</delete_saved_data> 
+		</delete>
+		<info>
+			<details>Détails</details>
+			<updated>Mis à jour</updated>
+		</info>
+		<load name="Charger">
+			<cancel_loading>Annuler le chargement ?</cancel_loading>
+			<no_saved_data>Aucune donnée sauvegardée.</no_saved_data>
+			<load_complete>Chargement terminé.</load_complete>
+			<loading>Chargement en cours...</loading>
+			<load_saved_data>Charger ces données sauvegardées ?</load_saved_data>
+		</load>
+		<save name="Sauvegarder">
+			<cancel_saving>Annuler la sauvegarde ?</cancel_saving>
+			<could_not_save>La sauvegarde du fichier a échoué.
+Espace libre insuffisant sur la carte mémoire.</could_not_save>
+			<not_free_space>Espace libre insuffisant sur la carte mémoire.</not_free_space>
+			<new_saved_data>Nouvelles données sauvegardées</new_saved_data>
+			<saving_complete>Sauvegarde terminée.</saving_complete>
+			<save_the_data>Sauvegarder les données ?</save_the_data>
+			<saving>Sauvegarde en cours...</saving>
+			<warning_saving>Sauvegarde en cours...
+Ne pas éteindre le système, ni fermer l'application.</warning_saving>
+			<overwrite_saved_data>Écraser ces données sauvegardées ?</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>L'application a été ajoutée à l'écran d'accueil.</app_added_home>
 	<delete_all>Supprimer tout</delete_all>

--- a/lang/it.xml
+++ b/lang/it.xml
@@ -41,6 +41,43 @@
 	<version>Versione</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>Preparazione per l'avvio dell'applicazione...</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>Vuoi annullare l'eliminazione?</cancel_deleting> 
+			<deletion_complete>Eliminazione completata.</deletion_complete> 
+			<delete_saved_data>Vuoi eliminare questi dati salvati?</delete_saved_data> 
+		</delete>
+		<info>
+			<details>Dettagli</details>
+			<updated>Aggiornato</updated>
+		</info>
+		<load name="Carica">
+			<cancel_loading>Vuoi annullare il caricamento?</cancel_loading>
+			<no_saved_data>Non ci sono dati salvati.</no_saved_data>
+			<load_complete>Caricamento completato.</load_complete>
+			<loading>Caricamento in corso...</loading>
+			<load_saved_data>Vuoi caricare questi dati salvati?</load_saved_data>
+		</load>
+		<save name="Salva">
+			<cancel_saving>Vuoi annullare il salvataggio?</cancel_saving>
+			<could_not_save>Impossibile salvare il file.
+Spazio libero insufficiente sulla scheda di memoria.</could_not_save>
+			<not_free_space>Spazio libero insufficiente sulla scheda di memoria.</not_free_space>
+			<new_saved_data>Nuovi dati salvati</new_saved_data>
+			<saving_complete>Salvataggio completato.</saving_complete>
+			<save_the_data>Vuoi salvare i dati?</save_the_data>
+			<saving>Salvataggio in corso...</saving>
+			<warning_saving>Salvataggio in corso...
+Non spegnere il sistema né chiudere l'applicazione.</warning_saving>
+			<overwrite_saved_data>Vuoi sovrascrivere questi dati salvati?</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>L'applicazione è stata aggiunta alla schermata principale.</app_added_home>
 	<delete_all>Elimina tutto</delete_all>

--- a/lang/ja.xml
+++ b/lang/ja.xml
@@ -13,6 +13,43 @@
 	<version>バージョン</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>アプリケーションを始める準備中です...</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>削除をキャンセルしますか？</cancel_deleting> 
+			<deletion_complete>削除しました。</deletion_complete> 
+			<delete_saved_data>このセーブデータを削除しますか？</delete_saved_data> 
+		</delete>
+		<info>
+			<details>詳細</details>
+			<updated>更新日</updated>
+		</info>
+		<load name="ロード">
+			<cancel_loading>ロードをキャンセルしますか？</cancel_loading>
+			<no_saved_data>セーブデータがありません。</no_saved_data>
+			<load_complete>ロードしました。</load_complete>
+			<loading>ロード中です...</loading>
+			<load_saved_data>このセーブデータをロードしますか？</load_saved_data>
+		</load>
+		<save name="セーブ">
+			<cancel_saving>セーブをキャンセルしますか？</cancel_saving>
+			<could_not_save>セーブできませんでした。
+メモリーカードの空き容量が不足しています。</could_not_save>
+			<not_free_space>メモリーカードの空き容量が不足しています。</not_free_space>
+			<new_saved_data>新しいセーブデータ</new_saved_data>
+			<saving_complete>セーブしました。</saving_complete>
+			<save_the_data>データをセーブしますか？</save_the_data>
+			<saving>セーブ中です...</saving>
+			<warning_saving>セーブ中です...
+電源を切ったり、アプリケーションを終了したりしないでください。</warning_saving>
+			<overwrite_saved_data>このセーブデータを上書きしますか？</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>ホーム画面にアプリケーションが追加されました。</app_added_home>
 	<delete_all>すべて削除</delete_all>

--- a/lang/ko.xml
+++ b/lang/ko.xml
@@ -13,6 +13,43 @@
 	<version>버전</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>애플리케이션을 시작하기 위한 준비중입니다...</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>삭제를 취소하시겠습니까?</cancel_deleting> 
+			<deletion_complete>삭제했습니다.</deletion_complete> 
+			<delete_saved_data>이 저장 데이터를 삭제하시겠습니까?</delete_saved_data> 
+		</delete>
+		<info>
+			<details>상세</details>
+			<updated>갱신일</updated>
+		</info>
+		<load name="불러오기">
+			<cancel_loading>불러오기를 취소하시겠습니까?</cancel_loading>
+			<no_saved_data>저장 데이터가 없습니다.</no_saved_data>
+			<load_complete>불러오기를 완료했습니다.</load_complete>
+			<loading>불러오기 중입니다...</loading>
+			<load_saved_data>이 저장 데이터를 불러오시겠습니까?</load_saved_data>
+		</load>
+		<save name="저장">
+			<cancel_saving>저장을 취소하시겠습니까?</cancel_saving>
+			<could_not_save>저장하지 못했습니다.
+메모리 카드의 빈 용량이 부족합니다.</could_not_save>
+			<not_free_space>메모리 카드의 빈 용량이 부족합니다.</not_free_space>
+			<new_saved_data>새 저장 데이터</new_saved_data>
+			<saving_complete>저장했습니다.</saving_complete>
+			<save_the_data>데이터를 저장하시겠습니까?</save_the_data>
+			<saving>저장중입니다...</saving>
+			<warning_saving>저장중입니다…
+전원을 끄거나 애플리케이션을 종료하지 마십시오.</warning_saving>
+			<overwrite_saved_data>이 저장 데이터를 덮어쓰시겠습니까?</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>홈 화면에 애플리케이션이 추가되었습니다.</app_added_home>
 	<delete_all>모두 삭제</delete_all>

--- a/lang/nl.xml
+++ b/lang/nl.xml
@@ -36,6 +36,43 @@
 	<version>Versie</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>Bezig met het voorbereiden voor het starten van de applicatie...</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>Wil je het verwijderen annuleren?</cancel_deleting> 
+			<deletion_complete>Het verwijderen is voltooid.</deletion_complete> 
+			<delete_saved_data>Wil je deze opgeslagen data verwijderen?</delete_saved_data> 
+		</delete>
+		<info>
+			<details>Details</details>
+			<updated>Geüpdatet</updated>
+		</info>
+		<load name="Laden">
+			<cancel_loading>Wil je het laden annuleren?</cancel_loading>
+			<no_saved_data>Er zijn geen opgeslagen data.</no_saved_data>
+			<load_complete>Het laden is voltooid.</load_complete>
+			<loading>Bezig met laden...</loading>
+			<load_saved_data>Wil je deze opgeslagen data laden?</load_saved_data>
+		</load>
+		<save name="Opslaan">
+			<cancel_saving>Wil je het opslaan annuleren?</cancel_saving>
+			<could_not_save>Kan het bestand niet opslaan.
+Er is onvoldoende vrije ruimte op de geheugenkaart.</could_not_save>
+			<not_free_space>Er is onvoldoende vrije ruimte op de geheugenkaart.</not_free_space>
+			<new_saved_data>Nieuwe opgeslagen data</new_saved_data>
+			<saving_complete>Opslaan voltooid.</saving_complete>
+			<save_the_data>Wil je de data opslaan?</save_the_data>
+			<saving>Bezig met opslaan...</saving>
+			<warning_saving>Bezig met opslaan...
+Schakel het systeem niet uit en sluit de applicatie niet.</warning_saving>
+			<overwrite_saved_data>Wil je deze opgeslagen data overschrijven?</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>De applicatie is toegevoegd aan het beginscherm.</app_added_home>
 	<delete_all>Alles verwijderen</delete_all>

--- a/lang/ru.xml
+++ b/lang/ru.xml
@@ -7,25 +7,20 @@
 		<install_pkg>Установить файл .pkg</install_pkg>
 		<install_zip>Установить файл .zip или .vpk</install_zip>
 	</file>
-
 	<emulation name="Эмуляция">
 		<load_last_app>Загрузить последнее приложение</load_last_app>
 	</emulation>
-
 	<configuration name="Конфигурация">
 		<settings>Настройки</settings>
 		<user_management>Управление пользователями</user_management>
 	</configuration>
-
 	<controls name="Управление">
 		<keyboard_controls>Элементы управления клавиатурой</keyboard_controls>
 	</controls>
-
 	<help name="Справка">
 		<about>О программе</about>
 		<welcome>Добро пожаловать</welcome>
 	</help>
-
 </main_menubar>
 
 <app_context>
@@ -40,6 +35,43 @@
 	<size>Размер</size>
 	<version>Версия</version>
 </app_context>
+
+<dialog>
+	<trophy>
+		<preparing_start_app>Подготовка к запуску приложения...</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>Отменить удаление?</cancel_deleting> 
+			<deletion_complete>Удаление завершено.</deletion_complete> 
+			<delete_saved_data>Удалить эти сохраненные данные?</delete_saved_data> 
+		</delete>
+		<info>
+			<details>Подробности</details>
+			<updated>Обновлен</updated>
+		</info>
+		<load name="Загрузить">
+			<cancel_loading>Отменить загрузку?</cancel_loading>
+			<no_saved_data>Отсутствуют сохраненные данные.</no_saved_data>
+			<load_complete>Загрузка завершена.</load_complete>
+			<loading>Идет загрузка...</loading>
+			<load_saved_data>Загрузить эти сохраненные данные?</load_saved_data>
+		</load>
+		<save name="Сохранить">
+			<cancel_saving>Отменить сохранение?</cancel_saving>
+			<could_not_save>Не удалось сохранить файл.
+На карте памяти недостаточно свободного места.</could_not_save>
+			<not_free_space>На карте памяти недостаточно свободного места.</not_free_space>
+			<new_saved_data>Новые сохраненные данные</new_saved_data>
+			<saving_complete>Сохранение завершено.</saving_complete>
+			<save_the_data>Сохранить данные?</save_the_data>
+			<saving>Идет сохранение...</saving>
+			<warning_saving>Идет сохранение...
+Не выключайте систему и не закрывайте приложение.</warning_saving>
+			<overwrite_saved_data>Перезаписать сохраненные данные?</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
 
 <indicator>
 	<app_added_home>Приложение добавлено на начальный экран.</app_added_home>

--- a/lang/zh-s.xml
+++ b/lang/zh-s.xml
@@ -36,6 +36,43 @@
 	<version>版本</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>正在准备启动应用程序…</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>要取消删除吗？</cancel_deleting> 
+			<deletion_complete>删除完毕。</deletion_complete> 
+			<delete_saved_data>要删除此保存数据吗？</delete_saved_data> 
+		</delete>
+		<info>
+			<details>详细信息</details>
+			<updated>升级日期</updated>
+		</info>
+		<load name="读取">
+			<cancel_loading>要取消读取吗？</cancel_loading>
+			<no_saved_data>保存数据不存在。</no_saved_data>
+			<load_complete>读取完毕。</load_complete>
+			<loading>正在读取…</loading>
+			<load_saved_data>要读取此保存数据吗？</load_saved_data>
+		</load>
+		<save name="保存">
+			<cancel_saving>要取消保存吗？</cancel_saving>
+			<could_not_save>无法保存文件。
+存储卡没有足够的空余容量。</could_not_save>
+			<not_free_space>存储卡没有足够的空余容量。</not_free_space>
+			<new_saved_data>新建保存数据</new_saved_data>
+			<saving_complete>保存完毕。</saving_complete>
+			<save_the_data>要保存数据吗？</save_the_data>
+			<saving>正在保存…</saving>
+			<warning_saving>正在保存…
+请勿关闭电源或关闭应用程序。</warning_saving>
+			<overwrite_saved_data>要覆盖此保存数据吗？</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>已将应用程序添加至主画面。</app_added_home>
 	<delete_all>全部删除</delete_all>

--- a/lang/zh-t.xml
+++ b/lang/zh-t.xml
@@ -36,6 +36,43 @@
 	<version>版本</version>
 </app_context>
 
+<dialog>
+	<trophy>
+		<preparing_start_app>正在準備啟動應用程式……</preparing_start_app>
+	</trophy>
+	<save_data>
+		<delete>
+			<cancel_deleting>確定要取消刪除嗎？</cancel_deleting> 
+			<deletion_complete>已刪除。</deletion_complete> 
+			<delete_saved_data>確定要刪除此保存資料嗎?</delete_saved_data> 
+		</delete>
+		<info>
+			<details>詳細內容</details>
+			<updated>更新日</updated>
+		</info>
+		<load name="載入">
+			<cancel_loading>確定要取消載入嗎？</cancel_loading>
+			<no_saved_data>找不到保存資料。</no_saved_data>
+			<load_complete>已載入。</load_complete>
+			<loading>載入中……</loading>
+			<load_saved_data>確定要載入此保存資料嗎？</load_saved_data>
+		</load>
+		<save name="保存">
+			<cancel_saving>確定要取消保存嗎？</cancel_saving>
+			<could_not_save>無法保存。
+記憶卡的可用容量不足。</could_not_save>
+			<not_free_space>記憶卡的可用容量不足。</not_free_space>
+			<new_saved_data>新的保存資料</new_saved_data>
+			<saving_complete>已保存。</saving_complete>
+			<save_the_data>確定要保存資料嗎？</save_the_data>
+			<saving>保存中……</saving>
+			<warning_saving>保存中……
+請勿關閉電源或結束應用程式。</warning_saving>
+			<overwrite_saved_data>確定要覆寫此保存資料嗎？</overwrite_saved_data>
+		</save>
+	</save_data>
+</dialog>
+
 <indicator>
 	<app_added_home>已追加應用程式至主頁畫面。</app_added_home>
 	<delete_all>全部刪除</delete_all>

--- a/vita3k/dialog/include/dialog/state.h
+++ b/vita3k/dialog/include/dialog/state.h
@@ -89,7 +89,13 @@ struct SavedataState {
     bool draw_info_window = false;
 };
 
+struct DialogLang {
+    std::map<std::string, std::string> trophy;
+    std::map<std::string, std::string> save_data;
+};
+
 struct DialogState {
+    DialogLang lang;
     DialogType type = NO_DIALOG;
     SceCommonDialogStatus status = SCE_COMMON_DIALOG_STATUS_NONE;
     SceCommonDialogStatus substatus = SCE_COMMON_DIALOG_STATUS_NONE;

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -129,6 +129,52 @@ void init_lang(GuiState &gui, HostState &host) {
                 lang_app_context["version"] = app_context.child("version").text().as_string();
             }
 
+            // Dialog
+            if (!lang_xml.child("dialog").empty()) {
+                const auto dialog = lang_xml.child("dialog");
+                // Trophy
+                if (!dialog.child("trophy").empty())
+                    host.common_dialog.lang.trophy["preparing_start_app"] = dialog.child("trophy").child("preparing_start_app").text().as_string();
+                // Save Data
+                if (!dialog.child("save_data").empty()) {
+                    auto &lang_save_data = host.common_dialog.lang.save_data;
+                    const auto save_data = dialog.child("save_data");
+                    if (!save_data.child("delete").empty()) {
+                        const auto delete_child = save_data.child("delete");
+                        //lang_save_data["delete"] = delete_child.attribute("name").as_string();
+                        lang_save_data["cancel_deleting"] = delete_child.child("cancel_deleting").text().as_string();
+                        lang_save_data["deletion_complete"] = delete_child.child("deletion_complete").text().as_string();
+                        lang_save_data["delete_saved_data"] = delete_child.child("delete_saved_data").text().as_string();
+                    }
+                    if (!save_data.child("info").empty()) {
+                        lang_save_data["details"] = save_data.child("info").child("details").text().as_string();
+                        lang_save_data["updated"] = save_data.child("info").child("updated").text().as_string();
+                    }
+                    if (!save_data.child("load").empty()) {
+                        const auto load = save_data.child("load");
+                        lang_save_data["load"] = load.attribute("name").as_string();
+                        lang_save_data["cancel_loading"] = load.child("cancel_loading").text().as_string();
+                        lang_save_data["no_saved_data"] = load.child("no_saved_data").text().as_string();
+                        lang_save_data["load_complete"] = load.child("load_complete").text().as_string();
+                        lang_save_data["loading"] = load.child("loading").text().as_string();
+                        lang_save_data["load_saved_data"] = load.child("load_saved_data").text().as_string();
+                    }
+                    if (!save_data.child("save").empty()) {
+                        const auto save = save_data.child("save");
+                        lang_save_data["save"] = save.attribute("name").as_string();
+                        lang_save_data["cancel_saving"] = save.child("cancel_saving").text().as_string();
+                        lang_save_data["could_not_save"] = save.child("could_not_save").text().as_string();
+                        lang_save_data["not_free_space"] = save.child("not_free_space").text().as_string();
+                        lang_save_data["new_saved_data"] = save.child("new_saved_data").text().as_string();
+                        lang_save_data["saving_complete"] = save.child("saving_complete").text().as_string();
+                        lang_save_data["save_the_data"] = save.child("save_the_data").text().as_string();
+                        lang_save_data["saving"] = save.child("saving").text().as_string();
+                        lang_save_data["warning_saving"] = save.child("warning_saving").text().as_string();
+                        lang_save_data["overwrite_saved_data"] = save.child("overwrite_saved_data").text().as_string();
+                    }
+                }
+            }
+
             // Indicator
             if (!lang_xml.child("indicator").empty()) {
                 auto &lang_indicator = gui.lang.indicator;
@@ -244,7 +290,7 @@ static void draw_notice_info(GuiState &gui, HostState &host) {
     const auto NOTICE_SIZE = gui.notice_info_count_new ? ImVec2(104.0f * SCAL.x, 95.0f * SCAL.y) : ImVec2(90.0f * SCAL.x, 82.0f * SCAL.y);
     const auto NOTICE_POS = ImVec2(display_size.x - NOTICE_SIZE.x, 0.f);
     const ImU32 NOTICE_COLOR = 4294967295; // White
-    const auto WINDOW_SIZE = notice_info ? display_size : gui.notice_info_count_new ? ImVec2(84.f * SCAL.x, 76.f * SCAL.y) : ImVec2(72.f * SCAL.x, 62.f * SCAL.y);
+    const auto WINDOW_SIZE = notice_info ? display_size : (gui.notice_info_count_new ? ImVec2(84.f * SCAL.x, 76.f * SCAL.y) : ImVec2(72.f * SCAL.x, 62.f * SCAL.y));
     const auto WINDOW_POS = ImVec2(notice_info ? 0.f : display_size.x - WINDOW_SIZE.x, 0.f);
 
     ImGui::SetNextWindowPos(WINDOW_POS, ImGuiCond_Always);
@@ -1338,10 +1384,9 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
     const auto GATE_SIZE = ImVec2(280.0f * scal.x, 158.0f * scal.y);
     const auto GATE_POS = ImVec2(display_size.x - (items_pos[type[app_path]]["gate"]["pos"].x * scal.x), display_size.y - (items_pos[type[app_path]]["gate"]["pos"].y * scal.y));
     const auto START_SIZE = ImVec2((ImGui::CalcTextSize(BUTTON_STR.c_str()).x * scal_font_size), (ImGui::CalcTextSize(BUTTON_STR.c_str()).y * scal_font_size));
-    const auto START_BUTTON_SIZE = ImVec2((START_SIZE.x + 26.0f) * scal.x, (START_SIZE.y + 5.0f) * scal.y);
+    const auto START_BUTTON_SIZE = ImVec2(START_SIZE.x + 26.0f, START_SIZE.y + 5.0f);
     const auto POS_BUTTON = ImVec2((GATE_POS.x + (GATE_SIZE.x - START_BUTTON_SIZE.x) / 2.0f), (GATE_POS.y + (GATE_SIZE.y - START_BUTTON_SIZE.y) / 1.08f));
-    const auto POS_START = ImVec2(POS_BUTTON.x + (START_BUTTON_SIZE.x - (START_SIZE.x * scal.x)) / 2,
-        POS_BUTTON.y + (START_BUTTON_SIZE.y - (START_SIZE.y * scal.y)) / 2);
+    const auto POS_START = ImVec2(POS_BUTTON.x + (START_BUTTON_SIZE.x - START_SIZE.x) / 2.f, POS_BUTTON.y + (START_BUTTON_SIZE.y - START_SIZE.y) / 2.f);
     const auto SELECT_SIZE = ImVec2(GATE_SIZE.x - (10.f * scal.x), GATE_SIZE.y - (5.f * scal.y));
     const auto SELECT_POS = ImVec2(GATE_POS.x + (5.f * scal.y), GATE_POS.y + (2.f * scal.y));
     const auto SIZE_GATE = ImVec2(GATE_POS.x + GATE_SIZE.x, GATE_POS.y + GATE_SIZE.y);
@@ -1354,7 +1399,7 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
     }
     ImGui::PushID(app_path.c_str());
     ImGui::GetWindowDrawList()->AddRectFilled(POS_BUTTON, ImVec2(POS_BUTTON.x + START_BUTTON_SIZE.x, POS_BUTTON.y + START_BUTTON_SIZE.y), IM_COL32(20, 168, 222, 255), 10.0f * scal.x, ImDrawCornerFlags_All);
-    ImGui::GetWindowDrawList()->AddText(gui.vita_font, scal_default_font * scal.x, POS_START, IM_COL32(255, 255, 255, 255), BUTTON_STR.c_str());
+    ImGui::GetWindowDrawList()->AddText(gui.vita_font, scal_default_font, POS_START, IM_COL32(255, 255, 255, 255), BUTTON_STR.c_str());
     ImGui::SetCursorPos(SELECT_POS);
     const auto is_enable = host.io.title_id.empty()
         || (gui.apps_list_opened[gui.current_app_selected].find("NPXS") != std::string::npos)

--- a/vita3k/host/src/load_self.cpp
+++ b/vita3k/host/src/load_self.cpp
@@ -350,7 +350,7 @@ SceUID load_self(Ptr<const void> &entry_point, KernelState &kernel, MemState &me
         const uint8_t *const seg_bytes = self_bytes + self_header.header_len + seg_header.p_offset;
 
         auto get_seg_header_string = [&seg_header]() {
-            return seg_header.p_type == PT_LOAD ? "LOAD" : seg_header.p_type == PT_LOOS ? "LOOS" : "UNKNOWN";
+            return seg_header.p_type == PT_LOAD ? "LOAD" : (seg_header.p_type == PT_LOOS ? "LOOS" : "UNKNOWN");
         };
 
         auto dump_segment = [&](const uint8_t *const seg_data) {

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -657,8 +657,8 @@ static void check_empty_param(HostState &host, const SceAppUtilSaveDataSlotEmpty
     host.common_dialog.savedata.subtitle[host.common_dialog.savedata.selected_save] = "";
     host.common_dialog.savedata.icon_buffer[host.common_dialog.savedata.selected_save].clear();
     host.common_dialog.savedata.has_date[host.common_dialog.savedata.selected_save] = false;
-    if (empty_param != nullptr) {
-        host.common_dialog.savedata.title[host.common_dialog.savedata.selected_save] = empty_param->title.get(host.mem) == nullptr ? "New Saved Data" : empty_param->title.get(host.mem);
+    if (empty_param) {
+        host.common_dialog.savedata.title[host.common_dialog.savedata.selected_save] = empty_param->title.get(host.mem) ? empty_param->title.get(host.mem) : (!host.common_dialog.lang.save_data["new_saved_data"].empty() ? host.common_dialog.lang.save_data["new_saved_data"] : "New Saved Data");
         auto device = device::get_device(empty_param->iconPath.get(host.mem));
         auto thumbnail_path = translate_path(empty_param->iconPath.get(host.mem), device, host.io.device_paths);
         vfs::read_file(VitaIoDevice::ux0, thumbnail_buffer, host.pref_path, thumbnail_path);
@@ -677,8 +677,8 @@ static void check_save_file(SceUID fd, std::vector<SceAppUtilSaveDataSlotParam> 
         host.common_dialog.savedata.icon_buffer[index].clear();
         host.common_dialog.savedata.has_date[index] = false;
         auto empty_param = host.common_dialog.savedata.list_empty_param;
-        if (empty_param != nullptr) {
-            host.common_dialog.savedata.title[index] = empty_param->title.get(host.mem) == nullptr ? "New Saved Data" : empty_param->title.get(host.mem);
+        if (empty_param) {
+            host.common_dialog.savedata.title[index] = empty_param->title.get(host.mem) ? empty_param->title.get(host.mem) : (!host.common_dialog.lang.save_data["new_saved_data"].empty() ? host.common_dialog.lang.save_data["new_saved_data"] : "New Saved Data");
             auto device = device::get_device(empty_param->iconPath.get(host.mem));
             auto thumbnail_path = translate_path(empty_param->iconPath.get(host.mem), device, host.io.device_paths);
             vfs::read_file(VitaIoDevice::ux0, thumbnail_buffer, host.pref_path, thumbnail_path);
@@ -722,10 +722,12 @@ static void handle_user_message(SceSaveDataDialogUserMessageParam *user_message,
         break;
     }
 }
+
 static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message, HostState &host) {
+    auto lang = host.common_dialog.lang.save_data;
     switch (sys_message->sysMsgType) {
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_NODATA:
-        host.common_dialog.savedata.msg = "There is no saved data.";
+        host.common_dialog.savedata.msg = !lang["no_saved_data"].empty() ? lang["no_saved_data"] : "There is no saved data.";
         host.common_dialog.savedata.btn_num = 1;
         host.common_dialog.savedata.btn[0] = "OK";
         host.common_dialog.savedata.btn_val[0] = SCE_SAVEDATA_DIALOG_BUTTON_ID_OK;
@@ -733,13 +735,13 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_CONFIRM:
         switch (host.common_dialog.savedata.display_type) {
         case SCE_SAVEDATA_DIALOG_TYPE_SAVE:
-            host.common_dialog.savedata.msg = "Do you want to save the data?";
+            host.common_dialog.savedata.msg = !lang["save_the_data"].empty() ? lang["save_the_data"] : "Do you want to save the data?";
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_LOAD:
-            host.common_dialog.savedata.msg = "Do you want to load this saved data?";
+            host.common_dialog.savedata.msg = !lang["load_saved_data"].empty() ? lang["load_saved_data"] : "Do you want to load this saved data?";
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_DELETE:
-            host.common_dialog.savedata.msg = "Do you want to delete this saved data?";
+            host.common_dialog.savedata.msg = !lang["delete_saved_data"].empty() ? lang["delete_saved_data"] : "Do you want to delete this saved data?";
             break;
         }
         host.common_dialog.savedata.btn_num = 2;
@@ -749,7 +751,7 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
         host.common_dialog.savedata.btn_val[1] = SCE_SAVEDATA_DIALOG_BUTTON_ID_YES;
         break;
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_OVERWRITE:
-        host.common_dialog.savedata.msg = "Do you want to overwrite this saved data?";
+        host.common_dialog.savedata.msg = !lang["overwrite_saved_data"].empty() ? lang["overwrite_saved_data"] : "Do you want to overwrite this saved data?";
         host.common_dialog.savedata.btn_num = 2;
         host.common_dialog.savedata.btn[0] = "No";
         host.common_dialog.savedata.btn_val[0] = SCE_SAVEDATA_DIALOG_BUTTON_ID_NO;
@@ -757,17 +759,17 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
         host.common_dialog.savedata.btn_val[1] = SCE_SAVEDATA_DIALOG_BUTTON_ID_YES;
         break;
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_NOSPACE:
-        host.common_dialog.savedata.msg = "There is not enough free space on the memory card.";
+        host.common_dialog.savedata.msg = !lang["not_free_space"].empty() ? lang["not_free_space"] : "There is not enough free space on the memory card.";
         host.common_dialog.savedata.btn_num = 0;
         break;
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_PROGRESS:
         host.common_dialog.savedata.btn_num = 0;
         switch (host.common_dialog.savedata.display_type) {
         case SCE_SAVEDATA_DIALOG_TYPE_SAVE:
-            host.common_dialog.savedata.msg = "Saving...\nDo not power off the system or close the application";
+            host.common_dialog.savedata.msg = !lang["warning_saving"].empty() ? lang["warning_saving"] : "Saving...\nDo not power off the system or close the application";
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_LOAD:
-            host.common_dialog.savedata.msg = "Loading...";
+            host.common_dialog.savedata.msg = !lang["loading"].empty() ? lang["loading"] : "Loading...";
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_DELETE:
             host.common_dialog.savedata.msg = "Please Wait...";
@@ -777,13 +779,13 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_FINISHED:
         switch (host.common_dialog.savedata.display_type) {
         case SCE_SAVEDATA_DIALOG_TYPE_SAVE:
-            host.common_dialog.savedata.msg = "Saving complete.";
+            host.common_dialog.savedata.msg = !lang["saving_complete"].empty() ? lang["saving_complete"] : "Saving complete.";
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_LOAD:
-            host.common_dialog.savedata.msg = "Loading complete.";
+            host.common_dialog.savedata.msg = !lang["load_complete"].empty() ? lang["load_complete"] : "Loading complete.";
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_DELETE:
-            host.common_dialog.savedata.msg = "Deletion complete.";
+            host.common_dialog.savedata.msg = !lang["deletion_complete"].empty() ? lang["deletion_complete"] : "Deletion complete.";
             break;
         }
         host.common_dialog.savedata.btn_num = 1;
@@ -793,13 +795,13 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_CONFIRM_CANCEL:
         switch (host.common_dialog.savedata.display_type) {
         case SCE_SAVEDATA_DIALOG_TYPE_SAVE:
-            host.common_dialog.savedata.msg = "Do you want to cancel saving?";
+            host.common_dialog.savedata.msg = !lang["cancel_loading"].empty() ? lang["cancel_loading"] : "Do you want to cancel saving?";
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_LOAD:
-            host.common_dialog.savedata.msg = "Do you want to cancel loading?";
+            host.common_dialog.savedata.msg = !lang["cancel_saving"].empty() ? lang["cancel_saving"] : "Do you want to cancel loading?";
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_DELETE:
-            host.common_dialog.savedata.msg = "Do you want to cancel deleting?";
+            host.common_dialog.savedata.msg = !lang["cancel_deleting"].empty() ? lang["cancel_deleting"] : "Do you want to cancel deleting?";
             break;
         }
         host.common_dialog.savedata.btn_num = 2;
@@ -815,7 +817,7 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
         host.common_dialog.savedata.btn_val[0] = SCE_SAVEDATA_DIALOG_BUTTON_ID_OK;
         break;
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_NOSPACE_CONTINUABLE:
-        host.common_dialog.savedata.msg = "Could not save the file.\n\
+        host.common_dialog.savedata.msg = !lang["could_not_save"].empty() ? lang["could_not_save"] : "Could not save the file.\n\
 			There is not enough free space on the memory card.";
         host.common_dialog.savedata.btn_num = 1;
         host.common_dialog.savedata.btn[0] = "OK";
@@ -828,6 +830,7 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
         host.common_dialog.savedata.btn[0] = "OK";
         host.common_dialog.savedata.btn_val[0] = SCE_SAVEDATA_DIALOG_BUTTON_ID_OK;
         break;
+    default: break;
     }
 }
 
@@ -943,14 +946,15 @@ EXPORT(int, sceSaveDataDialogContinue, const Ptr<SceSaveDataDialogParam> param) 
             if (progress_bar->msg.get(host.mem) != nullptr) {
                 host.common_dialog.savedata.msg = reinterpret_cast<const char *>(progress_bar->msg.get(host.mem));
             } else {
+                auto lang = host.common_dialog.lang.save_data;
                 switch (progress_bar->sysMsgParam.sysMsgType) {
                 case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_PROGRESS:
                     switch (host.common_dialog.savedata.display_type) {
                     case SCE_SAVEDATA_DIALOG_TYPE_SAVE:
-                        host.common_dialog.savedata.msg = "Saving...";
+                        host.common_dialog.savedata.msg = !lang["saving"].empty() ? lang["saving"] : "Saving...";
                         break;
                     case SCE_SAVEDATA_DIALOG_TYPE_LOAD:
-                        host.common_dialog.savedata.msg = "Loading...";
+                        host.common_dialog.savedata.msg = !lang["loading"].empty() ? lang["loading"] : "Loading...";
                         break;
                     case SCE_SAVEDATA_DIALOG_TYPE_DELETE:
                         host.common_dialog.savedata.msg = "Please Wait.";
@@ -1121,15 +1125,16 @@ EXPORT(int, sceSaveDataDialogInit, const Ptr<SceSaveDataDialogParam> param) {
         slot_list.resize(list_param->slotListSize);
         initialize_savedata_vectors(host, list_param->slotListSize);
 
-        if (list_param->listTitle.get(host.mem) != nullptr) {
+        if (list_param->listTitle.get(host.mem)) {
             host.common_dialog.savedata.list_title = reinterpret_cast<const char *>(list_param->listTitle.get(host.mem));
         } else {
+            auto lang = host.common_dialog.lang.save_data;
             switch (p->dispType) {
             case SCE_SAVEDATA_DIALOG_TYPE_SAVE:
-                host.common_dialog.savedata.list_title = "Save";
+                host.common_dialog.savedata.list_title = !lang["save"].empty() ? lang["save"] : "Save";
                 break;
             case SCE_SAVEDATA_DIALOG_TYPE_LOAD:
-                host.common_dialog.savedata.list_title = "Load";
+                host.common_dialog.savedata.list_title = !lang["load"].empty() ? lang["load"] : "Load";
                 break;
             case SCE_SAVEDATA_DIALOG_TYPE_DELETE:
                 host.common_dialog.savedata.list_title = "Delete";


### PR DESCRIPTION
- refactor gui code for prepare trophy setup with also add languague support, get more close psvita
- add support of diferent clock format for date and time
- add lang support for save data dialog
- fix start size in live area for full screen mode

- # Result:
- Trophy
![image](https://user-images.githubusercontent.com/5261759/110830891-fb244f00-8299-11eb-9f58-7c79393fb4eb.png)

- Save Data
![image](https://user-images.githubusercontent.com/5261759/110823219-29059580-8292-11eb-9333-399ea11b5e6d.png)
![image](https://user-images.githubusercontent.com/5261759/110823232-2e62e000-8292-11eb-97f0-cc72c4e1715d.png)
![image](https://user-images.githubusercontent.com/5261759/110823241-31f66700-8292-11eb-8492-c0b7f13dfc3b.png)
![image](https://user-images.githubusercontent.com/5261759/110823448-6833e680-8292-11eb-99a1-de0a77bf9625.png)
![image](https://user-images.githubusercontent.com/5261759/110823512-77b32f80-8292-11eb-9d05-a8f43feefd5d.png)
![image](https://user-images.githubusercontent.com/5261759/110823823-c1037f00-8292-11eb-8081-fb0ae29de90c.png)


