### PR TITLE
Fixes for the crash issue when the time is uninitialized

### DIFF
--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -581,7 +581,7 @@ void draw_app_selector(GuiState &gui, HostState &host) {
                     ImGui::NextColumn();
                     ImGui::Selectable(app.category.c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, icon_size));
                     ImGui::NextColumn();
-                    if (app.last_time) {
+                    if (app.last_time > 0) {
                         tm date_tm = {};
                         SAFE_LOCALTIME(&app.last_time, &date_tm);
                         auto LAST_TIME = get_date_time(gui, host, date_tm);

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -435,6 +435,7 @@ void init_home(GuiState &gui, HostState &host) {
     }
 
     get_time_apps(gui, host);
+    init_last_time_apps(gui, host);
 
     if (!gui.users.empty() && (gui.users.find(host.cfg.user_id) != gui.users.end()) && (is_cmd || host.cfg.auto_user_login)) {
         init_user(gui, host, host.cfg.user_id);

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -376,6 +376,7 @@ static bool get_user_apps(GuiState &gui, HostState &host) {
             app.title = read();
             app.title_id = read();
             app.path = read();
+            app.last_time = 0;
 
             gui.app_selector.user_apps.push_back(app);
         }

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -182,7 +182,6 @@ void init_user(GuiState &gui, HostState &host, const std::string &user_id) {
     }
     init_theme(gui, host, gui.users[user_id].theme_id);
     init_notice_info(gui, host);
-    init_last_time_apps(gui, host);
 }
 
 void open_user(GuiState &gui, HostState &host) {


### PR DESCRIPTION
I don't know if this is the best way to resolve the problem because as @Zangetsu38 mentioned, the GUI is very complicated but this at least mitigates the crashing.