### PR TITLE
kernel: Make ThreadState resume thread safe

### DIFF
--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -367,8 +367,12 @@ void ThreadState::suspend() {
 }
 
 void ThreadState::resume(bool step) {
-    assert(to_do == ThreadToDo::wait);
-    to_do = step ? ThreadToDo::step : ThreadToDo::run;
+    assert(to_do == ThreadToDo::wait || to_do == ThreadToDo::suspend);
+
+    {
+        const auto thread_lock = std::lock_guard(mutex);
+        to_do = step ? ThreadToDo::step : ThreadToDo::run;
+    }
     something_to_do.notify_one();
 }
 


### PR DESCRIPTION
When a thread is resumed immediately after being paused, a race condition can occur between the thread transitioning to the wait state and resuming at the same time.

To prevent that, the thread mutex must be locked in the resume function, to make sure the thread is not going into the wait state at the same time.

This race condition can occur in the vblank thread. This fixes the random freeze in Tales of Innocence R.