### PR TITLE
display: fix sceDisplayWaitSetFrameBuf

### DIFF
--- a/vita3k/display/include/display/functions.h
+++ b/vita3k/display/include/display/functions.h
@@ -23,4 +23,4 @@
 struct DisplayState;
 struct KernelState;
 
-void wait_vblank(DisplayState &display, KernelState &kernel, const ThreadStatePtr &wait_thread, const int count, const bool since_last_setbuf, const bool is_cb);
+void wait_vblank(DisplayState &display, KernelState &kernel, const ThreadStatePtr &wait_thread, const int count, const bool is_cb);


### PR DESCRIPTION
`sceDisplayWaitSetFrameBuf(Multi)` was broken since #1697, leading to a regression causing some games to go faster or slower than expected because of the wrong wait time.

This allows the fps to go back to 30 (from 20) in AOT Wings of Freedom and Jet Set Radio.