### PR TITLE
modules/SceKernelThreadMgr: stub SceKernel(Resume/Suspend)ThreadForVM.

### DIFF
--- a/vita3k/kernel/include/kernel/types.h
+++ b/vita3k/kernel/include/kernel/types.h
@@ -735,6 +735,22 @@ struct SceKernelThreadInfo {
     SceInt32 reserved;
 };
 
+struct SceKernelThreadCpuRegisterInfo {
+    SceSize size;
+    SceUInt32 cpsr;
+    SceUInt32 reg[16];
+    SceUInt32 tpidrurw;
+    SceUInt32 teehbr;
+    SceUInt32 sb;
+    SceUInt32 st;
+};
+
+struct SceKernelThreadVfpRegisterInfo {
+    SceSize size;
+    SceUInt32 fpscr;
+    SceFloat reg[64];
+};
+
 struct SceProcessParam {
     SceSize size;
     SceUInt32 magic;

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
@@ -40,6 +40,10 @@ EXPORT(int, _sceKernelPollEventFlag, SceUID event_id, unsigned int flags, unsign
 EXPORT(int, _sceKernelWaitThreadEnd, SceUID thid, int *stat, SceUInt *timeout);
 EXPORT(int, _sceKernelWaitThreadEndCB, SceUID thid, int *stat, SceUInt *timeout);
 EXPORT(int, _sceKernelWaitSignal, uint32_t unknown, uint32_t delay, uint32_t timeout);
+EXPORT(int, _sceKernelSetThreadContextForVM, SceUID threadId, Ptr<SceKernelThreadCpuRegisterInfo> pCpuRegisterInfo, Ptr<SceKernelThreadVfpRegisterInfo> pVfpRegisterInfo);
+EXPORT(int, _sceKernelGetThreadContextForVM, SceUID threadId, Ptr<SceKernelThreadCpuRegisterInfo> pCpuRegisterInfo, Ptr<SceKernelThreadVfpRegisterInfo> pVfpRegisterInfo);
+EXPORT(int, sceKernelResumeThreadForVM, SceUID threadId);
+EXPORT(int, sceKernelSuspendThreadForVM, SceUID threadId);
 
 BRIDGE_DECL(__sceKernelCreateLwMutex)
 BRIDGE_DECL(_sceKernelCancelEvent)

--- a/vita3k/modules/SceLibKernel/SceKernelForMono.cpp
+++ b/vita3k/modules/SceLibKernel/SceKernelForMono.cpp
@@ -16,21 +16,22 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "SceKernelForMono.h"
+#include "../SceKernelThreadMgr/SceThreadmgr.h"
 
-EXPORT(int, sceKernelGetThreadContextForMono) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelGetThreadContextForMono, SceUID threadId, Ptr<SceKernelThreadCpuRegisterInfo> pCpuRegisterInfo, Ptr<SceKernelThreadVfpRegisterInfo> pVfpRegisterInfo) {
+    return CALL_EXPORT(_sceKernelGetThreadContextForVM, threadId, pCpuRegisterInfo, pVfpRegisterInfo);
 }
 
-EXPORT(int, sceKernelResumeThreadForMono) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelResumeThreadForMono, SceUID threadId) {
+    return CALL_EXPORT(sceKernelResumeThreadForVM, threadId);
 }
 
-EXPORT(int, sceKernelSetThreadContextForMono) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSetThreadContextForMono, SceUID threadId, Ptr<SceKernelThreadCpuRegisterInfo> pCpuRegisterInfo, Ptr<SceKernelThreadVfpRegisterInfo> pVfpRegisterInfo) {
+    return CALL_EXPORT(_sceKernelSetThreadContextForVM, threadId, pCpuRegisterInfo, pVfpRegisterInfo);
 }
 
