### PR TITLE
shader: Fix non-F32 components not all stored

### DIFF
--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -1119,7 +1119,7 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
         int source_value_taken_count = 0;
 
         // We need to pack source
-        for (auto i = 0; i < static_cast<int>(total_comp_source); i += num_comp_in_float) {
+        for (auto i = 0; i < 4 - nearest_swizz_on; i += num_comp_in_float) {
             // Shuffle to get the type out
             std::vector<spv::Id> ops;
             for (auto j = 0; j < num_comp_in_float; j++) {
@@ -1164,6 +1164,9 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
             source = b.createCompositeConstruct(final_composite_type, composites);
             total_comp_source = static_cast<std::uint8_t>(composites.size());
         }
+
+        // Replace it with a full mask, since we have already pre-process this into storable F32
+        dest_mask = 0b1111;
     }
 
     // Now we do store!


### PR DESCRIPTION
# About: 
- Fix Noise on Cloth in Valkyrie Drive


# Result:
- before
![image](https://user-images.githubusercontent.com/5261759/145144307-39d4446b-f117-4880-b246-c667fcc75d8c.png)
![image](https://user-images.githubusercontent.com/5261759/145144363-849b5098-73c2-47b3-a924-f2f1985cd050.png)


- after

![image](https://user-images.githubusercontent.com/5261759/145144355-0195c844-ea19-44cb-aad4-185dd28125ed.png)
![image](https://user-images.githubusercontent.com/5261759/145144377-c0ae124c-83b1-4d17-9cbd-b76925ecf6dd.png)
![image](https://user-images.githubusercontent.com/5261759/145144397-82723bcc-ae0a-4e53-9344-bfce8950a4dd.png)
![image](https://user-images.githubusercontent.com/5261759/145144403-3e57a697-5bd4-4ea2-849e-d76673dd5569.png)
