### PR TITLE
Update building.md

### DIFF
--- a/building.md
+++ b/building.md
@@ -107,7 +107,7 @@ From there, the project will be ready to build right from the Visual Studio UI.
 - Install dependencies.
 
   ```sh
-  sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev clang libboost-program-options-dev
+  sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev clang
   ```
 
 - Clone this repo.
@@ -140,5 +140,5 @@ From there, the project will be ready to build right from the Visual Studio UI.
 
   ```sh
   brew install boost # for macOS
-  sudo apt install libboost-all-dev # for Ubuntu/Debian
+  sudo apt install libboost-filesystem-dev libboost-program-options-dev libboost-system-dev # for Ubuntu/Debian
   ```

--- a/building.md
+++ b/building.md
@@ -107,7 +107,7 @@ From there, the project will be ready to build right from the Visual Studio UI.
 - Install dependencies.
 
   ```sh
-  sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev clang
+  sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev clang libboost-program-options-dev
   ```
 
 - Clone this repo.


### PR DESCRIPTION
Ubuntu (20.04.2) build fail without this package:

`<pre>CMake Error at /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake:117 (find_package):
  Could not find a package configuration file provided by
  &quot;boost_program_options&quot; (requested version 1.71.0) with any of the
  following names:

    boost_program_optionsConfig.cmake
    boost_program_options-config.cmake

  Add the installation prefix of &quot;boost_program_options&quot; to CMAKE_PREFIX_PATH
  or set &quot;boost_program_options_DIR&quot; to a directory containing one of the
  above files.  If &quot;boost_program_options&quot; provides a separate development
  package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake:182 (boost_find_component)
  /usr/share/cmake-3.16/Modules/FindBoost.cmake:443 (find_package)
  external/psvpfstools/CMakeLists.txt:8 (FIND_PACKAGE)


-- Configuring incomplete, errors occurred!
</pre>`