### PR TITLE
util: Use std::optional for C++17 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ macro(pre_configure_boost)
 	set (Boost_USE_STATIC_LIBS ON)
 	find_package(Boost COMPONENTS filesystem system program_options QUIET)
 
-	if (Boost_FOUND)
+	if (${Boost_FOUND})
 		set(BOOST_INCLUDEDIR ${Boost_INCLUDE_DIRS})
 		set(BOOST_LIBRARYDIR ${Boost_LIBRARIES})
 	else()
@@ -38,6 +38,14 @@ endmacro(pre_configure_boost)
 
 if(NOT CI)
 	pre_configure_boost()
+endif()
+
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/GetStandard.cmake")
+get_standard_for_build()
+if(${CPP17_SUPPORTED})
+	set(STANDARD_NUM 17)
+else()
+	set(STANDARD_NUM 11)
 endif()
 
 if(WIN32)

--- a/cmake/GetStandard.cmake
+++ b/cmake/GetStandard.cmake
@@ -1,0 +1,60 @@
+option(COMPILE_MODERN_CPP "Compile ${PROJECT_NAME} as a C++17 or C++14 program" ON)
+option(COMPILE_CPP17 "Force compilation of ${PROJECT_NAME} as C++17" OFF)
+option(COMPILE_CPP14 "Force compilation of ${PROJECT_NAME} as C++14" OFF)
+mark_as_advanced(FORCE COMPILE_CPP17)
+mark_as_advanced(FORCE COMPILE_CPP14)
+
+# Assign the proper standard and compilation to the project based on the flags available.
+# This tests for C++17 and C++14 compatibility, while applying C++11 as a fallback.
+# Based on https://stackoverflow.com/a/44964919
+function(get_standard_for_build)
+	unset(STANDARD_FLAG PARENT_SCOPE)
+
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		set(COMPILER_TEST "-std=c++1z;-std=c++1y;-std=c++0x")
+	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+		# VS 2015.3+ does not have a C++11 option
+		set(COMPILER_TEST "/std:c++17;/std:c++14;INVALID")
+	elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+		set(COMPILER_TEST "-std=c++17;-std=c++14;-std=c++11")
+	else()
+		set(COMPILER_TEST "-std:c++17;-std:c++14;-std:c++11")
+	endif()
+
+	if(COMPILE_MODERN_CPP)
+		if(NOT COMPILE_CPP17 AND NOT COMPILE_CPP14)
+			include(CheckCXXCompilerFlag)
+			list(GET COMPILER_TEST 0 STANDARD_FLAG)
+			check_cxx_compiler_flag(${STANDARD_FLAG} HAS_CPP17_FLAG)
+
+			include(CheckIncludeFileCXX)
+			check_include_file_cxx("filesystem" HAS_CPP17_INCLUDE)
+			if(HAS_CPP17_FLAG AND HAS_CPP17_INCLUDE)
+				set(COMPILE_CPP17 ON)
+			else()
+				list(GET COMPILER_TEST 1 STANDARD_FLAG)
+				check_cxx_compiler_flag(${STANDARD_FLAG} HAS_CPP14_FLAG)
+				check_include_file_cxx("experimental/filesystem" HAS_EXPERIMENTAL)
+				if(HAS_CPP14_FLAG AND HAS_EXPERIMENTAL)
+					set(COMPILE_CPP14 ON)
+				else()
+					message(FATAL_ERROR "Your compiler does not support C++14 or C++17. "
+					"Call\ncmake -DCOMPILE_MODERN_CPP=OFF ..\n"
+					"to build ${PROJECT_NAME}.")
+				endif()
+			endif()
+		endif()
+
+		if(COMPILE_CPP17)
+			set(CPP17_SUPPORTED ON PARENT_SCOPE)
+			list(GET COMPILER_TEST 0 STANDARD_FLAG)
+		elseif(COMPILE_CPP14)
+			set(CPP14_SUPPORTED ON PARENT_SCOPE)
+			list(GET COMPILER_TEST 1 STANDARD_FLAG)
+		endif()
+	else()
+		list(GET COMPILER_TEST 2 STANDARD_FLAG)
+	endif()
+
+	set(STANDARD_FLAG ${STANDARD_FLAG} PARENT_SCOPE)
+endfunction()

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -34,16 +34,15 @@ macro(configure_boost)
 
 	include_directories(${Boost_INCLUDE_DIRS})
 
