### PR TITLE
addcont: Add support of INSTALL_DIR_ADDCONT value in sfo.

### DIFF
--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -63,6 +63,7 @@ struct App {
     std::string app_ver;
     std::string category;
     std::string content_id;
+    std::string addcont;
     std::string savedata;
     std::string parental_level;
     std::string stitle;

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -197,7 +197,7 @@ void delete_app(GuiState &gui, HostState &host, const std::string &app_path) {
         const auto CUSTOM_CONFIG_PATH{ BASE_PATH / "config" / fmt::format("config_{}.xml", app_path) };
         if (fs::exists(CUSTOM_CONFIG_PATH))
             fs::remove_all(CUSTOM_CONFIG_PATH);
-        const auto DLC_PATH{ PREF_PATH / "ux0/addcont" / title_id };
+        const auto DLC_PATH{ PREF_PATH / "ux0/addcont" / APP_INDEX->addcont };
         if (fs::exists(DLC_PATH))
             fs::remove_all(DLC_PATH);
         const auto LICENSE_PATH{ PREF_PATH / "ux0/license" / title_id };
@@ -258,7 +258,7 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
 
     const auto APP_PATH{ fs::path(host.pref_path) / "ux0/app" / app_path };
     const auto CUSTOM_CONFIG_PATH{ fs::path(host.base_path) / "config" / fmt::format("config_{}.xml", app_path) };
-    const auto DLC_PATH{ fs::path(host.pref_path) / "ux0/addcont" / title_id };
+    const auto DLC_PATH{ fs::path(host.pref_path) / "ux0/addcont" / APP_INDEX->addcont };
     const auto LICENSE_PATH{ fs::path(host.pref_path) / "ux0/license" / title_id };
     const auto SAVE_DATA_PATH{ fs::path(host.pref_path) / "ux0/user" / host.io.user_id / "savedata" / APP_INDEX->savedata };
     const auto SHADER_CACHE_PATH{ fs::path(host.base_path) / "shaders" / title_id };

--- a/vita3k/host/include/host/state.h
+++ b/vita3k/host/include/host/state.h
@@ -56,6 +56,7 @@ struct HostState {
     std::string app_version;
     std::string app_category;
     std::string app_content_id;
+    std::string app_addcont;
     std::string app_savedata;
     std::string app_parental_level;
     std::string app_short_title;

--- a/vita3k/io/include/io/state.h
+++ b/vita3k/io/include/io/state.h
@@ -104,6 +104,7 @@ struct IOState {
         std::string addcont0;
     } device_paths;
 
+    std::string addcont;
     std::string savedata;
     std::string title_id;
     std::string app_path;

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -136,7 +136,7 @@ bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path, boo
 void init_device_paths(IOState &io) {
     io.device_paths.savedata0 = "user/" + io.user_id + "/savedata/" + io.savedata;
     io.device_paths.app0 = "app/" + io.app_path;
-    io.device_paths.addcont0 = "addcont/" + io.title_id;
+    io.device_paths.addcont0 = "addcont/" + io.addcont;
 }
 
 bool init_savedata_app_path(IOState &io, const fs::path &pref_path) {

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -198,6 +198,7 @@ int main(int argc, char *argv[]) {
     host.app_version = APP_INDEX->app_ver;
     host.app_category = APP_INDEX->category;
     host.app_content_id = APP_INDEX->content_id;
+    host.io.addcont = APP_INDEX->addcont;
     host.io.savedata = APP_INDEX->savedata;
     host.current_app_title = APP_INDEX->title;
     host.app_short_title = APP_INDEX->stitle;


### PR DESCRIPTION
# About: 
Is close things in my recent pr for savedata, some game using diferent value for store dlc compare title id, example one app have diferent title id, and using same dlc folder for this all id
- should fix game no found dlc after install it.
# Result
- in app list, i have this using diferent addcont id compare title id
![image](https://user-images.githubusercontent.com/5261759/139367060-d4b6377d-85ac-4a73-97b7-c2a5bcb3fa25.png)
