### PR TITLE
debugger: Fix crash when update_watches is called without valid parent

### DIFF
--- a/vita3k/kernel/include/kernel/debugger.h
+++ b/vita3k/kernel/include/kernel/debugger.h
@@ -57,7 +57,7 @@ struct Debugger {
 
 private:
     std::mutex mutex;
-    KernelState *parent;
+    KernelState *parent = nullptr;
     WatchMemoryAddrs watch_memory_addrs;
     Breakpoints breakpoints;
     Trampolines trampolines;

--- a/vita3k/kernel/src/debugger.cpp
+++ b/vita3k/kernel/src/debugger.cpp
@@ -129,5 +129,7 @@ Address Debugger::get_watch_memory_addr(Address addr) {
 }
 
 void Debugger::update_watches() {
+    if (!parent)
+        return;
     parent->set_memory_watch(watch_memory);
 }


### PR DESCRIPTION
Happens when Debug settings are configured prior to initialization of kernel