### PR TITLE
Support regformat vertex attributes

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1242,8 +1242,8 @@ struct SceGxmProgramVertexVaryings {
     union {
         // Vertex Program variables
         struct {
-            uint32_t attrib_pa_regs[2];
-            uint32_t untyped_pa_regs[2];
+            uint64_t attrib_pa_regs;
+            uint64_t untyped_pa_regs;
         };
 
         // Fragment Program Variables

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -86,7 +86,6 @@ struct GLTextureCacheState;
 struct TextureCacheState;
 
 // Attribute formats.
-size_t attribute_format_size(SceGxmAttributeFormat format);
 GLenum attribute_format_to_gl_type(SceGxmAttributeFormat format);
 GLboolean attribute_format_normalised(SceGxmAttributeFormat format);
 

--- a/vita3k/shader/include/shader/usse_program_analyzer.h
+++ b/vita3k/shader/include/shader/usse_program_analyzer.h
@@ -198,13 +198,16 @@ public:
 
 struct AttributeInformation {
     std::uint32_t info;
+    bool regformat;
 
     explicit AttributeInformation()
-        : info(0) {
+        : info(0)
+        , regformat(false) {
     }
 
-    explicit AttributeInformation(const std::uint16_t loc, const std::uint16_t gxm_type)
-        : info(loc | (static_cast<std::uint32_t>(gxm_type) << 16)) {
+    explicit AttributeInformation(const std::uint16_t loc, const std::uint16_t gxm_type, const bool regformat)
+        : info(loc | (static_cast<std::uint32_t>(gxm_type) << 16))
+        , regformat(regformat) {
     }
 
     std::uint16_t location() const {

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -382,6 +382,7 @@ struct AttributeInputSource {
     // resource index
     std::uint32_t index;
     std::uint16_t semantic;
+    bool regformat;
 };
 
 struct LiteralInputSource {

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -878,36 +878,70 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         }
     }
 
-    const auto add_var_to_reg = [&](const Input &input, const std::string &name, std::uint16_t semantic, bool pa, std::int32_t location) {
+    const auto add_var_to_reg = [&](const Input &input, const std::string &name, std::uint16_t semantic, bool pa, bool regformat, std::int32_t location) {
         const spv::Id param_type = get_param_type(b, input);
         int type_size = get_data_type_size(input.type);
-        spv::Id var = b.createVariable(spv::NoPrecision, spv::StorageClassInput, param_type, name.c_str());
+        spv::Id var;
+        if (regformat) {
+            int num_comp = (type_size * input.array_size * input.component_count + 3) / 4;
+            spv::Id type = utils::make_vector_or_scalar_type(b, b.makeIntType(32), num_comp);
+            var = b.createVariable(spv::NoPrecision, spv::StorageClassInput, type, name.c_str());
 
-        switch (semantic) {
-        case SCE_GXM_PARAMETER_SEMANTIC_INDEX:
-            b.addDecoration(var, spv::DecorationBuiltIn, spv::BuiltInVertexId);
-            break;
+            // should not happen, but just in case
+            switch (semantic) {
+            case SCE_GXM_PARAMETER_SEMANTIC_INDEX:
+                b.addDecoration(var, spv::DecorationBuiltIn, spv::BuiltInVertexId);
+                break;
 
-        case SCE_GXM_PARAMETER_SEMANTIC_INSTANCE:
-            b.addDecoration(var, spv::DecorationBuiltIn, spv::BuiltInInstanceId);
-            break;
+            case SCE_GXM_PARAMETER_SEMANTIC_INSTANCE:
+                b.addDecoration(var, spv::DecorationBuiltIn, spv::BuiltInInstanceId);
+                break;
 
-        default:
-            break;
-        }
+            default:
+                break;
+            }
 
-        if (location != -1) {
-            b.addDecoration(var, spv::DecorationLocation, location);
+            if (location != -1) {
+                b.addDecoration(var, spv::DecorationLocation, location);
+            }
+
+            VarToReg var_to_reg = {};
+            var_to_reg.var = var;
+            var_to_reg.pa = pa;
+            var_to_reg.offset = input.offset;
+            var_to_reg.size = num_comp * 4;
+            var_to_reg.dtype = DataType::INT32;
+            translation_state.var_to_regs.push_back(var_to_reg);
+        } else {
+            var = b.createVariable(spv::NoPrecision, spv::StorageClassInput, param_type, name.c_str());
+
+            switch (semantic) {
+            case SCE_GXM_PARAMETER_SEMANTIC_INDEX:
+                b.addDecoration(var, spv::DecorationBuiltIn, spv::BuiltInVertexId);
+                break;
+
+            case SCE_GXM_PARAMETER_SEMANTIC_INSTANCE:
+                b.addDecoration(var, spv::DecorationBuiltIn, spv::BuiltInInstanceId);
+                break;
+
+            default:
+                break;
+            }
+
+            if (location != -1) {
+                b.addDecoration(var, spv::DecorationLocation, location);
+            }
+
+            VarToReg var_to_reg = {};
+            var_to_reg.var = var;
+            var_to_reg.pa = pa;
+            var_to_reg.offset = input.offset;
+            var_to_reg.size = input.array_size * input.component_count * 4;
+            var_to_reg.dtype = input.type;
+            translation_state.var_to_regs.push_back(var_to_reg);
         }
 
         translation_state.interfaces.push_back(var);
-        VarToReg var_to_reg;
-        var_to_reg.var = var;
-        var_to_reg.pa = pa;
-        var_to_reg.offset = input.offset;
-        var_to_reg.size = input.array_size * input.component_count * 4;
-        var_to_reg.dtype = input.type;
-        translation_state.var_to_regs.push_back(var_to_reg);
     };
 
     for (const auto &sampler : program_input.samplers) {
@@ -969,7 +1003,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                            spv_params.samplers.emplace(input.offset, spv_sampler);
                        },
                        [&](const AttributeInputSource &s) {
-                           add_var_to_reg(input, s.name, s.semantic, true, in_fcount_allocated / 4);
+                           add_var_to_reg(input, s.name, s.semantic, true, s.regformat, in_fcount_allocated / 4);
                            in_fcount_allocated += ((input.array_size * input.component_count + 3) / 4 * 4);
                        } },
             input.source);
@@ -990,7 +1024,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                 inp.component_count = 4;
                 inp.array_size = (hint_attributes->at(i).componentCount + 3) >> 2;
 
-                add_var_to_reg(inp, fmt::format("attribute{}", i), 0, true, static_cast<std::int32_t>(i));
+                add_var_to_reg(inp, fmt::format("attribute{}", i), 0, true, false, static_cast<std::int32_t>(i));
             }
         }
     }

--- a/vita3k/shader/src/usse_program_analyzer.cpp
+++ b/vita3k/shader/src/usse_program_analyzer.cpp
@@ -174,11 +174,13 @@ void get_uniform_buffer_sizes(const SceGxmProgram &program, UniformBufferSizes &
 void get_attribute_informations(const SceGxmProgram &program, AttributeInformationMap &locmap) {
     const SceGxmProgramParameter *const gxp_parameters = gxp::program_parameters(program);
     std::uint32_t fcount_allocated = 0;
+    const auto vertex_varyings_ptr = program.vertex_varyings();
 
     for (size_t i = 0; i < program.parameter_count; ++i) {
         const SceGxmProgramParameter &parameter = gxp_parameters[i];
         if (parameter.category == SCE_GXM_PARAMETER_CATEGORY_ATTRIBUTE) {
-            locmap.emplace(parameter.resource_index, AttributeInformation(fcount_allocated / 4, parameter.type));
+            bool regformat = (vertex_varyings_ptr->untyped_pa_regs & ((uint64_t)1 << parameter.resource_index)) != 0;
+            locmap.emplace(parameter.resource_index, AttributeInformation(fcount_allocated / 4, parameter.type, regformat));
             fcount_allocated += ((parameter.array_size * parameter.component_count + 3) / 4) * 4;
         }
     }


### PR DESCRIPTION
This fix mesh render of lbp. It's still broken but we get something like this in intermediate framebuffer. (it's overwritten by another broken shader immediately so it doesn't show in final render) 

![image](https://user-images.githubusercontent.com/12246126/137597634-a8d1bfe2-1e82-4ea5-85e3-25a11ef3b286.png)
