### PR TITLE
draw: handle two sided rendering for fragment program disable.

### DIFF
--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -113,8 +113,11 @@ void draw(GLState &renderer, GLContext &context, GxmContextState &state, const F
     set_uniform_buffer(context, true, SCE_GXM_REAL_MAX_UNIFORM_BUFFER, sizeof(GXMRenderVertUniformBlock), &vert_ublock, false);
 
     GXMRenderFragUniformBlock frag_ublock;
-    frag_ublock.back_disabled = (state.back_side_fragment_program_mode == SCE_GXM_FRAGMENT_PROGRAM_DISABLED) ? 1.0f : 0.0f;
     frag_ublock.front_disabled = (state.front_side_fragment_program_mode == SCE_GXM_FRAGMENT_PROGRAM_DISABLED) ? 1.0f : 0.0f;
+    if (state.two_sided == SCE_GXM_TWO_SIDED_DISABLED)
+        frag_ublock.back_disabled = frag_ublock.front_disabled;
+    else
+        frag_ublock.back_disabled = (state.back_side_fragment_program_mode == SCE_GXM_FRAGMENT_PROGRAM_DISABLED) ? 1.0f : 0.0f;
 
     set_uniform_buffer(context, false, SCE_GXM_REAL_MAX_UNIFORM_BUFFER, sizeof(GXMRenderFragUniformBlock), &frag_ublock, false);
 

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -341,8 +341,6 @@ COMMAND_SET_STATE(fragment_texture) {
 }
 
 COMMAND_SET_STATE(two_sided) {
-    REPORT_STUBBED();
-
     const SceGxmTwoSidedMode two_sided = helper.pop<SceGxmTwoSidedMode>();
     state->two_sided = two_sided;
 }


### PR DESCRIPTION
- fix issue for some game when two side is disabled.

# Result: 
- fix image remanent on wheel rotate
![image](https://user-images.githubusercontent.com/5261759/116399192-efc8bb00-a828-11eb-8a83-3d88d7696abb.png)

- fix black screen on ingame render.
![image](https://cdn.discordapp.com/attachments/534180053865725962/836935528599126046/unknown.png)

- fix font render and charachter missing 
![image](https://user-images.githubusercontent.com/5261759/116400015-d70cd500-a829-11eb-8a61-214d652320aa.png)