### PR TITLE
renderer: Fix PVRTII decompression

### DIFF
--- a/vita3k/renderer/src/pvrt-dec.cpp
+++ b/vita3k/renderer/src/pvrt-dec.cpp
@@ -514,9 +514,45 @@ static void pvrtcBuildPalette(Pixel128S &colorAP, Pixel128S &colorBP, Pixel128S 
 
 static void pvrtcGetDecompressedPixels(const PVRTCWord &P, const PVRTCWord &Q, const PVRTCWord &R, const PVRTCWord &S, Pixel32 *pColorData, uint32_t ui8Bpp, uint32_t uiII) {
     // 4bpp only needs 8*8 values, but 2bpp needs 16*8, so rather than wasting processor time we just statically allocate 16*8.
-    int32_t i32ModulationValues[16][8];
+    int32_t i32ModulationValues[16][8] = {
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 }
+    };
+
     // Only 2bpp needs this.
-    int32_t i32ModulationModes[16][8];
+    int32_t i32ModulationModes[16][8] = {
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 },
+        { 0, 0, 0, 0, 0, 0, 0, 0 }
+    };
+
     // 4bpp only needs 16 values, but 2bpp needs 32, so rather than wasting processor time we just statically allocate 32.
     Pixel128S upscaledColorA[32];
     Pixel128S upscaledColorB[32];

--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -131,6 +131,14 @@ void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_t
         }
     }
 
+// Fix memory access error in the condition check for texture cache method
+// (hashed vs hashless) in Clang compilers due to compiler optimizations
+#ifdef __clang__
+    if (!info->use_hash) {
+        std::cout << "";
+    }
+#endif
+
     cache.select_callback(index, &gxm_texture);
 
     if (configure) {


### PR DESCRIPTION
This PR fixes PVRTII texture decompression issue caused by uninitialized memory in the modulation parameter arrays.

It also includes a fix for a Clang-specific issue uncovered by the PVRTII decompression fix and caused due to compiler optimizations that makes texture caching fail. The issue is likely caused by some optimizations done by Clang conflicting with the way pointers are implemented in the texture caching system, so the whole cache system should be revised at some point to detect more possible points of failure related to memory protection but for now this should do the job.