### PR TITLE
Fix ubc with width or height not divisible by 4 again

### DIFF
--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -154,7 +154,7 @@ const uint32_t *get_texture_palette(const SceGxmTexture &texture, const MemState
  * \param image            Pointer to the image where the decompressed pixels will be stored.
  * \param bc_type          Block compressed type. BC1 (DXT1), BC2 (DXT2) or BC3 (DXT3).
  */
-void decompress_bc_image(std::uint32_t width, std::uint32_t height, const std::uint8_t *block_storage, std::uint32_t *image, const std::uint8_t bc_type);
+void decompress_bc_swizz_image(std::uint32_t width, std::uint32_t height, const std::uint8_t *block_storage, std::uint32_t *image, const std::uint8_t bc_type);
 
 void swizzled_texture_to_linear_texture(uint8_t *dest, const uint8_t *src, uint16_t width, uint16_t height, uint8_t bits_per_pixel);
 void tiled_texture_to_linear_texture(uint8_t *dest, const uint8_t *src, uint16_t width, uint16_t height, uint8_t bits_per_pixel);

--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -93,7 +93,7 @@ void configure_bound_texture(const SceGxmTexture &gxm_texture) {
  * 
  * \return Size of source taken.
  */
-static size_t decompress_and_unswizzle_compressed_texture(SceGxmTextureBaseFormat fmt, void *dest, const void *data, const std::uint32_t width, const std::uint32_t height) {
+static size_t decompress_compressed_swizz_texture(SceGxmTextureBaseFormat fmt, void *dest, const void *data, const std::uint32_t width, const std::uint32_t height) {
     int ubc_type = 0;
 
     switch (fmt) {
@@ -114,15 +114,14 @@ static size_t decompress_and_unswizzle_compressed_texture(SceGxmTextureBaseForma
     }
 
     if (ubc_type) {
-        renderer::texture::decompress_bc_image(width, height, reinterpret_cast<const std::uint8_t *>(data),
+        renderer::texture::decompress_bc_swizz_image(width, height, reinterpret_cast<const std::uint8_t *>(data),
             reinterpret_cast<std::uint32_t *>(dest), ubc_type);
         return (((width + 3) / 4) * ((height + 3) / 4) * ((ubc_type > 1) ? 16 : 8));
     } else if ((fmt >= SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP) && (fmt <= SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP)) {
         // TODO, is not perfect for PVRT-II.
         pvr::PVRTDecompressPVRTC(data, (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP) || (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII2BPP), width, height,
             (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII2BPP) || (fmt == SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP), reinterpret_cast<uint8_t *>(dest));
-        renderer::texture::swizzled_texture_to_linear_texture(reinterpret_cast<uint8_t *>(dest), reinterpret_cast<uint8_t *>(dest), width, height, 32);
-        // TODO, calcule return is not sure.
+        // TODO, calcule return is not sur.
         return ((width + 3) / 4) * ((height + 3) / 4);
     }
 
@@ -249,7 +248,7 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
             if (need_decompress_and_unswizzle_on_cpu) {
                 // Must decompress them
                 texture_data_decompressed.resize(width * height * 4);
-                source_size = decompress_and_unswizzle_compressed_texture(base_format, texture_data_decompressed.data(), pixels, width, height);
+                source_size = decompress_compressed_swizz_texture(base_format, texture_data_decompressed.data(), pixels, width, height);
                 bytes_per_pixel = 4;
                 bpp = 32;
                 pixels = texture_data_decompressed.data();
@@ -282,8 +281,6 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
                 pixels = texture_data_decompressed.data();
                 break;
             default:
-                if (need_decompress_and_unswizzle_on_cpu)
-                    break;
                 // Convert data
                 texture_pixels_lineared.resize(width * height * bytes_per_pixel);
 
@@ -295,6 +292,9 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
                         static_cast<std::uint8_t>(bpp));
 
                 pixels = texture_pixels_lineared.data();
+
+                if (need_decompress_and_unswizzle_on_cpu)
+                    texture_data_decompressed.clear();
                 break;
             }
 

--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -204,6 +204,7 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
     size_t bytes_per_pixel = (bpp + 7) >> 3;
 
     const auto texture_type = gxm_texture.texture_type();
+    const bool is_ubc = (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC1) || (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC2) || (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC3);
     const bool is_swizzled = (texture_type == SCE_GXM_TEXTURE_SWIZZLED) || (texture_type == SCE_GXM_TEXTURE_CUBE) || (texture_type == SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY) || (texture_type == SCE_GXM_TEXTURE_CUBE_ARBITRARY);
     const bool need_decompress_and_unswizzle_on_cpu = is_swizzled && !can_texture_be_unswizzled_without_decode(base_format);
 
@@ -243,6 +244,11 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
             if ((texture_type == SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY) || (texture_type == SCE_GXM_TEXTURE_CUBE_ARBITRARY)) {
                 width = nearest_power_of_two(width);
                 height = nearest_power_of_two(height);
+            }
+
+            if (is_ubc) {
+                width = align(width, 4);
+                height = align(height, 4);
             }
 
             if (need_decompress_and_unswizzle_on_cpu) {
@@ -298,7 +304,7 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
                 break;
             }
 
-            if ((texture_type == SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY) || (texture_type == SCE_GXM_TEXTURE_CUBE_ARBITRARY)) {
+            if ((texture_type == SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY) || (texture_type == SCE_GXM_TEXTURE_CUBE_ARBITRARY) || is_ubc) {
                 width = org_width;
                 height = org_height;
             }


### PR DESCRIPTION
The ubc was swizzled outside 4x4 block so my recent pr that assumed linear layout was wrong. 

This pr reverts that recent pr and tris to solve the original problem again. It does by padding destination buffer to multiples of 4. It will not run out of source because source is destined to have enough amount of blocks. (since bc format doesn't define "half block") Texture will be read correctly by opengl since it's using appropriate stride that accounts for padding and supply "orig_width," and "orig_height" as texture size.

