### PR TITLE
config: add disable at9 audio decoder option in settings dialog

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -90,7 +90,8 @@
     code(bool, "asia-font-support", false, asia_font_support)                                           \
     code(bool, "video-playing", true, video_playing)                                                    \
     code(bool, "spirv-shader", false, spirv_shader)                                                     \
-    code(uint64_t, "current-ime-lang", 4, current_ime_lang)
+    code(uint64_t, "current-ime-lang", 4, current_ime_lang)                                             \
+    code(bool, "disable-at9-decoder", false, disable_at9_decoder)
 
 // Vector members produced in the config file
 // Order is code(option_type, option_name, default_value)

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -108,6 +108,7 @@ public:
         std::vector<std::string> lle_modules = {};
         bool disable_ngs = false;
         bool video_playing = true;
+        bool disable_at9_decoder = false;
     };
 
     CurrentConfig current_config;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -144,6 +144,7 @@ static bool get_custom_config(GuiState &gui, HostState &host, const std::string 
             // Load Emulator Config
             if (!custom_config_xml.child("emulator").empty()) {
                 const auto emulator_child = custom_config_xml.child("emulator");
+                config.disable_at9_decoder = emulator_child.attribute("disable-at9-decoder").as_bool();
                 config.disable_ngs = emulator_child.attribute("disable-ngs").as_bool();
                 config.video_playing = emulator_child.attribute("video-playing").as_bool();
             }
@@ -166,6 +167,7 @@ void init_config(GuiState &gui, HostState &host, const std::string &app_path) {
         config.lle_kernel = host.cfg.lle_kernel;
         config.auto_lle = host.cfg.auto_lle;
         config.lle_modules = host.cfg.lle_modules;
+        config.disable_at9_decoder = host.cfg.disable_at9_decoder;
         config.disable_ngs = host.cfg.disable_ngs;
         config.video_playing = host.cfg.video_playing;
     }
@@ -197,6 +199,7 @@ static void save_config(GuiState &gui, HostState &host) {
 
         // Emulator
         auto emulator_child = custom_config_xml.append_child("emulator");
+        emulator_child.append_attribute("disable-at9-decoder") = config.disable_at9_decoder;
         emulator_child.append_attribute("disable-ngs") = config.disable_ngs;
         emulator_child.append_attribute("video-playing") = config.video_playing;
 
@@ -209,6 +212,7 @@ static void save_config(GuiState &gui, HostState &host) {
         host.cfg.lle_kernel = config.lle_kernel;
         host.cfg.auto_lle = config.auto_lle;
         host.cfg.lle_modules = config.lle_modules;
+        host.cfg.disable_at9_decoder = config.disable_at9_decoder;
         host.cfg.disable_ngs = config.disable_ngs;
         host.cfg.video_playing = config.video_playing;
     }
@@ -222,6 +226,7 @@ void set_config(GuiState &gui, HostState &host, const std::string &app_path) {
         host.cfg.current_config.lle_kernel = config.lle_kernel;
         host.cfg.current_config.auto_lle = config.auto_lle;
         host.cfg.current_config.lle_modules = config.lle_modules;
+        host.cfg.current_config.disable_at9_decoder = config.disable_at9_decoder;
         host.cfg.current_config.disable_ngs = config.disable_ngs;
         host.cfg.current_config.video_playing = config.video_playing;
     } else {
@@ -230,6 +235,7 @@ void set_config(GuiState &gui, HostState &host, const std::string &app_path) {
         host.cfg.current_config.lle_kernel = host.cfg.lle_kernel;
         host.cfg.current_config.auto_lle = host.cfg.auto_lle;
         host.cfg.current_config.lle_modules = host.cfg.lle_modules;
+        host.cfg.current_config.disable_at9_decoder = host.cfg.disable_at9_decoder;
         host.cfg.current_config.disable_ngs = host.cfg.disable_ngs;
         host.cfg.current_config.video_playing = host.cfg.video_playing;
     }
@@ -385,12 +391,17 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
     if (ImGui::BeginTabItem("Emulator")) {
         ImGui::PopStyleColor();
         ImGui::Spacing();
+        ImGui::Checkbox("Disable At9 audio decoder", &config.disable_at9_decoder);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Enable this options that disables AT9 audio decoder.\nIt is required to prevent the crash in certain games such as Gravity (Rush/Daze) for the time being.");
         ImGui::Checkbox("Disable experimental ngs support", &config.disable_ngs);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Disable experimental support for advanced audio library ngs");
         ImGui::Checkbox("Enable video playing support", &config.video_playing);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Uncheck the box to disable video player.\nOn some game, disable it is required for more progress.");
+        ImGui::Spacing();
+        ImGui::Separator();
         ImGui::Spacing();
         if (ImGui::Combo("Log Level", &host.cfg.log_level, "Trace\0Debug\0Info\0Warning\0Error\0Critical\0Off\0"))
             logging::set_level(static_cast<spdlog::level::level_enum>(host.cfg.log_level));

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -304,6 +304,8 @@ static ExitCode load_app_impl(Ptr<const void> &entry_point, HostState &host, con
     }
 
     LOG_INFO("{}: {}", host.cfg[e_cpu_backend], host.cfg.current_config.cpu_backend);
+    LOG_INFO_IF(host.kernel.cpu_backend == CPUBackend::Dynarmic, "CPU Optimisation state: {}", host.cfg.current_config.cpu_opt);
+    LOG_INFO("at9 audio decoder state: {}", !host.cfg.current_config.disable_at9_decoder);
     LOG_INFO("ngs experimental state: {}", !host.cfg.current_config.disable_ngs);
     LOG_INFO("video player state: {}", host.cfg.current_config.video_playing);
     if (host.cfg.current_config.auto_lle)

--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
@@ -115,7 +115,7 @@ EXPORT(int, sceAudiodecCreateDecoder, SceAudiodecCtrl *ctrl, SceAudiodecCodec co
         info.sample_rate = decoder->get(DecoderQuery::SAMPLE_RATE);
         info.super_frame_size = decoder->get(DecoderQuery::AT9_SUPERFRAME_SIZE);
         info.frames_in_super_frame = decoder->get(DecoderQuery::AT9_FRAMES_IN_SUPERFRAME);
-        return 0;
+        return host.cfg.current_config.disable_at9_decoder ? -1 : 0;
     }
     case SCE_AUDIODEC_TYPE_MP3: {
         SceAudiodecInfoMp3 &info = ctrl->info.get(host.mem)->mp3;
@@ -144,7 +144,8 @@ EXPORT(int, sceAudiodecCreateDecoder, SceAudiodecCtrl *ctrl, SceAudiodecCodec co
 }
 
 EXPORT(int, sceAudiodecCreateDecoderExternal) {
-    return UNIMPLEMENTED();
+    STUBBED("Hack for LLE MP4"); // Remove this after implement AAC or impelment SceMP4 in HLE
+    return -1;
 }
 
 EXPORT(int, sceAudiodecCreateDecoderResident) {


### PR DESCRIPTION
# About: 
After request change, i so add option in setting dialog for can disable At9 audio decoder in setting dialog.
Obligatory request for moment in gravity rush.
- Hack for moment external for lle MP4

# Result:
![image](https://user-images.githubusercontent.com/5261759/118715264-baa9fa00-b823-11eb-850f-017718dc82f0.png)