### PR TITLE
gui: fix some small things.

### DIFF
--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -609,7 +609,7 @@ void draw_app_selector(GuiState &gui, HostState &host) {
 
     if (current_scroll_pos > 0) {
         const auto ARROW_UPP_CENTER = ImVec2(display_size.x - (30.f * SCALE.x), 110.f * SCALE.y);
-        ImGui::GetForegroundDrawList()->AddTriangleFilled(
+        ImGui::GetWindowDrawList()->AddTriangleFilled(
             ImVec2(ARROW_UPP_CENTER.x - (20.f * SCALE.x), ARROW_UPP_CENTER.y + (16.f * SCALE.y)),
             ImVec2(ARROW_UPP_CENTER.x, ARROW_UPP_CENTER.y - (16.f * SCALE.y)),
             ImVec2(ARROW_UPP_CENTER.x + (20.f * SCALE.x), ARROW_UPP_CENTER.y + (16.f * SCALE.y)), ARROW_COLOR);
@@ -620,7 +620,7 @@ void draw_app_selector(GuiState &gui, HostState &host) {
     }
     if (!gui.apps_list_opened.empty()) {
         const auto ARROW_CENTER = ImVec2(display_size.x - (30.f * SCALE.x), display_size.y - (250.f * SCALE.y));
-        ImGui::GetForegroundDrawList()->AddTriangleFilled(
+        ImGui::GetWindowDrawList()->AddTriangleFilled(
             ImVec2(ARROW_CENTER.x - (16.f * SCALE.x), ARROW_CENTER.y - (20.f * SCALE.y)),
             ImVec2(ARROW_CENTER.x + (16.f * SCALE.x), ARROW_CENTER.y),
             ImVec2(ARROW_CENTER.x - (16.f * SCALE.x), ARROW_CENTER.y + (20.f * SCALE.y)), ARROW_COLOR);

--- a/vita3k/gui/src/content_manager.cpp
+++ b/vita3k/gui/src/content_manager.cpp
@@ -251,12 +251,13 @@ void draw_content_manager(GuiState &gui, HostState &host) {
 
     ImGui::SetNextWindowPos(ImVec2(0, INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
-    ImGui::SetNextWindowBgAlpha(is_background ? 0.f : 0.999f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
 
-    ImGui::Begin("##content_manager", &gui.live_area.content_manager, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##content_manager", &gui.live_area.content_manager, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
-        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10026"], ImVec2(0.f, 0.f), display_size); // background image is 960x544
+        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10026"], ImVec2(0.f, 0.f), display_size);
+    else
+        ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, 0.f), display_size, IM_COL32(53.f, 54.f, 70.f, 255.f), 0.f, ImDrawCornerFlags_All);
 
     ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
 
@@ -275,13 +276,14 @@ void draw_content_manager(GuiState &gui, HostState &host) {
         ImGui::TextColored(GUI_COLOR_TEXT, "%s", title.c_str());
         ImGui::PopTextWrapPos();
         if (!menu.empty()) {
-            // Search Bar
-            const auto search_size = ImGui::CalcTextSize("Search");
-            ImGui::SetCursorPos(ImVec2(20.f * SCALE.y, (32.f * SCALE.y) - (search_size.y / 2.f)));
-            ImGui::TextColored(GUI_COLOR_TEXT, "Search");
-            ImGui::SameLine();
-            search_bar.Draw("##search_bar", 200 * SCALE.x);
-
+            if (((menu == "app") && !gui.app_selector.user_apps.empty()) || ((menu == "save") && !save_data_list.empty())) {
+                // Search Bar
+                const auto search_size = ImGui::CalcTextSize("Search");
+                ImGui::SetCursorPos(ImVec2(20.f * SCALE.y, (32.f * SCALE.y) - (search_size.y / 2.f)));
+                ImGui::TextColored(GUI_COLOR_TEXT, "Search");
+                ImGui::SameLine();
+                search_bar.Draw("##search_bar", 200 * SCALE.x);
+            }
             // Free Space
             const auto scal_font = 19.2f / ImGui::GetFontSize();
             ImGui::GetWindowDrawList()->AddText(gui.vita_font, 19.2f * SCALE.x, ImVec2((display_size.x - ((ImGui::CalcTextSize("Free Space").x * scal_font)) * SCALE.x) - (15.f * SCALE.x), 42.f * SCALE.y),

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -388,6 +388,7 @@ void get_sys_apps_title(GuiState &gui, HostState &host) {
         } else {
             host.app_version = "1.00";
             host.app_category = "gda";
+            host.app_title_id = app;
             if (app == "NPXS10008") {
                 host.app_short_title = "Trophies";
                 host.app_title = "Trophy Collection";

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -499,8 +499,8 @@ static void draw_notice_info(GuiState &gui, HostState &host) {
 
 void draw_information_bar(GuiState &gui, HostState &host) {
     const auto display_size = ImGui::GetIO().DisplaySize;
-    const auto RES_SCALE = ImVec2(display_size.x / host.res_width_dpi_scale, display_size.y / host.dpi_scale);
-    const auto SCALE = ImVec2(RES_SCALE.x * host.dpi_scale, RES_SCALE.x * host.dpi_scale);
+    const auto RES_SCALE = ImVec2(display_size.x / host.res_width_dpi_scale, display_size.y / host.res_height_dpi_scale);
+    const auto SCALE = ImVec2(RES_SCALE.x * host.dpi_scale, RES_SCALE.y * host.dpi_scale);
     const auto INFORMATION_BAR_HEIGHT = 32.f * SCALE.y;
     ImU32 DEFAULT_BAR_COLOR = 4278190080; // Black
     ImU32 DEFAULT_INDICATOR_COLOR = 4294967295; // White
@@ -538,12 +538,12 @@ void draw_information_bar(GuiState &gui, HostState &host) {
         }
     }
 
-    const auto SCAL_PIX_FONT = 19.2f / 24.f;
-    const auto scal_default_font = ImGui::GetFontSize() / (19.2f * host.dpi_scale);
-    const auto scal_clock_default_font = 24.f * scal_default_font;
-    const auto scal_format_default_font = 18.f * scal_default_font;
-    const auto scal_clock_font_size = scal_clock_default_font / ImGui::GetFontSize();
-    const auto scal_format_font_size = scal_format_default_font / ImGui::GetFontSize();
+    const auto PIX_FONT_SCALE = 19.2f / 24.f;
+    const auto DEFAULT_FONT_SCALE = ImGui::GetFontSize() / (19.2f * host.dpi_scale);
+    const auto CLOCK_DEFAULT_FONT_SCALE = (24.f * host.dpi_scale) * DEFAULT_FONT_SCALE;
+    const auto DAY_MOMENT_DEFAULT_FONT_SCALE = (18.f * host.dpi_scale) * DEFAULT_FONT_SCALE;
+    const auto CLOCK_FONT_SIZE_SCALE = CLOCK_DEFAULT_FONT_SCALE / ImGui::GetFontSize();
+    const auto DAY_MOMENT_FONT_SIZE_SCALE = DAY_MOMENT_DEFAULT_FONT_SCALE / ImGui::GetFontSize();
 
     const auto now = std::chrono::system_clock::now();
     const auto tt = std::chrono::system_clock::to_time_t(now);
@@ -553,16 +553,16 @@ void draw_information_bar(GuiState &gui, HostState &host) {
 
     auto DATE_TIME = get_date_time(gui, host, local);
     const auto CALC_CLOCK_SIZE = ImGui::CalcTextSize(DATE_TIME["clock"].c_str());
-    const auto SCAL_CLOCK_SIZE = ImVec2(CALC_CLOCK_SIZE.x * scal_clock_font_size, CALC_CLOCK_SIZE.y * scal_clock_font_size * SCAL_PIX_FONT);
-    const auto CALC_FORMAT_SIZE = ImGui::CalcTextSize(DATE_TIME["day-moment"].c_str());
-    const auto SCAL_FORMAT_SIZE = host.io.user_id.empty() || gui.users[host.io.user_id].clock_12_hour ? ImVec2((CALC_FORMAT_SIZE.x * scal_format_font_size), CALC_FORMAT_SIZE.y * scal_format_font_size * SCAL_PIX_FONT) : ImVec2(0.f, 0.f);
+    const auto CLOCK_SIZE_SCALE = ImVec2((CALC_CLOCK_SIZE.x * CLOCK_FONT_SIZE_SCALE) * RES_SCALE.x, (CALC_CLOCK_SIZE.y * CLOCK_FONT_SIZE_SCALE * PIX_FONT_SCALE) * RES_SCALE.y);
+    const auto CALC_DAY_MOMENT_SIZE = ImGui::CalcTextSize(DATE_TIME["day-moment"].c_str());
+    const auto DAY_MOMENT_SIZE_SCALE = host.io.user_id.empty() || gui.users[host.io.user_id].clock_12_hour ? ImVec2((CALC_DAY_MOMENT_SIZE.x * DAY_MOMENT_FONT_SIZE_SCALE) * RES_SCALE.y, (CALC_DAY_MOMENT_SIZE.y * DAY_MOMENT_FONT_SIZE_SCALE * PIX_FONT_SCALE) * RES_SCALE.y) : ImVec2(0.f, 0.f);
 
-    const auto CLOCK_POS = ImVec2(display_size.x - (62.f * SCALE.x) - (SCAL_CLOCK_SIZE.x * SCALE.x) - (SCAL_FORMAT_SIZE.x * SCALE.x) - is_notif_pos, (INFORMATION_BAR_HEIGHT / 2.f) - ((SCAL_CLOCK_SIZE.y * SCALE.y) / 2.f));
-    const auto FORMAT_POS = ImVec2(CLOCK_POS.x + (SCAL_CLOCK_SIZE.x * SCALE.x) + (4.f * SCALE.x), CLOCK_POS.y + (SCAL_CLOCK_SIZE.y - SCAL_FORMAT_SIZE.y));
+    const auto CLOCK_POS = ImVec2(display_size.x - (64.f * SCALE.x) - CLOCK_SIZE_SCALE.x - DAY_MOMENT_SIZE_SCALE.x - is_notif_pos, (INFORMATION_BAR_HEIGHT / 2.f) - (CLOCK_SIZE_SCALE.y / 2.f));
+    const auto DAY_MOMENT_POS = ImVec2(CLOCK_POS.x + CLOCK_SIZE_SCALE.x + (6.f * SCALE.x), CLOCK_POS.y + (CLOCK_SIZE_SCALE.y - DAY_MOMENT_SIZE_SCALE.y));
 
-    ImGui::GetForegroundDrawList()->AddText(gui.vita_font, scal_clock_default_font * SCALE.x, CLOCK_POS, is_theme_color ? gui.information_bar_color["indicator"] : DEFAULT_INDICATOR_COLOR, DATE_TIME["clock"].c_str());
+    ImGui::GetForegroundDrawList()->AddText(gui.vita_font, CLOCK_DEFAULT_FONT_SCALE * RES_SCALE.x, CLOCK_POS, is_theme_color ? gui.information_bar_color["indicator"] : DEFAULT_INDICATOR_COLOR, DATE_TIME["clock"].c_str());
     if (host.io.user_id.empty() || gui.users[host.io.user_id].clock_12_hour)
-        ImGui::GetForegroundDrawList()->AddText(gui.vita_font, scal_format_default_font * SCALE.x, FORMAT_POS, is_theme_color ? gui.information_bar_color["indicator"] : DEFAULT_INDICATOR_COLOR, DATE_TIME["day-moment"].c_str());
+        ImGui::GetForegroundDrawList()->AddText(gui.vita_font, DAY_MOMENT_DEFAULT_FONT_SCALE * RES_SCALE.x, DAY_MOMENT_POS, is_theme_color ? gui.information_bar_color["indicator"] : DEFAULT_INDICATOR_COLOR, DATE_TIME["day-moment"].c_str());
     ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (54.f * SCALE.x) - is_notif_pos, 12.f * SCALE.y), ImVec2(display_size.x - (50.f * SCALE.x) - is_notif_pos, 20 * SCALE.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 0.f, ImDrawCornerFlags_All);
     ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (50.f * SCALE.x) - is_notif_pos, 5.f * SCALE.y), ImVec2(display_size.x - (12.f * SCALE.x) - is_notif_pos, 27 * SCALE.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 2.f * SCALE.x, ImDrawCornerFlags_All);
 

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -76,9 +76,9 @@ static void draw_config_menu(GuiState &gui, HostState &host) {
     auto lang = gui.lang.main_menubar;
     const auto is_lang = !lang.empty();
     const auto CUSTOM_CONFIG_PATH{ fs::path(host.base_path) / "config" / fmt::format("config_{}.xml", host.io.app_path) };
-    const auto is_custom_config = !host.io.app_path.empty() && fs::exists(CUSTOM_CONFIG_PATH);
+    auto &settings_dialog = !host.io.app_path.empty() && fs::exists(CUSTOM_CONFIG_PATH) ? gui.configuration_menu.custom_settings_dialog : gui.configuration_menu.settings_dialog;
     if (ImGui::BeginMenu(is_lang ? lang["configuration"].c_str() : "Configuration")) {
-        if (ImGui::MenuItem(is_lang ? lang["settings"].c_str() : "Settings", nullptr, is_custom_config ? &gui.configuration_menu.custom_settings_dialog : &gui.configuration_menu.settings_dialog))
+        if (ImGui::MenuItem(is_lang ? lang["settings"].c_str() : "Settings", nullptr, &settings_dialog))
             init_config(gui, host, host.io.app_path);
         if (ImGui::MenuItem(is_lang ? lang["user_management"].c_str() : "User Management", nullptr, &gui.live_area.user_management, (!gui.live_area.user_management && host.io.title_id.empty()))) {
             gui.live_area.app_selector = false;

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -504,7 +504,7 @@ void draw_start_screen(GuiState &gui, HostState &host) {
     if (gui.start_background)
         ImGui::GetBackgroundDrawList()->AddImage(gui.start_background, ImVec2(0.f, INFORMATION_BAR_HEIGHT), display_size);
     else
-        ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, INFORMATION_BAR_HEIGHT), display_size, IM_COL32(128.f, 128.f, 128.f, 128.f), 0.f, ImDrawCornerFlags_All);
+        ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, INFORMATION_BAR_HEIGHT), display_size, IM_COL32(43.f, 44.f, 47.f, 255.f), 0.f, ImDrawCornerFlags_All);
 
     ImGui::GetForegroundDrawList()->AddRect(ImVec2(32.f * SCALE.x, 64.f * SCALE.y), ImVec2(display_size.x - (32.f * SCALE.x), display_size.y - (32.f * SCALE.y)), IM_COL32(255.f, 255.f, 255.f, 255.f), 20.0f * SCALE.x, ImDrawCornerFlags_All);
 
@@ -517,7 +517,7 @@ void draw_start_screen(GuiState &gui, HostState &host) {
     ImGui::PushFont(gui.vita_font);
     const auto DEFAULT_FONT_SCALE = ImGui::GetFontSize() / (19.2f * host.dpi_scale);
     const auto SCAL_PIX_DATE_FONT = 34.f / 28.f;
-    const auto DATE_FONT_SIZE = 34.f * DEFAULT_FONT_SCALE;
+    const auto DATE_FONT_SIZE = (34.f * host.dpi_scale) * DEFAULT_FONT_SCALE;
     const auto SCAL_DATE_FONT_SIZE = DATE_FONT_SIZE / ImGui::GetFontSize();
 
     auto DATE_TIME = get_date_time(gui, host, const_cast<tm &>(local));
@@ -525,12 +525,12 @@ void draw_start_screen(GuiState &gui, HostState &host) {
     const auto CALC_DATE_SIZE = ImGui::CalcTextSize(DATE_STR.c_str());
     const auto DATE_SIZE = ImVec2(CALC_DATE_SIZE.x * SCAL_DATE_FONT_SIZE, CALC_DATE_SIZE.y * SCAL_DATE_FONT_SIZE * SCAL_PIX_DATE_FONT);
     const auto DATE_POS = ImVec2(display_size.x - (start_param["dateLayout"] == "2" ? date["date"].x + DATE_SIZE.x : date["date"].x) * SCALE.x, display_size.y - (date["date"].y * SCALE.y));
-    ImGui::GetForegroundDrawList()->AddText(gui.vita_font, DATE_FONT_SIZE * SCALE.x, DATE_POS, date_color, DATE_STR.c_str());
+    ImGui::GetForegroundDrawList()->AddText(gui.vita_font, DATE_FONT_SIZE * RES_SCALE.x, DATE_POS, date_color, DATE_STR.c_str());
     ImGui::PopFont();
 
     ImGui::PushFont(gui.large_font);
     const auto DEFAULT_LARGE_FONT_SCALE = ImGui::GetFontSize() / (116.f * host.dpi_scale);
-    const auto LARGE_FONT_SIZE = 116.f * DEFAULT_FONT_SCALE;
+    const auto LARGE_FONT_SIZE = (116.f * host.dpi_scale) * DEFAULT_FONT_SCALE;
     const auto PIX_LARGE_FONT_SCALE = (96.f * host.dpi_scale) / ImGui::GetFontSize();
 
     const auto CLOCK_STR = DATE_TIME["clock"];
@@ -539,7 +539,7 @@ void draw_start_screen(GuiState &gui, HostState &host) {
 
     const auto DAY_MOMENT_STR = DATE_TIME["day-moment"];
     const auto CALC_DAY_MOMENT_SIZE = ImGui::CalcTextSize(DAY_MOMENT_STR.c_str());
-    const auto DAY_MOMENT_LARGE_FONT_SIZE = 56.f * DEFAULT_LARGE_FONT_SCALE;
+    const auto DAY_MOMENT_LARGE_FONT_SIZE = (56.f * host.dpi_scale) * DEFAULT_LARGE_FONT_SCALE;
     const auto LARGE_FONT_DAY_MOMENT_SCALE = DAY_MOMENT_LARGE_FONT_SIZE / ImGui::GetFontSize();
     const auto DAY_MOMENT_SIZE = gui.users[host.io.user_id].clock_12_hour ? ImVec2(CALC_DAY_MOMENT_SIZE.x * LARGE_FONT_DAY_MOMENT_SCALE, CALC_DAY_MOMENT_SIZE.y * LARGE_FONT_DAY_MOMENT_SCALE * PIX_LARGE_FONT_SCALE) : ImVec2(0.f, 0.f);
 
@@ -547,12 +547,12 @@ void draw_start_screen(GuiState &gui, HostState &host) {
     if (start_param["dateLayout"] == "2")
         CLOCK_POS.x -= (CLOCK_SIZE.x * SCALE.x) + (DAY_MOMENT_SIZE.x * SCALE.x);
     else if (std::stoi(DATE_TIME["hour"]) < 10)
-        CLOCK_POS.x += ImGui::CalcTextSize("0").x;
+        CLOCK_POS.x += ImGui::CalcTextSize("0").x * RES_SCALE.x;
 
-    ImGui::GetForegroundDrawList()->AddText(gui.large_font, LARGE_FONT_SIZE * SCALE.x, CLOCK_POS, date_color, CLOCK_STR.c_str());
+    ImGui::GetForegroundDrawList()->AddText(gui.large_font, LARGE_FONT_SIZE * RES_SCALE.x, CLOCK_POS, date_color, CLOCK_STR.c_str());
     if (gui.users[host.io.user_id].clock_12_hour) {
-        const auto DAY_MOMENT_POS = ImVec2(CLOCK_POS.x + ((CLOCK_SIZE.x + 6.f) * SCALE.x), CLOCK_POS.y + ((CLOCK_SIZE.y - DAY_MOMENT_SIZE.y) * SCALE.y));
-        ImGui::GetForegroundDrawList()->AddText(gui.large_font, DAY_MOMENT_LARGE_FONT_SIZE * SCALE.x, DAY_MOMENT_POS, date_color, DAY_MOMENT_STR.c_str());
+        const auto DAY_MOMENT_POS = ImVec2(CLOCK_POS.x + ((CLOCK_SIZE.x + (6.f * SCALE.x)) * RES_SCALE.x), CLOCK_POS.y + ((CLOCK_SIZE.y - DAY_MOMENT_SIZE.y) * RES_SCALE.y));
+        ImGui::GetForegroundDrawList()->AddText(gui.large_font, DAY_MOMENT_LARGE_FONT_SIZE * RES_SCALE.x, DAY_MOMENT_POS, date_color, DAY_MOMENT_STR.c_str());
     }
     ImGui::PopFont();
 
@@ -613,11 +613,13 @@ void draw_settings(GuiState &gui, HostState &host) {
 
     ImGui::SetNextWindowPos(ImVec2(0, INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
-    ImGui::SetNextWindowBgAlpha(is_background ? 0.f : 0.999f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
-    ImGui::Begin("##settings", &gui.live_area.settings, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##settings", &gui.live_area.settings, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
-        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10015"], ImVec2(0.f, 0.f), display_size); // background image is 960x544
+        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10015"], ImVec2(0.f, 0.f), display_size);
+    else
+        ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, 0.f), display_size, IM_COL32(36.f, 120.f, 12.f, 255.f), 0.f, ImDrawCornerFlags_All);
+
     ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
     const auto title_size_str = ImGui::CalcTextSize(title.c_str(), 0, false, SIZE_LIST.x);
     ImGui::PushTextWrapPos(((display_size.x - SIZE_LIST.x) / 2.f) + SIZE_LIST.x);

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -411,14 +411,16 @@ void draw_trophy_collection(GuiState &gui, HostState &host) {
 
     ImGui::SetNextWindowPos(ImVec2(0, INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
-    ImGui::SetNextWindowBgAlpha(is_background ? 0.f : 0.999f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
-    ImGui::Begin("##trophy_collection", &gui.live_area.trophy_collection, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##trophy_collection", &gui.live_area.trophy_collection, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
-        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10008"], ImVec2(0.f, 0.f), display_size); // background image is 960x544
+        ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10008"], ImVec2(0.f, 0.f), display_size);
+    else
+        ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, 0.f), display_size, IM_COL32(31.f, 12.f, 0.f, 255.f), 0.f, ImDrawCornerFlags_All);
+
     if (group_id_selected.empty()) {
         ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
-        if (np_com_id_selected.empty()) {
+        if (!np_com_id_list.empty() && np_com_id_selected.empty()) {
             ImGui::TextColored(GUI_COLOR_TEXT, "Search");
             ImGui::SameLine();
             search_bar.Draw("##search_bar", 200 * SCALE.x);

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -190,10 +190,7 @@ void open_user(GuiState &gui, HostState &host) {
     else
         init_theme_start_background(gui, host, gui.users[host.io.user_id].theme_id);
 
-    if (gui.start_background)
-        gui.live_area.start_screen = true;
-    else
-        gui.live_area.app_selector = true;
+    gui.live_area.start_screen = true;
 }
 
 static auto get_users_index(GuiState &gui, const std::string &user_name) {

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -424,15 +424,12 @@ bool handle_events(HostState &host, GuiState &gui) {
                     gui.is_capturing_keys = false;
                 }
             }
-            // toggle gui state
-            if (!host.io.title_id.empty() && !gui.live_area.user_management && !gui.configuration_menu.settings_dialog && !gui.is_capturing_keys) {
+            if (!host.io.title_id.empty() && !gui.live_area.user_management && !gui.configuration_menu.custom_settings_dialog && !gui.configuration_menu.settings_dialog && !gui.controls_menu.controls_dialog) {
+                // toggle gui state
                 if (event.key.keysym.sym == SDLK_g)
                     host.display.imgui_render = !host.display.imgui_render;
-            }
-            if (!host.io.title_id.empty() && !gui.live_area.app_selector && gui::get_sys_apps_state(gui)) {
-                // Show/Hide Live Area during app run
-                // TODO pause app running
-                if (event.key.keysym.scancode == host.cfg.keyboard_button_psbutton) {
+                // Show/Hide Live Area during app run, TODO pause app running
+                else if (gui::get_sys_apps_state(gui) && (event.key.keysym.scancode == host.cfg.keyboard_button_psbutton)) {
                     gui::update_apps_list_opened(gui, host, host.io.app_path);
                     gui::init_live_area(gui, host);
                     gui.live_area.information_bar = !gui.live_area.information_bar;


### PR DESCRIPTION
# About:
- interface: small refactor press key event.
- fix title id for sys app without fw.
- fix apply in general config.
- merge Save & Apply in one button in settings dialog.
- Add close button in setting dialog. (small cross have get me hungry on my tab 😂 )
- disable toogle gui and live area call if setting dialog/control dialog is open 
- set default background for system app if missing fw.

# Result: 
- small change button in setting dialog.
![image](https://user-images.githubusercontent.com/5261759/119063257-f2a66e00-b9d8-11eb-8fde-34b9f20d287f.png)
- fix  position broken recently for Day moment AM/PM in start screen and in formation bar 
![image](https://user-images.githubusercontent.com/5261759/119078360-525f4200-b9f6-11eb-9fcd-1ab789b6f750.png)
![image](https://user-images.githubusercontent.com/5261759/119078411-6f941080-b9f6-11eb-9e98-6d154851dd46.png)
