### PR TITLE
gui: add time app used & refactor.

### DIFF
--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -9,7 +9,7 @@
 		<install_license>Install License</install_license>
 	</file>
 	<emulation name="Emulation">
-		<last_loaded_apps>Last loaded Apps</last_loaded_apps>
+		<last_apps_used>Last Apps used</last_apps_used>
 	</emulation>
 	<configuration name="Configuration">
 		<settings>Settings</settings>
@@ -37,6 +37,7 @@
 	<version>Version</version>
 	<last_time_used>Last time used</last_time_used>
 	<never>Never</never>
+	<time_used>Time used</time_used>
 </app_context>
 
 <common>

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -9,7 +9,7 @@
 		<install_license>Install License</install_license>
 	</file>
 	<emulation name="Emulation">
-		<last_loaded_apps>Last loaded Apps</last_loaded_apps>
+		<last_apps_used>Last Apps used</last_apps_used>
 	</emulation>
 	<configuration name="Configuration">
 		<settings>Settings</settings>
@@ -37,6 +37,7 @@
 	<version>Version</version>
 	<last_time_used>Last time used</last_time_used>
 	<never>Never</never>
+	<time_used>Time used</time_used>
 </app_context>
 
 <common>

--- a/lang/es.xml
+++ b/lang/es.xml
@@ -8,7 +8,7 @@
 		<install_zip>Instalar un .zip, .vpk</install_zip>
 	</file>
 	<emulation name="Emulación">
-		<last_loaded_apps>Últimas aplicaciones cargadas</last_loaded_apps>
+		<last_apps_used>Últimas aplicaciones utilizadas</last_apps_used>
 	</emulation>
 	<configuration name="Configuración">
 		<settings>Ajustes</settings>

--- a/lang/fr.xml
+++ b/lang/fr.xml
@@ -9,7 +9,7 @@
 		<install_license>Installer une License</install_license>
 	</file>
 	<emulation name="Émulation">
-		<last_loaded_apps>Dernières Apps chargées</last_loaded_apps>
+		<last_apps_used>Dernières Apps utilisées</last_apps_used>
 	</emulation>
 	<configuration name="Configuration">
 		<settings>Paramètres</settings>
@@ -37,6 +37,7 @@
 	<version>Version</version>
 	<last_time_used>Dernière fois utilisé</last_time_used>
 	<never>Jamais</never>
+	<time_used>Temps utilisé</time_used>
 </app_context>
 
 <common>

--- a/lang/it.xml
+++ b/lang/it.xml
@@ -13,7 +13,7 @@
 		<install_zip>Installa un .zip, .vpk</install_zip>
 	</file>
 	<emulation name="Emulazione">
-		<last_loaded_apps>Ultime app caricate</last_loaded_apps>
+		<last_apps_used>Ultime app utilizzate</last_apps_used>
 	</emulation>
 	<configuration name="Configurazione">
 		<settings>Impostazioni</settings>

--- a/lang/nl.xml
+++ b/lang/nl.xml
@@ -8,7 +8,7 @@
 		<install_zip>Installeer .zip, .vpk</install_zip>
 	</file>
 	<emulation name="Emuleren">
-		<load_last_app>Laad Laatste App</load_last_app>
+		<last_apps_used>Laatste gebruikte apps</last_apps_used>
 	</emulation>
 	<configuration name="Configuratie">
 		<settings>Instellingen</settings>

--- a/lang/ru.xml
+++ b/lang/ru.xml
@@ -8,7 +8,7 @@
 		<install_zip>Установить файл .zip или .vpk</install_zip>
 	</file>
 	<emulation name="Эмуляция">
-		<last_loaded_apps>Последние загруженные приложения</last_loaded_apps>
+		<last_apps_used>Последние использованные приложения</last_apps_used>
 	</emulation>
 	<configuration name="Конфигурация">
 		<settings>Настройки</settings>

--- a/lang/zh-s.xml
+++ b/lang/zh-s.xml
@@ -8,7 +8,7 @@
 		<install_zip>安装 .zip 或者 .vpk</install_zip>
 	</file>
 	<emulation name="仿真拟">
-		<last_loaded_apps>上次加载的应用</last_loaded_apps>
+		<last_apps_used>使用的最新应用</last_apps_used>
 	</emulation>
 	<configuration name="配置">
 		<settings>设置</settings>

--- a/lang/zh-t.xml
+++ b/lang/zh-t.xml
@@ -8,7 +8,7 @@
 		<install_zip>安裝 .zip 或者 .vpk</install_zip>
 	</file>
 	<emulation name="模擬">
-		<last_loaded_apps>上次加載的應用</last_loaded_apps>
+		<last_apps_used>使用的最新應用</last_apps_used>
 	</emulation>
 	<configuration name="配置">
 		<settings>設定</settings>

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -95,8 +95,7 @@
 // When adding in a new macro for generation, ALL options must be stated.
 #define CONFIG_VECTOR(code)                                                                             \
     code(std::vector<std::string>, "lle-modules", std::vector<std::string>{}, lle_modules)              \
