### PR TITLE
modules/SceNet: fix return value in Init when is already inited.

### DIFF
--- a/vita3k/modules/SceNet/SceNet.cpp
+++ b/vita3k/modules/SceNet/SceNet.cpp
@@ -209,7 +209,7 @@ EXPORT(int, sceNetInetPton, int af, const char *src, void *dst) {
 
 EXPORT(int, sceNetInit, SceNetInitParam *param) {
     if (host.net.inited) {
-        return RET_ERROR(SCE_NET_ERROR_EINTERNAL);
+        return RET_ERROR(SCE_NET_ERROR_EBUSY);
     }
 #ifdef WIN32
     WORD versionWanted = MAKEWORD(2, 2);


### PR DESCRIPTION
# About:
- founded after try fix boot of corps party with hang on setup trophy.
@bookmist give me good error normally returned.
- fix infinite load on corps paarty//fat princess/tetris ultimate, counter Spy,  Asdivinie heart and more...

# Result
- can go load game file after trophy setup and go ingame
![image](https://user-images.githubusercontent.com/5261759/141382216-1aaea670-f672-473f-90f8-11e46b0153fd.png)
![image](https://user-images.githubusercontent.com/5261759/141382272-147f673a-be9e-4bb8-b1d5-5dd29934e6e8.png)

- can go and load ingame
![image](https://user-images.githubusercontent.com/5261759/141383670-73297a89-a287-4afc-88f0-79f6c62e5fc1.png)
![image](https://user-images.githubusercontent.com/5261759/141383714-c84b1637-5d25-4628-8934-18c433955bea.png)

- fix infinite loading check connexion, get start, menu, and ingame (warning on your ears)
![image](https://user-images.githubusercontent.com/5261759/141383902-855a4282-fe83-4f8d-be4e-7c1292606a32.png)
![image](https://user-images.githubusercontent.com/5261759/141383967-0b078cde-4679-4418-9913-e3d10d522817.png)
![image](https://user-images.githubusercontent.com/5261759/141386770-28085de1-1f6b-42c5-b764-df331ed47879.png)

- fix infinite loading on first logo and go ingame
![image](https://user-images.githubusercontent.com/5261759/141386734-c9f1372d-4baf-426f-b2d2-00ee5ff48d57.png)
![image](https://user-images.githubusercontent.com/5261759/141386713-ee965ff6-33d8-4122-bc7b-1c2697736950.png)
