### PR TITLE
mem: Split `mem.h` into `functions.h`, `state.h`, and `util.h`

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -23,7 +23,6 @@
 #include <gui/imgui_impl_sdl.h>
 #include <host/state.h>
 #include <io/functions.h>
-#include <mem/mem.h>
 #include <nids/functions.h>
 #include <renderer/functions.h>
 #include <rtc/rtc.h>

--- a/vita3k/cpu/include/cpu/functions.h
+++ b/vita3k/cpu/include/cpu/functions.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <mem/mem.h> // Address.
+#include <mem/util.h> // Address.
 #include <util/types.h>
 
 #include <cstdint>

--- a/vita3k/gdbstub/src/gdb.cpp
+++ b/vita3k/gdbstub/src/gdb.cpp
@@ -27,7 +27,7 @@
 #include <cpu/functions.h>
 #include <kernel/functions.h>
 
-#include <mem/mem.h>
+#include <mem/state.h>
 #include <spdlog/fmt/bundled/printf.h>
 #include <sstream>
 

--- a/vita3k/host/src/load_self.cpp
+++ b/vita3k/host/src/load_self.cpp
@@ -22,7 +22,6 @@
 #include <kernel/relocation.h>
 #include <kernel/state.h>
 #include <kernel/types.h>
-#include <mem/mem.h>
 
 #include <nids/functions.h>
 #include <util/arm.h>

--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include <mem/mem.h> // Address.
 #include <mem/ptr.h>
+#include <util/semaphore.h>
 
 #include <condition_variable>
 #include <mutex>
 #include <string>
-#include <util/semaphore.h>
 
 struct CPUState;
 struct CPUContext;

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -16,18 +16,15 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <kernel/functions.h>
-
 #include <kernel/state.h>
 #include <kernel/thread/thread_state.h>
 
 #include <cpu/functions.h>
-#include <mem/mem.h>
 #include <mem/ptr.h>
-
-#include <spdlog/fmt/fmt.h>
-
 #include <util/find.h>
 #include <util/log.h>
+
+#include <spdlog/fmt/fmt.h>
 
 Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID thread_id, int key) {
     SlotToAddress &slot_to_address = kernel.tls[thread_id];

--- a/vita3k/mem/CMakeLists.txt
+++ b/vita3k/mem/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(
 	mem
 	STATIC
-	src/mem.cpp
+	include/mem/functions.h
 	include/mem/mempool.h
-	include/mem/mem.h
 	include/mem/ptr.h
+	include/mem/state.h
+	include/mem/util.h
+	src/mem.cpp
 )
 
 target_include_directories(mem PUBLIC include)

--- a/vita3k/mem/include/mem/functions.h
+++ b/vita3k/mem/include/mem/functions.h
@@ -1,0 +1,32 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <mem/util.h>
+
+struct MemState;
+
+bool init(MemState &state);
+Address alloc(MemState &state, size_t size, const char *name);
+Address alloc(MemState &state, size_t size, const char *name, unsigned int alignment);
+Address alloc_at(MemState &state, Address address, size_t size, const char *name);
+void free(MemState &state, Address address);
+uint32_t mem_available(MemState &state);
+const char *mem_name(Address address, MemState &state);
+void add_breakpoint(MemState &state, bool gdb, bool thumb_mode, uint32_t addr, BreakpointCallback callback);
+void remove_breakpoint(MemState &state, uint32_t addr);

--- a/vita3k/mem/include/mem/ptr.h
+++ b/vita3k/mem/include/mem/ptr.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include <mem/mem.h>
+#include <mem/functions.h>
+#include <mem/state.h>
 
 template <class T>
 class Ptr {

--- a/vita3k/mem/include/mem/state.h
+++ b/vita3k/mem/include/mem/state.h
@@ -17,23 +17,10 @@
 
 #pragma once
 
-#include <functional>
+#include <mem/util.h>
+
 #include <map>
-#include <memory>
 #include <mutex>
-#include <string>
-#include <vector>
-
-typedef uint32_t Address;
-typedef size_t Generation;
-typedef std::unique_ptr<uint8_t[], std::function<void(uint8_t *)>> Memory;
-typedef std::vector<Generation> Allocated;
-typedef std::map<Generation, std::string> GenerationNames;
-
-struct CPUState;
-struct MemState;
-
-typedef void (*BreakpointCallback)(CPUState &, MemState &);
 
 struct Breakpoint {
     bool gdb;
@@ -52,25 +39,3 @@ struct MemState {
     std::map<Address, Address> aligned_addr_to_original;
     std::map<Address, Breakpoint> breakpoints;
 };
-
-constexpr size_t KB(size_t kb) {
-    return kb * 1024;
-}
-
-constexpr size_t MB(size_t mb) {
-    return mb * KB(1024);
-}
-
-constexpr size_t GB(size_t gb) {
-    return gb * MB(1024);
-}
-
-bool init(MemState &state);
-Address alloc(MemState &state, size_t size, const char *name);
-Address alloc(MemState &state, size_t size, const char *name, unsigned int alignment);
-Address alloc_at(MemState &state, Address address, size_t size, const char *name);
-void free(MemState &state, Address address);
-uint32_t mem_available(MemState &state);
-const char *mem_name(Address address, MemState &state);
-void add_breakpoint(MemState &state, bool gdb, bool thumb_mode, uint32_t addr, BreakpointCallback callback);
-void remove_breakpoint(MemState &state, uint32_t addr);

--- a/vita3k/mem/include/mem/util.h
+++ b/vita3k/mem/include/mem/util.h
@@ -1,0 +1,47 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+struct CPUState;
+struct MemState;
+
+typedef uint32_t Address;
+typedef size_t Generation;
+typedef std::unique_ptr<uint8_t[], std::function<void(uint8_t *)>> Memory;
+typedef std::vector<Generation> Allocated;
+typedef std::map<Generation, std::string> GenerationNames;
+
+typedef void (*BreakpointCallback)(CPUState &, MemState &);
+
+constexpr size_t KB(size_t kb) {
+    return kb * 1024;
+}
+
+constexpr size_t MB(size_t mb) {
+    return mb * KB(1024);
+}
+
+constexpr size_t GB(size_t gb) {
+    return gb * MB(1024);
+}

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -15,7 +15,9 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#include <mem/mem.h>
+#include <mem/functions.h>
+#include <mem/state.h>
+
 #include <util/align.h>
 #include <util/log.h>
 

--- a/vita3k/net/include/net/types.h
+++ b/vita3k/net/include/net/types.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mem/mem.h>
 #include <mem/ptr.h>
 
 enum SceNetProtocol {

--- a/vita3k/ngs/src/ngs.cpp
+++ b/vita3k/ngs/src/ngs.cpp
@@ -1,6 +1,5 @@
 #include <kernel/state.h>
 #include <kernel/thread/thread_functions.h>
-#include <mem/mem.h>
 #include <ngs/definitions/atrac9.h>
 #include <ngs/definitions/master.h>
 #include <ngs/definitions/passthrough.h>

--- a/vita3k/np/include/np/state.h
+++ b/vita3k/np/include/np/state.h
@@ -20,7 +20,7 @@
 #include <np/common.h>
 #include <np/trophy/context.h>
 
-#include <mem/mem.h> // Address.
+#include <mem/util.h> // Address.
 
 #include <map>
 #include <mutex>


### PR DESCRIPTION
I've had a lot of free time to do programming as of late, so I ended up doing more refactoring, naturally. However, it got to the point where this (which was _previously_ on my "To-Do List") has caught up: splitting `mem.h` so it properly reflects the rest of the repo.