-EXPORT(int, sceKernelSuspendThreadForMono) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSuspendThreadForMono, SceUID threadId) {
+    return CALL_EXPORT(sceKernelSuspendThreadForVM, threadId);
 }
 
 EXPORT(int, sceKernelWaitExceptionCBForMono) {

--- a/vita3k/modules/SceLibKernel/SceKernelForVM.cpp
+++ b/vita3k/modules/SceLibKernel/SceKernelForVM.cpp
@@ -16,17 +16,18 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "SceKernelForVM.h"
+#include "../SceKernelThreadMgr/SceThreadmgr.h"
 
-EXPORT(int, __sceKernelGetThreadContextForVM) {
-    return UNIMPLEMENTED();
+EXPORT(int, __sceKernelGetThreadContextForVM, SceUID threadId, Ptr<SceKernelThreadCpuRegisterInfo> pCpuRegisterInfo, Ptr<SceKernelThreadVfpRegisterInfo> pVfpRegisterInfo) {
+    return CALL_EXPORT(_sceKernelGetThreadContextForVM, threadId, pCpuRegisterInfo, pVfpRegisterInfo);
 }
 
-EXPORT(int, _sceKernelResumeThreadForVM) {
-    return UNIMPLEMENTED();
+EXPORT(int, _sceKernelResumeThreadForVM, SceUID threadId) {
+    return CALL_EXPORT(sceKernelResumeThreadForVM, threadId);
 }
 
-EXPORT(int, _sceKernelSuspendThreadForVM) {
-    return UNIMPLEMENTED();
+EXPORT(int, _sceKernelSuspendThreadForVM, SceUID threadId) {
+    return CALL_EXPORT(sceKernelSuspendThreadForVM, threadId);
 }
 
 BRIDGE_IMPL(__sceKernelGetThreadContextForVM)

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -1102,8 +1102,8 @@ EXPORT(Ptr<Ptr<void>>, sceKernelGetTLSAddr, int key) {
     return host.kernel.get_thread_tls_addr(host.mem, thread_id, key);
 }
 
-EXPORT(int, sceKernelGetThreadContextForVM) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelGetThreadContextForVM, SceUID threadId, Ptr<SceKernelThreadCpuRegisterInfo> pCpuRegisterInfo, Ptr<SceKernelThreadVfpRegisterInfo> pVfpRegisterInfo) {
+    return CALL_EXPORT(_sceKernelGetThreadContextForVM, threadId, pCpuRegisterInfo, pVfpRegisterInfo);
 }
 
 EXPORT(int, sceKernelGetThreadCpuAffinityMask2) {
@@ -1295,8 +1295,8 @@ EXPORT(int, sceKernelSetEventWithNotifyCallback) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelSetThreadContextForVM) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelSetThreadContextForVM, SceUID threadId, Ptr<SceKernelThreadCpuRegisterInfo> pCpuRegisterInfo, Ptr<SceKernelThreadVfpRegisterInfo> pVfpRegisterInfo) {
+    return CALL_EXPORT(_sceKernelSetThreadContextForVM, threadId, pCpuRegisterInfo, pVfpRegisterInfo);
 }
 
 EXPORT(int, sceKernelSetTimerEvent, SceUID timer_handle, int32_t type, SceKernelSysClock *clock, int32_t repeats) {


### PR DESCRIPTION
# About
Stub Resume/suspend thrad ForMono/Vm used by all unity game.
Prepare sceKernel(Get/Set)ThreadContextForVM for futur implement.

fix boot on 50 unity game, with go to playable on menu/intro, if crash on avplayer just using lle.

thx @sunho for help 

# Result: 
- go ingame for first time
![image](https://cdn.discordapp.com/attachments/534180053865725962/907123582121967616/unknown.png)

- story mode works  without any error
![image](https://user-images.githubusercontent.com/5261759/140689050-59a6f8c0-ab81-4331-a3aa-ab79f943aa70.png)

- acces instant ingame after video, no error
![image](https://user-images.githubusercontent.com/5261759/140689674-b4f96739-df5d-4aba-8477-b163a226a70c.png)

- first time ingame
![image](https://user-images.githubusercontent.com/5261759/140689634-c952f9ea-7da6-4853-b0b4-13438a9fa375.png)

and more....
