### PR TITLE
Fix ubc texture with width or height not divisible by 4

### DIFF
--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -154,7 +154,7 @@ const uint32_t *get_texture_palette(const SceGxmTexture &texture, const MemState
  * \param image            Pointer to the image where the decompressed pixels will be stored.
  * \param bc_type          Block compressed type. BC1 (DXT1), BC2 (DXT2) or BC3 (DXT3).
  */
-void decompress_bc_swizz_image(std::uint32_t width, std::uint32_t height, const std::uint8_t *block_storage, std::uint32_t *image, const std::uint8_t bc_type);
+void decompress_bc_image(std::uint32_t width, std::uint32_t height, const std::uint8_t *block_storage, std::uint32_t *image, const std::uint8_t bc_type);
 
 void swizzled_texture_to_linear_texture(uint8_t *dest, const uint8_t *src, uint16_t width, uint16_t height, uint8_t bits_per_pixel);
 void tiled_texture_to_linear_texture(uint8_t *dest, const uint8_t *src, uint16_t width, uint16_t height, uint8_t bits_per_pixel);

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -484,6 +484,7 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RED, GL_UNSIGNED_BYTE, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_U2F10F10F10_ABGR:
+    case SCE_GXM_COLOR_FORMAT_U2U10U10U10_ABGR:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_INT_2_10_10_10_REV, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_F16_R:

--- a/vita3k/renderer/src/texture_format.cpp
+++ b/vita3k/renderer/src/texture_format.cpp
@@ -437,20 +437,12 @@ static void decompress_block_dxt5(std::uint32_t x, std::uint32_t y, std::uint32_
  * \param image            Pointer to the image where the decompressed pixels will be stored.
  * \param bc_type          Block compressed type. BC1 (DXT1), BC2 (DXT2) or BC3 (DXT3).
  */
-void decompress_bc_swizz_image(std::uint32_t width, std::uint32_t height, const std::uint8_t *block_storage, std::uint32_t *image, const std::uint8_t bc_type) {
+void decompress_bc_image(std::uint32_t width, std::uint32_t height, const std::uint8_t *block_storage, std::uint32_t *image, const std::uint8_t bc_type) {
     std::uint32_t block_count_x = (width + 3) / 4;
     std::uint32_t block_count_y = (height + 3) / 4;
     std::uint32_t block_size = (bc_type > 1) ? 16 : 8;
 
     std::uint32_t temp_block_result[16] = {};
-
-    // This looks like swizzle order but it's not.
-    static const int dxt_order[] = {
-        0, 2, 8, 10,
-        1, 3, 9, 11,
-        4, 6, 12, 14,
-        5, 7, 13, 15
-    };
 
     for (std::uint32_t j = 0; j < block_count_y; j++) {
         for (std::uint32_t i = 0; i < block_count_x; i++) {
@@ -468,11 +460,15 @@ void decompress_bc_swizz_image(std::uint32_t width, std::uint32_t height, const 
                 break;
             }
 
-            for (int b = 0; b < 16; b++) {
-                image[dxt_order[b]] = temp_block_result[b];
+            for (int dy = 0; dy < 4; dy++) {
+                for (int dx = 0; dx < 4; dx++) {
+                    const uint32_t y = (j * block_size * 4 + dy);
+                    const uint32_t x = (i * block_size * 4 + dx);
+                    if (x >= width || y >= height)
+                        continue;
+                    image[width * y + x] = temp_block_result[dy * 4 + dx];
+                }
             }
-
-            image += 16;
         }
 
         block_storage += block_count_x * block_size;


### PR DESCRIPTION
This was causing heap corruption in gravity rush.