### PR TITLE
setting: move PS TV mode custom config.

### DIFF
--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -106,6 +106,7 @@ public:
         bool lle_kernel = false;
         bool auto_lle = false;
         std::vector<std::string> lle_modules = {};
+        bool pstv_mode = false;
         bool disable_ngs = false;
         bool video_playing = true;
         bool disable_at9_decoder = false;

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -79,17 +79,6 @@ void draw_controls_dialog(GuiState &gui, HostState &host) {
     remapper_button(gui, host, &host.cfg.keyboard_button_down, "D-pad down", ImVec2(7.0f, 7.0f));
     remapper_button(gui, host, &host.cfg.keyboard_button_right, "D-pad right", ImVec2(7.0f, 7.0f));
     remapper_button(gui, host, &host.cfg.keyboard_button_left, "D-pad left", ImVec2(7.0f, 7.0f));
-    if (host.cfg.pstv_mode) {
-        remapper_button(gui, host, &host.cfg.keyboard_button_l1, "L1 button", ImVec2(7.0f, 7.0f));
-        remapper_button(gui, host, &host.cfg.keyboard_button_r1, "R1 button", ImVec2(7.0f, 7.0f));
-        remapper_button(gui, host, &host.cfg.keyboard_button_l2, "L2 button", ImVec2(7.0f, 7.0f));
-        remapper_button(gui, host, &host.cfg.keyboard_button_r2, "R2 button", ImVec2(7.0f, 7.0f));
-        remapper_button(gui, host, &host.cfg.keyboard_button_l3, "L3 button", ImVec2(7.0f, 7.0f));
-        remapper_button(gui, host, &host.cfg.keyboard_button_r3, "R3 button", ImVec2(7.0f, 7.0f));
-    } else {
-        remapper_button(gui, host, &host.cfg.keyboard_button_l1, "L button", ImVec2(7.0f, 7.0f));
-        remapper_button(gui, host, &host.cfg.keyboard_button_r1, "R button", ImVec2(7.0f, 7.0f));
-    }
     remapper_button(gui, host, &host.cfg.keyboard_button_square, "Square button", ImVec2(7.0f, 7.0f));
     remapper_button(gui, host, &host.cfg.keyboard_button_cross, "Cross button", ImVec2(7.0f, 7.0f));
     remapper_button(gui, host, &host.cfg.keyboard_button_circle, "Circle button", ImVec2(7.0f, 7.0f));
@@ -97,7 +86,18 @@ void draw_controls_dialog(GuiState &gui, HostState &host) {
     remapper_button(gui, host, &host.cfg.keyboard_button_start, "Start button", ImVec2(7.0f, 7.0f));
     remapper_button(gui, host, &host.cfg.keyboard_button_select, "Select button", ImVec2(7.0f, 7.0f));
     remapper_button(gui, host, &host.cfg.keyboard_button_psbutton, "PS Button", ImVec2(7.0f, 7.0f));
+    remapper_button(gui, host, &host.cfg.keyboard_button_l1, "L1 button", ImVec2(7.0f, 7.0f));
+    remapper_button(gui, host, &host.cfg.keyboard_button_r1, "R1 button", ImVec2(7.0f, 7.0f));
     ImGui::Separator();
+    ImGui::Spacing();
+    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "Only in PS TV mode.");
+    ImGui::Spacing();
+    remapper_button(gui, host, &host.cfg.keyboard_button_l2, "L2 button", ImVec2(7.0f, 7.0f));
+    remapper_button(gui, host, &host.cfg.keyboard_button_r2, "R2 button", ImVec2(7.0f, 7.0f));
+    remapper_button(gui, host, &host.cfg.keyboard_button_l3, "L3 button", ImVec2(7.0f, 7.0f));
+    remapper_button(gui, host, &host.cfg.keyboard_button_r3, "R3 button", ImVec2(7.0f, 7.0f));
+    ImGui::Separator();
+    ImGui::Spacing();
     ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%-16s", "GUI");
     ImGui::Text("%-16s    %-16s", "Toggle Touch", "T");
     ImGui::Text("%-16s    %-16s", "Toggle GUI visibility", "G");

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -128,6 +128,12 @@ static bool get_custom_config(GuiState &gui, HostState &host, const std::string 
                 config.cpu_opt = cpu_child.attribute("cpu-opt").as_bool();
             }
 
+            // Load System Config
+            if (!config_child.child("system").empty()) {
+                const auto system_child = config_child.child("system");
+                system_child.attribute("pstv-mode") = config.pstv_mode;
+            }
+
             // Load Emulator Config
             if (!config_child.child("emulator").empty()) {
                 const auto emulator_child = config_child.child("emulator");
@@ -158,6 +164,7 @@ void init_config(GuiState &gui, HostState &host, const std::string &app_path) {
         config.lle_kernel = host.cfg.lle_kernel;
         config.auto_lle = host.cfg.auto_lle;
         config.lle_modules = host.cfg.lle_modules;
+        config.pstv_mode = host.cfg.pstv_mode;
         config.disable_at9_decoder = host.cfg.disable_at9_decoder;
         config.disable_ngs = host.cfg.disable_ngs;
         config.video_playing = host.cfg.video_playing;
@@ -196,6 +203,10 @@ static void save_config(GuiState &gui, HostState &host) {
         cpu_child.append_attribute("cpu-backend") = config.cpu_backend.c_str();
         cpu_child.append_attribute("cpu-opt") = config.cpu_opt;
 
+        // System
+        auto system_child = config_child.append_child("system");
+        system_child.append_attribute("pstv-mode") = config.pstv_mode;
+
         // Emulator
         auto emulator_child = config_child.append_child("emulator");
         emulator_child.append_attribute("disable-at9-decoder") = config.disable_at9_decoder;
@@ -211,6 +222,7 @@ static void save_config(GuiState &gui, HostState &host) {
         host.cfg.lle_kernel = config.lle_kernel;
         host.cfg.auto_lle = config.auto_lle;
         host.cfg.lle_modules = config.lle_modules;
+        host.cfg.pstv_mode = config.pstv_mode;
         host.cfg.disable_at9_decoder = config.disable_at9_decoder;
         host.cfg.disable_ngs = config.disable_ngs;
         host.cfg.video_playing = config.video_playing;
@@ -225,6 +237,7 @@ void set_config(GuiState &gui, HostState &host, const std::string &app_path) {
         host.cfg.current_config.lle_kernel = config.lle_kernel;
         host.cfg.current_config.auto_lle = config.auto_lle;
         host.cfg.current_config.lle_modules = config.lle_modules;
+        host.cfg.current_config.pstv_mode = config.pstv_mode;
         host.cfg.current_config.disable_at9_decoder = config.disable_at9_decoder;
         host.cfg.current_config.disable_ngs = config.disable_ngs;
         host.cfg.current_config.video_playing = config.video_playing;
@@ -234,6 +247,7 @@ void set_config(GuiState &gui, HostState &host, const std::string &app_path) {
         host.cfg.current_config.lle_kernel = host.cfg.lle_kernel;
         host.cfg.current_config.auto_lle = host.cfg.auto_lle;
         host.cfg.current_config.lle_modules = host.cfg.lle_modules;
+        host.cfg.current_config.pstv_mode = host.cfg.pstv_mode;
         host.cfg.current_config.disable_at9_decoder = host.cfg.disable_at9_decoder;
         host.cfg.current_config.disable_ngs = host.cfg.disable_ngs;
         host.cfg.current_config.video_playing = host.cfg.video_playing;
@@ -388,9 +402,9 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         ImGui::RadioButton("Circle", &host.cfg.sys_button, 0);
         ImGui::RadioButton("Cross", &host.cfg.sys_button, 1);
         ImGui::Spacing();
-        ImGui::Checkbox("Emulated Console \nSelect your Console mode.", &host.cfg.pstv_mode);
+        ImGui::Checkbox("PS TV Mode", &config.pstv_mode);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("Check the box to enable PS TV mode.");
+            ImGui::SetTooltip("Check the box to enable PS TV Emulated mode.");
         ImGui::EndTabItem();
     } else
         ImGui::PopStyleColor();

--- a/vita3k/modules/SceCtrl/SceCtrl.cpp
+++ b/vita3k/modules/SceCtrl/SceCtrl.cpp
@@ -403,9 +403,9 @@ EXPORT(int, sceCtrlGetControllerPortInfo, SceCtrlPortInfo *info) {
     CtrlState &state = host.ctrl;
     remove_disconnected_controllers(state);
     add_new_controllers(state);
-    info->port[0] = host.cfg.pstv_mode ? SCE_CTRL_TYPE_VIRT : SCE_CTRL_TYPE_PHY;
+    info->port[0] = host.cfg.current_config.pstv_mode ? SCE_CTRL_TYPE_VIRT : SCE_CTRL_TYPE_PHY;
     for (int i = 0; i < 4; i++) {
-        info->port[i + 1] = (host.cfg.pstv_mode && !host.ctrl.free_ports[i]) ? SCE_CTRL_TYPE_DS3 : SCE_CTRL_TYPE_UNPAIRED;
+        info->port[i + 1] = (host.cfg.current_config.pstv_mode && !host.ctrl.free_ports[i]) ? SCE_CTRL_TYPE_DS3 : SCE_CTRL_TYPE_UNPAIRED;
     }
     return 0;
 }
@@ -435,88 +435,88 @@ EXPORT(int, sceCtrlGetWirelessControllerInfo) {
 }
 
 EXPORT(bool, sceCtrlIsMultiControllerSupported) {
-    return host.cfg.pstv_mode;
+    return host.cfg.current_config.pstv_mode;
 }
 
 EXPORT(int, sceCtrlPeekBufferNegative, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, false, true, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferNegative2, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, true, true, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositive, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, false, false, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositive2, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, true, false, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositiveExt, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, false, false, true);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositiveExt2, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, true, false, true);
 }
 
 EXPORT(int, sceCtrlReadBufferNegative, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, false, true, false);
 }
 
 EXPORT(int, sceCtrlReadBufferNegative2, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, true, true, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositive, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, false, false, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositive2, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, true, false, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositiveExt, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, false, false, true);
 }
 
 EXPORT(int, sceCtrlReadBufferPositiveExt2, int port, SceCtrlData *pad_data, int count) {
-    if (port > 1 && !host.cfg.pstv_mode) {
+    if (port > 1 && !host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
     }
     return peek_buffer(host, port, pad_data, count, true, false, true);
@@ -531,7 +531,7 @@ EXPORT(int, sceCtrlResetLightBar) {
 }
 
 EXPORT(int, sceCtrlSetActuator, int port, const SceCtrlActuator *pState) {
-    if (!host.cfg.pstv_mode) {
+    if (!host.cfg.current_config.pstv_mode) {
         return RET_ERROR(SCE_CTRL_ERROR_NOT_SUPPORTED);
     }
 

--- a/vita3k/modules/SceSysmem/SceSysmem.cpp
+++ b/vita3k/modules/SceSysmem/SceSysmem.cpp
@@ -224,11 +224,11 @@ EXPORT(int, sceKernelGetMemBlockInfoByRange) {
 }
 
 EXPORT(int, sceKernelGetModel) {
-    return host.cfg.pstv_mode ? SCE_KERNEL_MODEL_VITATV : SCE_KERNEL_MODEL_VITA;
+    return host.cfg.current_config.pstv_mode ? SCE_KERNEL_MODEL_VITATV : SCE_KERNEL_MODEL_VITA;
 }
 
 EXPORT(int, sceKernelGetModelForCDialog) {
-    return host.cfg.pstv_mode ? SCE_KERNEL_MODEL_VITATV : SCE_KERNEL_MODEL_VITA;
+    return host.cfg.current_config.pstv_mode ? SCE_KERNEL_MODEL_VITATV : SCE_KERNEL_MODEL_VITA;
 }
 
 EXPORT(int, sceKernelGetSubbudgetInfo) {
@@ -236,7 +236,7 @@ EXPORT(int, sceKernelGetSubbudgetInfo) {
 }
 
 EXPORT(bool, sceKernelIsPSVitaTV) {
-    return host.cfg.pstv_mode;
+    return host.cfg.current_config.pstv_mode;
 }
 
 EXPORT(int, sceKernelOpenMemBlock) {


### PR DESCRIPTION
# About:
Move PS TV mode in custom config.

- No all game support ps tv mode, some can said controller no connected if is used, so request separate in for allow custom config by game.