### PR TITLE
Fix random texture cache crash

### DIFF
--- a/vita3k/mem/include/mem/functions.h
+++ b/vita3k/mem/include/mem/functions.h
@@ -30,6 +30,7 @@ Address alloc(MemState &state, size_t size, const char *name, unsigned int align
 bool add_write_protect(MemState &state, Address addr, const size_t size, WriteProtectCallback callback);
 bool remove_write_protect(MemState &state, Address addr);
 bool is_valid_addr(const MemState &state, Address addr);
+bool is_valid_addr_range(const MemState &state, Address start, Address end);
 bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcept;
 Block alloc_block(MemState &mem, size_t size, const char *name);
 Address alloc_at(MemState &state, Address address, size_t size, const char *name);

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -124,6 +124,12 @@ bool is_valid_addr(const MemState &state, Address addr) {
     return addr && state.allocator.free_slot_count(page_num, page_num + 1) == 0;
 }
 
+bool is_valid_addr_range(const MemState &state, Address start, Address end) {
+    const uint32_t start_page = start / state.page_size;
+    const uint32_t end_page = (end + state.page_size - 1) / state.page_size;
+    return state.allocator.free_slot_count(start_page, end_page) == 0;
+}
+
 static Address alloc_inner(MemState &state, uint32_t start_page, int page_count, const char *name, const bool force) {
     int page_num;
     if (force) {

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -148,6 +148,7 @@ void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_t
 size_t bits_per_pixel(SceGxmTextureBaseFormat base_format);
 bool is_compressed_format(SceGxmTextureBaseFormat base_format, std::uint32_t width, std::uint32_t height, size_t &source_size);
 TextureCacheHash hash_texture_data(const SceGxmTexture &texture, const MemState &mem);
+size_t texture_size(const SceGxmTexture &texture);
 
 } // namespace texture
 

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -299,6 +299,12 @@ void sync_texture(GLContext &context, MemState &mem, std::size_t index, SceGxmTe
         return;
     }
 
+    const size_t texture_size = renderer::texture::texture_size(texture);
+    if (is_valid_addr_range(mem, texture.data_addr << 2, texture_size)) {
+        LOG_WARN("Texture has freed data.");
+        return;
+    }
+
     const SceGxmTextureFormat format = gxm::get_format(&texture);
     if (gxm::is_paletted_format(format) && texture.palette_addr == 0) {
         LOG_WARN("Ignoring null palette texture");

--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -28,22 +28,11 @@ static TextureCacheHash hash_palette_data(const SceGxmTexture &texture, size_t c
     return palette_hash;
 }
 
-static size_t get_texture_size(const SceGxmTexture &texture) {
-    const SceGxmTextureFormat format = gxm::get_format(&texture);
-    const SceGxmTextureBaseFormat base_format = gxm::get_base_format(format);
-    const size_t width = gxm::get_width(&texture);
-    const size_t height = gxm::get_height(&texture);
-    const size_t stride = (width + 7) & ~7; // NOTE: This is correct only with linear textures.
-    const size_t bpp = texture::bits_per_pixel(base_format);
-    const size_t size = (bpp * stride * height) / 8;
-    return size;
-}
-
 TextureCacheHash hash_texture_data(const SceGxmTexture &texture, const MemState &mem) {
     R_PROFILE(__func__);
     const SceGxmTextureFormat format = gxm::get_format(&texture);
     const SceGxmTextureBaseFormat base_format = gxm::get_base_format(format);
-    const size_t size = get_texture_size(texture);
+    const size_t size = texture_size(texture);
     const Ptr<const void> data(texture.data_addr << 2);
     const TextureCacheHash data_hash = hash_data(data.get(mem), size);
 
@@ -80,10 +69,10 @@ void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_t
     size_t index = 0;
     bool configure = false;
     bool upload = false;
-    const size_t size = get_texture_size(gxm_texture);
+    const size_t size = texture_size(gxm_texture);
 
     // Try to find GXM texture in cache.
-    size_t cached_gxm_texture_index = -1;
+    int cached_gxm_texture_index = -1;
     for (size_t a = 0; a < cache.used; a++) {
         if (memcmp(&cache.infoes[a].texture, &gxm_texture, sizeof(SceGxmTexture)) == 0) {
             cached_gxm_texture_index = a;

--- a/vita3k/renderer/src/texture_format.cpp
+++ b/vita3k/renderer/src/texture_format.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <gxm/functions.h>
 #include <gxm/types.h>
 
 namespace renderer::texture {
@@ -97,6 +98,17 @@ size_t bits_per_pixel(SceGxmTextureBaseFormat base_format) {
     }
 
     return 0;
+}
+
+size_t texture_size(const SceGxmTexture &texture) {
+    const SceGxmTextureFormat format = gxm::get_format(&texture);
+    const SceGxmTextureBaseFormat base_format = gxm::get_base_format(format);
+    const size_t width = gxm::get_width(&texture);
+    const size_t height = gxm::get_height(&texture);
+    const size_t stride = (width + 7) & ~7; // NOTE: This is correct only with linear textures.
+    const size_t bpp = bits_per_pixel(base_format);
+    const size_t size = (bpp * stride * height) / 8;
+    return size;
 }
 
 // Based on this: http://xen.firefly.nu/up/rearrange.c.html


### PR DESCRIPTION
Add validity check to prevent accessing freed texture data.