### PR TITLE
display: Implement proper behavior of SceDisplay functions

### DIFF
--- a/vita3k/display/include/display/functions.h
+++ b/vita3k/display/include/display/functions.h
@@ -23,4 +23,4 @@
 struct DisplayState;
 struct KernelState;
 
-void wait_vblank(DisplayState &display, KernelState &kernel, const SceUID thread_id, const int count, const bool since_last_setbuf, const bool is_cb);
+void wait_vblank(DisplayState &display, KernelState &kernel, const ThreadStatePtr &wait_thread, const int count, const bool since_last_setbuf, const bool is_cb);

--- a/vita3k/display/src/display.cpp
+++ b/vita3k/display/src/display.cpp
@@ -64,8 +64,7 @@ static void vblank_sync_thread(DisplayState &display, KernelState &kernel) {
     }
 }
 
-void wait_vblank(DisplayState &display, KernelState &kernel, const SceUID thread_id, int count, const bool since_last_setbuf, const bool is_cb) {
-    const ThreadStatePtr wait_thread = util::find(thread_id, kernel.threads);
+void wait_vblank(DisplayState &display, KernelState &kernel, const ThreadStatePtr &wait_thread, int count, const bool since_last_setbuf, const bool is_cb) {
     if (!wait_thread) {
         return;
     }

--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -98,6 +98,7 @@ struct ThreadState {
 
     int priority;
     uint64_t start_tick;
+    uint64_t last_vblank_waited;
 
     CPUStatePtr cpu;
     ThreadStatus status = ThreadStatus::dormant;

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -70,6 +70,7 @@ int ThreadState::init(KernelState &kernel, const char *name, Ptr<const void> ent
     }
     this->stack_size = stack_size;
     start_tick = rtc_get_ticks(kernel.base_tick.tick);
+    last_vblank_waited = 0;
 
     cpu = init_cpu(kernel.cpu_backend, kernel.cpu_opt, id, static_cast<std::size_t>(core_num), mem, kernel.cpu_protocol.get());
     if (!cpu) {

--- a/vita3k/modules/SceDisplay/SceDisplay.cpp
+++ b/vita3k/modules/SceDisplay/SceDisplay.cpp
@@ -115,7 +115,7 @@ EXPORT(SceInt32, sceDisplayGetRefreshRate, float *pFps) {
 }
 
 EXPORT(SceInt32, sceDisplayGetVcount) {
-    return static_cast<int>(host.display.vblank_count.load());
+    return static_cast<SceInt32>(host.display.vblank_count.load()) & 0xFFFF;
 }
 
 EXPORT(int, sceDisplayGetVcountInternal) {


### PR DESCRIPTION
- `sceDisplayGetVcount` should only return the lower 16bit value of the vcount
- `sceDisplayWait...Multi(CB)` should cause the thread to wait for a specified amount of vblank from the last time it woke up to a display_wait and not from the time this function was called
- Fix some really tight race conditions, like getting a thread from its id without acquiring a mutex or the possibility that the vblank thread can be launched more than once (happened on my computer).

The second part allows Tales of games to run at a stable 30fps.