### PR TITLE
modules/SceGxm: Handle consecutive calls to sceGxmDisplayQueueAddEntry

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1019,8 +1019,11 @@ EXPORT(int, sceGxmDisplayQueueAddEntry, Ptr<SceGxmSyncObject> oldBuffer, Ptr<Sce
     SceGxmSyncObject *oldBufferSync = oldBuffer.get(host.mem);
     SceGxmSyncObject *newBufferSync = newBuffer.get(host.mem);
 
-    renderer::subject_in_progress(oldBufferSync, renderer::SyncObjectSubject::DisplayQueue);
-    renderer::subject_in_progress(newBufferSync, renderer::SyncObjectSubject::DisplayQueue);
+    renderer::wishlist_display_entry(oldBufferSync);
+    renderer::wishlist_display_entry(newBufferSync);
+
+    renderer::subject_in_progress_display_entry(oldBufferSync);
+    renderer::subject_in_progress_display_entry(newBufferSync);
 
     display_callback.data = address;
     display_callback.pc = host.gxm.params.displayQueueCallback.address();
@@ -1657,8 +1660,8 @@ static int SDLCALL thread_function(void *data) {
         free(*params.mem, display_callback->data);
 
         // Should not block anymore.
-        renderer::subject_done(oldBuffer, renderer::SyncObjectSubject::DisplayQueue);
-        renderer::subject_done(newBuffer, renderer::SyncObjectSubject::DisplayQueue);
+        renderer::subject_done_display_entry(oldBuffer);
+        renderer::subject_done_display_entry(newBuffer);
     }
 
     return 0;

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -42,6 +42,8 @@ void finish(State &state, Context &context);
  */
 void wishlist(SceGxmSyncObject *sync_object, const SyncObjectSubject subjects);
 
+void wishlist_display_entry(SceGxmSyncObject *sync_object);
+
 /**
  * \brief Set list of subject with sync object to done.
  *
@@ -49,10 +51,14 @@ void wishlist(SceGxmSyncObject *sync_object, const SyncObjectSubject subjects);
  */
 void subject_done(SceGxmSyncObject *sync_object, const SyncObjectSubject subjects);
 
+void subject_done_display_entry(SceGxmSyncObject *sync_object);
+
 /**
  * Set some subjects to be in progress.
  */
 void subject_in_progress(SceGxmSyncObject *sync_object, const SyncObjectSubject subjects);
+
+void subject_in_progress_display_entry(SceGxmSyncObject *sync_object);
 
 int wait_for_status(State &state, int *status, int signal, bool wake_on_equal);
 void reset_command_list(CommandList &command_list);

--- a/vita3k/renderer/include/renderer/gxm_types.h
+++ b/vita3k/renderer/include/renderer/gxm_types.h
@@ -123,7 +123,10 @@ enum class SceGxmLastReserveStatus {
 };
 
 struct SceGxmSyncObject {
-    std::uint32_t done;
+    uint32_t done;
+    // number of times this object is used in an entry of the display
+    // queue that is currently being processed
+    uint32_t nb_in_display_queue;
 
     std::mutex lock;
     std::condition_variable cond;


### PR DESCRIPTION
When there are two close calls to `sceGxmDisplayQueueAddEntry` (in particular when the second one is done before the first one has finished). There is a time window where between the time the first call and the second call is done, where a scene can be drawn and mess the buffer to be displayed.

One simple fix is to add wishlist calls to `sceGxmDisplayQueueAddEntry`. However it makes this function blocking (functions calling it can easily wait 2 frames). In order to prevent performance deteriorations, I had to implement specific sync functions in order to allow `sceGxmDisplayQueueAddEntry` calls to be non-blocking between them but to be blocking for other calls.

This also fixes a really tight softlock that can happen in `wishlist`.

This fixes Oreshika's intro and partially the intro of Little King's story.