### PR TITLE
display, app: More accurate vblank delay and fps displayed

### DIFF
--- a/vita3k/app/src/app.cpp
+++ b/vita3k/app/src/app.cpp
@@ -38,8 +38,10 @@ void calculate_fps(HostState &host) {
 
     if (ms >= 1000 && host.frame_count > 0) {
         // Set Current FPS
-        host.fps = static_cast<std::uint32_t>((host.frame_count * 1000) / ms);
-        host.ms_per_frame = ms / static_cast<std::uint32_t>(host.frame_count);
+        // round division to nearest integer instead of truncating
+        const uint32_t frame_count = static_cast<std::uint32_t>(host.frame_count);
+        host.fps = (frame_count * 1000 + ms / 2) / ms;
+        host.ms_per_frame = (ms + frame_count / 2) / frame_count;
         host.sdl_ticks = sdl_ticks_now;
         host.frame_count = 0;
         set_window_title(host);

--- a/vita3k/display/src/display.cpp
+++ b/vita3k/display/src/display.cpp
@@ -24,7 +24,7 @@
 // Code heavily influenced by PPSSSPP's SceDisplay.cpp
 
 static constexpr int TARGET_FPS = 60;
-static constexpr int TARGET_MS_PER_FRAME = 1000 / TARGET_FPS;
+static constexpr int64_t TARGET_MICRO_PER_FRAME = 1000000LL / TARGET_FPS;
 
 static void vblank_sync_thread(DisplayState &display, KernelState &kernel) {
     while (!display.abort.load()) {
@@ -70,9 +70,9 @@ static void vblank_sync_thread(DisplayState &display, KernelState &kernel) {
                 }
             }
         }
-        const auto time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-        const auto time_left = TARGET_MS_PER_FRAME - (time_ms % TARGET_MS_PER_FRAME);
-        std::this_thread::sleep_for(std::chrono::milliseconds(time_left));
+        const auto time_ms = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        const auto time_left = TARGET_MICRO_PER_FRAME - (time_ms % TARGET_MICRO_PER_FRAME);
+        std::this_thread::sleep_for(std::chrono::microseconds(time_left));
     }
 }
 


### PR DESCRIPTION
Pull request #1711 allowed the delay between vblanks to be more accurate: the average delay is now exactly `AVERAGE_MS_PER_FRAME`. However this value is `16` whereas its real value is `1000/60 = 16.666...`. This made the emulator slightly faster than expected with games running at 62 fps. 
Switching from milliseconds to microseconds solves this issue.

Also improves the accuracy of the displayed fps and ms_per_frame by rounding to the nearest integer the computed values instead of truncating (a game running at 29.9 fps would be shown as running at 29 fps before and 30 fps now).