### PR TITLE
Implement hashless texture cache

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -35,6 +35,7 @@
     code(int, "icon-size", 64, icon_size)                                                               \
     code(bool, "archive-log", false, archive_log)                                                       \
     code(bool, "texture-cache", true, texture_cache)                                                    \
+    code(bool, "hashless-texture-cache", false, hashless_taexture_cache)                                \
     code(bool, "disable-ngs", false, disable_ngs)                                                       \
     code(int, "sys-button", static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS), sys_button)          \
     code(int, "sys-lang", static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US), sys_lang)                 \

--- a/vita3k/cpu/src/dynarmic_cpu.cpp
+++ b/vita3k/cpu/src/dynarmic_cpu.cpp
@@ -256,7 +256,7 @@ std::unique_ptr<Dynarmic::A32::Jit> DynarmicCPU::make_jit() {
     config.hook_hint_instructions = true;
     config.global_monitor = monitor;
     config.coprocessors[15] = cp15;
-    config.page_table = (log_mem || !cpu_opt) ? nullptr : parent->mem->pages_cpu.get();
+    config.page_table = nullptr;
     config.processor_id = core_id;
     config.optimizations = cpu_opt ? Dynarmic::all_safe_optimizations : Dynarmic::no_optimizations;
 

--- a/vita3k/gdbstub/src/gdb.cpp
+++ b/vita3k/gdbstub/src/gdb.cpp
@@ -331,20 +331,19 @@ static std::string cmd_write_register(HostState &state, PacketCommand &command) 
 }
 
 static bool check_memory_region(Address address, Address length, MemState &mem) {
-    const auto first_page = static_cast<uint32_t>(address / mem.page_size);
-    const auto page_length = static_cast<uint32_t>(length / mem.page_size) + 1;
+    if (!address) {
+        return false;
+    }
 
-    const auto pages_start = mem.allocated_pages.begin() + first_page;
-    const auto pages_end = pages_start + page_length;
-
-    constexpr size_t empty_page = 0;
-    constexpr size_t null_page = 1;
-
-    const bool memory_empty = std::find(pages_start, pages_end, empty_page) != pages_end;
-    const bool memory_null = std::find(pages_start, pages_end, null_page) != pages_end;
-    const bool memory_safe = !(memory_empty || memory_null);
-
-    return memory_safe;
+    Address it = address;
+    bool valid = true;
+    for (; it < address + length; it += mem.page_size) {
+        if (!is_valid_addr(mem, it)) {
+            valid = false;
+            break;
+        }
+    }
+    return valid;
 }
 
 static std::string cmd_read_memory(HostState &state, PacketCommand &command) {

--- a/vita3k/gui/src/disassembly_dialog.cpp
+++ b/vita3k/gui/src/disassembly_dialog.cpp
@@ -41,7 +41,7 @@ static void evaluate_code(GuiState &gui, HostState &host, uint32_t from, uint32_
         size_t addr_page = addr / KB(4);
         size_t end_page = (addr + 4) / KB(4);
 
-        if (addr_page == 0 || host.mem.allocated_pages[addr_page] == 0 || host.mem.allocated_pages[end_page] == 0) {
+        if (addr_page == 0 || !is_valid_addr(host.mem, addr_page * KB(4))) {
             gui.disassembly.emplace_back(fmt::format("Disassembled {} instructions.", a));
             break;
         }

--- a/vita3k/mem/CMakeLists.txt
+++ b/vita3k/mem/CMakeLists.txt
@@ -15,3 +15,12 @@ add_library(
 
 target_include_directories(mem PUBLIC include)
 target_link_libraries(mem PUBLIC util)
+
+add_executable(
+	mem-tests
+	tests/allocator_tests.cpp
+)
+
+target_include_directories(mem-tests PRIVATE include)
+target_link_libraries(mem-tests PRIVATE mem googletest util)
+add_test(NAME mem COMMAND mem-tests)

--- a/vita3k/mem/include/mem/allocator.h
+++ b/vita3k/mem/include/mem/allocator.h
@@ -21,13 +21,6 @@ public:
     void free(const std::uint32_t offset, const int size);
     void reset();
 
-    /**
-     * @brief   Get the number of allocated cells from specified region.
-     * 
-     * @param   offset          Begin offset of the region.
-     * @param   offset_end      End offset of the region.
-     * 
-     * @returns Number of cells already allocated on this region.
-     */
-    int allocated_count(const std::uint32_t offset, const std::uint32_t offset_end) const;
+    // Count free bits in [offset, offset_end) (exclusive)
+    int free_slot_count(const std::uint32_t offset, const std::uint32_t offset_end) const;
 };

--- a/vita3k/mem/include/mem/allocator.h
+++ b/vita3k/mem/include/mem/allocator.h
@@ -29,5 +29,5 @@ public:
      * 
      * @returns Number of cells already allocated on this region.
      */
-    int allocated_count(const std::uint32_t offset, const std::uint32_t offset_end);
+    int allocated_count(const std::uint32_t offset, const std::uint32_t offset_end) const;
 };

--- a/vita3k/mem/include/mem/functions.h
+++ b/vita3k/mem/include/mem/functions.h
@@ -22,9 +22,15 @@
 
 struct MemState;
 
+typedef std::function<bool(uint8_t *addr, bool write)> AccessViolationHandler;
+
 bool init(MemState &state);
 Address alloc(MemState &state, size_t size, const char *name);
 Address alloc(MemState &state, size_t size, const char *name, unsigned int alignment);
+bool add_write_protect(MemState &state, Address addr, const size_t size, WriteProtectCallback callback);
+bool remove_write_protect(MemState &state, Address addr);
+bool is_valid_addr(const MemState &state, Address addr);
+bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcept;
 Block alloc_block(MemState &mem, size_t size, const char *name);
 Address alloc_at(MemState &state, Address address, size_t size, const char *name);
 void free(MemState &state, Address address);

--- a/vita3k/mem/include/mem/ptr.h
+++ b/vita3k/mem/include/mem/ptr.h
@@ -78,7 +78,7 @@ public:
     }
 
     bool valid(const MemState &mem) const {
-        return (mem.allocated_pages[addr / mem.page_size] != 0);
+        return is_valid_addr(mem, addr);
     }
 
     void reset() {

--- a/vita3k/mem/include/mem/util.h
+++ b/vita3k/mem/include/mem/util.h
@@ -27,12 +27,7 @@ struct CPUState;
 struct MemState;
 
 typedef uint32_t Address;
-typedef size_t Generation;
-typedef std::unique_ptr<uint8_t[], std::function<void(uint8_t *)>> Memory;
-typedef std::vector<Generation> Allocated;
-typedef std::map<Generation, std::string> GenerationNames;
-
-typedef void (*BreakpointCallback)(CPUState &, MemState &);
+typedef std::function<void()> WriteProtectCallback;
 
 constexpr size_t KB(size_t kb) {
     return kb * 1024;

--- a/vita3k/mem/src/allocator.cpp
+++ b/vita3k/mem/src/allocator.cpp
@@ -84,7 +84,7 @@ int BitmapAllocator::allocate_from(const std::uint32_t start_offset, int &size, 
         return -1;
     }
 
-    std::uint32_t *word = &words[0] + (start_offset << 5);
+    std::uint32_t *word = &words[0] + (start_offset >> 5);
 
     // We have arrived at le word that still have free position (bit 1)
     std::uint32_t *word_end = &words[words.size() - 1];
@@ -150,7 +150,7 @@ int BitmapAllocator::allocate_from(const std::uint32_t start_offset, int &size, 
         word++;
     }
 
-    if (best_fit && bofmin) {
+    if (best_fit && bofmin != -1) {
         // Force allocate and then return
         const int offset = static_cast<int>(31 - bofmin + ((wordmin - &words[0]) << 5));
         if (static_cast<std::size_t>(offset + size) <= max_offset) {
@@ -168,7 +168,7 @@ static int number_of_set_bits(std::uint32_t i) {
     return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
 }
 
-int BitmapAllocator::allocated_count(const std::uint32_t offset, const std::uint32_t offset_end) {
+int BitmapAllocator::allocated_count(const std::uint32_t offset, const std::uint32_t offset_end) const {
     if (offset > offset_end) {
         return -1;
     }

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -99,7 +99,6 @@ bool init(MemState &state) {
 #else
     mprotect(state.memory.get(), state.page_size, PROT_NONE);
 #endif
-    (*(state.pages_cpu))[0] = nullptr;
 
     return true;
 }

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -35,41 +35,17 @@
 #endif
 
 constexpr size_t STANDARD_PAGE_SIZE = 4096;
+constexpr size_t TOTAL_MEM_SIZE = GB(4);
+constexpr bool LOG_PROTECT = false;
+constexpr bool PAGE_NAME_TRACKING = false;
 
-static void delete_memory(uint8_t *memory) {
-    if (memory != nullptr) {
-#ifdef WIN32
-        const BOOL ret = VirtualFree(memory, 0, MEM_RELEASE);
-        assert(ret);
-#else
-        munmap(memory, GB(4));
-#endif
-    }
-}
+//TODO: support multiple handlers
+static AccessViolationHandler access_violation_handler;
+static void register_access_violation_handler(AccessViolationHandler handler);
 
-static void alloc_inner(MemState &state, Address address, size_t page_count, Allocated::iterator block, const char *name) {
-    // If we chopped off bytes when aligning, they would have spilled over to another page, so add it here
-    if (address % state.page_size != 0)
-        page_count++;
-
-    uint8_t *const memory = &state.memory[align_down(address, state.page_size)];
-
-    const size_t size = page_count * state.page_size;
-
-    const Generation generation = ++state.generation;
-    std::fill_n(block, page_count, generation);
-
-    const std::lock_guard<std::mutex> lock(state.generation_mutex);
-    state.generation_names[generation] = name;
-
-#ifdef WIN32
-    const void *const ret = VirtualAlloc(memory, size, MEM_COMMIT, PAGE_READWRITE);
-    LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", log_hex(GetLastError()));
-#else
-    mprotect(memory, size, PROT_READ | PROT_WRITE);
-#endif
-    std::memset(memory, 0, size);
-}
+static Address alloc_inner(MemState &state, uint32_t start_page, int page_count, const char *name, const bool force);
+static void delete_memory(uint8_t *memory);
+static void delete_pagetable(MemPage *page_table);
 
 bool init(MemState &state) {
 #ifdef WIN32
@@ -83,17 +59,8 @@ bool init(MemState &state) {
 
     assert(state.page_size >= 4096); // Limit imposed by Unicorn.
 
-    state.pages_cpu = std::make_unique<std::array<uint8_t *, MB(1)>>();
-
-    (*(state.pages_cpu))[0] = state.memory.get();
-
-    for (std::size_t i = 1; i < state.pages_cpu->size(); i++) {
-        (*(state.pages_cpu))[i] = (*(state.pages_cpu))[i - 1] + state.page_size;
-    }
-
-    const size_t length = GB(4);
 #ifdef WIN32
-    state.memory = Memory(static_cast<uint8_t *>(VirtualAlloc(nullptr, length, MEM_RESERVE, PAGE_NOACCESS)), delete_memory);
+    state.memory = Memory(static_cast<uint8_t *>(VirtualAlloc(nullptr, TOTAL_MEM_SIZE, MEM_RESERVE, PAGE_NOACCESS)), delete_memory);
     if (!state.memory) {
         LOG_CRITICAL("VirtualAlloc failed: {}", log_hex(GetLastError()));
         return false;
@@ -105,15 +72,25 @@ bool init(MemState &state) {
     const int flags = MAP_PRIVATE | MAP_ANONYMOUS;
     const int fd = 0;
     const off_t offset = 0;
-    state.memory = Memory(static_cast<uint8_t *>(mmap(addr, length, prot, flags, fd, offset)), delete_memory);
+    state.memory = Memory(static_cast<uint8_t *>(mmap(addr, TOTAL_MEM_SIZE, prot, flags, fd, offset)), delete_memory);
     if (state.memory.get() == MAP_FAILED) {
         LOG_CRITICAL("mmap failed");
         return false;
     }
 #endif
 
-    state.allocated_pages.resize(length / state.page_size);
-    const Address null_address = alloc(state, 1, "NULL");
+    const size_t table_length = TOTAL_MEM_SIZE / state.page_size;
+    state.page_table = PageTable(new MemPage[table_length], delete_pagetable);
+    memset(state.page_table.get(), 0, sizeof(MemPage) * table_length);
+
+    state.allocator.set_maximum(table_length);
+
+    const auto handler = [&state](uint8_t *addr, bool write) noexcept {
+        return handle_access_violation(state, addr, write);
+    };
+    register_access_violation_handler(handler);
+
+    const Address null_address = alloc_inner(state, 0, 1, "null", true);
     assert(null_address == 0);
 #ifdef WIN32
     DWORD old_protect = 0;
@@ -127,39 +104,212 @@ bool init(MemState &state) {
     return true;
 }
 
+static void delete_memory(uint8_t *memory) {
+    if (memory != nullptr) {
+#ifdef WIN32
+        const BOOL ret = VirtualFree(memory, 0, MEM_RELEASE);
+        assert(ret);
+#else
+        munmap(memory, TOTAL_MEM_SIZE);
+#endif
+    }
+}
+
+static void delete_pagetable(MemPage *page_table) {
+    delete[] page_table;
+}
+
+bool is_valid_addr(const MemState &state, Address addr) {
+    return addr && state.allocator.allocated_count(addr / state.page_size, 1) != 0;
+}
+
+static Address alloc_inner(MemState &state, uint32_t start_page, int page_count, const char *name, const bool force) {
+    // Try to find and allocate page
+    int page_num = state.allocator.allocate_from(start_page, page_count, !force);
+    if (page_num < 0) {
+        LOG_CRITICAL("Failed to allocate page");
+    }
+    if (force && page_num != start_page) {
+        LOG_CRITICAL("Failed to allocate at specific page");
+    }
+
+    const int size = page_count * state.page_size;
+    const Address addr = page_num * state.page_size;
+    uint8_t *const memory = &state.memory[addr];
+
+    // Make memory chunck available to access
+#ifdef WIN32
+    const void *const ret = VirtualAlloc(memory, size, MEM_COMMIT, PAGE_READWRITE);
+    LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", log_hex(GetLastError()));
+#else
+    mprotect(memory, size, PROT_READ | PROT_WRITE);
+#endif
+    std::memset(memory, 0, size);
+
+    MemPage &page = state.page_table[page_num];
+    assert(!page.allocated);
+    page.allocated = 1;
+    page.size = page_count;
+
+    if (PAGE_NAME_TRACKING) {
+        state.page_name_map.emplace(page_num, name);
+    }
+
+    return addr;
+}
+
 Address alloc(MemState &state, size_t size, const char *name, unsigned int alignment) {
-    if (alignment != 0)
-        size += alignment - 1;
-    auto addr = alloc(state, size, name);
     if (alignment == 0)
-        return addr;
-    auto new_addr = (addr + alignment - 1) & ~(alignment - 1);
-    state.aligned_addr_to_original[new_addr] = addr;
-    return new_addr;
+        return alloc(state, size, name);
+
+    const std::lock_guard<std::mutex> lock(state.generation_mutex);
+    size = align(size, alignment);
+    const size_t page_count = align(size, state.page_size) / state.page_size;
+    const Address addr = alloc_inner(state, 0, page_count, name, false);
+    const Address align_addr = align(addr, alignment);
+    const int page_num = addr / state.page_size;
+    const int align_page_num = align_addr / state.page_size;
+
+    if (page_num != align_page_num) {
+        const size_t remnant = align_page_num - page_num;
+        state.allocator.free(page_num, remnant);
+
+        MemPage &page = state.page_table[page_num];
+        MemPage &align_page = state.page_table[align_page_num];
+        page.allocated = 0;
+        align_page.allocated = 1;
+        align_page.size = page.size - remnant;
+    }
+
+    return align_addr;
+}
+
+static void align_to_page(MemState &state, WriteProtect &protect) {
+    const Address end = align(protect.addr + protect.size, state.page_size);
+    const Address addr = align_down(protect.addr, state.page_size);
+    const size_t size = end - addr;
+    protect.addr = addr;
+    protect.size = size;
+}
+
+static bool overlap_in_page(MemState &state, const WriteProtect &a, const WriteProtect &b) {
+    const Address a_start = align_down(a.addr, state.page_size);
+    const Address a_end = align(a.addr + a.size, state.page_size);
+    const Address b_start = align_down(b.addr, state.page_size);
+    const Address b_end = align(b.addr + b.size, state.page_size);
+    return a_start <= b_end && b_start <= a_end;
+}
+
+static void unprotect_inner(MemState &state, Address addr, size_t size) {
+    if (LOG_PROTECT) {
+        fmt::print("Unprotect: {} {}\n", log_hex(addr), size);
+    }
+#ifdef WIN32
+    DWORD old_protect = 0;
+    const BOOL ret = VirtualProtect(&state.memory[addr], size - 1, PAGE_READWRITE, &old_protect);
+    LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", log_hex(GetLastError()));
+#else
+    mprotect(&state.memory[addr], size, PROT_READ | PROT_WRITE);
+#endif
+}
+
+static void protect_inner(MemState &state, Address addr, size_t size) {
+#ifdef WIN32
+    DWORD old_protect = 0;
+    const BOOL ret = VirtualProtect(&state.memory[addr], size - 1, PAGE_READONLY, &old_protect);
+    LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", log_hex(GetLastError()));
+#else
+    mprotect(&state.memory[addr], size, PROT_READ);
+#endif
+}
+
+static WriteProtectTree::iterator find_write_protect(WriteProtectTree &tree, Address addr) {
+    if (tree.empty()) {
+        return tree.end();
+    }
+    return --tree.upper_bound(WriteProtect(addr));
+}
+
+bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcept {
+    // We only use write protect for now
+    if (!write) {
+        return false;
+    }
+    const uintptr_t memory_addr = reinterpret_cast<uintptr_t>(state.memory.get());
+    const uintptr_t fault_addr = reinterpret_cast<uintptr_t>(addr);
+    if (fault_addr < memory_addr || fault_addr >= memory_addr + TOTAL_MEM_SIZE) {
+        return false;
+    }
+    const Address vaddr = fault_addr - memory_addr;
+    if (!is_valid_addr(state, vaddr)) {
+        return false;
+    }
+    if (LOG_PROTECT) {
+        fmt::print("Access: {}\n", log_hex(vaddr));
+    }
+
+    const std::lock_guard<std::mutex> lock(state.protect_mutex);
+    const auto it = find_write_protect(state.write_protect_tree, vaddr);
+    if (it == state.write_protect_tree.end()) {
+        LOG_CRITICAL("Unhandled write protected region was valid.");
+        return false;
+    }
+
+    if (vaddr < it->addr || vaddr >= it->addr + it->size) {
+        LOG_CRITICAL("Unhandled write protected region was valid.");
+        return false;
+    }
+
+    for (const auto cb : it->callbacks) {
+        cb();
+    }
+    unprotect_inner(state, it->addr, it->size);
+    state.write_protect_tree.erase(it);
+    return true;
+}
+
+bool add_write_protect(MemState &state, Address addr, const size_t size, WriteProtectCallback callback) {
+    const std::lock_guard<std::mutex> lock(state.protect_mutex);
+    WriteProtect protect(addr, size, callback);
+    align_to_page(state, protect);
+
+    auto it = find_write_protect(state.write_protect_tree, protect.addr);
+    while (it != state.write_protect_tree.end() && overlap_in_page(state, *it, protect)) {
+        const Address start = std::min(it->addr, protect.addr);
+        protect.size = std::max(it->addr + it->size, protect.addr + protect.size) - start;
+        protect.addr = start;
+        protect.callbacks.insert(protect.callbacks.end(), it->callbacks.begin(), it->callbacks.end());
+        state.write_protect_tree.erase(it++);
+    }
+    state.write_protect_tree.emplace(protect);
+
+    protect_inner(state, protect.addr, protect.size);
+
+    return true;
+}
+
+bool remove_write_protect(MemState &state, Address addr) {
+    const auto it = find_write_protect(state.write_protect_tree, addr);
+    if (it == state.write_protect_tree.end())
+        return false;
+    unprotect_inner(state, it->addr, it->size);
+    state.write_protect_tree.erase(it);
+    return true;
 }
 
 Address alloc(MemState &state, size_t size, const char *name) {
-    const size_t page_count = (size + (state.page_size - 1)) / state.page_size;
-    const Allocated::iterator block = std::search_n(state.allocated_pages.begin(), state.allocated_pages.end(), page_count, 0);
-    if (block == state.allocated_pages.end()) {
-        assert(false);
-        return 0;
-    }
-
-    const size_t block_page_index = block - state.allocated_pages.begin();
-    const Address address = static_cast<Address>(block_page_index * state.page_size);
-
-    alloc_inner(state, address, page_count, block, name);
-
-    return address;
+    const std::lock_guard<std::mutex> lock(state.generation_mutex);
+    const size_t page_count = align(size, state.page_size) / state.page_size;
+    const Address addr = alloc_inner(state, 0, page_count, name, false);
+    return addr;
 }
 
 Address alloc_at(MemState &state, Address address, size_t size, const char *name) {
-    const size_t page_count = (size + (state.page_size - 1)) / state.page_size;
-    const Allocated::iterator block = state.allocated_pages.begin() + (address / state.page_size);
-
-    alloc_inner(state, address, page_count, block, name);
-
+    const std::lock_guard<std::mutex> lock(state.generation_mutex);
+    const uint32_t wanted_page = address / state.page_size;
+    size += address - wanted_page * state.page_size;
+    const size_t page_count = align(size, state.page_size) / state.page_size;
+    alloc_inner(state, wanted_page, page_count, name, true);
     return address;
 }
 
@@ -171,57 +321,70 @@ Block alloc_block(MemState &mem, size_t size, const char *name) {
 }
 
 void free(MemState &state, Address address) {
-    auto &addr_map = state.aligned_addr_to_original;
-    if (addr_map.find(address) != addr_map.end()) {
-        auto old_addr = address;
-        address = addr_map[old_addr];
-        addr_map.erase(old_addr);
+    const std::lock_guard<std::mutex> lock(state.generation_mutex);
+    const size_t page_num = address / state.page_size;
+    assert(page_num >= 0);
+
+    MemPage &page = state.page_table[page_num];
+    if (!page.allocated) {
+        LOG_CRITICAL("Freeing unallocated page");
     }
-    const size_t page = address / state.page_size;
-    assert(page >= 0);
-    assert(page < state.allocated_pages.size());
+    page.allocated = 0;
 
-    const Generation generation = state.allocated_pages[page];
-    assert(generation != 0);
+    state.allocator.free(page_num, page.size);
+    if (PAGE_NAME_TRACKING) {
+        state.page_name_map.erase(page_num);
+    }
 
-    const auto different_generation = std::bind(std::not_equal_to<Generation>(), std::placeholders::_1, generation);
-    const Allocated::iterator first_page = state.allocated_pages.begin() + page;
-    const Allocated::iterator last_page = std::find_if(first_page, state.allocated_pages.end(), different_generation);
-    std::fill(first_page, last_page, 0);
+    uint8_t *const memory = &state.memory[page_num * state.page_size];
 
-    // TODO Decommit/protect freed memory.
+#ifdef WIN32
+    const BOOL ret = VirtualFree(memory, page.size * state.page_size, MEM_DECOMMIT);
+    assert(ret);
+#else
+    mprotect(memory, page.size * state.page_size, PROT_NONE);
+#endif
 }
 
 uint32_t mem_available(MemState &state) {
-    const size_t page_count = 1;
-    const Allocated::iterator block = std::search_n(state.allocated_pages.begin(), state.allocated_pages.end(), page_count, 0);
-    if (block == state.allocated_pages.end()) {
-        assert(false);
-        return 0;
-    }
-
-    const size_t block_page_index = block - state.allocated_pages.begin();
-    const Address address = static_cast<Address>(GB(4) - static_cast<Address>(block_page_index * state.page_size));
-
-    return address;
+    return TOTAL_MEM_SIZE - state.allocator.allocated_count(0, state.allocator.max_offset) * state.page_size;
 }
 
 const char *mem_name(Address address, MemState &state) {
-    const size_t page = address / state.page_size;
-    assert(page >= 0);
-    assert(page < state.allocated_pages.size());
-
-    const Generation generation = state.allocated_pages[page];
-    if (generation == 0) {
-        return "UNALLOCATED";
+    if (PAGE_NAME_TRACKING) {
+        return state.page_name_map.find(address / state.page_size)->second.c_str();
     }
-
-    const std::lock_guard<std::mutex> lock(state.generation_mutex);
-    const GenerationNames::const_iterator found = state.generation_names.find(generation);
-    assert(found != state.generation_names.end());
-    if (found == state.generation_names.end()) {
-        return "UNNAMED";
-    }
-
-    return found->second.c_str();
+    return "";
 }
+
+#ifdef WIN32
+
+static LONG WINAPI exception_handler(PEXCEPTION_POINTERS pExp) noexcept {
+    if (pExp->ExceptionRecord->ExceptionCode == EXCEPTION_BREAKPOINT && IsDebuggerPresent()) {
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+    const auto ptr = reinterpret_cast<uint8_t *>(pExp->ExceptionRecord->ExceptionInformation[1]);
+    const bool is_writing = pExp->ExceptionRecord->ExceptionInformation[0] == 1;
+    const bool is_executing = pExp->ExceptionRecord->ExceptionInformation[0] == 8;
+
+    if (pExp->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && !is_executing) {
+        if (access_violation_handler(ptr, is_writing)) {
+            return EXCEPTION_CONTINUE_EXECUTION;
+        }
+    }
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+static void register_access_violation_handler(AccessViolationHandler handler) {
+    access_violation_handler = handler;
+    if (!AddVectoredExceptionHandler(1, (PVECTORED_EXCEPTION_HANDLER)exception_handler)) {
+        LOG_CRITICAL("Failed to register an exception handler");
+    }
+}
+
+#else
+
+// TODO
+
+#endif

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -250,13 +250,17 @@ bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcep
     const std::lock_guard<std::mutex> lock(state.protect_mutex);
     const auto it = find_write_protect(state.write_protect_tree, vaddr);
     if (it == state.write_protect_tree.end()) {
+        // HACK: keep going
+        unprotect_inner(state, vaddr, 4);
         LOG_CRITICAL("Unhandled write protected region was valid.");
-        return false;
+        return true;
     }
 
     if (vaddr < it->addr || vaddr >= it->addr + it->size) {
+        // HACK: keep going
+        unprotect_inner(state, vaddr, 4);
         LOG_CRITICAL("Unhandled write protected region was valid.");
-        return false;
+        return true;
     }
 
     for (const auto cb : it->callbacks) {

--- a/vita3k/mem/tests/allocator_tests.cpp
+++ b/vita3k/mem/tests/allocator_tests.cpp
@@ -1,0 +1,169 @@
+// Vita3K emulator project
+// Copyright (C) 2018 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <mem/allocator.h>
+#include <mem/util.h>
+
+#include <gtest/gtest.h>
+
+TEST(bitmap_allocator, one_bit_allocation) {
+    BitmapAllocator allocator(KB(10));
+
+    for (int i = 0; i < KB(10); ++i) {
+        int size = 1;
+        int inoffset = 31 - i & 31;
+        int bit = (allocator.words[i >> 5] & (1 << inoffset)) >> inoffset;
+        ASSERT_EQ(bit, 1);
+        int ret = allocator.allocate_from(i, size, false);
+        ASSERT_EQ(ret, i);
+        bit = (allocator.words[i >> 5] & (1 << inoffset)) >> inoffset;
+        ASSERT_EQ(bit, 0);
+    }
+}
+
+TEST(bitmap_allocator, one_bit_free_slot) {
+    BitmapAllocator allocator(KB(10));
+    ASSERT_EQ(allocator.free_slot_count(0, KB(10)), KB(10));
+    for (int i = 0; i < KB(10); ++i) {
+        int size = 1;
+        ASSERT_EQ(allocator.free_slot_count(i, i + 1), 1);
+        int ret = allocator.allocate_from(i, size, false);
+        ASSERT_EQ(ret, i);
+        ASSERT_EQ(size, 1);
+        ASSERT_EQ(allocator.free_slot_count(i, i + 1), 0);
+    }
+    ASSERT_EQ(allocator.free_slot_count(0, KB(10)), 0);
+}
+
+TEST(bitmap_allocator, free_slot_count_aligned) {
+    BitmapAllocator allocator(KB(10));
+
+    for (int i = 0; i < KB(10); i += 2) {
+        int size = 2;
+        ASSERT_EQ(allocator.free_slot_count(i, i + 2), 2);
+        int ret = allocator.allocate_from(i, size, false);
+        ASSERT_EQ(ret, i);
+        ASSERT_EQ(size, 2);
+        ASSERT_EQ(allocator.free_slot_count(i, i + 2), 0);
+    }
+}
+
+TEST(bitmap_allocator, free_slot_count_unaligned) {
+    BitmapAllocator allocator(KB(10));
+
+    for (int i = 0; KB(10) - i >= 3; i += 3) {
+        int size = 3;
+        ASSERT_EQ(allocator.free_slot_count(i, i + 3), 3);
+        int ret = allocator.allocate_from(i, size, false);
+        ASSERT_EQ(ret, i);
+        ASSERT_EQ(size, 3);
+        ASSERT_EQ(allocator.free_slot_count(i, i + 3), 0);
+    }
+}
+
+// These tests are from EKA2L1 (https://github.com/EKA2L1/EKA2L1/blob/4fbd057da2a0c4f66a5c0f9dfc406c5d90f7531f/src/tests/common/allocator.cpp)
+TEST(bitmap_allocator, no_best_fit_only_one_fit) {
+    BitmapAllocator alloc(32);
+
+    // Bitmap:              1000 0101 0001 0001 0101 0001 00[11 1]001
+    alloc.words[0] = 0b10000101000100010101000100111001;
+
+    int to_alloc = 3;
+    ASSERT_EQ(alloc.allocate_from(0, to_alloc), 26);
+    ASSERT_EQ(to_alloc, 3);
+
+    // After allocate:      1000 0101 0001 0001 0101 0001 00[00 0]001
+    ASSERT_EQ(alloc.words[0], 0b10000101000100010101000100000001);
+}
+
+TEST(bitmap_allocator, no_best_fit_multiple_fit) {
+    BitmapAllocator alloc(32);
+
+    // Bitmap 1:            1000 0[111] 1001 0001 0101 0001 0011 1001
+    alloc.words[0] = 0b10000111100100010101000100111001;
+
+    int to_alloc = 3;
+    ASSERT_EQ(alloc.allocate_from(0, to_alloc), 5);
+    ASSERT_EQ(to_alloc, 3);
+
+    // After allocate:      1000 0[000] 1001 0001 0101 0001 0011 1001
+    ASSERT_EQ(alloc.words[0], 0b10000000100100010101000100111001);
+}
+
+TEST(bitmap_allocator, no_best_fit_alloc_across) {
+    BitmapAllocator alloc(64);
+
+    alloc.words[0] = 0b111;
+    alloc.words[1] = 0b11100000000000000000000000000000;
+
+    int to_alloc = 5;
+    ASSERT_EQ(alloc.allocate_from(0, to_alloc), 29);
+    ASSERT_EQ(to_alloc, 5);
+
+    ASSERT_EQ(alloc.words[0], 0);
+    ASSERT_EQ(alloc.words[1], 0b00100000000000000000000000000000);
+}
+
+TEST(bitmap_allocator, best_fit_multiple_fit) {
+    BitmapAllocator alloc(32);
+
+    // Bitmap 1:            1000 0111 1001 0001 0101 0001 00[11 1]001
+    alloc.words[0] = 0b10000111100100010101000100111001;
+
+    int to_alloc = 3;
+    ASSERT_EQ(alloc.allocate_from(0, to_alloc, true), 26);
+    ASSERT_EQ(to_alloc, 3);
+
+    // After allocate:      1000 0111 1001 0001 0101 0001 00[00 0]001
+    ASSERT_EQ(alloc.words[0], 0b10000111100100010101000100000001);
+}
+
+TEST(bitmap_allocator, count_bit_aligned) {
+    BitmapAllocator alloc(32 * 3);
+
+    // Bitmap 1: All bit on
+    alloc.words[0] = 0xFFFFFFFF;
+
+    // Bitmap 2: 12 bits on
+    alloc.words[1] = 0xF00F00F0;
+
+    // Bitmap 3: 12 bits on
+    alloc.words[2] = 0x00F00F0F;
+
+    ASSERT_EQ(alloc.free_slot_count(0, 32 * 3), 56);
+    ASSERT_EQ(alloc.free_slot_count(0, 32 * 3 - 1), 55);
+}
+
+TEST(bitmap_allocator, count_unaligned) {
+    BitmapAllocator alloc(32 * 3);
+
+    // Bitmap 1: 0b11 | 0011000011
+    //      ignored ^
+    // 4 valid bits on
+    alloc.words[0] = 0b110011000011;
+
+    // Bitmap 2: 12 bits on
+    alloc.words[1] = 0xF00F00F0;
+
+    // Bitmap 3: 0b1010111000 | 1111
+    //                          ^ ignored
+    // 5 valid bits on
+    alloc.words[2] = 0b10101110001111;
+
+    // 4 valid bits + 12 bits + 5 valid bits = 21
+    ASSERT_EQ(alloc.free_slot_count(22, 92), 21);
+}

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -144,7 +144,7 @@ void decompress_bc_swizz_image(std::uint32_t width, std::uint32_t height, const 
 void swizzled_texture_to_linear_texture(uint8_t *dest, const uint8_t *src, uint16_t width, uint16_t height, uint8_t bits_per_pixel);
 void tiled_texture_to_linear_texture(uint8_t *dest, const uint8_t *src, uint16_t width, uint16_t height, uint8_t bits_per_pixel);
 
-void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_texture, const MemState &mem);
+void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_texture, MemState &mem);
 size_t bits_per_pixel(SceGxmTextureBaseFormat base_format);
 bool is_compressed_format(SceGxmTextureBaseFormat base_format, std::uint32_t width, std::uint32_t height, size_t &source_size);
 TextureCacheHash hash_texture_data(const SceGxmTexture &texture, const MemState &mem);

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -58,7 +58,7 @@ void sync_rendertarget(const GLRenderTarget &rt);
 void set_context(GLContext &ctx, const MemState &mem, const GLRenderTarget *rt, const FeatureState &features);
 void get_surface_data(GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, SceGxmColorFormat format);
 void draw(GLState &renderer, GLContext &context, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format,
-    void *indices, size_t count, uint32_t instance_count, const MemState &mem, const char *base_path, const char *title_id, const Config &config);
+    void *indices, size_t count, uint32_t instance_count, MemState &mem, const char *base_path, const char *title_id, const Config &config);
 
 void upload_vertex_stream(GLContext &context, const std::size_t stream_index, const std::size_t length, const void *data);
 
@@ -79,7 +79,7 @@ void sync_polygon_mode(const SceGxmPolygonMode mode, const bool front);
 void sync_point_line_width(const std::uint32_t size, const bool front);
 void sync_depth_bias(const int factor, const int unit, const bool front);
 void sync_blending(const GxmRecordState &state, const MemState &mem);
-void sync_texture(GLContext &context, const MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config,
+void sync_texture(GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config,
     const std::string &base_path, const std::string &title_id);
 void sync_vertex_attributes(GLContext &context, const GxmRecordState &state, const MemState &mem);
 void bind_fundamental(GLContext &context);

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -50,7 +50,7 @@ bool set_uniform(GLuint program, const SceGxmProgram &shader_program, GLShaderSt
 bool set_uniform_buffer(GLContext &context, const bool vertex_shader, const int block_num, const int size, const void *data, bool log_active_shader);
 
 bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state);
-bool create(std::unique_ptr<Context> &context);
+bool create(std::unique_ptr<Context> &context, const bool hashless_texture_cache);
 bool create(std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &params, const FeatureState &features);
 bool create(std::unique_ptr<FragmentProgram> &fp, GLState &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
 bool create(std::unique_ptr<VertexProgram> &vp, GLState &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
@@ -109,7 +109,7 @@ GLenum translate_minmag_filter(SceGxmTextureFilter src);
 size_t bits_per_pixel(SceGxmTextureBaseFormat base_format);
 
 // Texture cache.
-bool init(GLTextureCacheState &cache);
+bool init(GLTextureCacheState &cache, const bool hashless_texture_cache);
 void dump(const SceGxmTexture &gxm_texture, const MemState &mem, const std::string &name, const std::string &base_path, const std::string &title_id, Sha256Hash hash);
 
 } // namespace texture

--- a/vita3k/renderer/include/renderer/texture_cache_state.h
+++ b/vita3k/renderer/include/renderer/texture_cache_state.h
@@ -15,19 +15,29 @@ constexpr size_t TextureCacheSize = KB(1);
 typedef uint64_t TextureCacheTimestamp;
 typedef uint32_t TextureCacheHash;
 
-typedef std::array<SceGxmTexture, TextureCacheSize> TextureCacheGxmTextures;
-typedef std::array<TextureCacheTimestamp, TextureCacheSize> TextureCacheTimestamps;
-typedef std::array<TextureCacheHash, TextureCacheSize> TextureCacheHashes;
+struct TextureCacheInfo {
+    bool use_hash = false;
+    bool dirty = false;
+    TextureCacheHash hash = 0;
+    uint64_t timestamp = 0;
+    SceGxmTexture texture;
+
+    explicit TextureCacheInfo(SceGxmTexture texture)
+        : texture(texture) {}
+
+    TextureCacheInfo() = default;
+};
+
+typedef std::array<TextureCacheInfo, TextureCacheSize> TextureCacheInfoes;
 typedef std::function<void(std::size_t)> TextureCacheStateSelectCallback;
 typedef std::function<void(std::size_t, const void *)> TextureCacheStateConfigureTextureCallback;
 typedef std::function<void(std::size_t, const void *, const MemState &)> TextureCacheStateUploadTextureCallback;
 
 struct TextureCacheState {
+    bool use_protect = true;
     size_t used = 0;
     TextureCacheTimestamp timestamp = 1;
-    TextureCacheGxmTextures gxm_textures;
-    TextureCacheTimestamps timestamps;
-    TextureCacheHashes hashes;
+    TextureCacheInfoes infoes;
     TextureCacheStateSelectCallback select_callback;
     TextureCacheStateConfigureTextureCallback configure_texture_callback;
     TextureCacheStateUploadTextureCallback upload_texture_callback;

--- a/vita3k/renderer/include/renderer/texture_cache_state.h
+++ b/vita3k/renderer/include/renderer/texture_cache_state.h
@@ -34,7 +34,7 @@ typedef std::function<void(std::size_t, const void *)> TextureCacheStateConfigur
 typedef std::function<void(std::size_t, const void *, const MemState &)> TextureCacheStateUploadTextureCallback;
 
 struct TextureCacheState {
-    bool use_protect = true;
+    bool use_protect = false;
     size_t used = 0;
     TextureCacheTimestamp timestamp = 1;
     TextureCacheInfoes infoes;

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -41,7 +41,7 @@ COMMAND(handle_create_context) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL: {
-        result = gl::create(*ctx);
+        result = gl::create(*ctx, config.hashless_taexture_cache);
         break;
     }
 

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -55,7 +55,7 @@ struct GXMRenderFragUniformBlock {
 };
 
 void draw(GLState &renderer, GLContext &context, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format, void *indices, size_t count, uint32_t instance_count,
-    const MemState &mem, const char *base_path, const char *title_id, const Config &config) {
+    MemState &mem, const char *base_path, const char *title_id, const Config &config) {
     R_PROFILE(__func__);
 
     GLuint program_id = context.last_draw_program;

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -23,7 +23,7 @@
 
 namespace renderer::gl {
 namespace texture {
-bool init(GLTextureCacheState &cache) {
+bool init(GLTextureCacheState &cache, const bool hashless_texture_cache) {
     cache.select_callback = [&](const std::size_t index) {
         const GLuint gl_texture = cache.textures[index];
         glBindTexture(GL_TEXTURE_2D, gl_texture);
@@ -36,6 +36,8 @@ bool init(GLTextureCacheState &cache) {
     cache.upload_texture_callback = [](const std::size_t index, const void *texture, const MemState &mem) {
         upload_bound_texture(*reinterpret_cast<const SceGxmTexture *>(texture), mem);
     };
+
+    cache.use_protect = hashless_texture_cache;
 
     return cache.textures.init(reinterpret_cast<renderer::Generator *>(glGenTextures), reinterpret_cast<renderer::Deleter *>(glDeleteTextures));
 }
@@ -274,13 +276,13 @@ bool create(SDL_Window *window, std::unique_ptr<State> &state) {
     return true;
 }
 
-bool create(std::unique_ptr<Context> &context) {
+bool create(std::unique_ptr<Context> &context, const bool hashless_texture_cache) {
     R_PROFILE(__func__);
 
     context = std::make_unique<GLContext>();
     GLContext *gl_context = reinterpret_cast<GLContext *>(context.get());
 
-    return !(!texture::init(gl_context->texture_cache) || !gl_context->vertex_array.init(reinterpret_cast<renderer::Generator *>(glGenVertexArrays), reinterpret_cast<renderer::Deleter *>(glDeleteVertexArrays)) || !gl_context->element_buffer.init(reinterpret_cast<renderer::Generator *>(glGenBuffers), reinterpret_cast<renderer::Deleter *>(glDeleteBuffers)) || !gl_context->stream_vertex_buffers.init(reinterpret_cast<renderer::Generator *>(glGenBuffers), reinterpret_cast<renderer::Deleter *>(glDeleteBuffers))
+    return !(!texture::init(gl_context->texture_cache, hashless_texture_cache) || !gl_context->vertex_array.init(reinterpret_cast<renderer::Generator *>(glGenVertexArrays), reinterpret_cast<renderer::Deleter *>(glDeleteVertexArrays)) || !gl_context->element_buffer.init(reinterpret_cast<renderer::Generator *>(glGenBuffers), reinterpret_cast<renderer::Deleter *>(glDeleteBuffers)) || !gl_context->stream_vertex_buffers.init(reinterpret_cast<renderer::Generator *>(glGenBuffers), reinterpret_cast<renderer::Deleter *>(glDeleteBuffers))
         || !gl_context->uniform_buffer.init(reinterpret_cast<renderer::Generator *>(glGenBuffers), reinterpret_cast<renderer::Deleter *>(glDeleteBuffers)));
 }
 

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -292,7 +292,7 @@ void sync_depth_bias(const int factor, const int unit, const bool is_front) {
     }
 }
 
-void sync_texture(GLContext &context, const MemState &mem, std::size_t index, SceGxmTexture texture,
+void sync_texture(GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture,
     const Config &config, const std::string &base_path, const std::string &title_id) {
     if (texture.data_addr == 0) {
         LOG_WARN("Texture has null data.");

--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -133,6 +133,7 @@ void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_t
     if (upload) {
         cache.upload_texture_callback(index, &gxm_texture, mem);
         if (!info->use_hash) {
+            info->dirty = false;
             add_write_protect(mem, gxm_texture.data_addr << 2, size, [&cache, info, gxm_texture] {
                 if (memcmp(&info->texture, &gxm_texture, sizeof(SceGxmTexture)) == 0) {
                     info->dirty = true;


### PR DESCRIPTION
# Description
- external: Update dynarmic
- mem: Fix bugs in bitmapallocator
- mem: Support windows write protect
- mem: Properly decommit memory in windows
- renderer: Add write protect based texture dirty flag
- mem: Use custom allocator and optimized page table
- dynarmic_cpu: Don't use page_table

Attempt to optimize texture cache further and use custom allocator.