### PR TITLE
app selector: refactor and add sort app by last time used.

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -39,7 +39,7 @@ enum GenericDialogState {
 void delete_app(GuiState &gui, HostState &host, const std::string &app_path);
 void get_app_info(GuiState &gui, HostState &host, const std::string &app_path);
 size_t get_app_size(GuiState &gui, HostState &host, const std::string &app_path);
-std::vector<App>::const_iterator get_app_index(GuiState &gui, const std::string &app_path);
+std::vector<App>::iterator get_app_index(GuiState &gui, const std::string &app_path);
 std::map<std::string, ImGui_Texture>::const_iterator get_app_icon(GuiState &gui, const std::string &app_path);
 std::vector<std::string>::iterator get_app_open_list_index(GuiState &gui, const std::string &app_path);
 std::map<std::string, std::string> get_date_time(GuiState &gui, HostState &host, const tm &date_time);
@@ -66,6 +66,7 @@ void init_notice_info(GuiState &gui, HostState &host);
 bool init_theme(GuiState &gui, HostState &host, const std::string &content_id);
 void init_themes(GuiState &gui, HostState &host);
 void init_theme_start_background(GuiState &gui, HostState &host, const std::string &content_id);
+void init_last_time_apps(GuiState &gui, HostState &host);
 void init_trophy_collection(GuiState &gui, HostState &host);
 void init_user(GuiState &gui, HostState &host, const std::string &user_id);
 void init_user_app(GuiState &gui, HostState &host, const std::string &app_path);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -51,6 +51,14 @@ enum SortState {
     DESCENDANT
 };
 
+enum SortType {
+    APP_VER,
+    CATEGORY,
+    LAST_TIME,
+    TITLE,
+    TITLE_ID
+};
+
 struct App {
     std::string app_ver;
     std::string category;
@@ -60,6 +68,7 @@ struct App {
     std::string title;
     std::string title_id;
     std::string path;
+    time_t last_time;
 };
 
 struct AppInfo {
@@ -99,10 +108,7 @@ struct AppsSelector {
     std::map<std::string, ImGui_Texture> sys_apps_icon;
     std::map<std::string, ImGui_Texture> user_apps_icon;
     bool is_app_list_sorted{ false };
-    SortState title_id_sort_state = NOT_SORTED;
-    SortState app_ver_sort_state = NOT_SORTED;
-    SortState category_sort_state = NOT_SORTED;
-    SortState title_sort_state = NOT_SORTED;
+    std::map<SortType, SortState> app_list_sorted;
     SelectorState state = SELECT_APP;
 };
 
@@ -171,13 +177,15 @@ enum DateFormat {
 
 struct User {
     std::string id;
-    std::string name;
+    std::string name = "Vita3K";
     DateFormat date_format = MM_DD_YYYY;
     bool clock_12_hour = true;
-    std::string avatar;
-    std::string theme_id;
+    std::string avatar = "default";
+    gui::SortType sort_apps_type = gui::TITLE;
+    gui::SortState sort_apps_state = gui::ASCENDANT;
+    std::string theme_id = "default";
     bool use_theme_bg = true;
-    std::string start_type;
+    std::string start_type = "default";
     std::string start_path;
     std::vector<std::string> backgrounds;
 };

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -167,6 +167,8 @@ void update_last_time_app_used(GuiState &gui, HostState &host, const std::string
     else
         gui.time_apps[host.io.user_id].push_back({ app, std::time(nullptr), 0 });
 
+    get_app_index(gui, app)->last_time = std::time(nullptr);
+
     save_time_apps(gui, host);
 }
 

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -461,7 +461,6 @@ void init_user_app(GuiState &gui, HostState &host, const std::string &app_path) 
     get_app_param(gui, host, app_path);
     init_app_icon(gui, host, app_path);
 
-    gui.app_selector.title_sort_state = NOT_SORTED;
     gui.app_selector.is_app_list_sorted = false;
 }
 
@@ -474,8 +473,8 @@ std::map<std::string, ImGui_Texture>::const_iterator get_app_icon(GuiState &gui,
     return app_icon;
 }
 
-std::vector<App>::const_iterator get_app_index(GuiState &gui, const std::string &app_path) {
-    const auto &app_type = app_path.find("NPXS") != std::string::npos ? gui.app_selector.sys_apps : gui.app_selector.user_apps;
+std::vector<App>::iterator get_app_index(GuiState &gui, const std::string &app_path) {
+    auto &app_type = app_path.find("NPXS") != std::string::npos ? gui.app_selector.sys_apps : gui.app_selector.user_apps;
     const auto app_index = std::find_if(app_type.begin(), app_type.end(), [&](const App &a) {
         return a.path == app_path;
     });
@@ -558,6 +557,10 @@ void get_sys_apps_title(GuiState &gui, HostState &host) {
         }
         gui.app_selector.sys_apps.push_back({ host.app_version, host.app_category, {}, {}, host.app_short_title, host.app_title, host.app_title_id, app });
     }
+
+    std::sort(gui.app_selector.sys_apps.begin(), gui.app_selector.sys_apps.end(), [](const App &lhs, const App &rhs) {
+        return string_utils::toupper(lhs.title) < string_utils::toupper(rhs.title);
+    });
 }
 
 static const char *const ymonth[] = {

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -1177,13 +1177,9 @@ void draw_settings(GuiState &gui, HostState &host) {
                             config::serialize_config(host.cfg, host.base_path);
                             init_lang(gui, host);
                             get_sys_apps_title(gui, host);
-                            std::sort(gui.app_selector.sys_apps.begin(), gui.app_selector.sys_apps.end(), [](const App &lhs, const App &rhs) {
-                                return string_utils::toupper(lhs.title) < string_utils::toupper(rhs.title);
-                            });
                             get_user_apps_title(gui, host);
-                            std::sort(gui.app_selector.user_apps.begin(), gui.app_selector.user_apps.end(), [](const App &lhs, const App &rhs) {
-                                return string_utils::toupper(lhs.title) < string_utils::toupper(rhs.title);
-                            });
+                            init_last_time_apps(gui, host);
+                            save_apps_cache(gui, host);
                             gui.apps_list_opened.clear();
                             gui.live_area_contents.clear();
                             gui.live_items.clear();


### PR DESCRIPTION
# About:
- Add last time used inside sort apps list and refactor full code of it.
- Add sort setting inside user file, for can load/save this change all time

# Result:
 - in grid mode
![image](https://user-images.githubusercontent.com/5261759/138125849-1c687739-ceca-48cf-bf94-5d3ac8798fff.png)

- in list
![image](https://user-images.githubusercontent.com/5261759/138127412-1ee7f9c5-a2b5-4cc2-b8c3-aea419e21ea3.png)