### PR TITLE
modules/SceMp4: Stub sceMp4OpenFile.

### DIFF
--- a/vita3k/modules/SceMp4/SceMp4.cpp
+++ b/vita3k/modules/SceMp4/SceMp4.cpp
@@ -50,7 +50,9 @@ EXPORT(int, sceMp4JumpPTS) {
 }
 
 EXPORT(int, sceMp4OpenFile) {
-    return UNIMPLEMENTED();
+    STUBBED("Fake Size");
+
+    return 13;
 }
 
 EXPORT(int, sceMp4PTSToTime) {


### PR DESCRIPTION
# About:
- After my pr of add Scemp4 library have get game stop boot on using this function, this function normally return size, so here i put fake size works fine. 
- fix Persona 4 GOLDEN (USA/EURO) pass intro video and go menu like before add this library.