### PR TITLE
modules/SceAudiodec: Handle multiple init and term library calls with different codecs

### DIFF
--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.h
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <module/module.h>
+#include <modules/module_parent.h>
 
 enum SceAudiodecCodec : uint32_t {
     SCE_AUDIODEC_TYPE_AT9 = 0x1003,
@@ -44,9 +45,10 @@ union SceAudiodecInitParam {
     SceAudiodecInitStreamParam celp;
 };
 
-EXPORT(SceInt32, sceAudiodecInitLibrary, SceUInt32 codecType, SceAudiodecInitParam *pInitParam);
-EXPORT(SceInt32, sceAudiodecTermLibrary, SceUInt32 codecType);
+EXPORT(SceInt32, sceAudiodecInitLibrary, SceAudiodecCodec codecType, SceAudiodecInitParam *pInitParam);
+EXPORT(SceInt32, sceAudiodecTermLibrary, SceAudiodecCodec codecType);
 
+LIBRARY_INIT_DECL(SceAudiodec);
 BRIDGE_DECL(sceAudiodecClearContext)
 BRIDGE_DECL(sceAudiodecCreateDecoder)
 BRIDGE_DECL(sceAudiodecCreateDecoderExternal)

--- a/vita3k/modules/include/modules/library_init_list.inc
+++ b/vita3k/modules/include/modules/library_init_list.inc
@@ -15,5 +15,6 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+LIBRARY(SceAudiodec)
 LIBRARY(SceFiber)
 LIBRARY(SceSysmem)


### PR DESCRIPTION
Fix a crash that happens when multiple calls to sceAudiodecInitLibrary and sceAudiodecTermLibrary are done.
sceAudiodecInitLibrary is called once for each codec used. However the object AudioCodec is discarded from the object store after a call to sceAudiodecTermLibrary, even though only decoders associated with the codec terminated should be discarded.

As an example the following code is valid but crashes in Vita3K:

sceAudiodecInitLibrary(codec1)
sceAudiodecInitLibrary(codec2)
sceAudiodecTermLibrary(codec2)
Use codec1 -> crash : AudioCodec could not be found

How I fixed it is by only removing decoders associated with the codec passed as a parameter to sceAudiodecTermLibrary when it is called. 

This fix allows Tales of Hearts R to get to the startup menu (and even ingame with AT9 audio decoder disabled)