### PR TITLE
SceKernelThreadMgr: implement 2 function getinfo and small refactor

### DIFF
--- a/vita3k/kernel/include/kernel/types.h
+++ b/vita3k/kernel/include/kernel/types.h
@@ -554,6 +554,10 @@ struct SceKernelEventFlagOptParam {
     SceSize size;
 };
 
+struct SceKernelCondOptParam {
+    SceSize size;
+};
+
 struct SceKernelLwCondOptParam {
     SceSize size;
 };
@@ -648,6 +652,25 @@ struct SceKernelMsgPipeInfo {
     /** Number of waiting threads */
     uint32_t numSenders;
     uint32_t numReceivers;
+};
+
+struct SceKernelCondInfo {
+    SceSize size;
+    SceUID condId;
+    char name[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+    SceUInt32 attr;
+    SceUID mutexId;
+    SceUInt32 numWaitThreads;
+};
+
+struct SceKernelEventFlagInfo {
+    SceSize size;
+    SceUID evfId;
+    char name[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+    SceUInt32 attr;
+    SceUInt32 initPattern;
+    SceUInt32 currentPattern;
+    SceUInt32 numWaitThreads;
 };
 
 struct SceKernelSemaInfo {

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
@@ -19,6 +19,8 @@
 
 #include <module/module.h>
 
+EXPORT(SceUID, _sceKernelCreateCond, const char *pName, SceUInt32 attr, SceUID mutexId, const SceKernelCondOptParam *pOptParam);
+EXPORT(SceInt32, _sceKernelGetCondInfo, SceUID condId, Ptr<SceKernelCondInfo> pInfo);
 EXPORT(int, __sceKernelCreateLwMutex, Ptr<SceKernelLwMutexWork> workarea, const char *name, unsigned int attr, Ptr<SceKernelCreateLwMutex_opt> opt);
 EXPORT(int, _sceKernelDeleteLwMutex, Ptr<SceKernelLwMutexWork> workarea);
 EXPORT(int, _sceKernelLockLwMutex, Ptr<SceKernelLwMutexWork> workarea, int lock_count, unsigned int *ptimeout);
@@ -27,11 +29,13 @@ EXPORT(int, _sceKernelCreateLwCond, Ptr<SceKernelLwCondWork> workarea, const cha
 EXPORT(SceInt32, _sceKernelGetCallbackInfo, SceUID callbackId, Ptr<SceKernelCallbackInfo> pInfo);
 EXPORT(int, sceKernelCreateThreadForUser, const char *name, SceKernelThreadEntry entry, int init_priority, SceKernelCreateThread_opt *options);
 EXPORT(int, _sceKernelStartThread, SceUID thid, SceSize arglen, Ptr<void> argp);
+EXPORT(SceInt32, _sceKernelGetThreadInfo, SceUID threadId, Ptr<SceKernelThreadInfo> pInfo);
 EXPORT(int, _sceKernelLockMutex, SceUID mutexid, int lock_count, unsigned int *timeout);
 EXPORT(SceUID, _sceKernelCreateEventFlag, const char *pName, SceUInt32 attr, SceUInt32 initPattern, const SceKernelEventFlagOptParam *pOptParam);
 EXPORT(int, _sceKernelCreateSema, const char *name, SceUInt attr, int initVal, Ptr<SceKernelCreateSema_opt> opt);
 EXPORT(SceInt32, _sceKernelGetSemaInfo, SceUID semaId, Ptr<SceKernelSemaInfo> pInfo);
 EXPORT(int, _sceKernelWaitSema, SceUID semaid, int signal, SceUInt *timeout);
+EXPORT(SceInt32, _sceKernelGetEventFlagInfo, SceUID evfId, Ptr<SceKernelEventFlagInfo> pInfo);
 EXPORT(int, _sceKernelPollEventFlag, SceUID event_id, unsigned int flags, unsigned int wait, unsigned int *outBits);
 EXPORT(int, _sceKernelWaitThreadEnd, SceUID thid, int *stat, SceUInt *timeout);
 EXPORT(int, _sceKernelWaitThreadEndCB, SceUID thid, int *stat, SceUInt *timeout);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -866,13 +866,8 @@ EXPORT(int, sceKernelCloseModule) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelCreateCond, const char *name, SceUInt attr, SceUID mutexid, void *opt_param) {
-    SceUID uid;
-
-    if (auto error = condvar_create(&uid, host.kernel, export_name, name, thread_id, attr, mutexid, SyncWeight::Heavy)) {
-        return error;
-    }
-    return uid;
+EXPORT(SceUID, sceKernelCreateCond, const char *pName, SceUInt32 attr, SceUID mutexId, const SceKernelCondOptParam *pOptParam) {
+    return CALL_EXPORT(_sceKernelCreateCond, pName, attr, mutexId, pOptParam);
 }
 
 EXPORT(int, sceKernelCreateEventFlag, const char *name, unsigned int attr, unsigned int flags, SceKernelEventFlagOptParam *opt) {
@@ -1006,16 +1001,16 @@ EXPORT(SceInt32, sceKernelGetCallbackInfo, SceUID callbackId, Ptr<SceKernelCallb
     return CALL_EXPORT(_sceKernelGetCallbackInfo, callbackId, pInfo);
 }
 
-EXPORT(int, sceKernelGetCondInfo) {
-    return UNIMPLEMENTED();
+EXPORT(SceInt32, sceKernelGetCondInfo, SceUID condId, Ptr<SceKernelCondInfo> pInfo) {
+    return CALL_EXPORT(_sceKernelGetCondInfo, condId, pInfo);
 }
 
 EXPORT(int, sceKernelGetCurrentThreadVfpException) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelGetEventFlagInfo) {
-    return UNIMPLEMENTED();
+EXPORT(SceInt32, sceKernelGetEventFlagInfo, SceUID evfId, Ptr<SceKernelEventFlagInfo> pInfo) {
+    return CALL_EXPORT(_sceKernelGetEventFlagInfo, evfId, pInfo);
 }
 
 EXPORT(int, sceKernelGetEventInfo) {
@@ -1142,28 +1137,8 @@ EXPORT(int, sceKernelGetThreadId) {
     return thread_id;
 }
 
-EXPORT(int, sceKernelGetThreadInfo, SceUID thid, SceKernelThreadInfo *info) {
-    STUBBED("STUB");
-
-    if (!info)
-        return SCE_KERNEL_ERROR_ILLEGAL_SIZE;
-
-    // TODO: SCE_KERNEL_ERROR_ILLEGAL_CONTEXT check
-
-    if (info->size > 0x80)
-        return SCE_KERNEL_ERROR_NOSYS;
-
-    const ThreadStatePtr thread = lock_and_find(thid ? thid : thread_id, host.kernel.threads, host.kernel.mutex);
-
-    strncpy(info->name, thread->name.c_str(), 0x1f);
-    info->stack = Ptr<void>(thread->stack.get());
-    info->stackSize = thread->stack_size;
-    info->initPriority = thread->priority;
-    info->currentPriority = thread->priority;
-    info->entry = SceKernelThreadEntry(thread->entry_point);
-    info->runClocks = rtc_get_ticks(host.kernel.base_tick.tick) - thread->start_tick;
-
-    return SCE_KERNEL_OK;
+EXPORT(SceInt32, sceKernelGetThreadInfo, SceUID threadId, Ptr<SceKernelThreadInfo> pInfo) {
+    return CALL_EXPORT(_sceKernelGetThreadInfo, threadId, pInfo);
 }
 
 EXPORT(int, sceKernelGetThreadRunStatus) {


### PR DESCRIPTION
# About:
- implement sceKernelGet(EventFlag/Cond)Info.
- move sceKernelCreateCond inside it and refactor sceKernelGetThreadInfo.

# Result:
fix lock on boot for some unity game
![image](https://cdn.discordapp.com/attachments/418026683015233546/906369699917463552/unknown.png)

- fix crash on first logo
![image](https://user-images.githubusercontent.com/5261759/140596514-c5e1f6a4-16f4-4d4a-9336-0c1b4ce4ba59.png)
