### PR TITLE
Redesign guest function calling

### DIFF
--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -85,7 +85,7 @@ add_subdirectory(touch)
 add_subdirectory(util)
 add_subdirectory(gdbstub)
 
-add_executable(vita3k MACOSX_BUNDLE main.cpp interface.cpp interface.h performance.cpp cpu_protocol.h cpu_protocol.cpp)
+add_executable(vita3k MACOSX_BUNDLE main.cpp interface.cpp interface.h performance.cpp)
 
 target_link_libraries(vita3k PRIVATE app gui modules)
 if(USE_DISCORD_RICH_PRESENCE)

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -96,10 +96,10 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
     const ResumeAudioThread resume_thread = [&state](SceUID thread_id) {
         const auto thread = lock_and_find(thread_id, state.kernel.threads, state.kernel.mutex);
         const std::lock_guard<std::mutex> lock(thread->mutex);
-        if (thread->to_do == ThreadToDo::wait) {
-            thread->to_do = ThreadToDo::run;
+        if (thread->status == ThreadStatus::wait) {
+            thread->status = ThreadStatus::run;
         }
-        thread->something_to_do.notify_all();
+        thread->status_cond.notify_all();
     };
 
     state.cfg = std::move(cfg);

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -24,6 +24,7 @@
 #include <host/state.h>
 #include <io/functions.h>
 #include <kernel/functions.h>
+#include <kernel/thread/thread_functions.h>
 #include <nids/functions.h>
 #include <renderer/functions.h>
 #include <rtc/rtc.h>
@@ -97,9 +98,8 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
         const auto thread = lock_and_find(thread_id, state.kernel.threads, state.kernel.mutex);
         const std::lock_guard<std::mutex> lock(thread->mutex);
         if (thread->status == ThreadStatus::wait) {
-            thread->status = ThreadStatus::run;
+            update_status(*thread, ThreadStatus::run);
         }
-        thread->status_cond.notify_all();
     };
 
     state.cfg = std::move(cfg);

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -286,7 +286,10 @@ static ExitCode load_app_impl(Ptr<const void> &entry_point, HostState &host, con
     if (path.empty())
         return InvalidApplicationPath;
 
-    if (!init(host.kernel, host.mem, host.cfg.cpu_pool_size, host.cpu_protocol.get(), host.kernel.cpu_backend, host.kernel.cpu_opt)) {
+    const auto call_import = [&host](CPUState &cpu, uint32_t nid, SceUID thread_id) {
+        ::call_import(host, cpu, nid, thread_id);
+    };
+    if (!init(host.kernel, host.mem, host.cfg.cpu_pool_size, call_import, host.kernel.cpu_backend, host.kernel.cpu_opt)) {
         LOG_WARN("Failed to init kernel!");
         return KernelInitFailed;
     }

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -546,10 +546,7 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
         LOG_DEBUG("Running module_start of library: {} at address {}", module_name, log_hex(module_start.address()));
 
         auto argp = Ptr<void>();
-        const SceUID module_thread_id = create_thread(module_start, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), nullptr);
-        const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
-        const auto ret = run_on_current(*module_thread, module_start, 0, argp);
-        delete_thread(host.kernel, *module_thread);
+        const auto ret = run_guest_function(host.kernel, module_start.address(), { 0, argp.address() });
 
         LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(ret));
     }

--- a/vita3k/kernel/CMakeLists.txt
+++ b/vita3k/kernel/CMakeLists.txt
@@ -5,11 +5,13 @@ set(SOURCE_LIST
 	include/kernel/thread/thread_data_queue.h
 	include/kernel/thread/thread_functions.h
 	include/kernel/thread/thread_state.h
+	include/kernel/cpu_protocol.h
 	include/kernel/sync_primitives.h
 	include/kernel/relocation.h
 	include/kernel/object_store.h
 	src/kernel.cpp
 	src/thread.cpp
+	src/cpu_protocol.cpp
 	src/sync_primitives.cpp
 	src/relocation.cpp
 )

--- a/vita3k/kernel/include/kernel/cpu_protocol.h
+++ b/vita3k/kernel/include/kernel/cpu_protocol.h
@@ -18,11 +18,12 @@
 #pragma once
 
 #include <cpu/common.h>
+#include <kernel/state.h>
 
