### PR TITLE
gui/perf overlay: Add position select and refactor.

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -28,8 +28,18 @@ enum ModulesMode {
 
 enum PerfomanceOverleyDetail {
     MINIMUM,
+    LOW,
     MEDIUM,
     MAXIMUM,
+};
+
+enum PerfomanceOverleyPosition {
+    TOP_LEFT,
+    TOP_CENTER,
+    TOP_RIGHT,
+    BOTTOM_LEFT,
+    BOTTOM_CENTER,
+    BOTTOM_RIGHT,
 };
 
 // clang-format off
@@ -67,6 +77,7 @@ enum PerfomanceOverleyDetail {
     code(bool, "color-surface-debug", false, color_surface_debug)                                       \
     code(bool, "performance-overlay", false, performance_overlay)                                       \
     code(int, "perfomance-overlay-detail", static_cast<int>(MINIMUM), performance_overlay_detail)       \
+    code(int, "perfomance-overlay-position", static_cast<int>(TOP_LEFT), performance_overlay_position)  \
     code(std::string, "backend-renderer", "OpenGL", backend_renderer)                                   \
     code(int, "keyboard-button-select", 229, keyboard_button_select)                                    \
     code(int, "keyboard-button-start", 40, keyboard_button_start)                                       \

--- a/vita3k/gui/src/manual.cpp
+++ b/vita3k/gui/src/manual.cpp
@@ -88,8 +88,8 @@ static auto hidden_button = false;
 
 void draw_manual(GuiState &gui, HostState &host) {
     const auto display_size = ImGui::GetIO().DisplaySize;
-    const auto RES_SCALE = ImVec2(display_size.x / host.res_width_dpi_scale, display_size.y / host.dpi_scale);
-    const auto SCALE = ImVec2(RES_SCALE.x * host.dpi_scale, RES_SCALE.x * host.dpi_scale);
+    const auto RES_SCALE = ImVec2(display_size.x / host.res_width_dpi_scale, display_size.y / host.res_height_dpi_scale);
+    const auto SCALE = ImVec2(RES_SCALE.x * host.dpi_scale, RES_SCALE.y * host.dpi_scale);
     ImGui::SetNextWindowPos(ImVec2(-5.f, -1.f), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x + 10.f, display_size.y + 2.f), ImGuiCond_Always);
     ImGui::SetNextWindowBgAlpha(0.999f);

--- a/vita3k/gui/src/perf_overlay.cpp
+++ b/vita3k/gui/src/perf_overlay.cpp
@@ -17,36 +17,71 @@
 
 #include "private.h"
 
-#include <host/state.h>
-
-#include <kernel/thread/thread_state.h>
-
 namespace gui {
-static const ImVec2 PERF_OVERLAY_POS = ImVec2(10.0f, 10.0f);
-static const ImVec4 PERF_OVERLAY_BG_COLOR = ImVec4(0.282f, 0.239f, 0.545f, 1.0f);
+static const ImVec2 PERF_OVERLAY_PAD = ImVec2(12.f, 12.f);
+static const ImVec4 PERF_OVERLAY_BG_COLOR = ImVec4(0.282f, 0.239f, 0.545f, 0.8f);
+
+static ImVec2 get_perf_pos(ImVec2 window_size, HostState &host) {
+    const auto TOP = host.viewport_pos.y - PERF_OVERLAY_PAD.y;
+    const auto LEFT = host.viewport_pos.x - PERF_OVERLAY_PAD.x;
+    const auto CENTER = host.viewport_pos.x + (host.viewport_size.x / 2.f) - (window_size.x / 2.f);
+    const auto RIGHT = host.viewport_pos.x + host.viewport_size.x - window_size.x + PERF_OVERLAY_PAD.x;
+    const auto BOTTOM = host.viewport_pos.y + host.viewport_size.y - window_size.y + PERF_OVERLAY_PAD.y;
+
+    switch (host.cfg.performance_overlay_position) {
+    case TOP_CENTER: return ImVec2(CENTER, TOP);
+    case TOP_RIGHT: return ImVec2(RIGHT, TOP);
+    case BOTTOM_LEFT: return ImVec2(LEFT, BOTTOM);
+    case BOTTOM_CENTER: return ImVec2(CENTER, BOTTOM);
+    case BOTTOM_RIGHT: return ImVec2(RIGHT, BOTTOM);
+    case TOP_LEFT:
+    default: break;
+    }
+
+    return ImVec2(LEFT, TOP);
+}
+
+static float get_perf_height(HostState &host) {
+    switch (host.cfg.performance_overlay_detail) {
+    case MAXIMUM: return 138.f;
+    case MEDIUM: return 80.f;
+    case LOW:
+    case MINIMUM:
+    default: break;
+    }
+
+    return 57.f;
+}
 
 void draw_perf_overlay(GuiState &gui, HostState &host) {
-    ImGui::SetNextWindowPos(ImVec2(PERF_OVERLAY_POS.x + host.viewport_pos.x, PERF_OVERLAY_POS.y));
-    ImGui::SetNextWindowBgAlpha(0.8f);
-    ImGui::PushStyleColor(ImGuiCol_WindowBg, PERF_OVERLAY_BG_COLOR);
-    ImGui::Begin("##performance", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::Text("FPS: %d", host.fps);
+    const auto MAIN_WINDOW_SIZE = ImVec2((host.cfg.performance_overlay_detail == MINIMUM ? 95.5f : 152.f) * host.dpi_scale, get_perf_height(host) * host.dpi_scale);
+    const auto WINDOW_POS = get_perf_pos(MAIN_WINDOW_SIZE, host);
+    const auto WINDOW_SIZE = ImVec2((host.cfg.performance_overlay_detail == MINIMUM ? 72.5f : 130.f) * host.dpi_scale, (host.cfg.performance_overlay_detail <= LOW ? 35.f : 58.f) * host.dpi_scale);
+
+    ImGui::SetNextWindowSize(MAIN_WINDOW_SIZE);
+    ImGui::SetNextWindowPos(WINDOW_POS);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
+    ImGui::Begin("##performance", nullptr, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, PERF_OVERLAY_BG_COLOR);
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 5.f * host.dpi_scale);
+    ImGui::BeginChild("#perf_stats", WINDOW_SIZE, true, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    if (host.cfg.performance_overlay_detail == PerfomanceOverleyDetail::MINIMUM)
+        ImGui::Text("FPS: %d", host.fps);
+    else
+        ImGui::Text("FPS: %d Avg: %d", host.fps, host.avg_fps);
     if (host.cfg.performance_overlay_detail >= PerfomanceOverleyDetail::MEDIUM) {
         ImGui::Separator();
-        ImGui::Text("Avg: %d\nMin: %d Max: %d", host.avg_fps, host.min_fps, host.max_fps);
+        ImGui::Text("Min: %d Max: %d", host.min_fps, host.max_fps);
+    }
+    ImGui::EndChild();
+    ImGui::PopStyleVar();
+    ImGui::PopStyleColor();
+    if (host.cfg.performance_overlay_detail == PerfomanceOverleyDetail::MAXIMUM) {
+        ImGui::SetCursorPosY(ImGui::GetCursorPosY() - (5.f * host.dpi_scale));
+        ImGui::PlotLines("##fps_graphic", host.fps_values, IM_ARRAYSIZE(host.fps_values), host.current_fps_offset, nullptr, 0.f, float(host.max_fps), WINDOW_SIZE);
     }
     ImGui::End();
-    ImGui::PopStyleColor();
-
-    if (host.cfg.performance_overlay_detail == PerfomanceOverleyDetail::MAXIMUM) {
-        ImGui::SetNextWindowPos(ImVec2(PERF_OVERLAY_POS.x + host.viewport_pos.x - (11.f * host.dpi_scale), PERF_OVERLAY_POS.y + (60.f * host.dpi_scale)));
-        ImGui::SetNextWindowBgAlpha(0.f);
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
-        ImGui::Begin("##fps_graphic", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
-        ImGui::PlotLines("##fps_graphic", host.fps_values, IM_ARRAYSIZE(host.fps_values), host.current_fps_offset, nullptr, 0.f, float(host.max_fps), ImVec2(160.f * host.dpi_scale, 60.f * host.dpi_scale));
-        ImGui::End();
-        ImGui::PopStyleVar();
-    }
+    ImGui::PopStyleVar();
 }
 
 } // namespace gui

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -446,9 +446,12 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Display performance information on the screen as an overlay.");
         if (host.cfg.performance_overlay) {
-            ImGui::Combo("Detail Level", &host.cfg.performance_overlay_detail, "Minimum\0Medium\0Maximum\0");
+            ImGui::Combo("Detail", &host.cfg.performance_overlay_detail, "Minimum\0Low\0Medium\0Maximum\0");
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("Select your preferred perfomance overley detail.");
+            ImGui::Combo("Position", &host.cfg.performance_overlay_position, "Top Left\0Top Center\0Top Right\0Botttom Left\0Botttom Center\0Botttom Right\0");
+            if (ImGui::IsItemHovered())
+                ImGui::SetTooltip("Select your preferred perfomance overley position.");
         }
         ImGui::Spacing();
 #ifndef WIN32


### PR DESCRIPTION
# About:
- Add position choice of performance overlay
- add low detail for separe fps alone and fps + avg
- code refactor

# Result:
![image](https://user-images.githubusercontent.com/5261759/149633243-3332babc-4f43-47ed-8ab5-019b51ee5ef1.png)
![image](https://user-images.githubusercontent.com/5261759/149633250-863750c8-22ba-432d-b4c2-e854562e6367.png)
![image](https://user-images.githubusercontent.com/5261759/150330105-c058e56c-7000-4ab5-8140-18e5e5eabd69.png)
![image](https://user-images.githubusercontent.com/5261759/149633287-3542583c-ac54-4ecf-804f-3ca25cc19270.png)

