### PR TITLE
renderer: Allow writing depth when both side fragment program is disabled

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1151,7 +1151,7 @@ struct SceGxmDepthStencilSurface {
     uint32_t zlsControl;
     Ptr<void> depthData;
     Ptr<void> stencilData;
-    float backgroundDepth = 1.0;
+    float backgroundDepth = 1.0f;
     Ptr<SceGxmDepthStencilControl> control;
 };
 


### PR DESCRIPTION
If both side is disabled, fragment shader discards every pixel, not writing to depth. But, we want it to still write to depth as long as depthwrite is enabled. This pr just mask color when both side is disabled to mitigate the issue. This fixes the regression in asphalt and progresses it by fixing the skybox.

I personally don't like the way we're implementing disabled side. Discarding pixel according to facing can be done by culling, so we don't need to have some sort of flag in fragbufferblock or have slow conditional discarding in fragment shader. But, I'm not sure what's going to happen when there is culling at the same time disabled side. So, I'm just keeping it for now.