-struct HostState;
+typedef std::function<void(CPUState &cpu, uint32_t nid, SceUID thread_id)> CallImportFunc;
 
 struct CPUProtocol : public CPUProtocolBase {
-    CPUProtocol(HostState &host);
+    CPUProtocol(KernelState &kernel, MemState &mem, const CallImportFunc &func);
     ~CPUProtocol();
     void call_svc(CPUState &cpu, uint32_t svc, Address pc, SceUID thread_id) override;
     Address get_watch_memory_addr(Address addr) override;
@@ -30,5 +31,7 @@ struct CPUProtocol : public CPUProtocolBase {
     ExclusiveMonitorPtr get_exlusive_monitor() override;
 
 private:
-    HostState *host;
+    CallImportFunc call_import;
+    KernelState *kernel;
+    MemState *mem;
 };

--- a/vita3k/kernel/include/kernel/cpu_protocol.h
+++ b/vita3k/kernel/include/kernel/cpu_protocol.h
@@ -18,7 +18,8 @@
 #pragma once
 
 #include <cpu/common.h>
-#include <kernel/state.h>
+
+struct KernelState;
 
 typedef std::function<void(CPUState &cpu, uint32_t nid, SceUID thread_id)> CallImportFunc;
 

--- a/vita3k/kernel/include/kernel/functions.h
+++ b/vita3k/kernel/include/kernel/functions.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cpu/common.h>
+#include <kernel/cpu_protocol.h>
 #include <kernel/types.h>
 #include <util/types.h>
 

--- a/vita3k/kernel/include/kernel/functions.h
+++ b/vita3k/kernel/include/kernel/functions.h
@@ -30,6 +30,7 @@ struct CPUState;
 
 Ptr<Ptr<void>> get_thread_tls_addr(KernelState &kernel, MemState &mem, SceUID thread_id, int key);
 void stop_all_threads(KernelState &kernel);
+int run_guest_function(KernelState &kernel, Address callback_address, const std::vector<uint32_t> &args);
 
 void add_watch_memory_addr(KernelState &state, Address addr, size_t size);
 void remove_watch_memory_addr(KernelState &state, Address addr);
@@ -37,4 +38,4 @@ Address get_watch_memory_addr(KernelState &state, Address addr);
 
 void update_watches(KernelState &state);
 
-bool init(KernelState &state, MemState &mem, int cpu_pool_size, CPUProtocolBase *cpu_protocol, CPUBackend cpu_backend, bool cpu_opt);
+bool init(KernelState &state, MemState &mem, int cpu_pool_size, CallImportFunc call_import, CPUBackend cpu_backend, bool cpu_opt);

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -38,6 +38,8 @@ struct ThreadState;
 
 struct SDL_Thread;
 
+struct CPUProtocol;
+
 struct WatchMemory;
 
 struct InitialFiber;
@@ -58,6 +60,7 @@ typedef std::map<Address, uint32_t> NidFromExport;
 typedef std::map<Address, uint32_t> NotFoundVars;
 typedef std::map<Address, WatchMemory> WatchMemoryAddrs;
 typedef std::vector<ModuleRegion> ModuleRegions;
+typedef std::unique_ptr<CPUProtocol> CPUProtocolPtr;
 typedef Pool<CPUState> CPUPool;
 
 struct CodecEngineBlock {
@@ -138,11 +141,12 @@ struct KernelState {
     NotFoundVars not_found_vars;
     WatchMemoryAddrs watch_memory_addrs;
     ModuleRegions module_regions;
-    ExclusiveMonitorPtr exclusive_monitor;
+
     CPUPool cpu_pool;
     CPUBackend cpu_backend;
     bool cpu_opt;
-    CPUProtocolBase *cpu_protocol;
+    CPUProtocolPtr cpu_protocol;
+    ExclusiveMonitorPtr exclusive_monitor;
 
     ObjectStore obj_store;
 

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cpu/functions.h>
+#include <kernel/cpu_protocol.h>
 #include <kernel/sync_primitives.h>
 #include <kernel/thread/thread_state.h>
 #include <kernel/types.h>
@@ -37,8 +38,6 @@
 struct ThreadState;
 
 struct SDL_Thread;
-
-struct CPUProtocol;
 
 struct WatchMemory;
 
@@ -132,8 +131,6 @@ struct KernelState {
     EventFlagPtrs eventflags;
     MsgPipePtrs msgpipes;
     ThreadStatePtrs threads;
-    ThreadPtrs running_threads;
-    KernelWaitingThreadStates waiting_threads;
     SceKernelModuleInfoPtrs loaded_modules;
     LoadedSysmodules loaded_sysmodules;
     ExportNids export_nids;
@@ -142,7 +139,7 @@ struct KernelState {
     WatchMemoryAddrs watch_memory_addrs;
     ModuleRegions module_regions;
 
-    CPUPool cpu_pool;
+    ThreadStatePtr guest_func_runner;
     CPUBackend cpu_backend;
     bool cpu_opt;
     CPUProtocolPtr cpu_protocol;

--- a/vita3k/kernel/include/kernel/sync_primitives.h
+++ b/vita3k/kernel/include/kernel/sync_primitives.h
@@ -148,12 +148,6 @@ struct MsgPipe : SyncPrimitive {
 typedef std::shared_ptr<MsgPipe> MsgPipePtr;
 typedef std::map<SceUID, MsgPipePtr> MsgPipePtrs;
 
-struct WaitingThreadState {
-    std::string name; // for debugging
-};
-
-typedef std::map<SceUID, WaitingThreadState> KernelWaitingThreadStates;
-
 enum class SyncWeight {
     Light, // lightweight
     Heavy // 'heavy'weight

--- a/vita3k/kernel/include/kernel/thread/thread_functions.h
+++ b/vita3k/kernel/include/kernel/thread/thread_functions.h
@@ -34,6 +34,7 @@ typedef std::function<void(CPUState &, uint32_t, SceUID)> CallImport;
 typedef std::function<std::string(Address)> ResolveNIDName;
 typedef std::shared_ptr<ThreadState> ThreadStatePtr;
 
+ThreadStatePtr create_thread(KernelState &kernel, MemState &mem, const char *name);
 SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState &mem, const char *name, int init_priority, int stack_size, const SceKernelThreadOptParam *option);
 int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const Ptr<void> &argp);
 Ptr<void> copy_block_to_stack(ThreadState &thread, MemState &mem, const Ptr<void> &data, const int size);
@@ -44,5 +45,5 @@ void delete_thread(KernelState &kernel, ThreadState &thread);
 int wait_thread_end(ThreadStatePtr &waiter, ThreadStatePtr &target, int *stat);
 void raise_waiting_threads(ThreadState *thread);
 
-int run_callback(KernelState &kernel, ThreadState &thread, const SceUID &thid, Address callback_address, const std::vector<uint32_t> &args);
-uint32_t run_on_current(ThreadState &thread, const Ptr<const void> entry_point, SceSize arglen, const Ptr<void> &argp);
+int run_guest_function(KernelState &kernel, ThreadState &thread, Address callback_address, const std::vector<uint32_t> &args);
+void request_callback(ThreadState &thread, Address callback_address, const std::vector<uint32_t> &args, const std::function<void(int res)> notify = nullptr);

--- a/vita3k/kernel/include/kernel/thread/thread_functions.h
+++ b/vita3k/kernel/include/kernel/thread/thread_functions.h
@@ -24,6 +24,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 
 struct CPUState;
@@ -39,6 +40,8 @@ SceUID create_thread(Ptr<const void> entry_point, KernelState &kernel, MemState 
 int start_thread(KernelState &kernel, const SceUID &thid, SceSize arglen, const Ptr<void> &argp);
 Ptr<void> copy_block_to_stack(ThreadState &thread, MemState &mem, const Ptr<void> &data, const int size);
 bool is_running(KernelState &kernel, ThreadState &thread);
+void update_status(ThreadState &thread, ThreadStatus status, std::optional<ThreadStatus> expected = std::nullopt);
+void wait_thread_status(ThreadState &thread, ThreadStatus status);
 void exit_thread(ThreadState &thread);
 void exit_and_delete_thread(ThreadState &thread);
 void delete_thread(KernelState &kernel, ThreadState &thread);

--- a/vita3k/kernel/src/cpu_protocol.cpp
+++ b/vita3k/kernel/src/cpu_protocol.cpp
@@ -17,6 +17,8 @@
 
 #include <kernel/cpu_protocol.h>
 #include <kernel/functions.h>
+#include <kernel/state.h>
+#include <util/lock_and_find.h>
 
 CPUProtocol::CPUProtocol(KernelState &kernel, MemState &mem, const CallImportFunc &func)
     : call_import(func)
@@ -28,8 +30,27 @@ CPUProtocol::~CPUProtocol() {
 }
 
 void CPUProtocol::call_svc(CPUState &cpu, uint32_t svc, Address pc, SceUID thread_id) {
+    // TODO: just supply ThreadStatePtr to call_import
+    // the only benefit of using thread_id instead--namely less locking--is now gone.
+    ThreadStatePtr thread = lock_and_find(thread_id, kernel->threads, kernel->mutex);
     uint32_t nid = *Ptr<uint32_t>(pc + 4).get(*mem);
     call_import(cpu, nid, thread_id);
+    if (!thread->jobs_to_add.empty()) {
+        const auto current = thread->run_queue.begin();
+        // Add resuming job
+        ThreadJob job;
+        job.ctx = save_context(cpu);
+        job.notify = current->notify;
+        thread->run_queue.erase(current);
+        thread->run_queue.push_front(job);
+
+        // Add requested callback jobs
+        for (auto it = thread->jobs_to_add.rbegin(); it != thread->jobs_to_add.rend(); ++it) {
+            thread->run_queue.push_front(*it);
+        }
+        thread->jobs_to_add.clear();
+        stop(*thread->cpu);
+    }
 }
 
 Address CPUProtocol::get_watch_memory_addr(Address addr) {

--- a/vita3k/kernel/src/cpu_protocol.cpp
+++ b/vita3k/kernel/src/cpu_protocol.cpp
@@ -15,30 +15,31 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#include "cpu_protocol.h"
+#include <kernel/cpu_protocol.h>
 #include <kernel/functions.h>
-#include <modules/module_parent.h>
 
-CPUProtocol::CPUProtocol(HostState &host)
-    : host(&host) {
+CPUProtocol::CPUProtocol(KernelState &kernel, MemState &mem, const CallImportFunc &func)
+    : call_import(func)
+    , kernel(&kernel)
+    , mem(&mem) {
 }
 
 CPUProtocol::~CPUProtocol() {
 }
 
 void CPUProtocol::call_svc(CPUState &cpu, uint32_t svc, Address pc, SceUID thread_id) {
-    uint32_t nid = *Ptr<uint32_t>(pc + 4).get(host->mem);
-    ::call_import(*host, cpu, nid, thread_id);
+    uint32_t nid = *Ptr<uint32_t>(pc + 4).get(*mem);
+    call_import(cpu, nid, thread_id);
 }
 
 Address CPUProtocol::get_watch_memory_addr(Address addr) {
-    return ::get_watch_memory_addr(host->kernel, addr);
+    return ::get_watch_memory_addr(*kernel, addr);
 }
 
 std::vector<ModuleRegion> &CPUProtocol::get_module_regions() {
-    return host->kernel.module_regions;
+    return kernel->module_regions;
 }
 
 ExclusiveMonitorPtr CPUProtocol::get_exlusive_monitor() {
-    return host->kernel.exclusive_monitor;
+    return kernel->exclusive_monitor;
 }

--- a/vita3k/kernel/src/sync_primitives.cpp
+++ b/vita3k/kernel/src/sync_primitives.cpp
@@ -80,12 +80,12 @@ inline int handle_timeout(const ThreadStatePtr &thread, std::unique_lock<std::mu
     std::unique_lock<std::mutex> &primitive_lock, WaitingThreadQueuePtr &queue,
     const WaitingThreadData &data, const char *export_name, SceUInt *const timeout) {
     if (timeout && *timeout > 0) {
-        auto status = thread->something_to_do.wait_for(thread_lock, std::chrono::microseconds{ *timeout }, [&] { return thread->to_do == ThreadToDo::run; });
+        auto status = thread->status_cond.wait_for(thread_lock, std::chrono::microseconds{ *timeout }, [&] { return thread->status == ThreadStatus::run; });
 
         if (!status) {
             *timeout = 0; // Time run out, so remaining time is 0
 
-            thread->to_do = ThreadToDo::run;
+            thread->status = ThreadStatus::run;
 
             primitive_lock.lock();
             queue->erase(data);
@@ -93,7 +93,7 @@ inline int handle_timeout(const ThreadStatePtr &thread, std::unique_lock<std::mu
             return RET_ERROR(SCE_KERNEL_ERROR_WAIT_TIMEOUT);
         }
     } else {
-        thread->something_to_do.wait(thread_lock, [&] { return thread->to_do == ThreadToDo::run; });
+        thread->status_cond.wait(thread_lock, [&] { return thread->status == ThreadStatus::run; });
     }
 
     return SCE_KERNEL_OK;
@@ -198,8 +198,8 @@ inline int mutex_lock_impl(KernelState &kernel, MemState &mem, const char *expor
 
         // Sleep thread!
         std::unique_lock<std::mutex> thread_lock(thread->mutex);
-        assert(thread->to_do == ThreadToDo::run);
-        thread->to_do = ThreadToDo::wait;
+        assert(thread->status == ThreadStatus::run);
+        thread->status = ThreadStatus::wait;
 
         WaitingThreadData data;
         data.thread = thread;
@@ -278,14 +278,14 @@ inline int mutex_unlock_impl(KernelState &kernel, const char *export_name, SceUI
 
                 const std::lock_guard<std::mutex> waiting_thread_lock(waiting_thread->mutex);
 
-                assert(waiting_thread->to_do == ThreadToDo::wait);
-                waiting_thread->to_do = ThreadToDo::run;
+                assert(waiting_thread->status == ThreadStatus::wait);
+                waiting_thread->status = ThreadStatus::run;
 
                 mutex->waiting_threads->pop();
                 mutex->lock_count += waiting_lock_count;
                 mutex->owner = waiting_thread;
 
-                waiting_thread->something_to_do.notify_one();
+                waiting_thread->status_cond.notify_one();
             }
         }
     }
@@ -405,8 +405,8 @@ int semaphore_wait(KernelState &kernel, const char *export_name, SceUID thread_i
 
     if (semaphore->val < signal) {
         std::unique_lock<std::mutex> thread_lock(thread->mutex);
-        assert(thread->to_do == ThreadToDo::run);
-        thread->to_do = ThreadToDo::wait;
+        assert(thread->status == ThreadStatus::run);
+        thread->status = ThreadStatus::wait;
 
         WaitingThreadData data;
         data.thread = thread;
@@ -458,13 +458,13 @@ int semaphore_signal(KernelState &kernel, const char *export_name, SceUID thread
         if (!waiting_thread_lock)
             continue;
 
-        assert(waiting_thread->to_do == ThreadToDo::wait);
-        waiting_thread->to_do = ThreadToDo::run;
+        assert(waiting_thread->status == ThreadStatus::wait);
+        waiting_thread->status = ThreadStatus::run;
 
         semaphore->waiting_threads->pop();
         semaphore->val -= waiting_signal_count;
 
-        waiting_thread->something_to_do.notify_one();
+        waiting_thread->status_cond.notify_one();
     }
 
     return SCE_KERNEL_OK;
@@ -557,8 +557,8 @@ int condvar_wait(KernelState &kernel, MemState &mem, const char *export_name, Sc
         return error;
 
     std::unique_lock<std::mutex> thread_lock(thread->mutex);
-    assert(thread->to_do == ThreadToDo::run);
-    thread->to_do = ThreadToDo::wait;
+    assert(thread->status == ThreadStatus::run);
+    thread->status = ThreadStatus::wait;
 
     WaitingThreadData data;
     data.thread = thread;
@@ -601,9 +601,9 @@ int condvar_signal(KernelState &kernel, const char *export_name, SceUID thread_i
         if (waiting_thread_iter != waiting_threads->end()) {
             const std::lock_guard<std::mutex> waiting_thread_lock(waiting_thread->mutex);
 
-            assert(waiting_thread->to_do == ThreadToDo::wait);
-            waiting_thread->to_do = ThreadToDo::run;
-            waiting_thread->something_to_do.notify_one();
+            assert(waiting_thread->status == ThreadStatus::wait);
+            waiting_thread->status = ThreadStatus::run;
+            waiting_thread->status_cond.notify_one();
             waiting_threads->erase(waiting_thread_iter);
         } else {
             LOG_ERROR("{}: Target thread {} not found", export_name, waiting_thread->name);
@@ -616,9 +616,9 @@ int condvar_signal(KernelState &kernel, const char *export_name, SceUID thread_i
             if (!waiting_thread_lock)
                 continue;
 
-            assert(waiting_thread->to_do == ThreadToDo::wait);
-            waiting_thread->to_do = ThreadToDo::run;
-            waiting_thread->something_to_do.notify_one();
+            assert(waiting_thread->status == ThreadStatus::wait);
+            waiting_thread->status = ThreadStatus::run;
+            waiting_thread->status_cond.notify_one();
             waiting_threads->pop();
         }
     }
@@ -741,8 +741,8 @@ static int eventflag_waitorpoll(KernelState &kernel, const char *export_name, Sc
         }
     } else if (dowait) {
         std::unique_lock<std::mutex> thread_lock(thread->mutex);
-        assert(thread->to_do == ThreadToDo::run);
-        thread->to_do = ThreadToDo::wait;
+        assert(thread->status == ThreadStatus::run);
+        thread->status = ThreadStatus::wait;
 
         WaitingThreadData data;
         data.thread = thread;
@@ -813,9 +813,9 @@ SceInt32 eventflag_set(KernelState &kernel, const char *export_name, SceUID thre
                 continue;
             }
 
-            assert(waiting_thread->to_do == ThreadToDo::wait);
-            waiting_thread->to_do = ThreadToDo::run;
-            waiting_thread->something_to_do.notify_one();
+            assert(waiting_thread->status == ThreadStatus::wait);
+            waiting_thread->status = ThreadStatus::run;
+            waiting_thread->status_cond.notify_one();
 
             event->waiting_threads->erase(it++);
         } else {
@@ -957,8 +957,8 @@ int msgpipe_recv(KernelState &kernel, const char *export_name, SceUID thread_id,
                     assert(jt != msgpipe->sender_threads->end());
 
                     msgpipe->sender_threads->erase(jt);
-                    sender_thread->to_do = ThreadToDo::run;
-                    sender_thread->something_to_do.notify_one();
+                    sender_thread->status = ThreadStatus::run;
+                    sender_thread->status_cond.notify_one();
                 }
             }
 
@@ -972,8 +972,8 @@ int msgpipe_recv(KernelState &kernel, const char *export_name, SceUID thread_id,
             } else {
                 // Wait
                 std::unique_lock<std::mutex> thread_lock(thread->mutex);
-                assert(thread->to_do == ThreadToDo::run);
-                thread->to_do = ThreadToDo::wait;
+                assert(thread->status == ThreadStatus::run);
+                thread->status = ThreadStatus::wait;
 
                 WaitingThreadData data;
                 data.thread = thread;
@@ -996,8 +996,8 @@ int msgpipe_recv(KernelState &kernel, const char *export_name, SceUID thread_id,
     if (!msgpipe->reciever_threads->empty()) {
         auto recv_thread = (*msgpipe->reciever_threads->begin()).thread;
         msgpipe->reciever_threads->pop();
-        recv_thread->to_do = ThreadToDo::run;
-        recv_thread->something_to_do.notify_one();
+        recv_thread->status = ThreadStatus::run;
+        recv_thread->status_cond.notify_one();
     }
 
     return read_size;
@@ -1034,15 +1034,15 @@ int msgpipe_send(KernelState &kernel, const char *export_name, SceUID thread_id,
     if (!msgpipe->reciever_threads->empty()) {
         auto recv_thread = (*msgpipe->reciever_threads->begin()).thread;
         msgpipe->reciever_threads->pop();
-        recv_thread->to_do = ThreadToDo::run;
-        recv_thread->something_to_do.notify_one();
+        recv_thread->status = ThreadStatus::run;
+        recv_thread->status_cond.notify_one();
     }
 
     // Wait
     if (data.waiting_sender) {
         std::unique_lock<std::mutex> thread_lock(thread->mutex);
-        assert(thread->to_do == ThreadToDo::run);
-        thread->to_do = ThreadToDo::wait;
+        assert(thread->status == ThreadStatus::run);
+        thread->status = ThreadStatus::wait;
 
         WaitingThreadData data;
         data.thread = thread;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -17,7 +17,6 @@
 
 #include "interface.h"
 
-#include "cpu_protocol.h"
 #include <app/functions.h>
 #include <app/screen_render.h>
 #include <config/functions.h>
@@ -128,8 +127,6 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    // TODO move this to app_init after module refactoring
-    host.cpu_protocol = std::make_unique<CPUProtocol>(host);
     if (!app::init(host, cfg, root_paths)) {
         app::error_dialog("Host initialization failed.", host.window.get());
         return HostInitFailed;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -222,8 +222,8 @@ int main(int argc, char *argv[]) {
     if (cfg.console) {
         auto main_thread = host.kernel.threads.at(host.main_thread_id);
         auto lock = std::unique_lock<std::mutex>(main_thread->mutex);
-        main_thread->something_to_do.wait(lock, [&]() {
-            return main_thread->to_do == ThreadToDo::exit;
+        main_thread->status_cond.wait(lock, [&]() {
+            return main_thread->status == ThreadStatus::dormant;
         });
         return Success;
     } else {

--- a/vita3k/modules/SceAudio/SceAudio.cpp
+++ b/vita3k/modules/SceAudio/SceAudio.cpp
@@ -120,10 +120,10 @@ EXPORT(int, sceAudioOutOutput, int port, const void *buf) {
         lock.unlock();
 
         std::unique_lock<std::mutex> mlock(thread->mutex);
-        if (thread->to_do != ThreadToDo::run)
+        if (thread->status != ThreadStatus::run)
             return 0;
-        thread->to_do = ThreadToDo::wait;
-        thread->something_to_do.wait(mlock);
+        thread->status = ThreadStatus::wait;
+        thread->status_cond.wait(mlock, [&]() { return thread->status == ThreadStatus::run; });
     }
 
     return 0;

--- a/vita3k/modules/SceAvPlayer/SceAvPlayer.cpp
+++ b/vita3k/modules/SceAvPlayer/SceAvPlayer.cpp
@@ -313,7 +313,9 @@ EXPORT(int32_t, sceAvPlayerEnableStream, SceUID player_handle, uint32_t stream_n
 EXPORT(bool, sceAvPlayerGetAudioData, SceUID player_handle, SceAvPlayerFrameInfo *frame_info) {
     const auto state = host.kernel.obj_store.get<AvPlayerState>();
     const PlayerPtr &player_info = lock_and_find(player_handle, state->players, state->mutex);
-
+    if (!player_info) {
+        return SCE_AVPLAYER_ERROR_ILLEGAL_ADDR;
+    }
     Ptr<uint8_t> buffer;
 
     if (player_info->paused) {

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -24,6 +24,7 @@
 #include <gxm/functions.h>
 #include <gxm/types.h>
 #include <immintrin.h>
+#include <kernel/functions.h>
 #include <kernel/thread/thread_functions.h>
 #include <mem/allocator.h>
 #include <mem/mempool.h>
@@ -40,7 +41,7 @@ static Ptr<void> gxmRunDeferredMemoryCallback(KernelState &kernel, const MemStat
     const ThreadStatePtr thread = lock_and_find(thread_id, kernel.threads, kernel.mutex);
     const Address final_size_addr = stack_alloc(*thread->cpu, 4);
 
-    Ptr<void> result(static_cast<Address>(run_callback(kernel, *thread, thread_id, callback.address(),
+    Ptr<void> result(static_cast<Address>(run_guest_function(kernel, callback.address(),
         { userdata.address(), size, final_size_addr })));
 
     return_size = *Ptr<std::uint32_t>(final_size_addr).get(mem);
@@ -1593,13 +1594,8 @@ static int SDLCALL thread_function(void *data) {
         renderer::wishlist(newBuffer, renderer::SyncObjectSubject::Fragment);
 
         // Now run callback
-        {
-            const ThreadStatePtr thread = lock_and_find(params.thid, params.kernel->threads, params.kernel->mutex);
-            if ((!thread) || thread->to_do == ThreadToDo::exit)
-                break;
-        }
         const ThreadStatePtr display_thread = util::find(params.thid, params.kernel->threads);
-        run_callback(*params.kernel, *display_thread, params.thid, display_callback->pc, { display_callback->data });
+        run_guest_function(*params.kernel, *display_thread, display_callback->pc, { display_callback->data });
 
         free(*params.mem, display_callback->data);
 
@@ -1644,9 +1640,8 @@ EXPORT(int, sceGxmInitialize, const SceGxmInitializeParams *params) {
     gxm_params.gxm = &host.gxm;
     gxm_params.renderer = host.renderer.get();
 
-    const ThreadPtr running_thread(SDL_CreateThread(&thread_function, "SceGxmDisplayQueue", &gxm_params), [](SDL_Thread *running_thread) {});
+    SDL_CreateThread(&thread_function, "SceGxmDisplayQueue", &gxm_params);
     SDL_SemWait(gxm_params.host_may_destroy_params.get());
-    host.kernel.running_threads.emplace(host.gxm.display_queue_thread, running_thread);
     host.gxm.notification_region = Ptr<uint32_t>(alloc(host.mem, MB(1), "SceGxmNotificationRegion"));
     memset(host.gxm.notification_region.get(host.mem), 0, MB(1));
     return 0;

--- a/vita3k/modules/SceIme/SceIme.cpp
+++ b/vita3k/modules/SceIme/SceIme.cpp
@@ -27,8 +27,9 @@ EXPORT(void, SceImeEventHandler, Ptr<void> arg, const SceImeEvent *e) {
     Ptr<SceImeEvent> e1 = Ptr<SceImeEvent>(alloc(host.mem, sizeof(SceImeEvent), "ime2"));
     memcpy(e1.get(host.mem), e, sizeof(SceImeEvent));
     auto thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
-    run_callback(host.kernel, *thread, thread_id, host.ime.param.handler.address(), { arg.address(), e1.address() });
-    free(host.mem, e1.address());
+    request_callback(*thread, host.ime.param.handler.address(), { arg.address(), e1.address() }, [&host, e1](int res) {
+        free(host.mem, e1.address());
+    });
 }
 
 EXPORT(SceInt32, sceImeClose) {

--- a/vita3k/modules/SceKernelModulemgr/SceModulemgr.cpp
+++ b/vita3k/modules/SceKernelModulemgr/SceModulemgr.cpp
@@ -18,6 +18,7 @@
 #include "SceModulemgr.h"
 #include <host/load_self.h>
 #include <io/functions.h>
+#include <kernel/functions.h>
 #include <kernel/state.h>
 #include <kernel/thread/thread_functions.h>
 #include <modules/module_parent.h>
@@ -102,19 +103,12 @@ EXPORT(SceUID, _sceKernelLoadStartModule, const char *moduleFileName, SceSize ar
     if (!load_module(mod_id, entry_point, module, host, export_name, moduleFileName, error_val))
         return error_val;
 
-    const SceUID thid = create_thread(entry_point.cast<const void>(), host.kernel, host.mem, module->module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER,
-        static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), nullptr);
-
-    const ThreadStatePtr thread = lock_and_find(thid, host.kernel.threads, host.kernel.mutex);
-
-    uint32_t result = run_on_current(*thread, entry_point, args, argp);
+    uint32_t result = run_guest_function(host.kernel, entry_point.address(), { args, argp.address() });
 
     LOG_INFO("Module {} (at \"{}\") module_start returned {}", module->module_name, module->path, log_hex(result));
 
     if (pRes)
         *pRes = result;
-
-    delete_thread(host.kernel, *thread);
 
     return mod_id;
 }

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -677,7 +677,7 @@ EXPORT(int, sceKernelDeleteSimpleEvent) {
 
 EXPORT(int, sceKernelDeleteThread, SceUID thid) {
     const ThreadStatePtr thread = lock_and_find(thid, host.kernel.threads, host.kernel.mutex);
-    if (!thread || thread->to_do != ThreadToDo::exit) {
+    if (!thread || thread->status != ThreadStatus::dormant) {
         return SCE_KERNEL_ERROR_NOT_DORMANT;
     }
     delete_thread(host.kernel, *thread);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -1136,7 +1136,7 @@ EXPORT(int, sceKernelGetThreadExitStatus, SceUID thid, SceInt32 *pExitStatus) {
     if (!thread) {
         return SCE_KERNEL_ERROR_UNKNOWN_THREAD_ID;
     }
-    if (thread->to_do != ThreadToDo::exit) {
+    if (thread->status != ThreadStatus::dormant) {
         return SCE_KERNEL_ERROR_NOT_DORMANT;
     }
     if (pExitStatus) {

--- a/vita3k/modules/SceNetCtl/SceNetCtl.cpp
+++ b/vita3k/modules/SceNetCtl/SceNetCtl.cpp
@@ -117,7 +117,7 @@ EXPORT(int, sceNetCtlCheckCallback) {
 
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
     for (auto &callback : host.net.cbs) {
-        run_callback(host.kernel, *thread, thread_id, callback.second.pc, { 1, callback.second.data });
+        request_callback(*thread, callback.second.pc, { 1, callback.second.data });
     }
     return STUBBED("Stub");
 }

--- a/vita3k/modules/SceNpManager/SceNpManager.cpp
+++ b/vita3k/modules/SceNpManager/SceNpManager.cpp
@@ -47,7 +47,7 @@ EXPORT(int, sceNpCheckCallback) {
 
     const ThreadStatePtr thread = lock_and_find(thread_id, host.kernel.threads, host.kernel.mutex);
     for (auto &callback : host.np.cbs) {
-        run_callback(host.kernel, *thread, thread_id, callback.second.pc, { (uint32_t)host.np.state, callback.second.data });
+        request_callback(*thread, callback.second.pc, { (uint32_t)host.np.state, callback.second.data });
     }
 
     return STUBBED("Stub");

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -196,11 +196,7 @@ bool load_module(HostState &host, SceSysmoduleModuleId module_id) {
                 LOG_DEBUG("Running module_start of module: {}", module_name);
 
                 Ptr<void> argp = Ptr<void>();
-                const SceUID module_thread_id = create_thread(lib_entry_point, host.kernel, host.mem, module_name, SCE_KERNEL_DEFAULT_PRIORITY_USER,
-                    static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_DEFAULT), nullptr);
-                const ThreadStatePtr module_thread = util::find(module_thread_id, host.kernel.threads);
-                const auto ret = run_on_current(*module_thread, lib_entry_point, 0, argp);
-                delete_thread(host.kernel, *module_thread);
+                const auto ret = run_guest_function(host.kernel, lib_entry_point.address(), { 0, argp.address() });
                 LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(ret));
             }
 

--- a/vita3k/ngs/src/ngs.cpp
+++ b/vita3k/ngs/src/ngs.cpp
@@ -1,3 +1,4 @@
+#include <kernel/functions.h>
 #include <kernel/state.h>
 #include <kernel/thread/thread_functions.h>
 #include <ngs/definitions/atrac9.h>
@@ -127,7 +128,7 @@ void ModuleData::invoke_callback(KernelState &kernel, const MemState &mem, const
     info->callback_ptr = Ptr<void>(reason_ptr);
     info->userdata = user_data;
 
-    run_callback(kernel, *thread, thread_id, callback.address(), { callback_info_addr });
+    run_guest_function(kernel, callback.address(), { callback_info_addr });
     stack_free(*thread->cpu, sizeof(CallbackInfo));
 }
 


### PR DESCRIPTION
You can call guest function through three ways.

1. request_callback(current_thread, address, args) inside the interrupt handler

This queue a callback to current thread. After hle function returns, the thread will run the callback function, and return to the previous point. Any number of callbacks work, callback inside callback also works.

2. run_guest_function(kernel, address, args) from anywhere

This will queue a quest function call to single global worker thread. The worker thread will run requested quest functions one by one. This function is blocking and returned value is what guest function returned.

3. run_guest_function(kernel, worker_thread, address, args) from anywhere

If you don't want to use global worker in concern of bottleneck, you can create additional thread and specify here. GXM display callback is using a custom worker thread.


DON'T USE RUN_GUEST_FUNCTION WITH CURRENT THREAD INSIDE INTERRUPT HANDLER. It will be broken after callback finish. If you want to use current thread to run callback, use request_callback function.
