### PR TITLE
gl/texture_formats: fix value for U2F10F10F10.

### DIFF
--- a/vita3k/renderer/src/gl/texture_formats.cpp
+++ b/vita3k/renderer/src/gl/texture_formats.cpp
@@ -436,8 +436,7 @@ GLenum translate_type(SceGxmTextureFormat format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8:
         return GL_BYTE;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U2F10F10F10:
-        LOG_WARN("Unhandled base format SCE_GXM_TEXTURE_BASE_FORMAT_U2F10F10F10");
-        return GL_INT_2_10_10_10_REV;
+        return GL_UNSIGNED_INT_2_10_10_10_REV;
     }
 
     LOG_WARN("Unhandled base format {}", log_hex(base_format));


### PR DESCRIPTION
# About:
- fix gl error and visible render on Valkyrie drive.

# Result:
- tv crypted effect and black and white is caused by one frag shader broken.
![image](https://user-images.githubusercontent.com/5261759/120710533-8b031f00-c4be-11eb-9b29-6a0c546adb90.png)
- using hack on this broken shader
![image](https://user-images.githubusercontent.com/5261759/120712106-82abe380-c4c0-11eb-840b-ce682dce1adb.png)

Render keep have glitch on color, skin is full white etc
