### PR TITLE
gui: fix trophy dialog for multiple unlock in same time.

### DIFF
--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -243,7 +243,7 @@ struct GuiState {
     TrophyAnimationStage trophy_window_frame_stage{ TrophyAnimationStage::SLIDE_IN };
     ImTextureID trophy_window_icon{};
 
-    std::queue<NpTrophyUnlockCallbackData> trophy_unlock_display_requests;
+    std::vector<NpTrophyUnlockCallbackData> trophy_unlock_display_requests;
     std::mutex trophy_unlock_display_requests_access_mutex;
 
     ImVec2 trophy_window_pos;

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -490,7 +490,7 @@ void init(GuiState &gui, HostState &host) {
     // Initialize trophy callback
     host.np.trophy_state.trophy_unlock_callback = [&gui](NpTrophyUnlockCallbackData &callback_data) {
         const std::lock_guard<std::mutex> guard(gui.trophy_unlock_display_requests_access_mutex);
-        gui.trophy_unlock_display_requests.push(std::move(callback_data));
+        gui.trophy_unlock_display_requests.insert(gui.trophy_unlock_display_requests.begin(), callback_data);
     };
 }
 

--- a/vita3k/gui/src/trophy_unlocked.cpp
+++ b/vita3k/gui/src/trophy_unlocked.cpp
@@ -118,7 +118,7 @@ void draw_trophies_unlocked(GuiState &gui, HostState &host) {
     if (!gui.trophy_unlock_display_requests.empty()) {
         if (gui.trophy_window_frame_stage == TrophyAnimationStage::END) {
             update_notice_info(gui, host, "trophy");
-            gui.trophy_unlock_display_requests.pop();
+            gui.trophy_unlock_display_requests.pop_back();
 
             // Destroy the texture
             if (gui.trophy_window_frame_count != 0xFFFFFFFF)


### PR DESCRIPTION
# About: 
In master, i have see case on MS RC, i have get 3 trophy in same time with using my psvita save, and Unlocked dialog + notification have glitched with get 3 time same trophy unlock.
 
- fix trophy order and out in unlocked and notif dialog if get few trophy in same time.


# Result:
| Before | After |
| --- | --- |
| <img  src="https://user-images.githubusercontent.com/5261759/118427410-6856c500-b6cd-11eb-9130-24cd2abff257.png"> | <img  src="https://user-images.githubusercontent.com/5261759/118426978-82dc6e80-b6cc-11eb-8467-4928089aabc7.png"> |
