### PR TITLE
live area: fix color issue, rgb value request divide by 255.f.

### DIFF
--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -1023,9 +1023,9 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
                     else
                         sscanf(str_tag.color.c_str(), "#%x", &color);
 
-                    str_color.push_back(ImVec4(float((color >> 16) & 0xFF), float((color >> 8) & 0xFF), float((color >> 0) & 0xFF), 255.f));
+                    str_color.push_back(ImVec4(((color >> 16) & 0xFF) / 255.f, ((color >> 8) & 0xFF) / 255.f, ((color >> 0) & 0xFF) / 255.f, 1.f));
                 } else
-                    str_color.push_back(ImVec4(255.f, 255.f, 255.f, 255.f));
+                    str_color.push_back(ImVec4(1.f, 1.f, 1.f, 1.f));
 
                 auto str_size = scal_size_frame, text_pos = pos_frame;
 


### PR DESCRIPTION
# About pr
ImVec4 value for color is max 1,1,1, so need divide rgb value by 255 
i fix my proper stupid fail after moving from AddText to Textcolored, forget changed it.

- fix color wrong on some game.

# Result: 
- Uncharted
![image](https://cdn.discordapp.com/attachments/570773633270546442/841697225670393866/unknown.png)
- Senran kargura bon apetit
![image](https://user-images.githubusercontent.com/5261759/117844146-bd36ad80-b27f-11eb-945e-6731a69fbaae.png)
