### PR TITLE
config: Use dynarmic as default

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -48,7 +48,7 @@
     code(int, "delay-start", 10, delay_start)                                                           \
     code(float, "background-alpha", .300f, background_alpha)                                            \
     code(int, "log-level", static_cast<int>(spdlog::level::trace), log_level)                           \
-    code(std::string, "cpu-backend", "Unicorn", cpu_backend)                                            \
+    code(std::string, "cpu-backend", "Dynarmic", cpu_backend)                                           \
     code(bool, "cpu-opt", true, cpu_opt)                                                                \
     code(std::string, "pref-path", std::string{}, pref_path)                                            \
     code(std::string, "last-app", std::string{}, last_app)                                              \


### PR DESCRIPTION
All games using libult are essentially broken in unicorn. (which is quite a lot of games) Even if games use unimplemented/unpredictable instructions, we've got unicorn fallback. Why not making dynarmic default.