### PR TITLE
kernel: Reimplement SceFiber

### DIFF
--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -45,8 +45,6 @@ struct ThreadState {
     int priority;
     int stack_size;
     CPUStatePtr cpu;
-    CPUContext cpu_context;
-    Ptr<void> fiber;
     ThreadToDo to_do = ThreadToDo::run;
     std::mutex mutex;
     sync_utils::Semaphore signal;

--- a/vita3k/kernel/src/thread/thread.cpp
+++ b/vita3k/kernel/src/thread/thread.cpp
@@ -105,8 +105,6 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
         write_reg(*thread->cpu, 1, option->size);
     }
 
-    thread->cpu_context = save_context(*thread->cpu);
-
     alloc_name = fmt::format("TLS for thread {} (#{})", name, thid);
 
     auto tls_size = kernel_tls_size + (kernel.tls_msize == 0xcccccccc ? 0 : kernel.tls_msize);

--- a/vita3k/modules/SceFiber/SceFiber.h
+++ b/vita3k/modules/SceFiber/SceFiber.h
@@ -41,14 +41,24 @@ struct SceFiberOptParam {
     char reserved[128];
 };
 
+enum class FiberStatus {
+    INIT,
+    SUSPEND,
+    RUN
+};
+
 typedef struct SceFiber {
     Ptr<SceFiberEntry> entry;
-    SceUInt32 argOnInitialize;
     Address addrContext;
     SceSize sizeContext;
     char name[32];
     CPUContext *cpu;
+    SceUInt32 argOnInitialize;
+    Ptr<uint32_t> argOnRun;
+    FiberStatus status;
 } SceFiber;
+
+static_assert(sizeof(SceFiber) <= 128, "SceFiber sturct size is more than 128");
 
 LIBRARY_INIT_DECL(SceFiber)
 BRIDGE_DECL(_sceFiberAttachContextAndRun)


### PR DESCRIPTION
# About
There were many bugs in our fiber implementation mostly on dealing of status, returntothread, no context fiber, and runOn notification. This pr reimplements fiber with cleaner code.
# Fixes
- Gravity rush demo random crash at the beginning.
- Saenai random crash. (seems to be fixed; need to confirm)

