### PR TITLE
implement some function for precomputed.

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1692,7 +1692,7 @@ struct SceGxmPrecomputedDraw {
     uint32_t vertex_count;
 };
 
-static constexpr size_t SCE_GXM_PRECOMPUTED_FRAGMENT_STATE_EXTRA_SIZE = sizeof(TextureDatas) + sizeof(UniformBuffers);
+static constexpr size_t SCE_GXM_PRECOMPUTED_STATE_EXTRA_SIZE = sizeof(TextureDatas) + sizeof(UniformBuffers);
 
 struct SceGxmPrecomputedFragmentState {
     Ptr<const SceGxmFragmentProgram> program;
@@ -1703,10 +1703,11 @@ struct SceGxmPrecomputedFragmentState {
     Ptr<UniformBuffers> uniform_buffers;
 };
 
-static constexpr size_t SCE_GXM_PRECOMPUTED_VERTEX_STATE_EXTRA_SIZE = sizeof(UniformBuffers);
-
 struct SceGxmPrecomputedVertexState {
     Ptr<const SceGxmVertexProgram> program;
+
+    Ptr<TextureDatas> textures;
+    uint16_t texture_count;
 
     Ptr<UniformBuffers> uniform_buffers;
 };

--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1690,6 +1690,7 @@ struct SceGxmPrecomputedDraw {
     SceGxmIndexFormat index_format;
     Ptr<const void> index_data;
     uint32_t vertex_count;
+    uint32_t instance_count;
 };
 
 static constexpr size_t SCE_GXM_PRECOMPUTED_STATE_EXTRA_SIZE = sizeof(TextureDatas) + sizeof(UniformBuffers);


### PR DESCRIPTION
- sceGxmPrecomputedDrawSetParamsInstanced.
- implement sceGxmPrecomputedVertexStateSetAllTextures & sceGxmPrecomputedVertexStateSetTexture.
- implement add texture for vertex texture in sceGxmDrawPrecomputed.
- add support of vertex texture in SceGxmPrecomputedVertex.

thx to @pent0, for found myè stupid forget things.

# Todo:
- [x] crash on set texture in sceGxmPrecomputedVertexStateSetAllTextures on resogun and furmins.

# Result: 
- stub sceGxmPrecomputedDrawSetParamsInstanced give this game go ingame and playable.
![image](https://user-images.githubusercontent.com/5261759/143582183-9ce2286d-1e56-47e3-9fd0-e41c7f3d6784.png)
![image](https://cdn.discordapp.com/attachments/418026683015233546/913577907488694312/unknown.png)