### PR TITLE
interface: print string of modules mode used in log.

### DIFF
--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <config/config.h>
 #include <dialog/state.h>
 #include <ime/state.h>
 #include <np/state.h>
@@ -233,6 +234,26 @@ enum NoticeIcon {
     NO,
     NEW
 };
+
+enum ModulesModeType {
+    MODE,
+    DESCRIPTION,
+};
+
+static constexpr auto MODULES_MODE_COUNT = 3;
+using ConfigModuleMode = std::array<std::vector<const char *>, MODULES_MODE_COUNT>;
+
+inline ConfigModuleMode init_modules_mode() {
+    ConfigModuleMode m;
+
+    m[ModulesMode::AUTOMATIC] = { "Automatic", "Select Automatic mode to use a preset list of modules." };
+    m[ModulesMode::AUTO_MANUAL] = { "Auto & Manual", "Select this mode to load Automatic module and selected modules from the list below." };
+    m[ModulesMode::MANUAL] = { "Manual", "Select Manual mode to load selected modules from the list below." };
+
+    return m;
+}
+
+const ConfigModuleMode config_modules_mode = init_modules_mode();
 
 struct GuiState {
     std::unique_ptr<ImGui_State> imgui_state;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -281,17 +281,13 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("Enable this to use driver_us modules (experimental).");
             ImGui::Spacing();
-            ImGui::RadioButton("Automatic", &config.modules_mode, ModulesMode::AUTOMATIC);
-            if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("Select Automatic mode to use a preset list of modules.");
-            ImGui::SameLine();
-            ImGui::RadioButton("Auto & Manual", &config.modules_mode, ModulesMode::AUTO_MANUAL);
-            if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("Select this mode to load Automatic module and selected modules from the list below.");
-            ImGui::SameLine();
-            ImGui::RadioButton("Manual", &config.modules_mode, ModulesMode::MANUAL);
-            if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("Select Manual mode to load selected modules from the list below.");
+            for (auto m = 0; m < MODULES_MODE_COUNT; m++) {
+                if (m)
+                    ImGui::SameLine();
+                ImGui::RadioButton(config_modules_mode[m][ModulesModeType::MODE], &config.modules_mode, m);
+                if (ImGui::IsItemHovered())
+                    ImGui::SetTooltip(config_modules_mode[m][ModulesModeType::DESCRIPTION]);
+            }
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -407,7 +407,7 @@ static ExitCode load_app_impl(Ptr<const void> &entry_point, HostState &host, con
         for (auto i = 0; i < host.ctrl.controllers_num; i++)
             LOG_INFO("Controller {}: {}", i, host.ctrl.controllers_name[i]);
     }
-    LOG_INFO("modules mode: {}", host.cfg.current_config.modules_mode);
+    LOG_INFO("modules mode: {}", config_modules_mode[host.cfg.current_config.modules_mode][ModulesModeType::MODE]);
     if ((host.cfg.current_config.modules_mode != ModulesMode::AUTOMATIC) && !host.cfg.current_config.lle_modules.empty()) {
         std::string modules;
         for (const auto &mod : host.cfg.current_config.lle_modules) {


### PR DESCRIPTION
# About:
- print modules mode used in log like string.
- gui/settings_dialog: using loop for modules mode view.