### PR TITLE
kernel: fix crash when try erase object no exist

### DIFF
--- a/vita3k/kernel/include/kernel/object_store.h
+++ b/vita3k/kernel/include/kernel/object_store.h
@@ -75,7 +75,8 @@ public:
     template <typename T>
     void erase() {
         auto it = objs.find(TypeInfo::registered<T>::index);
-        assert(it != objs.end());
+        if (it == objs.end())
+            return;
         objs.erase(it);
     }
 


### PR DESCRIPTION
# About: 
Regression caused by commit: https://github.com/Vita3K/Vita3K/commit/8576b497a75039e4301203234a3203f964b15df6 in pr : #1388
For user and  want testing this game.
 you need this shader hacked for can get playable.
[6b232cb61f61808c116740b095bdae607996a730aaddbb7d315d5d0f9c9b0e08.zip](https://github.com/Vita3K/Vita3K/files/7371604/6b232cb61f61808c116740b095bdae607996a730aaddbb7d315d5d0f9c9b0e08.zip)
put it with using emu on right click on this game and click on open folder/shader cache, and set file inside

- this, also fix some unity game

# Result:
with shader hacked and commit here, you can finish tutorial without any problem.
![image](https://user-images.githubusercontent.com/5261759/137874500-6c02497a-7e72-4a22-a9b1-80b1e81bbde8.png)
