### PR TITLE
Add missing virtual destructors

### DIFF
--- a/vita3k/kernel/include/kernel/sync_primitives.h
+++ b/vita3k/kernel/include/kernel/sync_primitives.h
@@ -75,12 +75,16 @@ struct SyncPrimitive {
     std::mutex mutex;
 
     char name[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+
+    virtual ~SyncPrimitive() {}
 };
 
 struct Semaphore : SyncPrimitive {
     WaitingThreadQueuePtr waiting_threads;
     int max;
     int val;
+
+    ~Semaphore() {}
 };
 
 typedef std::shared_ptr<Semaphore> SemaphorePtr;
@@ -92,6 +96,8 @@ struct Mutex : SyncPrimitive {
     ThreadStatePtr owner;
     WaitingThreadQueuePtr waiting_threads;
     Ptr<SceKernelLwMutexWork> workarea;
+
+    ~Mutex() {}
 };
 
 typedef std::shared_ptr<Mutex> MutexPtr;
@@ -100,6 +106,8 @@ typedef std::map<SceUID, MutexPtr> MutexPtrs;
 struct EventFlag : SyncPrimitive {
     WaitingThreadQueuePtr waiting_threads;
     int flags;
+
+    ~EventFlag() {}
 };
 
 typedef std::shared_ptr<EventFlag> EventFlagPtr;
@@ -125,6 +133,8 @@ struct Condvar : SyncPrimitive {
 
     WaitingThreadQueuePtr waiting_threads;
     MutexPtr associated_mutex;
+
+    ~Condvar() {}
 };
 typedef std::shared_ptr<Condvar> CondvarPtr;
 typedef std::map<SceUID, CondvarPtr> CondvarPtrs;
@@ -143,6 +153,8 @@ struct MsgPipe : SyncPrimitive {
     WaitingThreadQueuePtr sender_threads;
     WaitingThreadQueuePtr reciever_threads;
     std::list<MsgPipeData> data_buffer;
+
+    ~MsgPipe() {}
 };
 
 typedef std::shared_ptr<MsgPipe> MsgPipePtr;

--- a/vita3k/renderer/include/renderer/gl/types.h
+++ b/vita3k/renderer/include/renderer/gl/types.h
@@ -80,6 +80,8 @@ struct GLContext : public renderer::Context {
 
     std::vector<UniformSetRequest> vertex_set_requests;
     std::vector<UniformSetRequest> fragment_set_requests;
+
+    ~GLContext() {}
 };
 
 struct GLShaderStatics {
@@ -117,5 +119,7 @@ struct GLRenderTarget : public renderer::RenderTarget {
     GLObjectArray<2> renderbuffers;
     GLObjectArray<1> framebuffer;
     GLObjectArray<1> color_attachment;
+
+    ~GLRenderTarget() {}
 };
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -132,6 +132,8 @@ struct Context {
 
     std::string last_draw_fragment_program_hash;
     std::string last_draw_vertex_program_hash;
+
+    virtual ~Context() {}
 };
 
 struct ShaderProgram {
@@ -147,6 +149,7 @@ struct VertexProgram : ShaderProgram {
 
 struct RenderTarget {
     int holder;
+    virtual ~RenderTarget() {}
 };
 
 } // namespace renderer


### PR DESCRIPTION
Remove memory leaks in new game. It should remove memory leaks in other games destroying sync primitives and render target frequently as well.