### PR TITLE
build: add suport of VS 2022.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -44,7 +44,7 @@ jobs:
             extra_cmake_args: -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/linux-x64.cmake -DUSE_DISCORD_RICH_PRESENCE=OFF
           - os: windows-latest
             cache_path: ~\AppData\Local\Mozilla\sccache
-            extra_cmake_args: -DBOOST_ROOT=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64 -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+            extra_cmake_args: -DBOOST_ROOT=C:\hostedtoolcache\windows\Boost\1.78.0\x86_64 -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
     steps:
       - name: Set up build environment (macos-latest)
@@ -61,9 +61,9 @@ jobs:
 
       - name: Set up build environment (windows-latest)
         run: |
-          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
+          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.78.0/boost_1_78_0-msvc-14.2-64.exe"
           (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
-          Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
+          Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.78.0\x86_64"
           Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
           scoop install ninja sccache --global
           echo "${env:PATH}" >> ${env:GITHUB_PATH}

--- a/building.md
+++ b/building.md
@@ -4,7 +4,7 @@ Vita3K uses CMake for its project configuration and generation and should in the
 
 Target OS | Host OS | [Project generator](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html) (`-G`) | C/C++ Compiler (`-DCMAKE_C_COMPILER` and `-DCMAKE_CXX_COMPILER`)
 --- | --- | --- | ---
-Windows | Windows | Visual Studio / MSBuild | `cl` a.k.a Microsoft Visual C/C++ Compiler (included as a part of the [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019) and the ` Dekstop development with C++` Visual Studio workload)
+Windows | Windows | Visual Studio / MSBuild | `cl` a.k.a Microsoft Visual C/C++ Compiler (included as a part of the [Build Tools for Visual Studio 2022](https://aka.ms/vs/17/release/vs_BuildTools.exe) and the ` Desktop development with C++` Visual Studio workload)
 macOS | macOS | Xcode | Clang (`clang` and `clang++`)
 Linux | Linux | Ninja | Clang (`clang` and `clang++`)
 
@@ -16,12 +16,12 @@ For convenience, the following building instructions are given as examples based
 
 ## Windows
 
-### Visual Studio 2019
-- Install Visual Studio 2019 and choose to install `Desktop development with C++`. You will get compiler and `cmake` required for building.
+### Visual Studio 2022
+- Install Visual Studio 2022 and choose to install `Desktop development with C++`. You will get compiler and `cmake` required for building.
 
   Example for Visual Studio 2019:
 
-  ![Required tools for VS 2019](https://i.imgur.com/bkY15Oh.png)
+  ![Required tools for VS 2022](https://i.imgur.com/bkY15Oh.png)
 
 - Install `git` to `clone` the project. Download and install `git` from [here](https://git-scm.com).
 
@@ -32,8 +32,8 @@ For convenience, the following building instructions are given as examples based
   cd Vita3K
   ```
 
-- Run Visual Studio 2019. On the project selection window open the local clone of the repository as a folder. Thanks to the integration between Visual Studio and CMake, Visual Studio will automatically setup the project for you.
-- Use the [CMake Settings Editor](https://docs.microsoft.com/en-us/cpp/build/customize-cmake-settings?view=msvc-160) to set "CMake toolchain file" to `./cmake/toolchain/windows-x64.cmake`. If asked to do so, delete and re-generate the CMake cache.
+- Run Visual Studio 2022. On the project selection window open the local clone of the repository as a folder. Thanks to the integration between Visual Studio and CMake, Visual Studio will automatically setup the project for you.
+- Use the [CMake Settings Editor](https://docs.microsoft.com/en-us/cpp/build/customize-cmake-settings?view=msvc-170) to set "CMake toolchain file" to `./cmake/toolchain/windows-x64.cmake`. If asked to do so, delete and re-generate the CMake cache.
 
 From there, the project will be ready to build right from the Visual Studio UI.
 
@@ -42,8 +42,8 @@ From there, the project will be ready to build right from the Visual Studio UI.
 -  Install:
    -  [Git](https://git-scm.com)
    -  [CMake](https://cmake.org/download/)
-   -  Either the [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019) or Visual Studio 2019 with the ` Dekstop development with C++` workload.
-- On the Start Menu, open the `x64 Native Tools Command Prompt for Visual Studio 2019`.
+   -  Either the [Build Tools for Visual Studio 2022](https://aka.ms/vs/17/release/vs_BuildTools.exe) or Visual Studio 2022 with the ` Desktop development with C++` workload.
+- On the Start Menu, open the `x64 Native Tools Command Prompt for Visual Studio 2022`.
   <p align="center">
     <img src="./_building/vs-cmd-prompt.png">
   </p>
@@ -56,9 +56,9 @@ From there, the project will be ready to build right from the Visual Studio UI.
 
 - Generate the project:
   ```cmd
-  cmake -S . -B build-windows -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake
+  cmake -S . -B build-windows -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake
   ```
-  The line above will generate a Visual Studio 2019 project inside a folder called `build-windows`.
+  The line above will generate a Visual Studio 2022 project inside a folder called `build-windows`.
 
 - Build the project:
   ```cmd

--- a/gen-windows.bat
+++ b/gen-windows.bat
@@ -1,5 +1,5 @@
 @echo off
 
-REM Generate project files for Visual Studio 2019
-call cmake -S . -B build-windows -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake
+REM Generate project files for your last Visual Studio version you have
+call cmake -S . -B build-windows -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake
 pause

--- a/vita3k/gxm/src/gxp.cpp
+++ b/vita3k/gxm/src/gxp.cpp
@@ -20,6 +20,8 @@
 #include <gxm/types.h>
 #include <util/log.h>
 
+#include <algorithm>
+
 namespace gxp {
 
 const char *log_parameter_semantic(const SceGxmProgramParameter &parameter) {

--- a/vita3k/io/include/io/device.h
+++ b/vita3k/io/include/io/device.h
@@ -21,6 +21,7 @@
 
 #include <util/fs.h>
 
+#include <algorithm>
 #include <string>
 
 namespace device {

--- a/vita3k/ngs/src/modules/master.cpp
+++ b/vita3k/ngs/src/modules/master.cpp
@@ -18,6 +18,7 @@
 #include <ngs/modules/master.h>
 #include <util/log.h>
 
+#include <algorithm>
 #include <fstream>
 
 namespace ngs::master {

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -24,6 +24,7 @@
 #include <spdlog/sinks/msvc_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
+#include <algorithm>
 #include <codecvt> // std::codecvt_utf8
 #include <iostream>
 #include <locale> // std::wstring_convert


### PR DESCRIPTION
# About:
- add support of Visual Studio 2022 (VC143), with update boost on 1.78, and with update gen window