### PR TITLE
shader: fix shader crash for a virus named tom

### DIFF
--- a/vita3k/shader/src/translator/branch_cond.cpp
+++ b/vita3k/shader/src/translator/branch_cond.cpp
@@ -375,16 +375,17 @@ bool USSETranslatorVisitor::vtst(
     const Imm4 load_mask = tb_decode_load_mask[chan_cc];
 
     bool use_double_reg = alu_sel == 0;
+    uint8_t bits_max = (load_data_type == DataType::F32) ? 8 : 7;
 
     // Build up source
-    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_ext, use_double_reg, 8, m_second_program);
-    inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank, src2_ext, use_double_reg, 8, m_second_program);
+    inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank, src1_ext, use_double_reg, bits_max, m_second_program);
+    inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank, src2_ext, use_double_reg, bits_max, m_second_program);
 
     inst.opr.src1.type = load_data_type;
     inst.opr.src2.type = load_data_type;
 
     inst.opr.src1.swizzle = SWIZZLE_CHANNEL_4_DEFAULT;
-    inst.opr.src2.swizzle = src2_vscomp ? (Swizzle4 SWIZZLE_CHANNEL_4(X, X, X, X)) : (Swizzle4 SWIZZLE_CHANNEL_4_DEFAULT);
+    inst.opr.src2.swizzle = (src2_vscomp && (load_data_type == DataType::F32)) ? (Swizzle4 SWIZZLE_CHANNEL_4(X, X, X, X)) : (Swizzle4 SWIZZLE_CHANNEL_4_DEFAULT);
 
     if (src1_neg) {
         inst.opr.src1.flags |= RegisterFlags::Negative;


### PR DESCRIPTION
# About:
Correct bits of VTST sources on non-F32 data type. fix already two game for move it to Ingame/playable.
- Fix A virus named tom & ONE PIECE Unlimited WR.

# Result:
- One piece go ingame
![image](https://user-images.githubusercontent.com/5261759/120889158-1df5a380-c5fc-11eb-9b06-3f07fff9d3a2.png)
with some shader hack
![image](https://cdn.discordapp.com/attachments/725005006717190295/850516295795343390/unknown.png)
- A virus named tom to
![image](https://user-images.githubusercontent.com/5261759/120889180-36fe5480-c5fc-11eb-941f-a42491b6e11a.png)
![image](https://user-images.githubusercontent.com/5261759/120889187-3cf43580-c5fc-11eb-81c5-9a04642fca11.png)
