### PR TITLE
renderer: Overhaul fragment masking

### DIFF
--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -99,8 +99,9 @@ struct GxmRecordState {
     SceGxmFragmentProgramMode front_side_fragment_program_mode = SCE_GXM_FRAGMENT_PROGRAM_ENABLED;
     SceGxmFragmentProgramMode back_side_fragment_program_mode = SCE_GXM_FRAGMENT_PROGRAM_ENABLED;
 
-    bool writing_mask = false;
+    float writing_mask = 0.0f;
     bool viewport_flat = false;
+    bool is_maskupdate = false;
 };
 
 struct Context {

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -413,15 +413,6 @@ void set_context(GLContext &context, const MemState &mem, const GLRenderTarget *
         context.render_target = reinterpret_cast<const GLRenderTarget *>(context.current_render_target);
     }
 
-    if (context.record.fragment_program && context.record.fragment_program.get(mem)->is_maskupdate) {
-        uint8_t mask = context.record.writing_mask ? 0xFF : 0;
-        set_uniform_buffer(context, false, 14, sizeof(mask), &mask, false);
-
-        glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->maskbuffer[0]);
-    } else {
-        glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->framebuffer[0]);
-    }
-
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);
     glClearDepth(context.record.depth_stencil_surface.backgroundDepth);
@@ -452,6 +443,7 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
         return;
     }
 
+    glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->framebuffer[0]);
     glPixelStorei(GL_PACK_ROW_LENGTH, static_cast<GLint>(stride_in_pixels));
 
     // TODO Need more check into this

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -951,8 +951,6 @@ void convert_gxp_usse_to_spirv(spv::Builder &b, const SceGxmProgram &program, co
     std::vector<spv::Id> empty_args;
     if (features.should_use_shader_interlock() && program.is_fragment() && program.is_native_color())
         b.createNoResultOp(spv::OpEndInvocationInterlockEXT);
-
-    b.leaveFunction();
 }
 
 } // namespace shader::usse


### PR DESCRIPTION
Fix vitagl clipping.

Together with the recent kernel pr, SuperMarioWar vita port renders almost perfectly.