### PR TITLE
gui: fix missing atomic header

### DIFF
--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -28,6 +28,7 @@
 
 #include <glutil/object.h>
 
+#include <atomic>
 #include <mutex>
 #include <optional>
 #include <queue>

--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -33,14 +33,14 @@
 #include <sce-elf-defs.h>
 #undef SCE_ELF_DEFS_TARGET
 // clang-format on
-#include <self.h>
 #include <miniz.h>
+#include <self.h>
 
 #include <cassert>
 #include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <fstream>
 
 #define ET_SCE_EXEC 0xFE00
 


### PR DESCRIPTION
Hopefully helps fix:

<img width="876" alt="Screen Shot 2021-07-13 at 7 04 58 PM" src="https://user-images.githubusercontent.com/32211852/125536173-a24de27f-789f-46d1-9487-a7c50a82ae6f.png">
