### PR TITLE
codeql: Fix warning "git checkout HEAD^2 is no longer necessary"

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,15 +46,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
           submodules: recursive
-
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
https://docs.github.com/en/code-security/secure-coding/troubleshooting-the-codeql-workflow#warning-git-checkout-head2-is-no-longer-necessary