### PR TITLE
Correct copying data to stack in startthread

### DIFF
--- a/vita3k/cpu/include/cpu/common.h
+++ b/vita3k/cpu/include/cpu/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <fmt/format.h>
 #include <mem/ptr.h> // Address.
 #include <util/types.h>
 
@@ -7,6 +8,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -66,6 +68,20 @@ struct CPUContext {
 
     void set_pc(uint32_t val) {
         cpu_registers[15] = val;
+    }
+
+    std::string description() {
+        std::stringstream ss;
+        uint32_t pc = get_pc();
+        uint32_t sp = get_sp();
+        uint32_t lr = get_lr();
+
+        ss << fmt::format("PC: 0x{:0>8x},   SP: 0x{:0>8x},   LR: 0x{:0>8x}\n", pc, sp, lr);
+        for (int a = 0; a < 6; a++) {
+            ss << fmt::format("r{: <2}: 0x{:0>8x}   r{: <2}: 0x{:0>8x}\n", a, cpu_registers[a], a + 6, cpu_registers[a + 6]);
+        }
+        ss << fmt::format("r12: 0x{:0>8x}\n", cpu_registers[12]);
+        return ss.str();
     }
 };
 

--- a/vita3k/kernel/include/kernel/thread/thread_functions.h
+++ b/vita3k/kernel/include/kernel/thread/thread_functions.h
@@ -40,7 +40,7 @@ void exit_thread(ThreadState &thread);
 void exit_and_delete_thread(ThreadState &thread);
 void delete_thread(KernelState &kernel, ThreadState &thread);
 int wait_thread_end(ThreadStatePtr &waiter, ThreadStatePtr &target, int *stat);
-Ptr<void> copy_stack(SceUID thid, SceUID thread_id, const Ptr<void> &argp, KernelState &kernel, MemState &mem);
+Ptr<void> copy_block_to_stack(ThreadState &thread, MemState &mem, const Ptr<void> &data, const int size);
 int run_callback(KernelState &kernel, ThreadState &thread, const SceUID &thid, Address callback_address, const std::vector<uint32_t> &args);
 uint32_t run_on_current(ThreadState &thread, const Ptr<const void> entry_point, SceSize arglen, const Ptr<void> &argp);
 void raise_waiting_threads(ThreadState *thread);

--- a/vita3k/modules/SceFiber/SceFiber.cpp
+++ b/vita3k/modules/SceFiber/SceFiber.cpp
@@ -19,6 +19,7 @@
 
 #include "cpu/functions.h"
 
+#include <sstream>
 #include <util/lock_and_find.h>
 #include <util/log.h>
 
@@ -40,6 +41,18 @@ LIBRARY_INIT_IMPL(SceFiber) {
     host.kernel.obj_store.create<FiberState>();
 }
 LIBRARY_INIT_REGISTER(SceFiber)
+
+std::string _describeFiber(ThreadStatePtr thread, SceFiber *fiber) {
+    std::stringstream ss;
+    ss << fmt::format("Fiber (name: {})\n", fiber->name);
+    ss << fmt::format("entry: {}\n", log_hex(fiber->cpu->get_pc()), log_hex(fiber->entry.address()));
+    ss << "CPU Context:\n";
+    ss << fiber->cpu->description();
+    ss << "Referenced from " << thread->id << "\n";
+    ss << "CPU Context:\n";
+    ss << thread->cpu_context.description();
+    return ss.str();
+}
 
 InitialFiber *_findIntialFiber(FiberState &state, Address sp) {
     // TODO use interval tree

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -396,7 +396,11 @@ EXPORT(int, _sceKernelSignalLwCondTo) {
 }
 
 EXPORT(int, _sceKernelStartThread, SceUID thid, SceSize arglen, Ptr<void> argp) {
-    Ptr<void> new_argp = copy_stack(thid, thread_id, argp, host.kernel, host.mem);
+    auto thread = lock_and_find(thid, host.kernel.threads, host.kernel.mutex);
+    Ptr<void> new_argp(0);
+    if (argp && arglen > 0) {
+        new_argp = copy_block_to_stack(*thread, host.mem, argp, arglen);
+    }
     const int res = start_thread(host.kernel, thid, arglen, new_argp);
     if (res < 0) {
         return RET_ERROR(res);


### PR DESCRIPTION
# About
- Correct copying data to stack in startthread
- Add some functions for debugging

This one fixes the crash happening in the boot stage of gravity crash full version. (it's still in black screen so don't be hyped yet)