### PR TITLE
kernel: Immediatly resume from wait if *timeout is 0

### DIFF
--- a/vita3k/kernel/src/sync_primitives.cpp
+++ b/vita3k/kernel/src/sync_primitives.cpp
@@ -81,8 +81,12 @@ inline int handle_timeout(const ThreadStatePtr &thread, std::unique_lock<std::mu
     std::unique_lock<std::mutex> &primitive_lock, WaitingThreadQueuePtr &queue,
     const WaitingThreadData &data, const ThreadDataQueueInterator<WaitingThreadData> &data_it,
     const char *export_name, SceUInt *const timeout) {
-    if (timeout && *timeout > 0) {
-        auto status = thread->status_cond.wait_for(primitive_lock, std::chrono::microseconds{ *timeout }, [&] { return thread->status == ThreadStatus::run; });
+    if (timeout) {
+        bool status = false;
+
+        if (*timeout > 0) {
+            status = thread->status_cond.wait_for(primitive_lock, std::chrono::microseconds{ *timeout }, [&] { return thread->status == ThreadStatus::run; });
+        }
 
         if (!status) {
             *timeout = 0; // Time run out, so remaining time is 0


### PR DESCRIPTION
When waiting for a primitive (event, semaphore, mutex, ...) with *timeout = 0, we should resume immediately the thread instead of considering it the same way as timeout = nullptr which is not the case ([https://wiki.henkaku.xyz/vita/SceKernelThreadMgr#sceKernelWaitEventFlag](https://wiki.henkaku.xyz/vita/SceKernelThreadMgr#sceKernelWaitEventFlag)).

This fixes the freeze during startup on A.W. : Phoenix Festa.