### PR TITLE
modules/SceGxm: fix regression in loop of both StateSetAllUniformBuffers

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1924,7 +1924,7 @@ EXPORT(int, sceGxmPrecomputedFragmentStateSetAllUniformBuffers, SceGxmPrecompute
     if (!uniform_buffers)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
 
-    for (auto b = 0; b <= SCE_GXM_MAX_UNIFORM_BUFFERS; b++)
+    for (auto b = 0; b < SCE_GXM_MAX_UNIFORM_BUFFERS; b++)
         (*uniform_buffers)[b] = bufferDataArray[b];
 
     return 0;
@@ -2032,7 +2032,7 @@ EXPORT(int, sceGxmPrecomputedVertexStateSetAllUniformBuffers, SceGxmPrecomputedV
     if (!uniform_buffers)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
 
-    for (auto b = 0; b <= SCE_GXM_MAX_UNIFORM_BUFFERS; b++)
+    for (auto b = 0; b < SCE_GXM_MAX_UNIFORM_BUFFERS; b++)
         (*uniform_buffers)[b] = bufferDataArray[b];
 
     return 0;


### PR DESCRIPTION
# About:
- fix loop set value too much, max size is 14, so have only 14 array available (0-13), fix crash with dynarmic error on load ingame

![image](https://cdn.discordapp.com/attachments/534180053865725962/915357325974442004/unknown.png)