### PR TITLE
audio: Programmatic audio control

### DIFF
--- a/vita3k/audio/include/audio/state.h
+++ b/vita3k/audio/include/audio/state.h
@@ -27,6 +27,9 @@
 #include <mutex>
 #include <vector>
 
+#define SCE_AUDIO_OUT_MAX_VOL 32768 //!< Maximum output port volume
+#define SCE_AUDIO_VOLUME_0DB SCE_AUDIO_OUT_MAX_VOL //!< Maximum output port volume
+
 typedef std::shared_ptr<SDL_AudioStream> AudioStreamPtr;
 typedef std::function<void(SceUID)> ResumeAudioThread;
 
@@ -43,6 +46,11 @@ struct SharedAudioOutPortState {
 struct AudioOutPort {
     ReadOnlyAudioOutPortState ro;
     SharedAudioOutPortState shared;
+    // Channel range from 0 - 32768
+    int left_channel_volume = SCE_AUDIO_VOLUME_0DB;
+    int right_channel_volume = SCE_AUDIO_VOLUME_0DB;
+    // Volume range from 1 - 128
+    float volume = SDL_MIX_MAXVOLUME;
 };
 
 struct AudioInPort {

--- a/vita3k/audio/src/audio.cpp
+++ b/vita3k/audio/src/audio.cpp
@@ -52,7 +52,7 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
     const int bytes_got = SDL_AudioStreamGet(port.shared.stream.get(), temp_buffer, bytes_to_get);
     lock.unlock();
     if (bytes_got > 0) {
-        SDL_MixAudio(stream, temp_buffer, bytes_got, SDL_MIX_MAXVOLUME);
+        SDL_MixAudio(stream, temp_buffer, bytes_got, port.volume);
     }
 }
 


### PR DESCRIPTION
Implementing sceAudioOutSetVolume to allow software to adjust volume

This turns out to be a little more complicated than expected. Since audio relies on the **SDL_MixAudio** function, that function takes a volume param and applies the volume when mixing the samples. But the sceAudioOutSetVolume function can specify which channel it wants to lower volume on, which you cannot do with SDL_MixAudio. What I did in this PR is average the left and right channel volumes together and applied that to the **SDL_MixAudio** function, which I'm assuming we're not going to want to do. 

Possible solutions:
Apply the volume to the samples in the streams before mixing, but then we're running essentially the same function twice over the same set of sample data, also we'd have to account for every possible format the sample data can be received in.

Mix our own audio, which wouldn't be too hard, just mimicking what SDL_MixAudio does, but accounting for individual channels. 

I may be making this way more complicated than it is an there's an obvious solution that I am missing or don't know about.