### PR TITLE
shader: Correct default UB index in input analyzing.

### DIFF
--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -202,7 +202,7 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
     if ((default_ub_ite == program_input.uniform_buffers.end()) && (program.default_uniform_buffer_count != 0)) {
         // Must there be a one if possible
         UniformBuffer buffer;
-        buffer.index = 0;
+        buffer.index = 14;
         buffer.reg_block_size = program.default_uniform_buffer_count;
         buffer.reg_start_offset = 0;
         buffer.rw = false;


### PR DESCRIPTION
# About:
- fix one regression of some game causing black or white screen.
- like on durara relay/uncharted fight for fortune/flow