### PR TITLE
vita3k: Fix xdg-open hanging the emu on some linux systems

### DIFF
--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -241,6 +241,8 @@ void open_path(const std::string &path) {
     static const char OS_PREFIX[] = "open ";
 #else
     static const char OS_PREFIX[] = "xdg-open ";
+    system((OS_PREFIX + ("\"" + path + "\" & disown")).c_str());
+    return;
 #endif
 
     system((OS_PREFIX + ("\"" + path + "\"")).c_str());


### PR DESCRIPTION
Some linux systems, when vita3k opens the browser through the Download Firmware button it hangs the emulator until the browser closes, this is due to xdg-open waiting for the process to finish, although the reason of why it only happens on some systems its unknown, it doesn't bring any downside of transferring the browser to a unattached background job.