### PR TITLE
Fix booting of old vitasdk homebrew in dynarmic

### DIFF
--- a/vita3k/cpu/src/dynarmic_cpu.cpp
+++ b/vita3k/cpu/src/dynarmic_cpu.cpp
@@ -252,11 +252,11 @@ std::unique_ptr<Dynarmic::A32::Jit> DynarmicCPU::make_jit() {
     Dynarmic::A32::UserConfig config;
     config.arch_version = Dynarmic::A32::ArchVersion::v7;
     config.callbacks = cb.get();
-    config.fastmem_pointer = log_mem ? nullptr : parent->mem->memory.get();
+    config.fastmem_pointer = (log_mem || !cpu_opt) ? nullptr : parent->mem->memory.get();
     config.hook_hint_instructions = true;
     config.global_monitor = monitor;
     config.coprocessors[15] = cp15;
-    config.page_table = log_mem ? nullptr : parent->mem->pages_cpu.get();
+    config.page_table = (log_mem || !cpu_opt) ? nullptr : parent->mem->pages_cpu.get();
     config.processor_id = core_id;
     config.optimizations = cpu_opt ? Dynarmic::all_safe_optimizations : Dynarmic::no_optimizations;
 

--- a/vita3k/host/src/load_self.cpp
+++ b/vita3k/host/src/load_self.cpp
@@ -236,13 +236,13 @@ static bool load_func_exports(Ptr<const void> &entry_point, const uint32_t *nids
     return true;
 }
 
-static bool load_var_exports(const uint32_t *nids, const Ptr<uint32_t> *entries, size_t count, KernelState &kernel, const Config &cfg) {
+static bool load_var_exports(const uint32_t *nids, const Ptr<uint32_t> *entries, size_t count, KernelState &kernel, MemState &mem, const Config &cfg) {
     for (size_t i = 0; i < count; ++i) {
         const uint32_t nid = nids[i];
         const Ptr<uint32_t> entry = entries[i];
 
         if (nid == NID_PROCESS_PARAM) {
-            kernel.process_param = entry;
+            kernel.load_process_param(mem, entry);
             LOG_DEBUG("\tNID {} (SCE_PROC_PARAMS) at {}", log_hex(nid), log_hex(entry.address()));
             continue;
         }
@@ -270,7 +270,7 @@ static bool load_var_exports(const uint32_t *nids, const Ptr<uint32_t> *entries,
     return true;
 }
 
-static bool load_exports(Ptr<const void> &entry_point, const sce_module_info_raw &module, Ptr<const void> segment_address, KernelState &kernel, const MemState &mem, const Config &cfg) {
+static bool load_exports(Ptr<const void> &entry_point, const sce_module_info_raw &module, Ptr<const void> segment_address, KernelState &kernel, MemState &mem, const Config &cfg) {
     const uint8_t *const base = segment_address.cast<const uint8_t>().get(mem);
     const sce_module_exports_raw *const exports_begin = reinterpret_cast<const sce_module_exports_raw *>(base + module.export_top);
     const sce_module_exports_raw *const exports_end = reinterpret_cast<const sce_module_exports_raw *>(base + module.export_end);
@@ -294,7 +294,7 @@ static bool load_exports(Ptr<const void> &entry_point, const sce_module_info_raw
             LOG_INFO("Loading var exports from {}", lib_name ? lib_name : "unknown");
         }
 
-        if (!load_var_exports(&nids[exports->num_syms_funcs], &entries[exports->num_syms_funcs], var_count, kernel, cfg)) {
+        if (!load_var_exports(&nids[exports->num_syms_funcs], &entries[exports->num_syms_funcs], var_count, kernel, mem, cfg)) {
             return false;
         }
     }

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -374,12 +374,8 @@ static ExitCode load_app_impl(Ptr<const void> &entry_point, HostState &host, con
 
     pre_load_module(host, lib_load_list, VitaIoDevice::vs0);
 
-    // if is Mai Dump, using original eboot
-    const std::string eboot_origin = "mai_moe/eboot_origin.bin";
-    const auto is_mai_dump = fs::exists(fs::path(host.pref_path) / "ux0/app" / host.io.app_path / eboot_origin);
-
     // Load main executable
-    host.self_path = !host.cfg.self_path.empty() ? host.cfg.self_path : (is_mai_dump ? eboot_origin : EBOOT_PATH);
+    host.self_path = !host.cfg.self_path.empty() ? host.cfg.self_path : EBOOT_PATH;
     vfs::FileBuffer eboot_buffer;
     if (vfs::read_app_file(eboot_buffer, host.pref_path, host.io.app_path, host.self_path)) {
         SceUID module_id = load_self(entry_point, host.kernel, host.mem, eboot_buffer.data(), "app0:" + host.self_path, host.cfg);

--- a/vita3k/io/include/io/util.h
+++ b/vita3k/io/include/io/util.h
@@ -33,7 +33,7 @@ inline constexpr TtyType TTY_INOUT = TTY_IN | TTY_OUT;
 
 struct FileInfo {
     // The actual location on the Vita
-    const char *vita_loc;
+    std::string vita_loc;
     // The translated location on the Vita
     std::string translated;
     // The actual location in the preference path.
@@ -46,7 +46,7 @@ struct FileInfo {
     int access_mode;
 
     FileInfo()
-        : vita_loc(nullptr)
+        : vita_loc("")
         , open_mode(SCE_O_RDONLY)
         , file_mode(SCE_SO_IFREG | SCE_SO_IROTH)
         , access_mode(SCE_S_IRUSR) {}
@@ -62,7 +62,7 @@ protected:
 
 public:
     VitaStats() {
-        file_info.vita_loc = nullptr;
+        file_info.vita_loc = "";
     }
 
     VitaStats(const char *vita, const std::string &t, const fs::path &file) {
@@ -72,7 +72,7 @@ public:
     }
 
     const char *get_vita_loc() const {
-        return file_info.vita_loc;
+        return file_info.vita_loc.c_str();
     }
 
     const std::string &get_translated_path() const {

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -162,6 +162,7 @@ struct KernelState {
     }
 
     bool init(MemState &mem, CallImportFunc call_import, CPUBackend cpu_backend, bool cpu_opt);
+    void load_process_param(MemState &mem, Ptr<uint32_t> ptr);
     ThreadStatePtr create_thread(MemState &mem, const char *name);
     ThreadStatePtr create_thread(MemState &mem, const char *name, Ptr<const void> entry_point, int init_priority, int stack_size, const SceKernelThreadOptParam *option);
     void exit_thread(ThreadStatePtr thread);

--- a/vita3k/kernel/include/kernel/types.h
+++ b/vita3k/kernel/include/kernel/types.h
@@ -675,6 +675,22 @@ struct SceKernelThreadInfo {
     SceInt32 reserved;
 };
 
+struct SceProcessParam {
+    SceSize size;
+    SceUInt32 magic;
+    SceUInt32 version;
+    SceUInt32 fw_version;
+    Ptr<char> main_thread_name;
+    SceInt32 main_thread_priority;
+    SceUInt32 main_thread_stacksize;
+    SceUInt32 main_thread_attribute;
+    Ptr<char> process_name;
+    SceUInt32 process_preload_disabled;
+    SceUInt32 main_thread_cpu_affinity_mask;
+    Ptr<void> sce_libc_param;
+    SceUInt32 unk;
+};
+
 struct SceKernelThreadOptParam {
     /** Size of the ::SceKernelThreadOptParam structure. */
     SceSize size;

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -86,6 +86,16 @@ bool KernelState::init(MemState &mem, CallImportFunc call_import, CPUBackend cpu
     return true;
 }
 
+void KernelState::load_process_param(MemState &mem, Ptr<uint32_t> ptr) {
+    const SceProcessParam *param = ptr.cast<SceProcessParam>().get(mem);
+    if (param->version == 0) {
+        // Homebrews built with old vitasdk
+        process_param = nullptr;
+        return;
+    }
+    process_param = ptr;
+}
+
 void KernelState::set_memory_watch(bool enabled) {
     std::lock_guard<std::mutex> lock(mutex);
     for (const auto &thread : threads) {

--- a/vita3k/mem/include/mem/ptr.h
+++ b/vita3k/mem/include/mem/ptr.h
@@ -94,6 +94,11 @@ public:
         return *this;
     }
 
+    Ptr &operator=(std::nullptr_t) {
+        addr = 0;
+        return *this;
+    }
+
 private:
     Address addr;
 };

--- a/vita3k/modules/SceFiber/SceFiber.cpp
+++ b/vita3k/modules/SceFiber/SceFiber.cpp
@@ -100,7 +100,7 @@ void initialize_fiber(HostState &host, const ThreadStatePtr thread, SceFiber *fi
     fiber->entry = entry;
     strncpy(fiber->name, name, 32);
     fiber->argOnInitialize = argOnInitialize;
-    fiber->argOnRun = 0;
+    fiber->argOnRun = nullptr;
     fiber->addrContext = addrContext.address();
     fiber->sizeContext = sizeContext;
     fiber->cpu = new CPUContext;

--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -506,7 +506,7 @@ EXPORT(SceInt32, sceNgsVoiceGetOutputPatch, SceNgsVoiceHandle voice_handle, cons
     *handle = voice->patches[output_index][output_subindex];
     if (!(*handle) || (handle->get(host.mem))->output_sub_index == -1) {
         LOG_WARN("Getting non-existen output patch port {}:{}", output_index, output_subindex);
-        *handle = 0;
+        *handle = nullptr;
     }
 
     return 0;

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -34,7 +34,7 @@ COMMAND(handle_set_context) {
     } else {
         // Disable writing to this surface.
         // Data is still in render target though.
-        render_context->record.color_surface.data = 0;
+        render_context->record.color_surface.data = nullptr;
     }
 
     // Maybe we should disable writing to depth stencil too if it's null


### PR DESCRIPTION
# Description
- mem: Allow Ptr = nullptr
- kernel: Ignore some invalid process param
- dynarmic_cpu: Disable fastmem when optimization is off
- vita3k: Remove mai dump hack
- io: Correct life cycle of vita_loc

Various fixes to make it working.