### PR TITLE
vita3k: support msvc llvm compiler toolset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ enable_testing()
 macro(boost_configure)
 	if (WIN32)
 		execute_process(
-			COMMAND ${BOOST_SOURCEDIR}/bootstrap.bat
+			COMMAND ${BOOST_SOURCEDIR}/bootstrap.bat --with-toolset=${BOOST_TOOLSET}
 			WORKING_DIRECTORY ${BOOST_SOURCEDIR}
 		)
 	elseif(UNIX)
@@ -44,7 +44,7 @@ endmacro(boost_configure)
 macro(boost_compile)
 	if (CMAKE_SYSTEM_NAME STREQUAL Windows)
 		execute_process(
-			COMMAND ${BOOST_SOURCEDIR}/b2 -j${CPU_COUNT} --build-dir=${BOOST_INSTALLDIR} --stagedir=${BOOST_INSTALLDIR} toolset=msvc stage
+			COMMAND ${BOOST_SOURCEDIR}/b2 -j${CPU_COUNT} --build-dir=${BOOST_INSTALLDIR} --stagedir=${BOOST_INSTALLDIR} address-model=64 --architecture=x64 toolset=${BOOST_TOOLSET} stage
 			WORKING_DIRECTORY ${BOOST_SOURCEDIR}
 		)
 	elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
@@ -91,6 +91,15 @@ if(NOT CI)
 	# Prevents the function from using CMake cache to retrieve the path and
 	# avoid errors in case b2 was deleted between cache generation events
 	unset(b2 CACHE)
+	
+	#set toolset for windows
+	if (WIN32)
+		if (CMAKE_GENERATOR_TOOLSET STREQUAL clangcl)
+			set(BOOST_TOOLSET clang-win)
+		else()	
+			set(BOOST_TOOLSET msvc)
+		endif()
+	endif()
 
 	# Skips Boost configuration and b2 compilation if it already exists by trying to find b2
 	# b2 compilation takes a while and time for consecutive cache re-generations can be reduced this way
@@ -143,7 +152,7 @@ if(WIN32)
 endif()
 
 # Allow per-translation-unit parallel builds when using MSVC
-if(CMAKE_GENERATOR MATCHES "Visual Studio" AND (CMAKE_C_COMPILER_ID MATCHES "MSVC|Intel" OR CMAKE_CXX_COMPILER_ID MATCHES "MSVC|Intel"))
+if(CMAKE_GENERATOR MATCHES "Visual Studio" AND (CMAKE_C_COMPILER_ID MATCHES "MSVC|Intel|Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "MSVC|Intel|Clang"))
 	string(APPEND CMAKE_C_FLAGS " /MP")
 	string(APPEND CMAKE_CXX_FLAGS " /MP")
 endif()

--- a/cmake/GetStandard.cmake
+++ b/cmake/GetStandard.cmake
@@ -16,7 +16,11 @@ function(get_standard_for_build)
 		# VS 2015.3+ does not have a C++11 option
 		set(COMPILER_TEST "/std:c++17;/std:c++14;INVALID")
 	elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
-		set(COMPILER_TEST "-std=c++17;-std=c++14;-std=c++11")
+		if(MSVC) ##for msvc-clang
+			set(COMPILER_TEST "/std:c++17;/std:c++14;/std:c++11")
+		else()
+			set(COMPILER_TEST "-std=c++17;-std=c++14;-std=c++11")
+		endif()
 	else()
 		set(COMPILER_TEST "-std:c++17;-std:c++14;-std:c++11")
 	endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -300,6 +300,17 @@ set_property(TARGET xxhash PROPERTY FOLDER externals)
 set(SOUNDSTRETCH OFF CACHE BOOL "Build soundstretch command line utility." FORCE)
 add_subdirectory(soundtouch)
 set_property(TARGET SoundTouch PROPERTY FOLDER externals)
+if(MSVC AND CMAKE_GENERATOR_TOOLSET STREQUAL clangcl)
+	get_target_property(defs SoundTouch COMPILE_DEFINITIONS)
+	set_property(TARGET SoundTouch PROPERTY COMPILE_DEFINITIONS "")
+	foreach(def IN LISTS defs) 
+		if (def MATCHES "/.*")
+			target_compile_options(SoundTouch PRIVATE ${def})
+		else()
+			target_compile_definitions(SoundTouch PRIVATE ${def})
+		endif()
+	endforeach()
+endif()
 
 # Tracy
 option(TRACY_ENABLE_ON_CORE_COMPONENTS

--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -233,7 +233,7 @@ enum SceGxmParameterSemantic {
     SCE_GXM_PARAMETER_SEMANTIC_INSTANCE
 };
 
-enum SceGxmTextureType {
+enum SceGxmTextureType : unsigned int {
     SCE_GXM_TEXTURE_SWIZZLED = 0x00000000u,
     SCE_GXM_TEXTURE_CUBE = 0x40000000u,
     SCE_GXM_TEXTURE_LINEAR = 0x60000000u,

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -265,7 +265,7 @@ we can have 3 cases
 2b we can't include and use F16C intrinsic - use basic conversion
 msvc allow to include any intrinsic independent of architecture flags, other compilers disallow this
 */
-#if (defined(__AVX__) && defined(__F16C__)) || defined(__AVX2__) || defined(_MSC_VER)
+#if (defined(__AVX__) && defined(__F16C__)) || defined(__AVX2__) || (defined(_MSC_VER) && !defined(__clang__))
 #include <immintrin.h>
 void float_to_half_AVX_F16C(const float *src, std::uint16_t *dest, const int total) {
     float toconvert[8] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
@@ -299,7 +299,7 @@ void float_to_half_basic(const float *src, std::uint16_t *dest, const int total)
         dest[i] = util::encode_flt16(src[i]);
     }
 }
-#if defined(_MSC_VER)
+#if (defined(_MSC_VER) && !defined(__clang__))
 // check and use AVX+F16C instruction set if possible
 
 // use function variable as imitation of self-modifying code.


### PR DESCRIPTION
to use llvm compiler in MSVC remove build folder (build-windows) and add -Tclangcl to cmake flags in gen-windows.bat
or use this command
`cmake -S . -Tclangcl -B build-windows-clang -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain/windows-x64.cmake`