### PR TITLE
Implement pre-compile shaders cache.

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -97,6 +97,7 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
 void draw_common_dialog(GuiState &gui, HostState &host);
 void draw_ime(Ime &ime, HostState &host);
 void draw_reinstall_dialog(GenericDialogState *status, HostState &host);
+void draw_pre_compiling_shaders_progress(GuiState &gui, HostState &host, const uint32_t &total);
 void draw_shaders_count_compiled(GuiState &gui, HostState &host);
 void draw_trophies_unlocked(GuiState &gui, HostState &host);
 void draw_perf_overlay(GuiState &gui, HostState &host);

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -209,12 +209,9 @@ void delete_app(GuiState &gui, HostState &host, const std::string &app_path) {
         const auto SAVE_DATA_PATH{ PREF_PATH / "ux0/user" / host.io.user_id / "savedata" / APP_INDEX->savedata };
         if (fs::exists(SAVE_DATA_PATH))
             fs::remove_all(SAVE_DATA_PATH);
-        const auto SHADER_CACHE_PATH{ BASE_PATH / "shaders" / title_id };
+        const auto SHADER_CACHE_PATH{ BASE_PATH / "cache/shaders" / title_id };
         if (fs::exists(SHADER_CACHE_PATH))
             fs::remove_all(SHADER_CACHE_PATH);
-        const auto SHADER_LOG_PATH{ BASE_PATH / "shaderlog" / title_id };
-        if (fs::exists(SHADER_LOG_PATH))
-            fs::remove_all(SHADER_LOG_PATH);
 
         if (gui.app_selector.user_apps_icon.find(app_path) != gui.app_selector.user_apps_icon.end()) {
             gui.app_selector.user_apps_icon[app_path] = {};
@@ -261,8 +258,7 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
     const auto DLC_PATH{ fs::path(host.pref_path) / "ux0/addcont" / APP_INDEX->addcont };
     const auto LICENSE_PATH{ fs::path(host.pref_path) / "ux0/license" / title_id };
     const auto SAVE_DATA_PATH{ fs::path(host.pref_path) / "ux0/user" / host.io.user_id / "savedata" / APP_INDEX->savedata };
-    const auto SHADER_CACHE_PATH{ fs::path(host.base_path) / "shaders" / title_id };
-    const auto SHADER_LOG_PATH{ fs::path(host.base_path) / "shaderlog" / title_id };
+    const auto SHADER_CACHE_PATH{ fs::path(host.base_path) / "cache/shaders" / title_id };
 
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto RES_SCALE = ImVec2(display_size.x / host.res_width_dpi_scale, display_size.y / host.res_height_dpi_scale);
@@ -320,13 +316,8 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
                     open_path(LICENSE_PATH.string());
                 if (fs::exists(SAVE_DATA_PATH) && ImGui::MenuItem("Save Data"))
                     open_path(SAVE_DATA_PATH.string());
-                if (ImGui::MenuItem("Shader Cache")) {
-                    if (!fs::exists(SHADER_CACHE_PATH))
-                        fs::create_directories(SHADER_CACHE_PATH);
+                if (fs::exists(SHADER_CACHE_PATH) && ImGui::MenuItem("Shader Cache"))
                     open_path(SHADER_CACHE_PATH.string());
-                }
-                if (fs::exists(SHADER_LOG_PATH) && ImGui::MenuItem("Shader Log"))
-                    open_path(SHADER_LOG_PATH.string());
                 ImGui::EndMenu();
             }
             if (!host.cfg.show_live_area_screen && ImGui::MenuItem("Live Area", nullptr, &gui.live_area.live_area_screen))
@@ -342,8 +333,6 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
                     context_dialog = "save";
                 if (fs::exists(SHADER_CACHE_PATH) && ImGui::MenuItem("Shader Cache"))
                     fs::remove_all(SHADER_CACHE_PATH);
-                if (fs::exists(SHADER_LOG_PATH) && ImGui::MenuItem("Shader Log"))
-                    fs::remove_all(SHADER_LOG_PATH);
                 ImGui::EndMenu();
             }
             if (fs::exists(APP_PATH / "sce_sys/changeinfo/") && ImGui::MenuItem(is_lang ? lang["update_history"].c_str() : "Update History")) {

--- a/vita3k/gui/src/compile_shaders.cpp
+++ b/vita3k/gui/src/compile_shaders.cpp
@@ -21,6 +21,55 @@
 
 namespace gui {
 
+static std::vector<std::string> points = { ".", "..", "..." };
+static int pos = 2;
+static uint64_t time = std::time(nullptr);
+void draw_pre_compiling_shaders_progress(GuiState &gui, HostState &host, const uint32_t &total) {
+    const auto display_size = ImGui::GetIO().DisplaySize;
+    const auto RES_SCALE = ImVec2(display_size.x / host.res_width_dpi_scale, display_size.y / host.res_height_dpi_scale);
+    const auto SCALE = ImVec2(RES_SCALE.x * host.dpi_scale, RES_SCALE.y * host.dpi_scale);
+    const auto WINDOW_SIZE = ImVec2(616.f * SCALE.x, 236.f * SCALE.y);
+    const auto ICON_SIZE_SCALE = ImVec2(96.f * SCALE.x, 96.f * SCALE.y);
+
+    ImGui::PushFont(gui.vita_font);
+    ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(WINDOW_SIZE);
+    ImGui::SetNextWindowBgAlpha(0.9f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.f);
+    ImGui::Begin("##shaders_pre_compile", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
+    ImGui::SetWindowFontScale(1.1f * RES_SCALE.x);
+
+    // Check if icon exist
+    if (gui.app_selector.user_apps_icon.find(host.io.app_path) != gui.app_selector.user_apps_icon.end()) {
+        ImGui::SetCursorPos(ImVec2(54.f * SCALE.x, 32.f * SCALE.y));
+        ImGui::Image(get_app_icon(gui, host.io.app_path)->second, ICON_SIZE_SCALE);
+    }
+
+    const auto current_time = std::time(nullptr);
+    if (time < current_time) {
+        pos = pos < (points.size() - 1) ? pos + 1 : 0;
+        time = current_time;
+    }
+    ImGui::SetCursorPos(ImVec2((176.f * SCALE.x), (52.f * SCALE.y)));
+    ImGui::TextColored(GUI_COLOR_TEXT, "%s", host.current_app_title.c_str());
+    ImGui::SetCursorPos(ImVec2((176.f * SCALE.x), ImGui::GetCursorPosY() + (30.f * SCALE.y)));
+    ImGui::TextColored(GUI_COLOR_TEXT, "Compiling Shaders%s", points[pos].c_str());
+    const float PROGRESS_BAR_WIDTH = 508.f * SCALE.x;
+    ImGui::SetCursorPos(ImVec2((ImGui::GetWindowWidth() / 2) - (PROGRESS_BAR_WIDTH / 2.f), ImGui::GetCursorPosY() + 30.f * host.dpi_scale));
+    ImGui::PushStyleColor(ImGuiCol_PlotHistogram, GUI_PROGRESS_BAR);
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 12.f);
+    const auto progress_programs = (host.renderer->programs_count_pre_compiled * 100) / total;
+    ImGui::ProgressBar(progress_programs / 100.f, ImVec2(PROGRESS_BAR_WIDTH, 15.f * host.dpi_scale), "");
+    ImGui::PopStyleColor();
+    ImGui::PopStyleVar();
+    const auto progress_programs_str = fmt::format("{}/{}", host.renderer->programs_count_pre_compiled, total);
+    ImGui::SetCursorPos(ImVec2((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(progress_programs_str.c_str()).x / 2.f), ImGui::GetCursorPosY() + (6.f * host.dpi_scale)));
+    ImGui::TextColored(GUI_COLOR_TEXT, "%s", progress_programs_str.c_str());
+    ImGui::End();
+    ImGui::PopStyleVar();
+    ImGui::PopFont();
+}
+
 void set_shaders_compiled_display(GuiState &gui, HostState &host) {
     const uint64_t time = std::time(nullptr);
     if (host.renderer->shaders_count_compiled) {

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -122,7 +122,6 @@ bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path, boo
         fs::create_directory(uma0_data);
 
     fs::create_directory(base_path / "texturelog");
-    fs::create_directory(base_path / "shaderlog");
 
     io.redirect_stdio = redirect_stdio;
 

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -36,12 +36,14 @@ struct FeatureState;
 namespace renderer::gl {
 
 // Compile program.
-SharedGLObject compile_program(ProgramCache &program_cache, ShaderCache &vertex_cache, ShaderCache &fragment_cache,
-    const GxmRecordState &state, const FeatureState &features, const MemState &mem, bool spirv, bool maskupdate, const char *base_path, const char *title_id, uint32_t &shaders_count_compiled);
+SharedGLObject compile_program(GLState &renderer, const GxmRecordState &state, const FeatureState &features, const MemState &mem, bool spirv, bool maskupdate, const char *base_path, const char *title_id);
+void pre_compile_program(GLState &renderer, const char *base_path, const char *title_id, const ShadersHash &hashs);
 
 // Shaders.
-std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const std::vector<SceGxmVertexAttribute> *hint_attributes, bool maskupdate, const char *base_path, const char *title_id);
+bool get_shaders_cache_hashs(GLState &renderer, const char *base_path, const char *title_id);
+std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const std::vector<SceGxmVertexAttribute> *hint_attributes, bool maskupdate, const char *base_path, const char *title_id, const std::string &shader_version);
 std::vector<std::uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, const std::vector<SceGxmVertexAttribute> *hint_attributes, bool maskupdate, const char *base_path, const char *title_id);
+std::string pre_load_glsl_shader(const char *hash_text, const char *shader_type_str, const char *base_path, const char *title_id);
 
 // Uniforms.
 bool set_uniform_buffer(GLContext &context, MemState &mem, const bool vertex_shader, const int block_num, const int size, const void *data, bool log_active_shader);

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -36,6 +36,9 @@ struct GLState : public renderer::State {
     ShaderCache fragment_shader_cache;
     ShaderCache vertex_shader_cache;
     ProgramCache program_cache;
+
+    std::vector<ShadersHash> shaders_cache_hashs;
+    std::string shader_version = "v1";
 };
 
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -40,6 +40,7 @@ struct State {
     int last_scene_id = 0;
 
     uint32_t shaders_count_compiled;
+    uint32_t programs_count_pre_compiled;
 
     std::uint32_t scene_processed_since_last_frame = 0;
     std::uint32_t average_scene_per_frame = 1;

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -148,6 +148,11 @@ struct FragmentProgram : ShaderProgram {
 struct VertexProgram : ShaderProgram {
 };
 
+struct ShadersHash {
+    std::string frag;
+    std::string vert;
+};
+
 struct RenderTarget {
     int holder;
     virtual ~RenderTarget() = default;

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -85,8 +85,7 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
     // If it's different, we need to switch. Else just stick to it.
     if (context.record.vertex_program.get(mem)->renderer_data->hash != context.last_draw_vertex_program_hash || context.record.fragment_program.get(mem)->renderer_data->hash != context.last_draw_fragment_program_hash) {
         // Need to recompile!
-        SharedGLObject program = gl::compile_program(renderer.program_cache, renderer.vertex_shader_cache,
-            renderer.fragment_shader_cache, context.record, features, mem, config.spirv_shader, gxm_fragment_program.is_maskupdate, base_path, title_id, renderer.shaders_count_compiled);
+        SharedGLObject program = gl::compile_program(renderer, context.record, features, mem, config.spirv_shader, gxm_fragment_program.is_maskupdate, base_path, title_id);
 
         if (!program) {
             LOG_ERROR("Fail to get program!");


### PR DESCRIPTION
# About: 
- implement pre-compile shaders and program in boot game.
- Add progress bar during pre compile shader.
- remove useless shaderlog in io and app context
- move shader path in good path

# Result:
- Draw pre compile shaders progress bar
![image](https://user-images.githubusercontent.com/5261759/147211840-78ff3cb2-3c22-4b47-8948-bd5a2f178fdd.png)

video demonstration
https://www.youtube.com/watch?v=bYAXP3wmZq4