### PR TITLE
display: add option for can disable v-sync.

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -87,6 +87,7 @@
     code(bool, "asia-font-support", false, asia_font_support)                                           \
     code(bool, "video-playing", true, video_playing)                                                    \
     code(bool, "spirv-shader", false, spirv_shader)                                                     \
+    code(bool, "vsync", true, vsync)                                                                    \
     code(uint64_t, "current-ime-lang", 4, current_ime_lang)                                             \
     code(bool, "disable-at9-decoder", false, disable_at9_decoder)
 

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -106,6 +106,7 @@ public:
         bool lle_kernel = false;
         bool auto_lle = false;
         std::vector<std::string> lle_modules = {};
+        bool vsync = true;
         bool pstv_mode = false;
         bool disable_ngs = false;
         bool video_playing = true;

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -215,12 +215,6 @@ bool create(SDL_Window *window, std::unique_ptr<State> &state) {
     if (!gl_state.context)
         return false;
 
-    // Try adaptive vsync first, falling back to regular vsync.
-    if (SDL_GL_SetSwapInterval(-1) < 0) {
-        SDL_GL_SetSwapInterval(1);
-    }
-    LOG_INFO("Swap interval = {}", SDL_GL_GetSwapInterval());
-
     gladLoadGLLoader((GLADloadproc)SDL_GL_GetProcAddress);
 #if MICROPROFILE_ENABLED != 0
     glad_set_pre_callback(before_callback);


### PR DESCRIPTION
 About:
- Add option inside settings dialog for can disable /enable V-Sync, works also in real time. 
- option is also inside cutom config, for can choice better relate game.

# Result:
Fix perfomance issue on some game.
- here in King's story (this game run on 30 fps, so request fps limiter or vblank correct implement)
![image](https://user-images.githubusercontent.com/5261759/139181012-85a229a1-830a-4a1b-ae18-9dc7f0d88066.png)
![image](https://cdn.discordapp.com/attachments/418026683015233546/903110363313209354/unknown.png)

- compare speed if vsync enable (5 fps) 
![image](https://user-images.githubusercontent.com/5261759/139182418-8a2bb8b6-d815-41d2-b459-d03eb7dd785c.png)

