### PR TITLE
gui: add cache of apps list.

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -76,6 +76,7 @@ void open_user(GuiState &gui, HostState &host);
 void pre_load_app(GuiState &gui, HostState &host, bool live_area, const std::string &app_path);
 void pre_run_app(GuiState &gui, HostState &host, const std::string &app_path);
 bool refresh_app_list(GuiState &gui, HostState &host);
+void save_apps_cache(GuiState &gui, HostState &host);
 void save_user(GuiState &gui, HostState &host, const std::string &user_id);
 void set_config(GuiState &gui, HostState &host, const std::string &app_path);
 void update_apps_list_opened(GuiState &gui, HostState &host, const std::string &app_path);

--- a/vita3k/gui/include/gui/imgui_impl_sdl_state.h
+++ b/vita3k/gui/include/gui/imgui_impl_sdl_state.h
@@ -32,6 +32,7 @@ class ImGui_Texture {
 public:
     ImGui_Texture() = default;
     ImGui_Texture(ImGui_State *new_state, void *data, int width, int height);
+    ImGui_Texture(ImGui_Texture &&texture) noexcept;
 
     void init(ImGui_State *new_state, ImTextureID texture);
     void init(ImGui_State *new_state, void *data, int width, int height);
@@ -39,6 +40,9 @@ public:
     operator bool() const;
     operator ImTextureID() const;
     bool operator==(const ImGui_Texture &texture);
+
+    ImGui_Texture &operator=(ImGui_Texture &&texture) noexcept;
+    ImGui_Texture &operator=(const ImGui_Texture &texture) = delete;
 
     ~ImGui_Texture();
 };

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -223,6 +223,8 @@ void delete_app(GuiState &gui, HostState &host, const std::string &app_path) {
         LOG_INFO("Application successfully deleted '{} [{}]'.", title_id, APP_INDEX->title);
 
         gui.app_selector.user_apps.erase(APP_INDEX);
+
+        save_apps_cache(gui, host);
     } catch (std::exception &e) {
         LOG_ERROR("Failed to delete '{} [{}]'.\n{}", title_id, APP_INDEX->title, e.what());
     }

--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -47,6 +47,7 @@ bool refresh_app_list(GuiState &gui, HostState &host) {
     if (gui.app_selector.user_apps.empty())
         return false;
 
+    save_apps_cache(gui, host);
     init_apps_icon(gui, host, gui.app_selector.user_apps);
 
     std::sort(gui.app_selector.user_apps.begin(), gui.app_selector.user_apps.end(), [](const App &lhs, const App &rhs) {

--- a/vita3k/gui/src/archive_install_dialog.cpp
+++ b/vita3k/gui/src/archive_install_dialog.cpp
@@ -191,6 +191,7 @@ void draw_archive_install_dialog(GuiState &gui, HostState &host) {
                     if (delete_archive_file)
                         fs::remove(content.path);
                 }
+                save_apps_cache(gui, host);
                 archive_path = nullptr;
                 gui.file_menu.archive_install_dialog = false;
                 delete_archive_file = false;

--- a/vita3k/gui/src/imgui_impl_sdl.cpp
+++ b/vita3k/gui/src/imgui_impl_sdl.cpp
@@ -243,8 +243,25 @@ bool ImGui_Texture::operator==(const ImGui_Texture &texture) {
     return texture_id == texture.texture_id;
 }
 
+ImGui_Texture &ImGui_Texture::operator=(ImGui_Texture &&texture) noexcept {
+    this->state = texture.state;
+    this->texture_id = texture.texture_id;
+
+    texture.state = nullptr;
+    texture.texture_id = nullptr;
+
+    return *this;
+}
+
 ImGui_Texture::ImGui_Texture(ImGui_State *new_state, void *data, int width, int height) {
     init(new_state, data, width, height);
+}
+
+ImGui_Texture::ImGui_Texture(ImGui_Texture &&texture) noexcept
+    : state(texture.state)
+    , texture_id(texture.texture_id) {
+    texture.state = nullptr;
+    texture.texture_id = nullptr;
 }
 
 ImGui_Texture::~ImGui_Texture() {

--- a/vita3k/gui/src/pkg_install_dialog.cpp
+++ b/vita3k/gui/src/pkg_install_dialog.cpp
@@ -153,8 +153,10 @@ void draw_pkg_install_dialog(GuiState &gui, HostState &host) {
                     fs::remove(fs::path(string_utils::utf_to_wide(std::string(work_path))));
                     delete_work_file = false;
                 }
-                if (host.app_category == "gd")
+                if (host.app_category == "gd") {
                     init_user_app(gui, host, host.app_title_id);
+                    save_apps_cache(gui, host);
+                }
                 update_notice_info(gui, host, "content");
                 pkg_path = nullptr;
                 work_path = nullptr;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -78,6 +78,7 @@ static void reset_emulator(GuiState &gui, HostState &host) {
     get_sys_apps_title(gui, host);
     get_notice_list(host);
     get_users_list(gui, host);
+    save_apps_cache(gui, host);
     init_home(gui, host);
     gui.configuration_menu.settings_dialog = false;
 }

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -310,7 +310,7 @@ void draw_user_management(GuiState &gui, HostState &host) {
             ImGui::SetCursorPos(ImVec2(USER_POS.x, USER_POS.y - BUTTON_SIZE.y));
             if (ImGui::Button(EDIT_USER_STR.c_str(), ImVec2(AVATAR_SIZE.x, BUTTON_SIZE.y))) {
                 user_id = user.first;
-                gui.users_avatar["temp"] = gui.users_avatar[user.first];
+                gui.users_avatar["temp"] = std::move(gui.users_avatar[user.first]);
                 temp = gui.users[user.first];
                 menu = "edit";
             }
@@ -396,7 +396,7 @@ void draw_user_management(GuiState &gui, HostState &host) {
         ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.5f, 0.5f));
         const auto confirm = is_lang ? gui.lang.user_management["confirm"] : "Confirm";
         if (!temp.name.empty() && check_free_name ? ImGui::Button(confirm.c_str(), BUTTON_SIZE) : ImGui::Selectable(confirm.c_str(), false, ImGuiSelectableFlags_Disabled, BUTTON_SIZE)) {
-            gui.users_avatar[user_id] = gui.users_avatar["temp"];
+            gui.users_avatar[user_id] = std::move(gui.users_avatar["temp"]);
             gui.users[user_id] = temp;
             save_user(gui, host, user_id);
             if (menu == "create")

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -336,7 +336,10 @@ uint32_t install_contents(HostState &host, GuiState *gui, const fs::path &path) 
             ++installed;
     }
 
-    LOG_INFO_IF(installed, "Succesfully installed {} content!", installed);
+    if (installed) {
+        gui::save_apps_cache(*gui, host);
+        LOG_INFO("Succesfully installed {} content!", installed);
+    }
 
     return installed;
 }


### PR DESCRIPTION
# About: 
Add cache of apps list for can get boot emu more quickely after first time.
- boot emu (without icon), take littarly 1 sec compare 50 sec  in first boot with 1420 app installed.
- add async load app icon for get open emu very quickely in first boot