### PR TITLE
codec: Use libatrac9 library for atrac9 decoding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,3 +90,6 @@
 [submodule "external/fmt"]
 	path = external/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "external/LibAtrac9"]
+	path = external/LibAtrac9
+	url = https://github.com/Thealexbarney/LibAtrac9/

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -277,6 +277,16 @@ set_property(TARGET psvpfsparser PROPERTY FOLDER externals)
 set_property(TARGET libzRIF PROPERTY FOLDER externals)
 set_property(TARGET libb64 PROPERTY FOLDER externals)
 
+file(GLOB LIBATRAC9_SOURCES
+    LibAtrac9/C/src/*.c
+    LibAtrac9/C/src/*.h
+)
+
+add_library(libatrac9 SHARED ${LIBATRAC9_SOURCES})
+target_include_directories(libatrac9 PUBLIC LibAtrac9/C/src)
+set_target_properties(libatrac9 PROPERTIES
+	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
 option(XXHASH_BUILD_XXHSUM "Build the xxhsum binary" OFF)
 add_subdirectory(xxHash/cmake_unofficial EXCLUDE_FROM_ALL)

--- a/vita3k/codec/CMakeLists.txt
+++ b/vita3k/codec/CMakeLists.txt
@@ -10,4 +10,4 @@ add_library(codec STATIC
     src/player.cpp)
 
 target_include_directories(codec PUBLIC include)
-target_link_libraries(codec PRIVATE ffmpeg util)
+target_link_libraries(codec PRIVATE ffmpeg libatrac9 util) 

--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -103,7 +103,10 @@ struct MjpegDecoderState : public DecoderState {
 };
 
 struct Atrac9DecoderState : public DecoderState {
+    void *decoder_handle;
     uint32_t config_data;
+
+    std::vector<std::uint8_t> result;
 
     uint32_t get_channel_count();
     uint32_t get_samples_per_superframe();

--- a/vita3k/ngs/src/modules/atrac9.cpp
+++ b/vita3k/ngs/src/modules/atrac9.cpp
@@ -202,7 +202,7 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
         }
     }
 
-    std::uint8_t *data_ptr = data.extra_storage.data() + params->channels * sizeof(float) * state->decoded_passed;
+    std::uint8_t *data_ptr = data.extra_storage.data() + 2 * sizeof(float) * state->decoded_passed;
     std::uint32_t samples_to_be_passed = data.parent->rack->system->granularity;
 
     data.parent->products[0].data = data_ptr;


### PR DESCRIPTION
# About: 
- move atrac9 decoding to libatrac9
- fix sound quality of some game when using atrac9 decoder

We have more control and error codes, also avoid some shortcoming of
ffmpeg port