### PR TITLE
Try fix signal Notification issue

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1379,13 +1379,13 @@ EXPORT(int, sceGxmEndScene, SceGxmContext *context, Ptr<SceGxmNotification> vert
         ++host.renderer->last_scene_id);
 
     if (vertexNotification) {
-        renderer::add_command(context->renderer.get(), renderer::CommandOpcode::SignalNotification,
-            nullptr, vertexNotification, true);
+        volatile uint32_t *val = vertexNotification.get(host.mem)->address.get(host.mem);
+        *val = vertexNotification.get(host.mem)->value;
     }
 
     if (fragmentNotification) {
-        renderer::add_command(context->renderer.get(), renderer::CommandOpcode::SignalNotification,
-            nullptr, fragmentNotification, false);
+        volatile uint32_t *val = fragmentNotification.get(host.mem)->address.get(host.mem);
+        *val = fragmentNotification.get(host.mem)->value;
     }
 
     if (context->state.fragment_sync_object) {

--- a/vita3k/renderer/include/renderer/commands.h
+++ b/vita3k/renderer/include/renderer/commands.h
@@ -64,9 +64,7 @@ enum class CommandOpcode : std::uint8_t {
          */
     SignalSyncObject = 9,
 
-    SignalNotification = 10,
-
-    DestroyRenderTarget = 11
+    DestroyRenderTarget = 10
 };
 
 enum CommandErrorCode {

--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -57,7 +57,6 @@ void process_batch(renderer::State &state, const FeatureState &features, MemStat
         { CommandOpcode::Nop, cmd_handle_nop },
         { CommandOpcode::SetState, cmd_handle_set_state },
         { CommandOpcode::SignalSyncObject, cmd_handle_signal_sync_object },
-        { CommandOpcode::SignalNotification, cmd_handle_notification },
         { CommandOpcode::DestroyRenderTarget, cmd_handle_destroy_render_target }
     };
 

--- a/vita3k/renderer/src/driver_functions.h
+++ b/vita3k/renderer/src/driver_functions.h
@@ -64,6 +64,5 @@ COMMAND(handle_draw);
 // Sync
 COMMAND(handle_nop);
 COMMAND(handle_signal_sync_object);
-COMMAND(handle_notification);
 
 } // namespace renderer

--- a/vita3k/renderer/src/sync.cpp
+++ b/vita3k/renderer/src/sync.cpp
@@ -39,15 +39,6 @@ COMMAND(handle_signal_sync_object) {
     renderer::subject_done(sync, renderer::SyncObjectSubject::Fragment);
 }
 
-COMMAND(handle_notification) {
-    SceGxmNotification *nof = helper.pop<Ptr<SceGxmNotification>>().get(mem);
-    [[maybe_unused]] const bool is_vertex = helper.pop<bool>();
-
-    volatile std::uint32_t *val = nof->address.get(mem);
-    if (val) // Ratchet and clank Trilogy request this
-        *val = nof->value;
-}
-
 // Client side function
 void finish(State &state, Context &context) {
     // Wait for the code


### PR DESCRIPTION
# About:
- Inspired by GxmMidFlush improvement, i have wanted see if using same method can fix infinite wait caused bad bad value set on some game, with all time it same + 2 on value so get all time example on notifwait 12 vs 11.

- try fix issue #1489

I have see no using add command fix it and set so exactly good value, and for ratchet no need any if (val).

And see for ffx too, issue is no get by only VertexNotif but also on FragmentNotif.

No want said need merge pr like that, is just here for search and expertise and try fix this issue.
I waiting so expertise of @sunho or @pent0 

F1 keep broken, but it no infinite wait anymore and no crash, just freeze 🤷‍♂️ 

# Result:
- fix ffx(-2) for this screen is vertexnotif, but for can boot game, is fragment notif if waiting infinite before load self
![image](https://user-images.githubusercontent.com/5261759/141338071-a9ece1d4-b6a0-4629-ab29-f0df295e8d1a.png)
![image](https://user-images.githubusercontent.com/5261759/141338322-476c046d-4722-4070-8b63-d41df84d99e9.png)

- fix knyt undergrund too
![image](https://user-images.githubusercontent.com/5261759/141338437-5c8d0a1d-f184-49ba-ba89-a80ecee08c93.png)
