### PR TITLE
modules/SceGxm: fix array size for GxmContextState stream_data

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -344,11 +344,11 @@ static int init_texture_base(const char *export_name, SceGxmTexture *texture, Pt
 }
 
 uint16_t get_gxp_texture_count(const SceGxmProgram &program_gxp) {
-    const auto vert_paramters = gxp::program_parameters(program_gxp);
+    const auto parameters = gxp::program_parameters(program_gxp);
 
     uint16_t max_texture_index = 0;
     for (uint32_t i = 0; i < program_gxp.parameter_count; ++i) {
-        const auto parameter = vert_paramters[i];
+        const auto parameter = parameters[i];
         if (parameter.category == SCE_GXM_PARAMETER_CATEGORY_SAMPLER) {
             max_texture_index = std::max(max_texture_index, static_cast<uint16_t>(parameter.resource_index));
         }
@@ -1884,7 +1884,7 @@ EXPORT(int, sceGxmPrecomputedDrawSetVertexStream, SceGxmPrecomputedDraw *state, 
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
     }
 
-    auto stream_data = state->stream_data.get(host.mem);
+    const auto stream_data = state->stream_data.get(host.mem);
     stream_data[streamIndex] = streamData;
 
     return 0;
@@ -2152,7 +2152,7 @@ EXPORT(Ptr<SceGxmProgramParameter>, _sceGxmProgramFindParameterBySemantic, const
 }
 
 EXPORT(uint32_t, sceGxmProgramGetDefaultUniformBufferSize, const SceGxmProgram *program) {
-    return program->default_uniform_buffer_count * 4;
+    return program->default_uniform_buffer_count * sizeof(Ptr<const void>);
 }
 
 EXPORT(uint32_t, sceGxmProgramGetFragmentProgramInputs, Ptr<const SceGxmProgram> program_) {

--- a/vita3k/renderer/include/renderer/gxm_types.h
+++ b/vita3k/renderer/include/renderer/gxm_types.h
@@ -167,7 +167,7 @@ struct GxmContextState {
     uint32_t vdm_buffer_size;
 
     // Vertex streams.
-    std::array<StreamData, SCE_GXM_MAX_TEXTURE_UNITS * 2> stream_data;
+    std::array<StreamData, SCE_GXM_MAX_VERTEX_STREAMS> stream_data;
 
     // Depth.
     SceGxmDepthFunc front_depth_func = SCE_GXM_DEPTH_FUNC_LESS_EQUAL;


### PR DESCRIPTION
Fix GxmContextState's stream_data size from my previous pull request #1694. Also contains slight code readability improvements.