### PR TITLE
Fix fiber regression and remove cpu mem leak

### DIFF
--- a/vita3k/cpu/include/cpu/impl/interface.h
+++ b/vita3k/cpu/include/cpu/impl/interface.h
@@ -7,6 +7,8 @@
 
 /*! \brief Base class for all CPU backend implementation */
 struct CPUInterface {
+    virtual ~CPUInterface(){};
+
     virtual int run() = 0;
     virtual void stop() = 0;
 


### PR DESCRIPTION
Fixing some stupid mistakes. Cpu mem leak happens when you create bunch of threads. The derived destructor was not called so cpu was not freed even after thread was freed.