### PR TITLE
SceDisplay: proper implementation of _sceDisplaySetFrameBuf

### DIFF
--- a/vita3k/app/src/screen_render.cpp
+++ b/vita3k/app/src/screen_render.cpp
@@ -104,7 +104,7 @@ void gl_screen_renderer::render(const HostState &host) {
 
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    if ((display.image_size.x > 0) && (display.image_size.y > 0)) {
+    if ((display.frame.image_size.x > 0) && (display.frame.image_size.y > 0)) {
         glUseProgram(*m_render_shader);
         glBindVertexArray(m_vao);
         glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
@@ -132,10 +132,10 @@ void gl_screen_renderer::render(const HostState &host) {
         glEnableVertexAttribArray(uvAttrib);
 
         glBindTexture(GL_TEXTURE_2D, m_screen_texture);
-        const auto pixels = display.base.cast<void>().get(mem);
+        const auto pixels = display.frame.base.cast<void>().get(mem);
 
-        glPixelStorei(GL_UNPACK_ROW_LENGTH, display.pitch);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, display.image_size.x, display.image_size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, display.frame.pitch);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, display.frame.image_size.x, display.frame.image_size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);

--- a/vita3k/display/include/display/state.h
+++ b/vita3k/display/include/display/state.h
@@ -40,13 +40,19 @@ struct DisplayStateVBlankWaitInfo {
     bool is_cb;
 };
 
-struct DisplayState {
+struct DisplayFrameInfo {
     Ptr<const void> base;
     uint32_t pitch = 0;
     uint32_t pixelformat = SCE_DISPLAY_PIXELFORMAT_A8B8G8R8;
     SceIVector2 image_size = { 0, 0 };
-    std::mutex mutex;
+};
+
+struct DisplayState {
+    DisplayFrameInfo frame;
     std::mutex display_info_mutex;
+    bool has_next_frame = false;
+    DisplayFrameInfo next_frame;
+    std::mutex mutex;
     std::unique_ptr<std::thread> vblank_thread;
     std::atomic<bool> abort{ false };
     std::atomic<bool> imgui_render{ true };


### PR DESCRIPTION
Take into account the sync param when calling _sceDisplaySetFrameBuf: if it is set to `SCE_DISPLAY_SETBUF_NEXTFRAME` we should wait for the next vblank to change the framebuffer infos.

This pull request also contains slight improvements to the vblank thread and the way it sleeps between each vblank. This should allow games running at 28/29 fps to run at a stable 30fps.

It also contains a small fix, from my understanding (I'm not entirely sure), `sceDisplayWaitSetFrameBuf...` should not update `last_vblank_waited`.