### PR TITLE
live area: small refactor app list opened.

### DIFF
--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -76,8 +76,14 @@ std::vector<std::string>::iterator get_app_open_list_index(GuiState &gui, const 
 
 void update_apps_list_opened(GuiState &gui, const std::string &app_path) {
     if (get_app_open_list_index(gui, app_path) == gui.apps_list_opened.end())
-        gui.apps_list_opened.push_back(app_path);
+        gui.apps_list_opened.insert(gui.apps_list_opened.begin(), app_path);
     gui.current_app_selected = int32_t(std::distance(gui.apps_list_opened.begin(), get_app_open_list_index(gui, app_path)));
+    if (gui.apps_list_opened.size() > 6) {
+        const auto last_app = gui.apps_list_opened.back();
+        gui.live_area_contents.erase(last_app);
+        gui.live_items.erase(last_app);
+        gui.apps_list_opened.erase(get_app_open_list_index(gui, last_app));
+    }
 }
 
 static std::map<std::string, uint64_t> last_time;


### PR DESCRIPTION
# About
- just see on my psvita, it only using maximum 6 app open in same time on live area
- also new app open is open in first position and no in last, and delete so last app it already 6 app opened