-    code(std::vector<uint64_t>, "ime-langs", std::vector<uint64_t>{4}, ime_langs)                       \
-    code(std::vector<std::string>, "last-loaded-apps", std::vector<std::string>{}, last_loaded_apps)                                              
+    code(std::vector<uint64_t>, "ime-langs", std::vector<uint64_t>{4}, ime_langs)
 
 // Parent macro for easier generation
 #define CONFIG_LIST(code)                                                                               \

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -79,9 +79,10 @@ bool refresh_app_list(GuiState &gui, HostState &host);
 void save_user(GuiState &gui, HostState &host, const std::string &user_id);
 void set_config(GuiState &gui, HostState &host, const std::string &app_path);
 void update_apps_list_opened(GuiState &gui, HostState &host, const std::string &app_path);
+void update_last_time_app_used(GuiState &gui, HostState &host, const std::string &app);
 void update_notice_info(GuiState &gui, HostState &host, const std::string &type);
+void update_time_app_used(GuiState &gui, HostState &host, const std::string &app);
 void save_notice_list(HostState &host);
-void save_time_apps(GuiState &gui, HostState &host);
 
 void draw_begin(GuiState &gui, HostState &host);
 void draw_end(GuiState &host, SDL_Window *window);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -140,11 +140,11 @@ enum DateFormat {
 struct User {
     std::string id;
     std::string name;
-    DateFormat date_format;
-    bool clock_12_hour;
+    DateFormat date_format = MM_DD_YYYY;
+    bool clock_12_hour = true;
     std::string avatar;
     std::string theme_id;
-    bool use_theme_bg;
+    bool use_theme_bg = true;
     std::string start_type;
     std::string start_path;
     std::vector<std::string> backgrounds;
@@ -166,6 +166,12 @@ struct Lang {
         std::map<std::string, std::string> common;
     };
     Common common;
+};
+
+struct TimeApp {
+    std::string app;
+    time_t last_time_used;
+    int64_t time_used;
 };
 
 struct GuiState {
@@ -209,7 +215,7 @@ struct GuiState {
     std::vector<std::string> apps_list_opened;
     int32_t current_app_selected = -1;
 
-    std::map<std::string, std::map<std::string, time_t>> time_apps;
+    std::map<std::string, std::vector<TimeApp>> time_apps;
 
     std::uint64_t current_theme_bg;
     std::map<std::string, std::map<std::string, ImGui_Texture>> themes_preview;

--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -86,22 +86,6 @@ void update_apps_list_opened(GuiState &gui, HostState &host, const std::string &
     }
 }
 
-static std::vector<std::string>::iterator get_last_loaded_apps_index(HostState &host, const std::string &app_path) {
-    return std::find(host.cfg.last_loaded_apps.begin(), host.cfg.last_loaded_apps.end(), app_path);
-}
-
-static void update_last_loaded_apps(HostState &host, const std::string &app_path) {
-    if ((get_last_loaded_apps_index(host, app_path) != host.cfg.last_loaded_apps.end()) && (host.cfg.last_loaded_apps.front() != app_path))
-        host.cfg.last_loaded_apps.erase(get_last_loaded_apps_index(host, app_path));
-    if (get_last_loaded_apps_index(host, app_path) == host.cfg.last_loaded_apps.end())
-        host.cfg.last_loaded_apps.insert(host.cfg.last_loaded_apps.begin(), app_path);
-    if (host.cfg.last_loaded_apps.size() > 14)
-        host.cfg.last_loaded_apps.pop_back();
-
-    if (host.cfg.overwrite_config)
-        config::serialize_config(host.cfg, host.cfg.config_path);
-}
-
 static std::map<std::string, uint64_t> last_time;
 
 void pre_load_app(GuiState &gui, HostState &host, bool live_area, const std::string &app_path) {
@@ -125,9 +109,6 @@ void pre_run_app(GuiState &gui, HostState &host, const std::string &app_path) {
                 gui.live_area.information_bar = false;
                 gui.live_area.app_selector = false;
                 gui.live_area.live_area_screen = false;
-                update_last_loaded_apps(host, app_path);
-                gui.time_apps[host.io.user_id][app_path] = std::time(nullptr);
-                save_time_apps(gui, host);
                 host.io.app_path = app_path;
             }
         } else {
@@ -188,9 +169,7 @@ void draw_app_close(GuiState &gui, HostState &host) {
     ImGui::SameLine(0, 20.f * SCALE.x);
     if (ImGui::Button("OK", BUTTON_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_cross)) {
         const auto app_path = gui.apps_list_opened[gui.current_app_selected];
-        update_last_loaded_apps(host, app_path);
-        gui.time_apps[host.io.user_id][app_path] = std::time(nullptr);
-        save_time_apps(gui, host);
+        update_time_app_used(gui, host, host.io.app_path);
         host.kernel.exit_delete_all_threads();
         host.load_app_path = app_path;
         host.load_exec = true;

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -87,7 +87,7 @@ void init_lang(GuiState &gui, HostState &host) {
                 // Emulation Menu
                 if (!main_menubar.child("emulation").empty()) {
                     lang_main_menubar["emulation"] = main_menubar.child("emulation").attribute("name").as_string();
-                    lang_main_menubar["last_loaded_apps"] = main_menubar.child("emulation").child("last_loaded_apps").text().as_string();
+                    lang_main_menubar["last_apps_used"] = main_menubar.child("emulation").child("last_apps_used").text().as_string();
                 }
 
                 // Configuration Menu
@@ -131,6 +131,7 @@ void init_lang(GuiState &gui, HostState &host) {
                 lang_app_context["version"] = app_context.child("version").text().as_string();
                 lang_app_context["last_time_used"] = app_context.child("last_time_used").text().as_string();
                 lang_app_context["never"] = app_context.child("never").text().as_string();
+                lang_app_context["time_used"] = app_context.child("time_used").text().as_string();
             }
 
             // Common
@@ -1309,6 +1310,7 @@ void draw_live_area_screen(GuiState &gui, HostState &host) {
         ImGui::SetCursorPos(ImVec2(display_size.x - (60.0f * SCALE.x) - BUTTON_SIZE.x, 44.0f * SCALE.y));
         if (ImGui::Button("Esc", BUTTON_SIZE) || ImGui::IsKeyPressed(host.cfg.keyboard_button_circle)) {
             if (app_path == host.io.app_path) {
+                update_time_app_used(gui, host, app_path);
                 host.kernel.exit_delete_all_threads();
                 host.load_exec = true;
             } else {

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -51,12 +51,13 @@ static void draw_emulation_menu(GuiState &gui, HostState &host) {
     auto lang = gui.lang.main_menubar;
     const auto is_lang = !lang.empty();
     if (ImGui::BeginMenu(is_lang ? lang["emulation"].c_str() : "Emulation")) {
-        if (ImGui::BeginMenu(is_lang ? lang["last_loaded_apps"].c_str() : "Last loaded Apps")) {
-            if (!host.cfg.last_loaded_apps.empty()) {
-                for (const auto &app : host.cfg.last_loaded_apps) {
+        if (ImGui::BeginMenu(is_lang ? lang["last_apps_used"].c_str() : "Last Apps used")) {
+            if (!gui.time_apps[host.io.user_id].empty()) {
+                for (auto i = 0; i < std::min(14, int32_t(gui.time_apps[host.io.user_id].size())); i++) {
                     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
-                    if (ImGui::MenuItem(get_app_index(gui, app)->title.c_str(), app.c_str(), false))
-                        pre_load_app(gui, host, host.cfg.show_live_area_screen, app);
+                    const auto time_app = gui.time_apps[host.io.user_id][i];
+                    if (ImGui::MenuItem(get_app_index(gui, time_app.app)->title.c_str(), time_app.app.c_str(), false))
+                        pre_load_app(gui, host, host.cfg.show_live_area_screen, time_app.app);
                     ImGui::PopStyleColor();
                 }
             } else

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -494,6 +494,8 @@ bool handle_events(HostState &host, GuiState &gui) {
         ImGui_ImplSdl_ProcessEvent(gui.imgui_state.get(), &event);
         switch (event.type) {
         case SDL_QUIT:
+            if (!host.io.app_path.empty())
+                gui::update_time_app_used(gui, host, host.io.app_path);
             host.kernel.exit_delete_all_threads();
             host.gxm.display_queue.abort();
             host.display.abort.exchange(true);

--- a/vita3k/kernel/include/kernel/object_store.h
+++ b/vita3k/kernel/include/kernel/object_store.h
@@ -49,7 +49,7 @@ public:
     }
 
     template <typename T, typename... Args>
-    bool create(Args &&... args) {
+    bool create(Args &&...args) {
         std::lock_guard<std::mutex> lock(mutex);
         auto ptr = std::make_shared<T>(std::forward<Args>(args)...);
         objs.emplace(TypeInfo::registered<T>::index, ptr);

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -220,6 +220,7 @@ int main(int argc, char *argv[]) {
     }
 
     gui::init_app_background(gui, host, host.io.app_path);
+    gui::update_last_time_app_used(gui, host, host.io.app_path);
 
     app::gl_screen_renderer gl_renderer;
 


### PR DESCRIPTION
# About:
Add time app used inside app context menu in information.
Refactor code for can using new value for no get double value exist for same things.
Using so now app list by user.

- move cfg to new value.

# Result
- is fake time used here off course, is just for test etc :D 
![image](https://user-images.githubusercontent.com/5261759/122691155-308fef80-d22e-11eb-8af8-488f062055ad.png)
