### PR TITLE
[WIP] renderer: add some color format.

### DIFF
--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -442,9 +442,8 @@ void set_context(GLContext &context, const MemState &mem, const GLRenderTarget *
 void get_surface_data(GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, SceGxmColorFormat format) {
     R_PROFILE(__func__);
 
-    if (pixels == nullptr) {
+    if (!pixels)
         return;
-    }
 
     glPixelStorei(GL_PACK_ROW_LENGTH, static_cast<GLint>(stride_in_pixels));
 
@@ -454,15 +453,14 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_U8U8U8U8_ARGB:
+    case SCE_GXM_COLOR_FORMAT_U8U8U8U8_BGRA:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_U8U8U8U8_RGBA:
-        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-        for (int i = 0; i < width * height; ++i) {
-            uint8_t *pixel = reinterpret_cast<uint8_t *>(&pixels[i]);
-            std::swap(pixel[0], pixel[3]);
-            std::swap(pixel[1], pixel[2]);
-        }
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_INT_8_8_8_8, pixels);
+        break;
+    case SCE_GXM_COLOR_FORMAT_U1U5U5U5_ABGR:
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_SHORT_1_5_5_5_REV, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_U4U4U4U4_ARGB:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_BGRA, GL_UNSIGNED_SHORT_4_4_4_4_REV, pixels);
@@ -477,6 +475,7 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RED, GL_UNSIGNED_SHORT, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_U8U8_AR:
+    case SCE_GXM_COLOR_FORMAT_U8U8_GR:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RG, GL_UNSIGNED_BYTE, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_U8_A:
@@ -486,7 +485,9 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RED, GL_UNSIGNED_BYTE, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_U2F10F10F10_ABGR:
+    case SCE_GXM_COLOR_FORMAT_F10F10F10U2_RGBA:
     case SCE_GXM_COLOR_FORMAT_U2U10U10U10_ABGR:
+    case SCE_GXM_COLOR_FORMAT_U10U10U10U2_RGBA:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_UNSIGNED_INT_2_10_10_10_REV, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_F16_R:
@@ -500,6 +501,12 @@ void get_surface_data(GLContext &context, size_t width, size_t height, size_t st
         break;
     case SCE_GXM_COLOR_FORMAT_F16F16F16F16_ARGB:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_BGRA, GL_HALF_FLOAT, pixels);
+        break;
+    case SCE_GXM_COLOR_FORMAT_F16F16F16F16_RGBA:
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RGBA, GL_HALF_FLOAT, pixels);
+        break;
+    case SCE_GXM_COLOR_FORMAT_F32_R:
+        glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RED, GL_FLOAT, pixels);
         break;
     case SCE_GXM_COLOR_FORMAT_F32F32_GR:
         glReadPixels(0, 0, static_cast<GLsizei>(width), static_cast<GLsizei>(height), GL_RG, GL_FLOAT, pixels);


### PR DESCRIPTION
# About:
- add U10U10U10U2_RGBA for Chronovolt.
- add F10F10F10U2_RGBA for F1 2011 & silent hill.
- add F16F16F16F16_RGBA for Wipeout 2048 (Photos mode).
- add U8U8_GR for Grim fandango.
- add F32_R for Gundam Extreme.
- add U8U8U8U8_BGRA for To Love-Ru: Battle Ecstasy.
- add U1U5U5U5_ABGR for Hyperdimension Neptunia PP

- fix sizzle for for both U2_RGBA
- fix swizzle for U8U8U8X8_BGR1

# Result: 
- with some shader hack for improve broken texture
![image](https://user-images.githubusercontent.com/5261759/121369146-e52b3680-c93b-11eb-8855-b27431bd159a.png)
- with idsable process for pcm decoder
![image](https://cdn.discordapp.com/attachments/408917186254733317/852187513052987392/unknown.png)

