### PR TITLE
gui/Notice: fix load new notice selected.

### DIFF
--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -559,10 +559,11 @@ void draw_app_selector(GuiState &gui, HostState &host) {
                     continue;
                 const auto POS_ICON = ImGui::GetCursorPosY();
                 const auto GRID_INIT_POS = ImGui::GetCursorPosX() + (GRID_COLUMN_SIZE / 2.f) - (10.f * SCALE.x);
+                const auto ICON_SIZE = host.cfg.apps_list_grid ? GRID_ICON_SIZE : ImVec2(icon_size, icon_size);
                 if (apps_icon.find(app.path) != apps_icon.end()) {
                     if (host.cfg.apps_list_grid)
                         ImGui::SetCursorPosX(GRID_INIT_POS - (GRID_ICON_SIZE.x / 2.f));
-                    ImGui::Image(apps_icon[app.path], host.cfg.apps_list_grid ? GRID_ICON_SIZE : ImVec2(icon_size, icon_size));
+                    ImGui::Image(apps_icon[app.path], ICON_SIZE);
                 }
                 ImGui::SetCursorPosY(POS_ICON);
                 if (host.cfg.apps_list_grid)
@@ -577,7 +578,7 @@ void draw_app_selector(GuiState &gui, HostState &host) {
                 if (IS_CUSTOM_CONFIG) {
                     if (host.cfg.apps_list_grid)
                         ImGui::SetCursorPosX(GRID_INIT_POS - (GRID_ICON_SIZE.x / 2.f));
-                    ImGui::SetCursorPosY(ImGui::GetCursorPosY() - (ImGui::GetFontSize() + 26.f));
+                    ImGui::SetCursorPosY(POS_ICON + ICON_SIZE.y - ImGui::GetFontSize() - (7.8f * host.dpi_scale));
                     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
                     ImGui::Button("CC", ImVec2(40.f * SCALE.x, 0.f));
                     ImGui::PopStyleColor();

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -186,7 +186,8 @@ void init_notice_info(GuiState &gui, HostState &host) {
                         });
                         notice_list[user.first].erase(notice_index);
                         save_notice_list(host);
-                    }
+                    } else
+                        notice_info_new[notice.date] = notice_list_new[user.first][notice.date];
                 }
             }
         }
@@ -247,6 +248,10 @@ void save_notice_list(HostState &host) {
         auto user_child = notice_child.append_child("user");
         user_child.append_attribute("id") = user.first.c_str();
         user_child.append_attribute("count_new") = notice_list_count_new[user.first];
+
+        std::sort(notice_list[user.first].begin(), notice_list[user.first].end(), [&](const NoticeList &na, const NoticeList &nb) {
+            return na.date > nb.date;
+        });
 
         for (const auto &notice : user.second) {
             auto info_child = user_child.append_child("info");
@@ -397,7 +402,7 @@ static void draw_notice_info(GuiState &gui, HostState &host) {
             const auto SELECT_SIZE = ImVec2(POPUP_SIZE.x, 80.f * SCALE.y);
 
             for (const auto &notice : notice_info) {
-                if (notice.date != notice_info[0].date)
+                if (notice.date != notice_info.front().date)
                     ImGui::Separator();
                 const auto ICON_POS = ImGui::GetCursorPos();
                 if (gui.notice_info_icon.find(notice.date) != gui.notice_info_icon.end()) {
@@ -412,7 +417,7 @@ static void draw_notice_info(GuiState &gui, HostState &host) {
                 ImGui::PushStyleColor(ImGuiCol_Header, SELECT_COLOR);
                 ImGui::PushStyleColor(ImGuiCol_HeaderHovered, SELECT_COLOR_HOVERED);
                 ImGui::PushStyleColor(ImGuiCol_HeaderActive, SELECT_COLOR_ACTIVE);
-                if (ImGui::Selectable("##icon", notice_info_new[notice.date], host.io.app_path.empty() || ((notice.type == "content") && (notice.group == "theme")) || (notice.type == "trophy") ? ImGuiSelectableFlags_SpanAllColumns : ImGuiSelectableFlags_Disabled, SELECT_SIZE)) {
+                if (ImGui::Selectable("##icon", notice_info_new[notice.date], ImGuiSelectableFlags_SpanAllColumns, SELECT_SIZE)) {
                     clean_notice_info_new(host.io.user_id);
                     save_notice_list(host);
                     if (notice.type == "content") {


### PR DESCRIPTION
# About:
I have see after get one or some new notice, it is no select in blue if emu reboot, but only if get new notice during current running, i have so see in code, value for set notice info new is no set on init notice info.
- reworks order saved in xml.
- enable seletable for now all notification, with new code, game can switch in other game, so old code is no necessary anymore.
- fix position for cc button in app selector.