### PR TITLE
renderer: Fix scissors value being down aligned incorrectly.

### DIFF
--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -38,8 +38,8 @@ COMMAND_SET_STATE(region_clip) {
     const std::uint32_t yMin = helper.pop<std::uint32_t>();
     const std::uint32_t yMax = helper.pop<std::uint32_t>();
 
-    render_context->record.region_clip_min.x = static_cast<SceInt>(align(xMin, SCE_GXM_TILE_SIZEX) - SCE_GXM_TILE_SIZEX);
-    render_context->record.region_clip_min.y = static_cast<SceInt>(align(yMin, SCE_GXM_TILE_SIZEY) - SCE_GXM_TILE_SIZEY);
+    render_context->record.region_clip_min.x = static_cast<SceInt>(align_down(xMin, SCE_GXM_TILE_SIZEX));
+    render_context->record.region_clip_min.y = static_cast<SceInt>(align_down(yMin, SCE_GXM_TILE_SIZEY));
     render_context->record.region_clip_max.x = static_cast<SceInt>(align(xMax, SCE_GXM_TILE_SIZEX));
     render_context->record.region_clip_max.y = static_cast<SceInt>(align(yMax, SCE_GXM_TILE_SIZEY));
 


### PR DESCRIPTION
# About: 
- fix scissors value, relate a cropped corners on gintama.