### PR TITLE
cmake: Treat format-security warnings as errors

### DIFF
--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -59,6 +59,12 @@ endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+if(MSVC)
+	add_compile_options(/W4 /we4774)
+else()
+	add_compile_options(-Wformat -Werror=format-security)
+endif()
+
 add_subdirectory(app)
 add_subdirectory(audio)
 add_subdirectory(config)

--- a/vita3k/audio/CMakeLists.txt
+++ b/vita3k/audio/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_library(
-audio
-STATIC
-include/audio/functions.h
-include/audio/state.h
-src/audio.cpp
+    audio
+    STATIC
+    include/audio/functions.h
+    include/audio/state.h
+    src/audio.cpp
 )
 
 target_include_directories(audio PUBLIC include)

--- a/vita3k/codec/CMakeLists.txt
+++ b/vita3k/codec/CMakeLists.txt
@@ -1,6 +1,7 @@
-add_library(codec STATIC
+add_library(
+    codec
+    STATIC
     include/codec/state.h
-
     src/atrac9.cpp
     src/decoder.cpp
     src/aac.cpp
@@ -8,7 +9,8 @@ add_library(codec STATIC
     src/mjpeg.cpp
     src/mp3.cpp
     src/pcm.cpp
-    src/player.cpp)
+    src/player.cpp
+)
 
 target_include_directories(codec PUBLIC include)
 target_link_libraries(codec PRIVATE ffmpeg libatrac9 util) 

--- a/vita3k/dialog/CMakeLists.txt
+++ b/vita3k/dialog/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(
-dialog
-INTERFACE
+    dialog
+    INTERFACE
 )
 
 target_include_directories(dialog INTERFACE include)

--- a/vita3k/display/CMakeLists.txt
+++ b/vita3k/display/CMakeLists.txt
@@ -3,7 +3,6 @@ add_library(
 	STATIC
 	include/display/state.h
 	include/display/functions.h
-
 	src/display.cpp
 )
 

--- a/vita3k/gdbstub/CMakeLists.txt
+++ b/vita3k/gdbstub/CMakeLists.txt
@@ -1,9 +1,10 @@
 add_library(
-gdbstub
-STATIC
-include/gdbstub/functions.h
-include/gdbstub/state.h
-src/gdb.cpp)
+    gdbstub
+    STATIC
+    include/gdbstub/functions.h
+    include/gdbstub/state.h
+    src/gdb.cpp
+)
 
 target_include_directories(gdbstub PUBLIC include)
 target_link_libraries(gdbstub PUBLIC cpu host)

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -24,7 +24,12 @@
 #include <np/state.h>
 
 #include <imgui.h>
+// Disable warninig here is needed to compile on windows because we
+// are turning some warnings into errors to allow makepkg default flags
+#pragma warning(push)
+#pragma warning(disable : 4774)
 #include <imgui_memory_editor.h>
+#pragma warning(pop)
 
 #include <gui/imgui_impl_sdl_state.h>
 

--- a/vita3k/gui/src/allocations_dialog.cpp
+++ b/vita3k/gui/src/allocations_dialog.cpp
@@ -19,7 +19,13 @@
 
 #include <cpu/functions.h>
 
+// Disable warninig here is needed to compile on windows because we
+// are turning some warnings into errors to allow makepkg default flags
+#pragma warning(push)
+#pragma warning(disable : 4774)
 #include <imgui_memory_editor.h>
+#pragma warning(pop)
+
 #include <spdlog/fmt/fmt.h>
 
 namespace gui {

--- a/vita3k/ime/CMakeLists.txt
+++ b/vita3k/ime/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(
-ime
-INTERFACE
+    ime
+    INTERFACE
 )
 
 target_include_directories(ime INTERFACE include)

--- a/vita3k/modules/SceLibc/SceLibc.cpp
+++ b/vita3k/modules/SceLibc/SceLibc.cpp
@@ -1196,7 +1196,12 @@ EXPORT(int, vscanf_s) {
 }
 
 EXPORT(int, vsnprintf, char *s, size_t n, const char *format, va_list arg) {
-    return snprintf(s, n, format, "");
+    // Disable warninig here is needed to compile on windows because we
+    // are turning some warnings into errors to allow makepkg default flags
+#pragma warning(push)
+#pragma warning(disable : 4774)
+    return snprintf(s, n, format, arg);
+#pragma warning(pop)
 }
 
 EXPORT(int, vsnprintf_s) {

--- a/vita3k/net/CMakeLists.txt
+++ b/vita3k/net/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_library(
-net
-STATIC
-include/net/functions.h
-include/net/state.h
-include/net/types.h
-include/net/socket.h
-src/net.cpp
-src/posixsocket.cpp
-src/p2psocket.cpp
+    net
+    STATIC
+    include/net/functions.h
+    include/net/state.h
+    include/net/types.h
+    include/net/socket.h
+    src/net.cpp
+    src/posixsocket.cpp
+    src/p2psocket.cpp
 )
 
 target_include_directories(net PUBLIC include)

--- a/vita3k/ngs/CMakeLists.txt
+++ b/vita3k/ngs/CMakeLists.txt
@@ -32,7 +32,8 @@ add_library(
 	src/modules/passthrough.cpp
 	src/ngs.cpp
 	src/route.cpp
-	src/scheduler.cpp)
+	src/scheduler.cpp
+)
 
 target_include_directories(ngs PUBLIC include)
 target_link_libraries(ngs PUBLIC codec)

--- a/vita3k/np/CMakeLists.txt
+++ b/vita3k/np/CMakeLists.txt
@@ -6,7 +6,8 @@ add_library(np
     include/np/state.h
     src/trophy/context.cpp
     src/trophy/trp_parser.cpp
-    src/init.cpp)
+    src/init.cpp
+)
 
 target_include_directories(np PUBLIC include)
 target_link_libraries(np PUBLIC yaml-cpp mem)

--- a/vita3k/rtc/CMakeLists.txt
+++ b/vita3k/rtc/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(
-rtc
-STATIC
-include/rtc/rtc.h
-src/rtc.cpp
+    rtc
+    STATIC
+    include/rtc/rtc.h
+    src/rtc.cpp
 )
 
 target_include_directories(rtc PUBLIC include)


### PR DESCRIPTION
From now on the compiler will treat cases where the function arguments are string formatted, if the argument is not a string literal it will give an error. This is to make sure that it compiles on linux with the default makepkg flags And just makes the code more consistent