### PR TITLE
Fix constant swizzle accessors like pa2.111w

### DIFF
--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -863,7 +863,11 @@ spv::Id shader::usse::utils::load(spv::Builder &b, const SpirvShaderParameters &
     int highest_dest_write_offset = -1; ///< Highest offset of the component to write.
 
     for (int i = 0; i < 4; i++) {
-        const int swizzle_bit = (int)op.swizzle[i] - (int)SwizzleChannel::_X;
+        if (static_cast<int>(op.swizzle[i]) >= static_cast<int>(SwizzleChannel::_0)) {
+            continue;
+        }
+
+        const int swizzle_bit = static_cast<int>(op.swizzle[i]) - static_cast<int>(SwizzleChannel::_X);
 
         if (dest_mask & (1 << i)) {
             lowest_dest_write_offset = std::min(lowest_dest_write_offset, swizzle_bit);


### PR DESCRIPTION
In an example shader I use this assembly:
VF16MUL pa0.xyzw pa2.111w pa0.xyz1

Which is supposed to multiply a color value with a constant alpha value of 1.0 with a given alpha value in another register. In the current generator this doesn't happen and the alpha is some random value and leads to wrong results, see:
![broken_swizzle](https://user-images.githubusercontent.com/870059/119341347-f0236d00-bc93-11eb-9c7a-dc5e2e51006e.PNG)
Note the character sprites and the alpha on some of the groundwork in which occluded geometry shines through.

The corrected version leads to a more expected outcome:
![corrected_swizzle](https://user-images.githubusercontent.com/870059/119341363-f31e5d80-bc93-11eb-8fc9-2e0ede1a8a39.PNG)