### PR TITLE
renderer: don't call deleter of globjectarray when non inited

### DIFF
--- a/vita3k/glutil/include/glutil/object_array.h
+++ b/vita3k/glutil/include/glutil/object_array.h
@@ -35,9 +35,10 @@ public:
     }
 
     ~GLObjectArray() {
-        assert(deleter != nullptr);
-        deleter(static_cast<GLsizei>(names.size()), &names[0]);
-        names.fill(0);
+        if (deleter) {
+            deleter(static_cast<GLsizei>(names.size()), &names[0]);
+            names.fill(0);
+        }
     }
 
     bool init(renderer::Generator *generator, renderer::Deleter *deleter) {


### PR DESCRIPTION
Fixes crash in new game when running with intel gpu. In intel gpu, we don't init colorattachment globjectarray, and destructor will call null deletor. Solve it by just null check inside globjectarray. (I found it unnecessary to enforce the initialization of globjectarray cause it's unique ptr equivalent of gl object)