### PR TITLE
mem: Zeropage is invalid

### DIFF
--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -122,6 +122,7 @@ bool init(MemState &state) {
 #else
     mprotect(state.memory.get(), state.page_size, PROT_NONE);
 #endif
+    (*(state.pages_cpu))[0] = nullptr;
 
     return true;
 }


### PR DESCRIPTION
Mark the zero-page as invalid in the page-table.

This is so that the page-table access of the protected zero page will fail gracefully rather than crash.