### PR TITLE
shaders: split shaders cache to shaderlog.

### DIFF
--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -212,6 +212,9 @@ void delete_app(GuiState &gui, HostState &host, const std::string &app_path) {
         const auto SHADER_CACHE_PATH{ BASE_PATH / "cache/shaders" / title_id };
         if (fs::exists(SHADER_CACHE_PATH))
             fs::remove_all(SHADER_CACHE_PATH);
+        const auto SHADER_LOG_PATH{ BASE_PATH / "shaderlog" / title_id };
+        if (fs::exists(SHADER_LOG_PATH))
+            fs::remove_all(SHADER_LOG_PATH);
 
         if (gui.app_selector.user_apps_icon.find(app_path) != gui.app_selector.user_apps_icon.end()) {
             gui.app_selector.user_apps_icon[app_path] = {};
@@ -259,6 +262,7 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
     const auto LICENSE_PATH{ fs::path(host.pref_path) / "ux0/license" / title_id };
     const auto SAVE_DATA_PATH{ fs::path(host.pref_path) / "ux0/user" / host.io.user_id / "savedata" / APP_INDEX->savedata };
     const auto SHADER_CACHE_PATH{ fs::path(host.base_path) / "cache/shaders" / title_id };
+    const auto SHADER_LOG_PATH{ fs::path(host.base_path) / "shaderlog" / title_id };
 
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto RES_SCALE = ImVec2(display_size.x / host.res_width_dpi_scale, display_size.y / host.res_height_dpi_scale);
@@ -318,6 +322,8 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
                     open_path(SAVE_DATA_PATH.string());
                 if (fs::exists(SHADER_CACHE_PATH) && ImGui::MenuItem("Shader Cache"))
                     open_path(SHADER_CACHE_PATH.string());
+                if (fs::exists(SHADER_LOG_PATH) && ImGui::MenuItem("Shader Log"))
+                    open_path(SHADER_LOG_PATH.string());
                 ImGui::EndMenu();
             }
             if (!host.cfg.show_live_area_screen && ImGui::MenuItem("Live Area", nullptr, &gui.live_area.live_area_screen))
@@ -333,6 +339,8 @@ void draw_app_context_menu(GuiState &gui, HostState &host, const std::string &ap
                     context_dialog = "save";
                 if (fs::exists(SHADER_CACHE_PATH) && ImGui::MenuItem("Shader Cache"))
                     fs::remove_all(SHADER_CACHE_PATH);
+                if (fs::exists(SHADER_LOG_PATH) && ImGui::MenuItem("Shader Log"))
+                    fs::remove_all(SHADER_LOG_PATH);
                 ImGui::EndMenu();
             }
             if (fs::exists(APP_PATH / "sce_sys/changeinfo/") && ImGui::MenuItem(is_lang ? lang["update_history"].c_str() : "Update History")) {

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -121,6 +121,8 @@ bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path, boo
     if (!fs::exists(uma0_data))
         fs::create_directory(uma0_data);
 
+    fs::create_directories(base_path / "cache/shaders");
+    fs::create_directory(base_path / "shaderlog");
     fs::create_directory(base_path / "texturelog");
 
     io.redirect_stdio = redirect_stdio;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -248,6 +248,10 @@ int main(int argc, char *argv[]) {
                 ImVec2(0.f, 0.f), ImGui::GetIO().DisplaySize);
     };
 
+    Ptr<const void> entry_point;
+    if (const auto err = load_app(entry_point, host, string_utils::utf_to_wide(host.io.app_path)) != Success)
+        return err;
+
     // Pre-Compile Shader only for glsl, spriv is broken
     if (!host.cfg.spirv_shader) {
         auto &glstate = static_cast<renderer::gl::GLState &>(*host.renderer);
@@ -272,9 +276,6 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    Ptr<const void> entry_point;
-    if (const auto err = load_app(entry_point, host, string_utils::utf_to_wide(host.io.app_path)) != Success)
-        return err;
     if (const auto err = run_app(host, entry_point) != Success)
         return err;
 


### PR DESCRIPTION
# About:
- isolate inside shaders cache only shaders file  generated, without gxp/dsm file