### PR TITLE
modules: Fix texture size for swizzled and cubed

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1082,10 +1082,25 @@ struct SceGxmTexture {
     uint32_t unk2 : 2;
     uint32_t format0 : 1;
     // Control Word 1
-    uint32_t height : 12;
-    uint32_t width : 12;
-    uint32_t base_format : 5;
-    uint32_t type : 3;
+    union {
+        struct {
+            uint32_t height : 12;
+            uint32_t width : 12;
+        };
+
+        struct {
+            uint32_t height_base2 : 4;
+            uint32_t unknown1 : 12;
+            uint32_t width_base2 : 4;
+            uint32_t unknown2 : 4;
+        };
+
+        struct {
+            uint32_t whblock : 24;
+            uint32_t base_format : 5;
+            uint32_t type : 3;
+        };
+    };
     // Control Word 2
     uint32_t lod_min0 : 2;
     uint32_t data_addr : 30;
@@ -1099,6 +1114,8 @@ struct SceGxmTexture {
         return type << 29;
     }
 };
+
+static_assert(sizeof(SceGxmTexture) == 16);
 
 struct SceGxmColorSurface {
     // opaque start

--- a/vita3k/gxm/src/textures.cpp
+++ b/vita3k/gxm/src/textures.cpp
@@ -5,14 +5,14 @@ size_t get_width(const SceGxmTexture *texture) {
     if ((texture->type << 29 != SCE_GXM_TEXTURE_SWIZZLED) && (texture->type << 29 != SCE_GXM_TEXTURE_CUBE)) {
         return texture->width + 1;
     }
-    return 1ull << (texture->width & 0xF);
+    return 1ull << (texture->width_base2 & 0xF);
 }
 
 size_t get_height(const SceGxmTexture *texture) {
     if ((texture->type << 29 != SCE_GXM_TEXTURE_SWIZZLED) && (texture->type << 29 != SCE_GXM_TEXTURE_CUBE)) {
         return texture->height + 1;
     }
-    return 1ull << (texture->height & 0xF);
+    return 1ull << (texture->height_base2 & 0xF);
 }
 
 SceGxmTextureFormat get_format(const SceGxmTexture *texture) {

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -310,10 +310,10 @@ static int init_texture_base(const char *export_name, SceGxmTexture *texture, Pt
 
     if ((texture_type == SCE_GXM_TEXTURE_SWIZZLED) || (texture_type == SCE_GXM_TEXTURE_CUBE)) {
         // Find highest set bit of width and height. It's also the 2^? for width and height
-        static auto highest_set_bit = [](const int num) -> std::uint32_t {
-            for (std::uint32_t i = 12; i != 0; i--) {
+        static auto highest_set_bit = [](const std::uint32_t num) -> std::uint32_t {
+            for (std::int32_t i = 12; i >= 0; i--) {
                 if (num & (1 << i)) {
-                    return i;
+                    return static_cast<std::uint32_t>(i);
                 }
             }
 
@@ -321,8 +321,8 @@ static int init_texture_base(const char *export_name, SceGxmTexture *texture, Pt
         };
 
         texture->uaddr_mode = texture->vaddr_mode = SCE_GXM_TEXTURE_ADDR_MIRROR;
-        texture->height = highest_set_bit(height);
-        texture->width = highest_set_bit(width);
+        texture->height_base2 = highest_set_bit(height);
+        texture->width_base2 = highest_set_bit(width);
     } else {
         texture->uaddr_mode = texture->vaddr_mode = SCE_GXM_TEXTURE_ADDR_CLAMP;
         texture->height = height - 1;

--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -204,7 +204,6 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
     size_t bytes_per_pixel = (bpp + 7) >> 3;
 
     const auto texture_type = gxm_texture.texture_type();
-    const bool is_ubc = (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC1) || (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC2) || (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC3);
     const bool is_swizzled = (texture_type == SCE_GXM_TEXTURE_SWIZZLED) || (texture_type == SCE_GXM_TEXTURE_CUBE) || (texture_type == SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY) || (texture_type == SCE_GXM_TEXTURE_CUBE_ARBITRARY);
     const bool need_decompress_and_unswizzle_on_cpu = is_swizzled && !can_texture_be_unswizzled_without_decode(base_format);
 
@@ -241,14 +240,12 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
         case SCE_GXM_TEXTURE_TILED:
         case SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY:
         case SCE_GXM_TEXTURE_CUBE_ARBITRARY: {
+            org_width = width;
+            org_height = height;
+
             if ((texture_type == SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY) || (texture_type == SCE_GXM_TEXTURE_CUBE_ARBITRARY)) {
                 width = nearest_power_of_two(width);
                 height = nearest_power_of_two(height);
-            }
-
-            if (is_ubc) {
-                width = align(width, 4);
-                height = align(height, 4);
             }
 
             if (need_decompress_and_unswizzle_on_cpu) {
@@ -304,7 +301,7 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
                 break;
             }
 
-            if ((texture_type == SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY) || (texture_type == SCE_GXM_TEXTURE_CUBE_ARBITRARY) || is_ubc) {
+            if ((texture_type == SCE_GXM_TEXTURE_SWIZZLED_ARBITRARY) || (texture_type == SCE_GXM_TEXTURE_CUBE_ARBITRARY)) {
                 width = org_width;
                 height = org_height;
             }


### PR DESCRIPTION
# About 
- Fix some texture missing on gravity rush, like white texture for button confirm on option/ingame dialog, or also in texture view inside render doc

# Result: 
- Texture of dialog choice
![image](https://cdn.discordapp.com/attachments/534180053865725962/844603835586314320/unknown.png)
![image](https://cdn.discordapp.com/attachments/534180053865725962/844603600768335872/unknown.png)