### PR TITLE
project: fix typo on gen-windows.

### DIFF
--- a/building.md
+++ b/building.md
@@ -56,7 +56,7 @@ From there, the project will be ready to build right from the Visual Studio UI.
 
 - Generate the project:
   ```cmd
-  cmake -S . -B build-windows -G "Visual Studio 2019 16" -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake
+  cmake -S . -B build-windows -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake
   ```
   The line above will generate a Visual Studio 2019 project inside a folder called `build-windows`.
 

--- a/gen-windows.bat
+++ b/gen-windows.bat
@@ -1,4 +1,5 @@
 @echo off
 
 REM Generate project files for Visual Studio 2019
-call cmake -S . -B build-windows -G "Visual Studio 2019 16" -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake
+call cmake -S . -B build-windows -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake
+pause


### PR DESCRIPTION
# About: 
command is wrong, number is inversed for cmake, fix generate project.
- add pause in end script for can view result before close alone.