### PR TITLE
modules/SceCommonDialog: fix savedata dialog when emptyparam is null.

### DIFF
--- a/vita3k/dialog/include/dialog/types.h
+++ b/vita3k/dialog/include/dialog/types.h
@@ -363,10 +363,6 @@ struct SceSaveDataDialogFinishParam {
     SceChar8 reserved[36];
 };
 
-struct SceAppUtilMountPoint {
-    int8_t data[16];
-};
-
 struct SceSaveDataDialogProgressBarParam {
     SceSaveDataDialogProgressBarType barType;
     SceSaveDataDialogSystemMessageParam sysMsgParam;

--- a/vita3k/host/include/host/app_util.h
+++ b/vita3k/host/include/host/app_util.h
@@ -28,6 +28,7 @@ typedef unsigned int SceAppUtilAppParamId;
 typedef unsigned int SceAppUtilBgdlStatusType;
 
 #define SCE_APPUTIL_APPPARAM_ID_SKU_FLAG 0
+#define SCE_APPUTIL_MOUNTPOINT_DATA_MAXSIZE 16
 #define SCE_APPUTIL_NP_DRM_ADDCONT_ID_SIZE 17
 #define SCE_SYSTEM_PARAM_USERNAME_MAXSIZE 17
 
@@ -85,8 +86,8 @@ struct SceAppUtilSaveDataRemoveItem {
     uint8_t reserved[36];
 };
 
-struct SceAppUtilSaveDataMountPoint {
-    uint8_t data[16];
+struct SceAppUtilMountPoint {
+    SceChar8 data[SCE_APPUTIL_MOUNTPOINT_DATA_MAXSIZE];
 };
 
 enum SceSystemParamId {

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -183,7 +183,7 @@ std::string construct_slotparam_path(const unsigned int data) {
     return construct_savedata0_path("SlotParam_" + std::to_string(data), "bin");
 }
 
-EXPORT(int, sceAppUtilSaveDataDataRemove, SceAppUtilSaveDataFileSlot *slot, SceAppUtilSaveDataRemoveItem *files, unsigned int fileNum, SceAppUtilSaveDataMountPoint *mountPoint) {
+EXPORT(int, sceAppUtilSaveDataDataRemove, SceAppUtilSaveDataFileSlot *slot, SceAppUtilSaveDataRemoveItem *files, unsigned int fileNum, SceAppUtilMountPoint *mountPoint) {
     for (unsigned int i = 0; i < fileNum; i++) {
         remove_file(host.io, construct_savedata0_path(files[i].dataPath.get(host.mem)).c_str(), host.pref_path, export_name);
     }
@@ -194,7 +194,7 @@ EXPORT(int, sceAppUtilSaveDataDataRemove, SceAppUtilSaveDataFileSlot *slot, SceA
     return 0;
 }
 
-EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceAppUtilSaveDataDataSaveItem *files, unsigned int fileNum, SceAppUtilSaveDataMountPoint *mountPoint, SceSize *requiredSizeKB) {
+EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceAppUtilSaveDataDataSaveItem *files, unsigned int fileNum, SceAppUtilMountPoint *mountPoint, SceSize *requiredSizeKB) {
     SceUID fd;
 
     for (unsigned int i = 0; i < fileNum; i++) {
@@ -255,19 +255,19 @@ EXPORT(int, sceAppUtilSaveDataMount) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceAppUtilSaveDataSlotCreate, unsigned int slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilSaveDataMountPoint *mountPoint) {
+EXPORT(int, sceAppUtilSaveDataSlotCreate, unsigned int slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilMountPoint *mountPoint) {
     const auto fd = open_file(host.io, construct_slotparam_path(slotId).c_str(), SCE_O_WRONLY | SCE_O_CREAT, host.pref_path, export_name);
     write_file(fd, param, sizeof(SceAppUtilSaveDataSlotParam), host.io, export_name);
     close_file(host.io, fd, export_name);
     return 0;
 }
 
-EXPORT(int, sceAppUtilSaveDataSlotDelete, unsigned int slotId, SceAppUtilSaveDataMountPoint *mountPoint) {
+EXPORT(int, sceAppUtilSaveDataSlotDelete, unsigned int slotId, SceAppUtilMountPoint *mountPoint) {
     remove_file(host.io, construct_slotparam_path(slotId).c_str(), host.pref_path, export_name);
     return 0;
 }
 
-EXPORT(int, sceAppUtilSaveDataSlotGetParam, unsigned int slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilSaveDataMountPoint *mountPoint) {
+EXPORT(int, sceAppUtilSaveDataSlotGetParam, unsigned int slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilMountPoint *mountPoint) {
     const auto fd = open_file(host.io, construct_slotparam_path(slotId).c_str(), SCE_O_RDONLY, host.pref_path, export_name);
     if (fd < 0)
         return RET_ERROR(SCE_APPUTIL_ERROR_SAVEDATA_SLOT_NOT_FOUND);
@@ -281,7 +281,7 @@ EXPORT(int, sceAppUtilSaveDataSlotSearch) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceAppUtilSaveDataSlotSetParam, unsigned int slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilSaveDataMountPoint *mountPoint) {
+EXPORT(int, sceAppUtilSaveDataSlotSetParam, unsigned int slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilMountPoint *mountPoint) {
     const auto fd = open_file(host.io, construct_slotparam_path(slotId).c_str(), SCE_O_WRONLY | SCE_O_CREAT, host.pref_path, export_name);
     if (fd < 0)
         return RET_ERROR(SCE_APPUTIL_ERROR_SAVEDATA_SLOT_NOT_FOUND);

--- a/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
+++ b/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
@@ -31,7 +31,7 @@ struct SceAppMgrSaveDataDataDelete {
     uint8_t reserved[32];
     Ptr<SceAppUtilSaveDataDataSaveItem> files;
     int fileNum;
-    SceAppUtilSaveDataMountPoint *mountPoint;
+    SceAppUtilMountPoint *mountPoint;
 };
 
 struct SceAppMgrSaveDataData {
@@ -41,7 +41,7 @@ struct SceAppMgrSaveDataData {
     uint8_t reserved[32];
     Ptr<SceAppUtilSaveDataDataSaveItem> files;
     int fileNum;
-    SceAppUtilSaveDataMountPoint *mountPoint;
+    SceAppUtilMountPoint *mountPoint;
     unsigned int *requiredSizeKB;
 };
 


### PR DESCRIPTION
# About:
i split other pr for set other things no reélate app util function.
- modules/SceCommonDialog: fix savedata dialog when emptyparam is null.
- refactor check_empty_param for no have double code.
- app util: clean double value.
- modules/(SceAppUtil/SceAppMgrUser): set good value name.