### PR TITLE
modules/SceGxm: fix handle precomputation when state is null.

### DIFF
--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -311,11 +311,6 @@ void sync_depth_bias(const int factor, const int unit, const bool is_front) {
 
 void sync_texture(GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture,
     const Config &config, const std::string &base_path, const std::string &title_id) {
-    if (texture.data_addr == 0) {
-        LOG_WARN("Texture has null data.");
-        return;
-    }
-
     Address data_addr = texture.data_addr << 2;
 
     const size_t texture_size = renderer::texture::texture_size(texture);

--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -259,6 +259,11 @@ void upload_bound_texture(const SceGxmTexture &gxm_texture, const MemState &mem)
     auto height = static_cast<uint32_t>(gxm::get_height(&gxm_texture));
     const Ptr<uint8_t> data(gxm_texture.data_addr << 2);
     uint8_t *texture_data = data.get(mem);
+
+    if (!texture_data) {
+        return;
+    }
+
     std::vector<uint8_t> texture_data_decompressed;
     std::vector<uint8_t> texture_pixels_lineared; // TODO Move to context to avoid frequent allocation?
     std::vector<uint32_t> palette_texture_pixels;

--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -51,7 +51,11 @@ TextureCacheHash hash_texture_data(const SceGxmTexture &texture, const MemState 
     const SceGxmTextureBaseFormat base_format = gxm::get_base_format(format);
     const size_t size = texture_size(texture);
     const Ptr<const void> data(texture.data_addr << 2);
-    const TextureCacheHash data_hash = hash_data(data.get(mem), size);
+    TextureCacheHash data_hash = 0;
+
+    if (data.address()) {
+        data_hash = hash_data(data.get(mem), size);
+    }
 
     switch (base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_P4:
@@ -129,6 +133,10 @@ void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_t
         } else {
             upload = info->dirty;
         }
+    }
+
+    if (gxm_texture.data_addr == 0) {
+        upload = false;
     }
 
 // Fix memory access error in the condition check for texture cache method


### PR DESCRIPTION
# About: 
fix precompute draw when state is null.

# Result:
- fix missing render
![image](https://user-images.githubusercontent.com/5261759/159272338-3ea867ba-127c-4fa3-a3dd-e78e6b0698f7.png)
![image](https://cdn.discordapp.com/attachments/534180053865725962/955452903538163762/unknown.png)
![image](https://user-images.githubusercontent.com/5261759/159270604-552c8ee8-94a8-4ff6-a173-10f19441b531.png)
![image](https://user-images.githubusercontent.com/5261759/159272999-28fe9e9f-ef3d-4d84-a2e4-4dc3fe53a162.png)
![image](https://cdn.discordapp.com/attachments/418026683015233546/955459014139981914/unknown.png)
![image](https://user-images.githubusercontent.com/5261759/159270358-4ddba0d3-82e7-4a7b-898e-f2544cdfbdf7.png)
![image](https://cdn.discordapp.com/attachments/534180053865725962/955455185524772874/unknown.png)
![image](https://user-images.githubusercontent.com/5261759/159281473-7073fb9a-099a-48e6-bcae-e84783c08551.png)
![image](https://user-images.githubusercontent.com/5261759/159281572-6430f641-a422-4b53-bd3b-d8d8b5113a02.png)
