### PR TITLE
modules/SceIme: fix missing imput buffer to the pointer.

### DIFF
--- a/vita3k/modules/SceIme/SceIme.cpp
+++ b/vita3k/modules/SceIme/SceIme.cpp
@@ -64,12 +64,13 @@ EXPORT(SceInt32, sceImeOpen, SceImeParam *param) {
 
     gui::init_ime_lang(host.ime, SceImeLanguage(host.cfg.current_ime_lang));
 
-    host.ime.edit_text.str = Ptr<SceWChar16>(alloc(host.mem, SCE_IME_MAX_TEXT_LENGTH + host.ime.param.maxTextLength + 1, "ime_str"));
+    host.ime.edit_text.str = host.ime.param.inputTextBuffer;
+    host.ime.param.inputTextBuffer = Ptr<SceWChar16>(alloc(host.mem, SCE_IME_MAX_PREEDIT_LENGTH + host.ime.param.maxTextLength + 1, "ime_str"));
     host.ime.str = reinterpret_cast<char16_t *>(host.ime.param.initialText.get(host.mem));
     if (!host.ime.str.empty())
         host.ime.caretIndex = host.ime.edit_text.caretIndex = host.ime.edit_text.preeditIndex = SceUInt32(host.ime.str.length());
     else
-        host.ime.caps_level = 2;
+        host.ime.caps_level = 1;
 
     host.ime.event_id = SCE_IME_EVENT_OPEN;
     host.ime.state = true;


### PR DESCRIPTION
# About
- add missing inputbuffer used to the pointer for can get edit str result.
- fix shift for new open keyboard, move on low after press first leter.
- fix aloc size.

# Result;
- Dungon Hunter now go ingame and is playable.
![image](https://user-images.githubusercontent.com/5261759/136715595-c0e7e849-8478-42a7-8e9a-88129befee94.png)
![image](https://user-images.githubusercontent.com/5261759/136715600-be3ea0e6-15a4-4d65-a0c5-9b60e245971d.png)
