### PR TITLE
io: fix backslashes

### DIFF
--- a/vita3k/io/src/device.cpp
+++ b/vita3k/io/src/device.cpp
@@ -30,10 +30,6 @@ std::string construct_normalized_path(const VitaIoDevice dev, const std::string 
 
     // Normalize the path
     auto normalized = path;
-    string_utils::replace(normalized, "\\", "/");
-    string_utils::replace(normalized, "/./", "/");
-    string_utils::replace(normalized, "//", "/");
-    // TODO: Handle dot-dot paths
     normalized.front() == '/' ? normalized = device_path + normalized : normalized = device_path + '/' + normalized;
 
     if (!ext.empty()) {

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -193,6 +193,12 @@ fs::path find_in_cache(IOState &io, const std::string &system_path) {
 std::string translate_path(const char *path, VitaIoDevice &device, const IOState::DevicePaths &device_paths) {
     auto relative_path = device::remove_duplicate_device(path, device);
 
+    // replace invalid slashes with proper forward slash
+    string_utils::replace(relative_path, "\\", "/");
+    string_utils::replace(relative_path, "/./", "/");
+    string_utils::replace(relative_path, "//", "/");
+    // TODO: Handle dot-dot paths
+
     switch (device) {
     case +VitaIoDevice::savedata0: // Redirect savedata0: to ux0:user/00/savedata/<title_id>
     case +VitaIoDevice::savedata1: {


### PR DESCRIPTION
some games hardcode backslashes in their paths and this causes linux and macos to fail when checking if the path exists.
we do replace invalid slashes in the path but only AFTER checking if the path exists. this PR replaces the slashes before.

i moved the invalid slashes replacement to `translate_path` so `system_path` can be a valid path on *nix system.

games like TxK and minecraft boot further on unix systems with this fix