### PR TITLE
io: add IFREG if is_regular_file

### DIFF
--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -529,11 +529,8 @@ int stat_file(IOState &io, const char *file, SceIoStat *statp, const std::wstrin
 
     if (fs::is_regular_file(file_path)) {
         statp->st_size = fs::file_size(file_path);
-
-        if (fd != invalid_fd) {
-            statp->st_attr = SCE_SO_IFREG;
-            statp->st_mode |= SCE_S_IFREG;
-        }
+        statp->st_attr = SCE_SO_IFREG;
+        statp->st_mode |= SCE_S_IFREG;
     }
     if (fs::is_directory(file_path)) {
         statp->st_attr = SCE_SO_IFDIR;


### PR DESCRIPTION
I've removed a condition that doesn't make sense to me in order to fix dhewm3 finding a file.