### PR TITLE
modules/SceHttp: Fail on sceHttpInit

### DIFF
--- a/vita3k/modules/SceHttp/SceHttp.cpp
+++ b/vita3k/modules/SceHttp/SceHttp.cpp
@@ -166,7 +166,8 @@ EXPORT(int, sceHttpGetStatusCode) {
 }
 
 EXPORT(int, sceHttpInit) {
-    return UNIMPLEMENTED();
+    STUBBED("Fail when called");
+    return -1;
 }
 
 EXPORT(int, sceHttpParseResponseHeader) {


### PR DESCRIPTION
Temporary fix until #1676 is merged, fail when sceHttpInit is called;

This allows Run Sackboy! and Little King's story to reach the startup menu.