### PR TITLE
refactor and fix user icon set when default icon sys is used

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -58,6 +58,7 @@ void init_app_icon(GuiState &gui, HostState &host, const std::string &app_path);
 void init_apps_icon(GuiState &gui, HostState &host, const std::vector<gui::App> &app_list);
 void init_config(GuiState &gui, HostState &host, const std::string &app_path);
 void init_content_manager(GuiState &gui, HostState &host);
+vfs::FileBuffer init_default_icon(GuiState &gui, HostState &host, const std::string &app_path);
 void init_home(GuiState &gui, HostState &host);
 void init_lang(GuiState &gui, HostState &host);
 void init_live_area(GuiState &gui, HostState &host);

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -67,19 +67,10 @@ static bool init_notice_icon(GuiState &gui, HostState &host, const fs::path &con
             LOG_WARN("Icon no found for trophy id: {} on NpComId: {}", info.content_id, info.id);
             return false;
         } else {
-            if (!vfs::read_app_file(buffer, host.pref_path, info.id, "sce_sys/icon0.png")) {
-                const auto default_fw_icon{ fs::path(host.pref_path) / "vs0/data/internal/livearea/default/sce_sys/icon0.png" };
-                const auto default_icon{ fs::path(host.base_path) / "data/image/icon.png" };
-                if (fs::exists(default_fw_icon) || fs::exists(default_icon)) {
-                    std::ifstream image_stream(fs::exists(default_fw_icon) ? default_fw_icon.string() : default_icon.string(), std::ios::binary | std::ios::ate);
-                    const std::size_t fsize = image_stream.tellg();
-                    buffer.resize(fsize);
-                    image_stream.seekg(0, std::ios::beg);
-                    image_stream.read(reinterpret_cast<char *>(&buffer[0]), fsize);
-                } else {
-                    LOG_WARN("Not found defaut icon for this notice content: {}", info.content_id);
-                    return false;
-                }
+            buffer = init_default_icon(gui, host, info.content_id);
+            if (buffer.empty()) {
+                LOG_WARN("Not found defaut icon for this notice content: {}", info.content_id);
+                return false;
             }
         }
     }


### PR DESCRIPTION
# About
- gui/settings: fix user icon when using default sys icon.
- before it try set user icon but system icon appear and replace it.
- separe init system/user app icon.
- gui/information bar: remove double code with using new function.