### PR TITLE
gui/app_context_menu: Add week and days in  time used.

### DIFF
--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -117,6 +117,7 @@ struct AppsSelector {
 
 struct LiveAreaState {
     bool app_close = false;
+    bool app_information = false;
     bool app_selector = false;
     bool content_manager = false;
     bool information_bar = false;

--- a/vita3k/gui/src/app_selector.cpp
+++ b/vita3k/gui/src/app_selector.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -352,7 +352,9 @@ void draw_app_selector(GuiState &gui, HostState &host) {
     if (!host.display.imgui_render || ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows))
         gui.live_area.information_bar = true;
 
-    if (!gui.file_menu.archive_install_dialog && !gui.file_menu.firmware_install_dialog && !gui.file_menu.pkg_install_dialog && !gui.configuration_menu.custom_settings_dialog && !gui.configuration_menu.settings_dialog && !gui.controls_menu.controls_dialog) {
+    const auto config_dialog = gui.configuration_menu.custom_settings_dialog || gui.configuration_menu.settings_dialog || gui.controls_menu.controls_dialog;
+    const auto install_dialog = gui.file_menu.archive_install_dialog || gui.file_menu.firmware_install_dialog || gui.file_menu.pkg_install_dialog;
+    if (!config_dialog && !install_dialog && !gui.live_area.app_close && !gui.live_area.app_information) {
         if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) || ImGui::IsAnyItemActive() || ImGui::IsAnyItemHovered())
             last_time["start"] = 0;
         else {


### PR DESCRIPTION
# About:
small gui stuff add, after i have played more 24h on one game, see 25h is ugly, so i have thinks add days, and after add in same time week, exemple
- fix one things for no can shows start screen when app info is open

# 
- time player > 1 days 
![image](https://user-images.githubusercontent.com/5261759/150724151-946c731f-b5aa-478d-bbb1-106d8b563a7e.png)

- fake time for time played more 1 weeks (for testing code)
![image](https://user-images.githubusercontent.com/5261759/150665268-873b4234-3b9e-4a2e-b4f9-918efd04f36b.png)