-	if(Boost_FOUND)
-		message("Using Boost_VERSION: ${Boost_VERSION}")
-		message("Using Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
-		message("Using Boost_LIBRARY_DIRS: ${Boost_LIBRARY_DIRS}")
-	else()
-		message("Boost library is not found")
-	endif()
+	message("Using Boost_VERSION: ${Boost_VERSION}")
+	message("Using Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
+	message("Using Boost_LIBRARY_DIRS: ${Boost_LIBRARY_DIRS}")
 endmacro(configure_boost)
 
 configure_boost()
+if(${STANDARD_NUM} GREATER 14)
+	add_definitions(-DVITA3K_CPP${STANDARD_NUM})
+endif()
 
 if (USE_GDBSTUB)
 	add_definitions(-DUSE_GDBSTUB)
@@ -99,6 +98,9 @@ if(USE_DISCORD_RICH_PRESENCE)
 endif()
 if(LINUX)
 	target_link_libraries(vita3k PRIVATE stdc++fs)
+endif()
+if(${STANDARD_NUM} GREATER 14)
+	target_compile_features(vita3k PUBLIC cxx_std_${STANDARD_NUM})
 endif()
 
 set_target_properties(vita3k PROPERTIES OUTPUT_NAME Vita3K

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -21,12 +21,8 @@
 #include <config/yaml.h>
 
 #include <util/fs.h>
+#include <util/optional.h>
 #include <util/vector_utils.h>
-
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
-
-using boost::optional;
 
 // Enum based on members in Config file
 // Used for easier getting of options and their names for config files
@@ -59,17 +55,17 @@ private:
 
     // Perform comparisons with optional settings
     void check_members(const Config &rhs) {
-        if (rhs.vpk_path.is_initialized())
+        if (rhs.vpk_path.has_value())
             vpk_path = rhs.vpk_path;
-        if (rhs.run_app_path.is_initialized())
+        if (rhs.run_app_path.has_value())
             run_app_path = rhs.run_app_path;
-        if (rhs.recompile_shader_path.is_initialized())
+        if (rhs.recompile_shader_path.has_value())
             recompile_shader_path = rhs.recompile_shader_path;
-        if (rhs.delete_title_id.is_initialized())
+        if (rhs.delete_title_id.has_value())
             delete_title_id = rhs.delete_title_id;
-        if (rhs.pkg_path.is_initialized())
+        if (rhs.pkg_path.has_value())
             pkg_path = rhs.pkg_path;
-        if (rhs.pkg_zrif.is_initialized())
+        if (rhs.pkg_zrif.has_value())
             pkg_zrif = rhs.pkg_zrif;
 
         if (!rhs.config_path.empty())

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -25,6 +25,10 @@
 
 #include <CLI11.hpp>
 
+#ifndef VITA3K_CPP17
+#include <boost/optional/optional_io.hpp>
+#endif
+
 #include <exception>
 #include <iostream>
 
@@ -213,15 +217,15 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
         return QuitRequested;
     }
 
-    if (command_line.recompile_shader_path.is_initialized()) {
+    if (command_line.recompile_shader_path.has_value()) {
         cfg.recompile_shader_path = std::move(command_line.recompile_shader_path);
         return QuitRequested;
     }
-    if (command_line.delete_title_id.is_initialized()) {
+    if (command_line.delete_title_id.has_value()) {
         cfg.delete_title_id = std::move(command_line.delete_title_id);
         return QuitRequested;
     }
-    if (command_line.pkg_path.is_initialized() && command_line.pkg_zrif.is_initialized()) {
+    if (command_line.pkg_path.has_value() && command_line.pkg_zrif.has_value()) {
         cfg.pkg_path = std::move(command_line.pkg_path);
         cfg.pkg_zrif = std::move(command_line.pkg_zrif);
         return QuitRequested;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -61,18 +61,18 @@ int main(int argc, char *argv[]) {
     HostState host;
     if (const auto err = config::init_config(cfg, argc, argv, root_paths) != Success) {
         if (err == QuitRequested) {
-            if (cfg.recompile_shader_path.is_initialized()) {
+            if (cfg.recompile_shader_path.has_value()) {
                 LOG_INFO("Recompiling {}", *cfg.recompile_shader_path);
                 shader::convert_gxp_to_glsl_from_filepath(*cfg.recompile_shader_path);
             }
-            if (cfg.delete_title_id.is_initialized()) {
+            if (cfg.delete_title_id.has_value()) {
                 LOG_INFO("Deleting title id {}", *cfg.delete_title_id);
                 fs::remove_all(fs::path(root_paths.get_pref_path()) / "ux0/app" / *cfg.delete_title_id);
                 fs::remove_all(fs::path(root_paths.get_pref_path()) / "ux0/addcont" / *cfg.delete_title_id);
                 fs::remove_all(fs::path(root_paths.get_pref_path()) / "ux0/user/00/savedata" / *cfg.delete_title_id);
                 fs::remove_all(fs::path(root_paths.get_pref_path()) / "shaderlog" / *cfg.delete_title_id);
             }
-            if (cfg.pkg_path.is_initialized() && cfg.pkg_zrif.is_initialized()) {
+            if (cfg.pkg_path.has_value() && cfg.pkg_zrif.has_value()) {
                 LOG_INFO("Installing pkg from {} ", *cfg.pkg_path);
                 host.pref_path = string_utils::utf_to_wide(root_paths.get_pref_path_string());
                 install_pkg(*cfg.pkg_path, host, *cfg.pkg_zrif, [](float) {});

--- a/vita3k/renderer/include/renderer/commands.h
+++ b/vita3k/renderer/include/renderer/commands.h
@@ -21,8 +21,6 @@
 #include <cstdint>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 struct GxmContextState;
 
 namespace renderer {

--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -24,12 +24,10 @@
 #include <shader/usse_utilities.h>
 
 #include <SPIRV/SpvBuilder.h>
-#include <boost/optional/optional.hpp>
 
 #include <array>
 #include <map>
 
-using boost::optional;
 struct FeatureState;
 
 namespace shader::usse {
@@ -119,7 +117,7 @@ public:
     /*
      * \brief Given an operand, load it and returns a SPIR-V vector with total components count equals to total bit set in
      *        write/dest mask
-     * 
+     *
      * \returns A copy of given operand
     */
     spv::Id load(Operand op, const Imm4 dest_mask, int shift_offset = 0);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -34,7 +34,6 @@
 
 #include <SPIRV/SpvBuilder.h>
 #include <SPIRV/disassemble.h>
-#include <boost/optional.hpp>
 #include <spirv_glsl.hpp>
 
 #include <algorithm>
@@ -45,8 +44,6 @@
 #include <sstream>
 #include <utility>
 #include <vector>
-
-using boost::optional;
 
 static constexpr bool LOG_SHADER_CODE = true;
 static constexpr bool DUMP_SPIRV_BINARIES = false;

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -24,6 +24,7 @@
 #include <shader/usse_disasm.h>
 #include <shader/usse_types.h>
 #include <util/log.h>
+#include <util/optional.h>
 
 using namespace shader;
 using namespace usse;

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -24,8 +24,7 @@
 #include <shader/usse_translator.h>
 #include <shader/usse_translator_types.h>
 #include <util/log.h>
-
-#include <boost/optional/optional.hpp>
+#include <util/optional.h>
 
 #include <map>
 
@@ -35,7 +34,7 @@ template <typename Visitor>
 using USSEMatcher = shader::decoder::Matcher<Visitor, uint64_t>;
 
 template <typename V>
-boost::optional<const USSEMatcher<V> &> DecodeUSSE(uint64_t instruction) {
+static optional<const USSEMatcher<V>> DecodeUSSE(uint64_t instruction) {
     static const std::vector<USSEMatcher<V>> table = {
 #define INST(fn, name, bitstring) shader::decoder::detail::detail<USSEMatcher<V>>::GetMatcher(fn, name, bitstring)
         // clang-format off
@@ -737,7 +736,12 @@ boost::optional<const USSEMatcher<V> &> DecodeUSSE(uint64_t instruction) {
     const auto matches_instruction = [instruction](const auto &matcher) { return matcher.Matches(instruction); };
 
     auto iter = std::find_if(table.begin(), table.end(), matches_instruction);
-    return iter != table.end() ? boost::optional<const USSEMatcher<V> &>(*iter) : boost::none;
+    return iter != table.end() ? optional<const USSEMatcher<V>>(*iter) :
+#ifdef VITA3K_CPP17
+                               std::nullopt;
+#else
+                               boost::none;
+#endif
 }
 
 //
@@ -830,7 +834,7 @@ spv::Function *USSERecompiler::get_or_recompile_block(const usse::USSEBlock &blo
 
             // Recompile the instruction, to the current block
             auto decoder = usse::DecodeUSSE<usse::USSETranslatorVisitor>(cur_instr);
-            if (decoder)
+            if (decoder.has_value())
                 decoder->call(visitor, cur_instr);
             else
                 LOG_DISASM("{:016x}: error: instruction unmatched", cur_instr);

--- a/vita3k/util/CMakeLists.txt
+++ b/vita3k/util/CMakeLists.txt
@@ -1,29 +1,51 @@
 add_library(
-    util
-    STATIC
-    include/util/overloaded.h
-    include/util/align.h
-    include/util/bytes.h
-    include/util/safe_time.h
-    include/util/exit_code.h
-    include/util/exec.h
-    include/util/find.h
-    include/util/fs.h
-    include/util/function_info.h
-    include/util/instrset_detect.h
-    include/util/semaphore.h
-    include/util/lock_and_find.h
-    include/util/log.h
-    include/util/preprocessor.h
-    include/util/pool.h
-    include/util/resource.h
-    include/util/string_utils.h
-    include/util/system.h
-    include/util/types.h
-    include/util/vector_utils.h
-    src/util.cpp
-    src/instrset_detect.cpp
+	util
+	STATIC
+	include/util/overloaded.h
+	include/util/align.h
+	include/util/bytes.h
+	include/util/safe_time.h
+	include/util/exit_code.h
+	include/util/exec.h
+	include/util/find.h
+	include/util/fs.h
+	include/util/function_info.h
+	include/util/instrset_detect.h
+	include/util/semaphore.h
+	include/util/lock_and_find.h
+	include/util/log.h
+	include/util/preprocessor.h
+	include/util/pool.h
+	include/util/resource.h
+	include/util/string_utils.h
+	include/util/system.h
+	include/util/types.h
+	include/util/vector_utils.h
+	src/util.cpp
+	src/instrset_detect.cpp
 )
 
-target_include_directories(util PUBLIC include)
+set(INCLUDE_BEGIN "#pragma once
+
+/*
+    THIS IS AN AUTOMATICALLY GENERATED FILE. DO NOT EDIT!
+*/")
+
+if(${STANDARD_NUM} GREATER 14)
+	set(INCLUDE_HEADER "optional")
+	set(NAMESPACE "std::optional")
+else()
+	set(INCLUDE_HEADER "boost/optional.hpp")
+	set(NAMESPACE "boost::optional")
+endif()
+
+set(INCLUDE_COMPLETE "${INCLUDE_BEGIN}
+
+#include <${INCLUDE_HEADER}>
+using ${NAMESPACE}\;
+")
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/include/util/optional.h" ${INCLUDE_COMPLETE})
+
+target_include_directories(util PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_link_libraries(util PUBLIC ${Boost_LIBRARIES} spdlog::spdlog)


### PR DESCRIPTION
Subset of #660. Done for easier merging.

This adds in the ability to compile Vita3K as a C++17 program. C++17 compilation will be used by default, but we still need Boost for the rest of the program (such as `psvpsfstools`), so `external/boost` won't be modified in this PR for safety.

~~Note that the minimum version requirement of Boost version 1.72 is for `boost::optional::has_value()` (which is effectively the same as `boost::optional::is_initialized()`).~~

Edit: I originally had the Boost requirement as 1.72, but that will only be built by the user, the CI will never need to use that, and APT is *for some absurd reason* still stuck on 1.71. Since we already have a local Boost at 1.72 and C++17, this requirements seems to be fully satisfied.