### PR TITLE
shader/translator: add DUAL FADD handling

### DIFF
--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1360,6 +1360,7 @@ bool USSETranslatorVisitor::vdual(
             result = load(ops[0], write_mask_source);
             break;
         }
+        case Opcode::FADD:
         case Opcode::VADD: {
             const spv::Id first = load(ops[0], write_mask_source);
             const spv::Id second = load(ops[1], write_mask_source);


### PR DESCRIPTION
No visible difference, I just think that it's right. (In the following code it looks like F and V prefixes are the same)