### PR TITLE
codec, modules/SceAudiodec: Fix Atrac9 and implement sceAudiodecClearContext

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -52,7 +52,7 @@ enum class DecoderQuery {
     BIT_RATE,
     SAMPLE_RATE,
 
-    AT9_BLOCK_ALIGN,
+    AT9_SAMPLE_PER_FRAME,
     AT9_SAMPLE_PER_SUPERFRAME,
     AT9_FRAMES_IN_SUPERFRAME,
     AT9_SUPERFRAME_SIZE,
@@ -112,15 +112,11 @@ struct MjpegDecoderState : public DecoderState {
 
 struct Atrac9DecoderState : public DecoderState {
     void *decoder_handle;
-    uint32_t config_data;
-
-    std::vector<std::uint8_t> result;
-
-    uint32_t get_channel_count();
-    uint32_t get_samples_per_superframe();
-    uint32_t get_block_align();
-    uint32_t get_frames_in_superframe();
-    uint32_t get_superframe_size();
+    void *atrac9_info;
+    uint32_t es_size_used;
+    std::vector<uint8_t> result;
+    int superframe_frame_idx;
+    int superframe_data_left;
 
     uint32_t get(DecoderQuery query) override;
     uint32_t get_es_size() override;

--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -68,6 +68,7 @@ struct DecoderState {
     virtual bool send(const uint8_t *data, uint32_t size) = 0;
     virtual bool receive(uint8_t *data, DecoderSize *size = nullptr) = 0;
     virtual uint32_t get_es_size();
+    virtual void clear_context();
 
     virtual ~DecoderState();
 };
@@ -111,6 +112,7 @@ struct MjpegDecoderState : public DecoderState {
 };
 
 struct Atrac9DecoderState : public DecoderState {
+    uint32_t config_data;
     void *decoder_handle;
     void *atrac9_info;
     uint32_t es_size_used;
@@ -121,6 +123,8 @@ struct Atrac9DecoderState : public DecoderState {
     uint32_t get(DecoderQuery query) override;
     uint32_t get_es_size() override;
 
+    void clear_context() override;
+
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;
 
@@ -129,10 +133,13 @@ struct Atrac9DecoderState : public DecoderState {
 };
 
 struct Mp3DecoderState : public DecoderState {
+    AVCodec *codec;
     uint32_t es_size_used;
 
     uint32_t get(DecoderQuery query) override;
     uint32_t get_es_size() override;
+
+    void clear_context() override;
 
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;
@@ -175,6 +182,8 @@ struct AacDecoderState : public DecoderState {
     AVFrame *frame;
     uint32_t es_size_used;
     uint32_t get(DecoderQuery query) override;
+
+    void clear_context() override;
 
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;

--- a/vita3k/codec/src/aac.cpp
+++ b/vita3k/codec/src/aac.cpp
@@ -1,3 +1,20 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 #include <codec/state.h>
 
 #define DEBUG
@@ -79,6 +96,10 @@ bool AacDecoderState::receive(uint8_t *data, DecoderSize *size) {
 
 uint32_t AacDecoderState::get_es_size() {
     return es_size_used;
+}
+
+void AacDecoderState::clear_context() {
+    codec->flush(context);
 }
 
 AacDecoderState::AacDecoderState(uint32_t sample_rate, uint32_t channels) {

--- a/vita3k/codec/src/atrac9.cpp
+++ b/vita3k/codec/src/atrac9.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavutil/opt.h>
 #include <libswresample/swresample.h>
+#include <structures.h>
 }
 
 #include <error_codes.h>
@@ -72,6 +73,15 @@ uint32_t Atrac9DecoderState::get_es_size() {
     return es_size_used;
 }
 
+void Atrac9DecoderState::clear_context() {
+    Atrac9CodecInfo *info = reinterpret_cast<Atrac9CodecInfo *>(atrac9_info);
+    superframe_frame_idx = 0;
+    superframe_data_left = info->superframeSize;
+
+    // hopefully this is enough
+    reinterpret_cast<Atrac9Handle *>(decoder_handle)->Frame.IndexInSuperframe = 0;
+}
+
 bool Atrac9DecoderState::send(const uint8_t *data, uint32_t size) {
     Atrac9CodecInfo *info = reinterpret_cast<Atrac9CodecInfo *>(atrac9_info);
 
@@ -110,7 +120,8 @@ bool Atrac9DecoderState::receive(uint8_t *data, DecoderSize *size) {
     return true;
 }
 
-Atrac9DecoderState::Atrac9DecoderState(uint32_t config_data) {
+Atrac9DecoderState::Atrac9DecoderState(uint32_t config_data)
+    : config_data(config_data) {
     decoder_handle = Atrac9GetHandle();
     const int err = Atrac9InitDecoder(decoder_handle, reinterpret_cast<uint8_t *>(&config_data));
 

--- a/vita3k/codec/src/decoder.cpp
+++ b/vita3k/codec/src/decoder.cpp
@@ -33,6 +33,8 @@ uint32_t DecoderState::get_es_size() {
     return std::numeric_limits<uint32_t>::max();
 }
 
+void DecoderState::clear_context() {}
+
 void DecoderState::flush() {
     avcodec_flush_buffers(context);
 }

--- a/vita3k/codec/src/mp3.cpp
+++ b/vita3k/codec/src/mp3.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -123,6 +123,10 @@ uint32_t Mp3DecoderState::get_es_size() {
     return es_size_used;
 }
 
+void Mp3DecoderState::clear_context() {
+    codec->flush(context);
+}
+
 uint32_t Mp3DecoderState::get(DecoderQuery query) {
     switch (query) {
     case DecoderQuery::CHANNELS: return context->channels;
@@ -186,7 +190,7 @@ bool Mp3DecoderState::receive(uint8_t *data, DecoderSize *size) {
 }
 
 Mp3DecoderState::Mp3DecoderState(uint32_t channels) {
-    AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_MP3);
+    codec = avcodec_find_decoder(AV_CODEC_ID_MP3);
     assert(codec);
 
     context = avcodec_alloc_context3(codec);

--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
@@ -109,8 +109,13 @@ LIBRARY_INIT_IMPL(SceAudiodec) {
 }
 LIBRARY_INIT_REGISTER(SceAudiodec)
 
-EXPORT(int, sceAudiodecClearContext) {
-    return UNIMPLEMENTED();
+EXPORT(int, sceAudiodecClearContext, SceAudiodecCtrl *ctrl) {
+    const auto state = host.kernel.obj_store.get<AudiodecState>();
+    const DecoderPtr &decoder = lock_and_find(ctrl->handle, state->decoders, state->mutex);
+
+    decoder->clear_context();
+
+    return 0;
 }
 
 static int create_decoder(HostState &host, SceAudiodecCtrl *ctrl, SceAudiodecCodec codec) {

--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
@@ -128,7 +128,7 @@ static int create_decoder(HostState &host, SceAudiodecCtrl *ctrl, SceAudiodecCod
         state->decoders[handle] = decoder;
 
         ctrl->es_size_max = SCE_AUDIODEC_AT9_MAX_ES_SIZE;
-        ctrl->pcm_size_max = decoder->get(DecoderQuery::AT9_SAMPLE_PER_SUPERFRAME)
+        ctrl->pcm_size_max = decoder->get(DecoderQuery::AT9_SAMPLE_PER_FRAME)
             * decoder->get(DecoderQuery::CHANNELS) * sizeof(int16_t);
         info.channels = decoder->get(DecoderQuery::CHANNELS);
         info.bit_rate = decoder->get(DecoderQuery::BIT_RATE);

--- a/vita3k/ngs/src/modules/atrac9.cpp
+++ b/vita3k/ngs/src/modules/atrac9.cpp
@@ -207,6 +207,9 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                     data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_CALLBACK_REASON_DECODE_ERROR, state->current_byte_position_in_buffer,
                         params->buffer_params[state->current_buffer].buffer.address());
                     data.parent->voice_lock->lock();
+
+                    // clear the context or we'll get en error next time we cant to decode
+                    decoder->clear_context();
                 }
 
                 state->samples_generated_since_key_on += decoder->get(DecoderQuery::AT9_SAMPLE_PER_SUPERFRAME);


### PR DESCRIPTION
Atrac9 decoding was broken in its current state: `sceAudiodecDecode` should only decode one frame and then stop but for At9 it decoded at superframe which could be 1 frame (ok) or 4 frames (bad) which lead to a buffer overflow of the pcm buffer. This pull request fixes this behavior.
However, because there can be some padding bytes between two consecutive superframes, the Atrac9decoder must remember the decoding state in the superframe and add those padding bytes when needed.

This should fix games that were having random issues (caused by the buffer overflow) using atrac9. In particular Tales of games are now working with the sound enabled.

This pull request also implements sceAudiodecClearContext.  This fixes the crash happening in Tales of games when the background music loops back to the beginning.