### PR TITLE
modules/SceKernelThreadMgr: Handle null workarea for _sceKernelDeleteLwMutex

### DIFF
--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -136,6 +136,9 @@ EXPORT(int, _sceKernelDeleteLwCond, Ptr<SceKernelLwCondWork> workarea) {
 }
 
 EXPORT(int, _sceKernelDeleteLwMutex, Ptr<SceKernelLwMutexWork> workarea) {
+    if (!workarea)
+        return SCE_KERNEL_ERROR_ILLEGAL_ADDR;
+
     const auto lightweight_mutex_id = workarea.get(host.mem)->uid;
 
     return mutex_delete(host.kernel, export_name, thread_id, lightweight_mutex_id, SyncWeight::Light);


### PR DESCRIPTION
After a bit of reverse engineering, it looks like _sceKernelDeleteLwMutex returns value 0x80020006 (SCE_KERNEL_ERROR_ILLEGAL_ADDR) when workarea is nullptr.

This pull request replicates this behavior in the HLE (instead of crashing).

This allows Tales of Innocence R to go ingame.