### PR TITLE
gui/settings dialog: Add cpu backend choice.

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -117,6 +117,8 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
         state.pref_path = string_utils::utf_to_wide(state.cfg.pref_path);
     }
 
+    state.kernel.cpu_backend = state.cfg.cpu_backend == "Dynarmic" ? CPUBackend::Dynarmic : CPUBackend::Unicorn;
+
 #ifdef USE_VULKAN
     if (string_utils::toupper(state.cfg.backend_renderer) == "VULKAN")
         state.backend_renderer = renderer::Backend::Vulkan;
@@ -162,7 +164,7 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
         return false;
     }
 
-    if (!init(state.kernel, state.mem, cfg.cpu_pool_size, state.cpu_protocol.get(), cfg.dynarmic_cpu ? CPUBackend::Dynarmic : CPUBackend::Unicorn)) {
+    if (!init(state.kernel, state.mem, cfg.cpu_pool_size, state.cpu_protocol.get(), state.kernel.cpu_backend)) {
         LOG_WARN("Failed to init kernel!");
         return false;
     }

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -48,7 +48,7 @@
     code(int, "delay-start", 10, delay_start)                                                           \
     code(float, "background-alpha", .300f, background_alpha)                                            \
     code(int, "log-level", static_cast<int>(spdlog::level::trace), log_level)                           \
-    code(bool, "dynarmic-cpu", false, dynarmic_cpu)                                                     \
+    code(std::string, "cpu-backend", "Unicorn", cpu_backend)                                            \
     code(std::string, "pref-path", std::string{}, pref_path)                                            \
     code(std::string, "last-app", std::string{}, last_app)                                              \
     code(bool, "discord-rich-presence", true, discord_rich_presence)                                    \

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -266,6 +266,7 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
 
         LOG_INFO_IF(cfg.vpk_path, "input-vpk-path: {}", *cfg.vpk_path);
         LOG_INFO_IF(cfg.run_app_path, "input-installed-path: {}", *cfg.run_app_path);
+        LOG_INFO("{}: {}", cfg[e_cpu_backend], cfg.cpu_backend);
         LOG_INFO("{}: {}", cfg[e_backend_renderer], cfg.backend_renderer);
         LOG_INFO("{}: {}", cfg[e_log_level], cfg.log_level);
         LOG_INFO_IF(cfg.log_imports, "{}: enabled", cfg[e_log_imports]);


### PR DESCRIPTION
# About
- Add cpu backend choice in setting dialog.
- Add cpu backend used in log.
- reafctor cpu backend in app init

# Result:
![image](https://user-images.githubusercontent.com/5261759/117541970-d0931000-b016-11eb-8ec7-83dbde3ac5b5.png)
