### PR TITLE
config: change last app to vector last loaded apps.

### DIFF
--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -9,7 +9,7 @@
 		<install_license>Install License</install_license>
 	</file>
 	<emulation name="Emulation">
-		<load_last_app>Load last App</load_last_app>
+		<last_loaded_apps>Last loaded Apps</last_loaded_apps>
 	</emulation>
 	<configuration name="Configuration">
 		<settings>Settings</settings>

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -9,7 +9,7 @@
 		<install_license>Install License</install_license>
 	</file>
 	<emulation name="Emulation">
-		<load_last_app>Load last App</load_last_app>
+		<last_loaded_apps>Last loaded Apps</last_loaded_apps>
 	</emulation>
 	<configuration name="Configuration">
 		<settings>Settings</settings>

--- a/lang/es.xml
+++ b/lang/es.xml
@@ -8,7 +8,7 @@
 		<install_zip>Instalar un .zip, .vpk</install_zip>
 	</file>
 	<emulation name="Emulación">
-		<load_last_app>Cargar ultima aplicación</load_last_app>
+		<last_loaded_apps>Últimas aplicaciones cargadas</last_loaded_apps>
 	</emulation>
 	<configuration name="Configuración">
 		<settings>Ajustes</settings>

--- a/lang/fr.xml
+++ b/lang/fr.xml
@@ -9,7 +9,7 @@
 		<install_license>Installer une License</install_license>
 	</file>
 	<emulation name="Émulation">
-		<load_last_app>Charger la Dernière App</load_last_app>
+		<last_loaded_apps>Dernières Apps chargées</last_loaded_apps>
 	</emulation>
 	<configuration name="Configuration">
 		<settings>Paramètres</settings>

--- a/lang/it.xml
+++ b/lang/it.xml
@@ -13,7 +13,7 @@
 		<install_zip>Installa un .zip, .vpk</install_zip>
 	</file>
 	<emulation name="Emulazione">
-		<load_last_app>Carica l'Ultima App</load_last_app>
+		<last_loaded_apps>Ultime app caricate</last_loaded_apps>
 	</emulation>
 	<configuration name="Configurazione">
 		<settings>Impostazioni</settings>

--- a/lang/ru.xml
+++ b/lang/ru.xml
@@ -8,7 +8,7 @@
 		<install_zip>Установить файл .zip или .vpk</install_zip>
 	</file>
 	<emulation name="Эмуляция">
-		<load_last_app>Загрузить последнее приложение</load_last_app>
+		<last_loaded_apps>Последние загруженные приложения</last_loaded_apps>
 	</emulation>
 	<configuration name="Конфигурация">
 		<settings>Настройки</settings>

--- a/lang/zh-s.xml
+++ b/lang/zh-s.xml
@@ -8,7 +8,7 @@
 		<install_zip>安装 .zip 或者 .vpk</install_zip>
 	</file>
 	<emulation name="仿真拟">
-		<load_last_app>打开最后运行的APP</load_last_app>
+		<last_loaded_apps>上次加载的应用</last_loaded_apps>
 	</emulation>
 	<configuration name="配置">
 		<settings>设置</settings>

--- a/lang/zh-t.xml
+++ b/lang/zh-t.xml
@@ -8,7 +8,7 @@
 		<install_zip>安裝 .zip 或者 .vpk</install_zip>
 	</file>
 	<emulation name="模擬">
-		<load_last_app>打開最後運行的APP</load_last_app>
+		<last_loaded_apps>上次加載的應用</last_loaded_apps>
 	</emulation>
 	<configuration name="配置">
 		<settings>設定</settings>

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -51,7 +51,6 @@
     code(std::string, "cpu-backend", "Unicorn", cpu_backend)                                            \
     code(bool, "cpu-opt", true, cpu_opt)                                                                \
     code(std::string, "pref-path", std::string{}, pref_path)                                            \
-    code(std::string, "last-app", std::string{}, last_app)                                              \
     code(bool, "discord-rich-presence", true, discord_rich_presence)                                    \
     code(bool, "wait-for-debugger", false, wait_for_debugger)                                           \
     code(bool, "color-surface-debug", false, color_surface_debug)                                       \
@@ -98,7 +97,8 @@
 // When adding in a new macro for generation, ALL options must be stated.
 #define CONFIG_VECTOR(code)                                                                             \
     code(std::vector<std::string>, "lle-modules", std::vector<std::string>{}, lle_modules)              \
-    code(std::vector<uint64_t>, "ime-langs", std::vector<uint64_t>{4}, ime_langs)
+    code(std::vector<uint64_t>, "ime-langs", std::vector<uint64_t>{4}, ime_langs)                       \
+    code(std::vector<std::string>, "last-loaded-apps", std::vector<std::string>{}, last_loaded_apps)                                              
 
 // Parent macro for easier generation
 #define CONFIG_LIST(code)                                                                               \

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -87,7 +87,7 @@ void init_lang(GuiState &gui, HostState &host) {
                 // Emulation Menu
                 if (!main_menubar.child("emulation").empty()) {
                     lang_main_menubar["emulation"] = main_menubar.child("emulation").attribute("name").as_string();
-                    lang_main_menubar["load_last_app"] = main_menubar.child("emulation").child("load_last_app").text().as_string();
+                    lang_main_menubar["last_loaded_apps"] = main_menubar.child("emulation").child("last_loaded_apps").text().as_string();
                 }
 
                 // Configuration Menu

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -51,8 +51,18 @@ static void draw_emulation_menu(GuiState &gui, HostState &host) {
     auto lang = gui.lang.main_menubar;
     const auto is_lang = !lang.empty();
     if (ImGui::BeginMenu(is_lang ? lang["emulation"].c_str() : "Emulation")) {
-        if (ImGui::MenuItem(is_lang ? lang["load_last_app"].c_str() : "Load last App", host.cfg.last_app.c_str(), false, !host.cfg.last_app.empty() && host.io.title_id.empty()))
-            pre_load_app(gui, host, host.cfg.show_live_area_screen, host.cfg.last_app);
+        if (ImGui::BeginMenu(is_lang ? lang["last_loaded_apps"].c_str() : "Last loaded Apps")) {
+            if (!host.cfg.last_loaded_apps.empty()) {
+                for (const auto &app : host.cfg.last_loaded_apps) {
+                    ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
+                    if (ImGui::MenuItem(get_app_index(gui, app)->title.c_str(), app.c_str(), false))
+                        pre_load_app(gui, host, host.cfg.show_live_area_screen, app);
+                    ImGui::PopStyleColor();
+                }
+            } else
+                ImGui::MenuItem("Empty", nullptr, false, false);
+            ImGui::EndMenu();
+        }
         ImGui::EndMenu();
     }
 }


### PR DESCRIPTION
# About:
Like sugested in one doc 😄 , i have so remplaced launch one last app with can load last 10 apps
- settings dialog: refactor display title in custom config.
- custom config: fix warning of xml file.

# Result:
- for new custom config title.
![image](https://user-images.githubusercontent.com/5261759/119294257-538daa80-bc54-11eb-9e6a-a4cceb443626.png)
- for new last loaded apps
![image](https://user-images.githubusercontent.com/5261759/119294311-74560000-bc54-11eb-8a46-4173c7f99b0d.png)
 
