### PR TITLE
modules/SceVideodecUser: Add support to back res value of AvcdecDecode.

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -67,8 +67,6 @@ struct DecoderState {
     virtual bool send(const uint8_t *data, uint32_t size) = 0;
     virtual bool receive(uint8_t *data, DecoderSize *size = nullptr) = 0;
     virtual void configure(void *options);
-    virtual void get_res(uint32_t &width, uint32_t &height);
-    virtual void get_pts(uint32_t &upper, uint32_t &lower);
     virtual uint32_t get_es_size(const uint8_t *data);
 
     virtual ~DecoderState();
@@ -96,7 +94,7 @@ struct H264DecoderState : public DecoderState {
     uint32_t get(DecoderQuery query) override;
 
     bool send(const uint8_t *data, uint32_t size) override;
-    bool receive(uint8_t *data, DecoderSize *size) override;
+    bool receive(uint8_t *data, DecoderSize *size = nullptr) override;
     void configure(void *options) override;
     void get_res(uint32_t &width, uint32_t &height);
     void get_pts(uint32_t &upper, uint32_t &lower);

--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -67,6 +67,7 @@ struct DecoderState {
     virtual bool send(const uint8_t *data, uint32_t size) = 0;
     virtual bool receive(uint8_t *data, DecoderSize *size = nullptr) = 0;
     virtual void configure(void *options);
+    virtual void get_res(uint32_t &width, uint32_t &height);
     virtual void get_pts(uint32_t &upper, uint32_t &lower);
     virtual uint32_t get_es_size(const uint8_t *data);
 
@@ -83,6 +84,9 @@ struct H264DecoderOptions {
 struct H264DecoderState : public DecoderState {
     AVCodecParserContext *parser{};
 
+    uint32_t width_out = 0;
+    uint32_t height_out = 0;
+
     uint64_t pts = ~0ull;
     uint64_t dts = ~0ull;
     uint64_t pts_out = ~0ull;
@@ -94,6 +98,7 @@ struct H264DecoderState : public DecoderState {
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;
     void configure(void *options) override;
+    void get_res(uint32_t &width, uint32_t &height);
     void get_pts(uint32_t &upper, uint32_t &lower);
 
     H264DecoderState(uint32_t width, uint32_t height);

--- a/vita3k/codec/src/decoder.cpp
+++ b/vita3k/codec/src/decoder.cpp
@@ -37,6 +37,10 @@ void DecoderState::get_pts(uint32_t &upper, uint32_t &lower) {
     // do nothing
 }
 
+void DecoderState::get_res(uint32_t &width, uint32_t &height) {
+    // do nothing
+}
+
 uint32_t DecoderState::get_es_size(const uint8_t *data) {
     return std::numeric_limits<uint32_t>::max();
 }

--- a/vita3k/codec/src/decoder.cpp
+++ b/vita3k/codec/src/decoder.cpp
@@ -33,14 +33,6 @@ void DecoderState::configure(void *options) {
     // do nothing
 }
 
-void DecoderState::get_pts(uint32_t &upper, uint32_t &lower) {
-    // do nothing
-}
-
-void DecoderState::get_res(uint32_t &width, uint32_t &height) {
-    // do nothing
-}
-
 uint32_t DecoderState::get_es_size(const uint8_t *data) {
     return std::numeric_limits<uint32_t>::max();
 }

--- a/vita3k/codec/src/h264.cpp
+++ b/vita3k/codec/src/h264.cpp
@@ -107,7 +107,10 @@ bool H264DecoderState::receive(uint8_t *data, DecoderSize *size) {
         *size = { static_cast<uint32_t>(context->width), static_cast<uint32_t>(context->height) };
     }
 
-    pts_out = frame->pts == AV_NOPTS_VALUE ? ~0ull : frame->pts;
+    width_out = frame->width;
+    height_out = frame->height;
+
+    pts_out = frame->pts;
 
     av_frame_free(&frame);
     return true;
@@ -118,6 +121,11 @@ void H264DecoderState::configure(void *options) {
 
     pts = static_cast<uint64_t>(opt->pts_upper) << 32u | static_cast<uint64_t>(opt->pts_lower);
     dts = static_cast<uint64_t>(opt->dts_upper) << 32u | static_cast<uint64_t>(opt->dts_lower);
+}
+
+void H264DecoderState::get_res(uint32_t &width, uint32_t &height) {
+    width = width_out;
+    height = height_out;
 }
 
 void H264DecoderState::get_pts(uint32_t &upper, uint32_t &lower) {

--- a/vita3k/modules/SceVideodec/SceVideodecUser.cpp
+++ b/vita3k/modules/SceVideodec/SceVideodecUser.cpp
@@ -19,12 +19,12 @@
 #include <codec/state.h>
 #include <util/lock_and_find.h>
 
-typedef std::shared_ptr<DecoderState> DecoderPtr;
-typedef std::map<SceUID, DecoderPtr> DecoderStates;
+typedef std::shared_ptr<H264DecoderState> H264DecoderPtr;
+typedef std::map<SceUID, H264DecoderPtr> H264DecoderStates;
 
 struct VideodecState {
     std::mutex mutex;
-    DecoderStates decoders;
+    H264DecoderStates decoders;
 };
 
 enum SceVideodecType {
@@ -156,7 +156,7 @@ EXPORT(int, sceAvcdecCscInternal) {
 
 EXPORT(int, sceAvcdecDecode, SceAvcdecCtrl *decoder, const SceAvcdecAu *au, SceAvcdecArrayPicture *picture) {
     const auto state = host.kernel.obj_store.get<VideodecState>();
-    const DecoderPtr &decoder_info = lock_and_find(decoder->handle, state->decoders, state->mutex);
+    const H264DecoderPtr &decoder_info = lock_and_find(decoder->handle, state->decoders, state->mutex);
 
     H264DecoderOptions options = {};
     options.pts_upper = au->pts.upper;
@@ -198,7 +198,7 @@ EXPORT(int, sceAvcdecDecodeAuNongameapp) {
 
 EXPORT(int, sceAvcdecDecodeAvailableSize, SceAvcdecCtrl *decoder) {
     const auto state = host.kernel.obj_store.get<VideodecState>();
-    const DecoderPtr &decoder_info = lock_and_find(decoder->handle, state->decoders, state->mutex);
+    const H264DecoderPtr &decoder_info = lock_and_find(decoder->handle, state->decoders, state->mutex);
 
     return H264DecoderState::buffer_size(
         { decoder_info->get(DecoderQuery::WIDTH), decoder_info->get(DecoderQuery::HEIGHT) });
@@ -206,7 +206,7 @@ EXPORT(int, sceAvcdecDecodeAvailableSize, SceAvcdecCtrl *decoder) {
 
 EXPORT(int, sceAvcdecDecodeFlush, SceAvcdecCtrl *decoder) {
     const auto state = host.kernel.obj_store.get<VideodecState>();
-    const DecoderPtr &decoder_info = lock_and_find(decoder->handle, state->decoders, state->mutex);
+    const H264DecoderPtr &decoder_info = lock_and_find(decoder->handle, state->decoders, state->mutex);
 
     decoder_info->flush();
 
@@ -243,7 +243,7 @@ EXPORT(int, sceAvcdecDecodeSetUserDataSei1FieldMemSizeNongameapp) {
 
 EXPORT(int, sceAvcdecDecodeStop, SceAvcdecCtrl *decoder, SceAvcdecArrayPicture *picture) {
     const auto state = host.kernel.obj_store.get<VideodecState>();
-    const DecoderPtr &decoder_info = lock_and_find(decoder->handle, state->decoders, state->mutex);
+    const H264DecoderPtr &decoder_info = lock_and_find(decoder->handle, state->decoders, state->mutex);
 
     uint8_t *output = picture->pPicture.get(host.mem)[0].get(host.mem)->frame.pPicture[0].cast<uint8_t>().get(host.mem);
     decoder_info->receive(output);

--- a/vita3k/modules/SceVideodec/SceVideodecUser.cpp
+++ b/vita3k/modules/SceVideodec/SceVideodecUser.cpp
@@ -172,6 +172,7 @@ EXPORT(int, sceAvcdecDecode, SceAvcdecCtrl *decoder, const SceAvcdecAu *au, SceA
     decoder_info->configure(&options);
     decoder_info->send(reinterpret_cast<uint8_t *>(au->es.pBuf.get(host.mem)), au->es.size);
     decoder_info->receive(output);
+    decoder_info->get_res(pPicture->frame.frameWidth, pPicture->frame.frameHeight);
     decoder_info->get_pts(pPicture->info.pts.upper, pPicture->info.pts.lower);
 
     picture->numOfOutput++;


### PR DESCRIPTION
# About:
- Fix wrong resolution of video in few game (Street fighter, omega labyrinth, etc...)
thx special for @bookmist for disasm function.

# Result:
![image](https://user-images.githubusercontent.com/5261759/167131068-60631b38-c129-4e2d-9c52-b8a3782c8bd9.png)
![image](https://user-images.githubusercontent.com/5261759/167131495-204b7a70-5ac4-4097-855b-6b67f0c02b84.png)
