### PR TITLE
gui: Fix ImGui assertion on initial setup

### DIFF
--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -109,7 +109,7 @@ void draw_initial_setup(GuiState &gui, HostState &host) {
             ImGui::PopID();
         }
         ImGui::PopStyleVar();
-        ImGui::PopStyleColor();
+        ImGui::PopStyleColor(3);
         ImGui::Columns(1);
         ImGui::EndChild();
         ImGui::PopStyleVar();


### PR DESCRIPTION
Fix assertion on initial setup menu due to to 3 different style colors being pushed using `ImGui::PushStyleColor()` but only one being popped using `ImGui::PopStyleColor().

Debugger message due to assertion:
```log
Vita3K: /home/field/Development/Vita3K/external/imgui/imgui.cpp:7444: void ImGuiStackSizes::CompareWithCurrentState(): Assertion `SizeOfColorStack >= g.ColorStack.Size && "PushStyleColor/PopStyleColor Mismatch!"' failed.
```