### PR TITLE
renderer/batch: small improvement of process batch.

### DIFF
--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -90,7 +90,8 @@ void process_batch(renderer::State &state, const FeatureState &features, MemStat
 
 void process_batches(renderer::State &state, const FeatureState &features, MemState &mem, Config &config, const char *base_path,
     const char *title_id) {
-    const uint32_t queue_size = state.command_buffer_queue.size();
+    const bool is_avg_scene_per_frame = !state.command_buffer_queue.size() || (state.average_scene_per_frame > 1);
+    const uint32_t queue_size = is_avg_scene_per_frame ? state.average_scene_per_frame : state.command_buffer_queue.size();
 
     for (uint32_t pc = 0; pc < queue_size; pc++) {
         auto cmd_list = state.command_buffer_queue.pop(3);


### PR DESCRIPTION
# About:
- report by tester,  master have actually get regression on some game, particularity on low cpu 
- prefer using avg scene per frame when is used iside pad gxm function