### PR TITLE
renderer: Bind mask buffer properly

### DIFF
--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -112,9 +112,8 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
         // Tests bypassed in maskupdate
         glDisable(GL_DEPTH_TEST);
         glDisable(GL_STENCIL_TEST);
+
         glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->maskbuffer[0]);
-    } else {
-        glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->framebuffer[0]);
     }
 
     if (fragment_program_gxp.is_native_color() && features.is_programmable_blending_need_to_bind_color_attachment()) {
@@ -179,10 +178,11 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
         glDrawElementsInstanced(mode, static_cast<GLsizei>(count), gl_type, nullptr, instance_count);
     }
 
-    // Restore tests
+    // Restore context for normal draws
     if (context.record.is_maskupdate) {
         sync_depth_data(context.record);
         sync_stencil_data(context.record, mem);
+        glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->framebuffer[0]);
     }
 
     context.last_draw_vertex_program_hash = context.record.vertex_program.get(mem)->renderer_data->hash;

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -412,6 +412,7 @@ void set_context(GLContext &context, const MemState &mem, const GLRenderTarget *
     } else {
         context.render_target = reinterpret_cast<const GLRenderTarget *>(context.current_render_target);
     }
+    glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->framebuffer[0]);
 
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);
@@ -443,7 +444,6 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
         return;
     }
 
-    glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->framebuffer[0]);
     glPixelStorei(GL_PACK_ROW_LENGTH, static_cast<GLint>(stride_in_pixels));
 
     // TODO Need more check into this


### PR DESCRIPTION
Should bind framebuffer early cause set_context clear depth etc.