### PR TITLE
shader/translator: optimisation. implement operation [any OR 0] as assign

### DIFF
--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -393,7 +393,11 @@ spv::Id USSETranslatorVisitor::do_alu_op(Instruction &inst, const Imm4 source_ma
     }
 
     case Opcode::OR: {
-        result = m_b.createBinOp(spv::OpBitwiseOr, source_type, vsrc1, vsrc2);
+        if (m_b.getOpCode(vsrc2) == spv::Op::OpConstant && m_b.getConstantScalar(vsrc2) == 0) {
+            result = vsrc1;
+        } else {
+            result = m_b.createBinOp(spv::OpBitwiseOr, source_type, vsrc1, vsrc2);
+        }
         break;
     }
 


### PR DESCRIPTION
An optimization of shader recompiler. If second operand of OR operation is constant zero, then implement this OR operation as assignment operation.
Usually this also mean no conversion of float to uint and back to float. Code duplication is needed to avoid this unneeded conversion.

It's a small optimisation, but I hope it's just a first step.