### PR TITLE
renderer: Fix depth and stencil clear limited to scissor on context set

### DIFF
--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -448,6 +448,10 @@ void set_context(GLContext &context, const MemState &mem, const GLRenderTarget *
     }
     glBindFramebuffer(GL_FRAMEBUFFER, context.render_target->framebuffer[0]);
 
+    if (context.record.region_clip_mode != SCE_GXM_REGION_CLIP_NONE) {
+        glDisable(GL_SCISSOR_TEST);
+    }
+
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);
     glClearDepth(context.record.depth_stencil_surface.backgroundDepth);
@@ -468,6 +472,10 @@ void set_context(GLContext &context, const MemState &mem, const GLRenderTarget *
     if (sync_stencil_data(context.record, mem)) {
         sync_stencil_func(context.record.back_stencil_state, mem, true);
         sync_stencil_func(context.record.front_stencil_state, mem, false);
+    }
+
+    if (context.record.region_clip_mode != SCE_GXM_REGION_CLIP_NONE) {
+        glEnable(GL_SCISSOR_TEST);
     }
 }
 


### PR DESCRIPTION
# About:
- fix very old issue with some part of screen cut

# Result:
![image](https://user-images.githubusercontent.com/5261759/145033197-17d95bae-9ca5-4b16-a92c-64e72f9b595e.png)

![image](https://user-images.githubusercontent.com/5261759/145033237-41091d9e-7ffc-46fe-a405-d7efeffe1482.png)

![image](https://user-images.githubusercontent.com/5261759/145033253-a681a9be-97e8-465d-b8ef-b47232c4f41b.png)

and more... 
