### PR TITLE
gui: Add dialog warning for app close.

### DIFF
--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -131,6 +131,10 @@ Do not power off the system or close the application.</warning_saving>
 	</save_data>
 </dialog>
 
+<game_data>
+	<app_close>The following application will close.</app_close>
+</game_data>
+
 <indicator>
 	<app_added_home>The application has been added to the home screen.</app_added_home>
 	<delete_all>Delete All</delete_all>

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -131,6 +131,10 @@ Do not power off the system or close the application.</warning_saving>
 	</save_data>
 </dialog>
 
+<game_data>
+	<app_close>The following application will close.</app_close>
+</game_data>
+
 <indicator>
 	<app_added_home>The application has been added to the home screen.</app_added_home>
 	<delete_all>Delete All</delete_all>

--- a/lang/fr.xml
+++ b/lang/fr.xml
@@ -131,6 +131,10 @@ Ne pas éteindre le système, ni fermer l'application.</warning_saving>
 	</save_data>
 </dialog>
 
+<game_data>
+	<app_close>L'application suivante va être fermée.</app_close>
+</game_data>
+
 <indicator>
 	<app_added_home>L'application a été ajoutée à l'écran d'accueil.</app_added_home>
 	<delete_all>Supprimer tout</delete_all>

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -78,7 +78,7 @@ void pre_run_app(GuiState &gui, HostState &host, const std::string &app_path);
 bool refresh_app_list(GuiState &gui, HostState &host);
 void save_user(GuiState &gui, HostState &host, const std::string &user_id);
 void set_config(GuiState &gui, HostState &host, const std::string &app_path);
-void update_apps_list_opened(GuiState &gui, const std::string &app_path);
+void update_apps_list_opened(GuiState &gui, HostState &host, const std::string &app_path);
 void update_notice_info(GuiState &gui, HostState &host, const std::string &type);
 void save_notice_list(HostState &host);
 

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -75,6 +75,7 @@ struct AppsSelector {
 };
 
 struct LiveAreaState {
+    bool app_close = false;
     bool app_selector = false;
     bool content_manager = false;
     bool information_bar = false;
@@ -153,6 +154,7 @@ struct Lang {
     std::string user_lang;
     std::map<std::string, std::string> main_menubar;
     std::map<std::string, std::string> app_context;
+    std::map<std::string, std::string> game_data;
     std::map<std::string, std::string> indicator;
     std::map<std::string, std::string> settings;
     std::map<std::string, std::string> trophy_collection;

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -509,6 +509,9 @@ void draw_end(GuiState &gui, SDL_Window *window) {
 void draw_live_area(GuiState &gui, HostState &host) {
     ImGui::PushFont(gui.vita_font);
 
+    if (gui.live_area.app_close)
+        draw_app_close(gui, host);
+
     if (gui.live_area.app_selector)
         draw_app_selector(gui, host);
 

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -214,6 +214,13 @@ void init_lang(GuiState &gui, HostState &host) {
                 }
             }
 
+            // Game Data
+            if (!lang_xml.child("game_data").empty()) {
+                auto &lang_game_data = gui.lang.game_data;
+                const auto game_data = lang_xml.child("game_data");
+                lang_game_data["app_close"] = game_data.child("app_close").text().as_string();
+            }
+
             // Indicator
             if (!lang_xml.child("indicator").empty()) {
                 auto &lang_indicator = gui.lang.indicator;

--- a/vita3k/gui/src/private.h
+++ b/vita3k/gui/src/private.h
@@ -64,6 +64,7 @@ void draw_controls_dialog(GuiState &gui, HostState &host);
 void draw_about_dialog(GuiState &gui, HostState &host);
 void draw_welcome_dialog(GuiState &gui, HostState &host);
 
+void draw_app_close(GuiState &gui, HostState &host);
 void draw_app_selector(GuiState &gui, HostState &host);
 void draw_content_manager(GuiState &gui, HostState &host);
 void draw_information_bar(GuiState &gui, HostState &host);

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -1158,7 +1158,7 @@ void draw_settings(GuiState &gui, HostState &host) {
                             gui.apps_list_opened.clear();
                             gui.live_area_contents.clear();
                             gui.live_items.clear();
-                            update_apps_list_opened(gui, "NPXS10015");
+                            update_apps_list_opened(gui, host, "NPXS10015");
                             init_notice_info(gui, host);
                             init_live_area(gui, host);
                         }

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -423,7 +423,7 @@ bool handle_events(HostState &host, GuiState &gui) {
                 // Show/Hide Live Area during app run
                 // TODO pause app running
                 if (event.key.keysym.scancode == host.cfg.keyboard_button_psbutton) {
-                    gui::update_apps_list_opened(gui, host.io.title_id);
+                    gui::update_apps_list_opened(gui, host, host.io.app_path);
                     gui::init_live_area(gui, host);
                     gui.live_area.information_bar = !gui.live_area.information_bar;
                     gui.live_area.live_area_screen = !gui.live_area.live_area_screen;


### PR DESCRIPTION
# About:
- Adding dialog warning for can close app if one running.
- Improve update app list openend more psvitya close, app already open is move in first place, and for one app run if is last app in list, it erase just before it.

# Result:
![image](https://user-images.githubusercontent.com/5261759/117732667-92e9df00-b1f0-11eb-954d-cf46809eeded.png)