### PR TITLE
kernel: Fix deadlocks and handle_timeout

### DIFF
--- a/vita3k/kernel/include/kernel/thread/thread_data_queue.h
+++ b/vita3k/kernel/include/kernel/thread/thread_data_queue.h
@@ -89,8 +89,7 @@ public:
     virtual ThreadDataQueueInterator<T> begin() = 0;
     virtual ThreadDataQueueInterator<T> end() = 0;
     virtual void erase(const ThreadDataQueueInterator<T> &it) = 0;
-    virtual void erase(const T &val) = 0;
-    virtual void push(const T &val) = 0;
+    virtual ThreadDataQueueInterator<T> push(const T &val) = 0;
     virtual void pop() = 0;
     virtual bool empty() = 0;
     virtual size_t size() = 0;
@@ -148,14 +147,9 @@ public:
         c.erase(base->it);
     }
 
-    void erase(const T &val) override {
-        // TODO better search algo
-        auto it = std::find(c.begin(), c.end(), val);
-        c.erase(it);
-    }
-
-    void push(const T &val) override {
+    ThreadDataQueueInterator<T> push(const T &val) override {
         c.push_back(val);
+        return make_iterator(--c.end());
     }
 
     void pop() override {
@@ -237,12 +231,9 @@ public:
         c.erase(base->it);
     }
 
-    void erase(const T &val) override {
-        c.erase(val);
-    }
-
-    void push(const T &val) override {
-        c.insert(val);
+    ThreadDataQueueInterator<T> push(const T &val) override {
+        auto it = c.insert(val);
+        return make_iterator(it);
     }
 
     void pop() override {

--- a/vita3k/kernel/src/sync_primitives.cpp
+++ b/vita3k/kernel/src/sync_primitives.cpp
@@ -795,11 +795,7 @@ SceInt32 eventflag_set(KernelState &kernel, const char *export_name, SceUID thre
                 event->flags &= ~waiting_flags;
             }
 
-            const std::unique_lock<std::mutex> waiting_thread_lock(waiting_thread->mutex, std::try_to_lock);
-            if (!waiting_thread_lock) {
-                ++it;
-                continue;
-            }
+            const std::lock_guard<std::mutex> waiting_thread_lock(waiting_thread->mutex);
 
             waiting_thread->update_status(ThreadStatus::run, ThreadStatus::wait);
 


### PR DESCRIPTION
This pull request contains fixes for the following 3 bugs in sync_primitives.cpp:

- When calling `erase` on a `PriorityThreadDataQueue`, all waiting threads with the same priority will be erased because a multiset tests equalities using `<` and not `==`. 
- All mutex locks in sync_primitives are acquired the following way: acquire the primitive (event/mutex/semaphore...) mutex first then the thread mutex second. The same must be done for handle_timeout in order to prevent deadlocks. Unlocking one mutex before locking the other kind of works but it allows race conditions to happen.
- Fix race condition in `eventflag_set`: if the thread mutex cannot be acquired immediatly, the thread will sleep forever. The thread mutex is locked to prevent this issue. There should not be any deadlock with the previous fix.

The last part fixes the random freeze in Resident Evil : Revelations 2.

This pull request also contains performance improvements for ThreadDataQueue.