### PR TITLE
renderer/gl: Use persistent mapped buffer for continous data streaming.

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -181,7 +181,7 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
 #endif
 
     if (!cfg.console) {
-        if (renderer::init(state.window.get(), state.renderer, state.backend_renderer)) {
+        if (renderer::init(state.window.get(), state.renderer, state.backend_renderer, state.cfg)) {
             update_viewport(state);
             return true;
         } else {

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -59,7 +59,7 @@ enum PerfomanceOverleyPosition {
     code(int, "icon-size", 64, icon_size)                                                               \
     code(bool, "archive-log", false, archive_log)                                                       \
     code(bool, "texture-cache", true, texture_cache)                                                    \
-    code(bool, "hashless-texture-cache", false, hashless_taexture_cache)                                \
+    code(bool, "hashless-texture-cache", false, hashless_texture_cache)                                 \
     code(bool, "disable-ngs", false, disable_ngs)                                                       \
     code(int, "sys-button", static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS), sys_button)          \
     code(int, "sys-lang", static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US), sys_lang)                 \

--- a/vita3k/renderer/CMakeLists.txt
+++ b/vita3k/renderer/CMakeLists.txt
@@ -25,16 +25,20 @@ add_library(
 	include/renderer/texture_cache_state.h
 	include/renderer/types.h
 
+	include/renderer/gl/fence.h
 	include/renderer/gl/types.h
 	include/renderer/gl/state.h
+	include/renderer/gl/ring_buffer.h
 	include/renderer/gl/surface_cache.h
 	include/renderer/gl/functions.h
 
 	src/gl/attribute_formats.cpp
 	src/gl/compile_program.cpp
 	src/gl/draw.cpp
+	src/gl/fence.cpp
 	src/gl/load_shaders.cpp
 	src/gl/renderer.cpp
+	src/gl/ring_buffer.cpp
 	src/gl/surface_cache.cpp
 	src/gl/sync_state.cpp
 	src/gl/texture_formats.cpp

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -65,7 +65,7 @@ void reset_command_list(CommandList &command_list);
 void submit_command_list(State &state, renderer::Context *context, CommandList &command_list);
 void process_batch(State &state, MemState &mem, Config &config, CommandList &command_list, const char *base_path, const char *title_id);
 void process_batches(State &state, const FeatureState &features, MemState &mem, Config &config, const char *base_path, const char *title_id, const char *self_name);
-bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend);
+bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config);
 
 void set_depth_bias(State &state, Context *ctx, bool is_front, int factor, int units);
 void set_depth_func(State &state, Context *ctx, bool is_front, SceGxmDepthFunc depth_func);

--- a/vita3k/renderer/include/renderer/gl/fence.h
+++ b/vita3k/renderer/include/renderer/gl/fence.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,35 +17,25 @@
 
 #pragma once
 
-#include <renderer/gl/surface_cache.h>
-#include <renderer/state.h>
-#include <renderer/texture_cache_state.h>
-#include <renderer/types.h>
-
-#include "types.h"
-#include <features/state.h>
-
-#include <SDL.h>
-
-#include <map>
-#include <string>
-#include <vector>
+#include <glutil/gl.h>
 
 namespace renderer::gl {
-struct GLState : public renderer::State {
-    GLContextPtr context;
 
-    ShaderCache fragment_shader_cache;
-    ShaderCache vertex_shader_cache;
-    ProgramCache program_cache;
+class Fence {
+private:
+    GLsync sync_;
+    bool signaled_;
 
-    GLTextureCacheState texture_cache;
-    GLSurfaceCache surface_cache;
+public:
+    explicit Fence();
+    ~Fence();
 
-    std::vector<ShadersHash> shaders_cache_hashs;
-    std::string shader_version = "v1";
+    void insert();
+    bool wait_for_signal();
 
-    bool init(const bool hashless_texture_cache);
+    bool empty() const {
+        return !sync_;
+    }
 };
 
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -48,18 +48,16 @@ std::string pre_load_glsl_shader(const char *hash_text, const char *shader_type_
 // Uniforms.
 bool set_uniform_buffer(GLContext &context, MemState &mem, const bool vertex_shader, const int block_num, const int size, const void *data, bool log_active_shader);
 
-bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state);
-bool create(std::unique_ptr<Context> &context, const bool hashless_texture_cache);
+bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const bool hashless_texture_cache);
+bool create(std::unique_ptr<Context> &context);
 bool create(std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &params, const FeatureState &features);
 bool create(std::unique_ptr<FragmentProgram> &fp, GLState &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
 bool create(std::unique_ptr<VertexProgram> &vp, GLState &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
 void sync_rendertarget(const GLRenderTarget &rt);
-void set_context(GLContext &ctx, const MemState &mem, const GLRenderTarget *rt, const FeatureState &features);
-void get_surface_data(GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, SceGxmColorFormat format);
+void set_context(GLState &state, GLContext &ctx, const MemState &mem, const GLRenderTarget *rt, const FeatureState &features);
+void get_surface_data(GLState &renderer, GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, SceGxmColorFormat format);
 void draw(GLState &renderer, GLContext &context, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format,
     void *indices, size_t count, uint32_t instance_count, MemState &mem, const char *base_path, const char *title_id, const char *self_name, const Config &config);
-
-void upload_vertex_stream(GLContext &context, const std::size_t stream_index, const std::size_t length, const void *data);
 
 // State
 void sync_viewport_flat(GLContext &context);
@@ -78,10 +76,11 @@ void sync_polygon_mode(const SceGxmPolygonMode mode, const bool front);
 void sync_point_line_width(const std::uint32_t size, const bool front);
 void sync_depth_bias(const int factor, const int unit, const bool front);
 void sync_blending(const GxmRecordState &state, const MemState &mem);
-void sync_texture(GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config,
+void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config,
     const std::string &base_path, const std::string &title_id);
-void sync_vertex_attributes(GLContext &context, const GxmRecordState &state, const MemState &mem);
+void sync_vertex_streams_and_attributes(GLContext &context, GxmRecordState &state, const MemState &mem);
 void bind_fundamental(GLContext &context);
+void clear_previous_uniform_storage(GLContext &context);
 
 struct GLTextureCacheState;
 struct TextureCacheState;

--- a/vita3k/renderer/include/renderer/gl/ring_buffer.h
+++ b/vita3k/renderer/include/renderer/gl/ring_buffer.h
@@ -1,0 +1,58 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <cstdint>
+#include <glutil/object_array.h>
+#include <renderer/gl/fence.h>
+#include <tuple>
+
+namespace renderer::gl {
+
+struct RingBuffer {
+private:
+    GLObjectArray<1> buffer_;
+    Fence safe_segment_consumed_fence_;
+
+    std::uint8_t *base_;
+    std::size_t cursor_;
+    std::size_t capacity_;
+
+    GLenum purpose_;
+
+    void create_and_map();
+
+public:
+    explicit RingBuffer(GLenum purpose, const std::size_t capacity);
+    ~RingBuffer();
+
+    // Allocate new data from ring buffer, return offset of the data resided in the buffer
+    // In case the data is full, it will wait for fence to notify previous draw commands has finished on previous buffer part
+    // and then reset the cursor
+    std::pair<std::uint8_t *, std::size_t> allocate(const std::size_t data_size);
+
+    // Notify the buffer that a draw call is done. This inserts a fence depends on the amount of data that has been consumed
+    // previously by push
+    void draw_call_done();
+
+    GLint handle() const {
+        return buffer_[0];
+    }
+};
+
+} // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -88,10 +88,17 @@ enum SyncObjectSubject : std::uint32_t {
 
 struct RenderTarget;
 
+struct GXMStreamInfo {
+    std::uint8_t *data = nullptr;
+    std::size_t size = 0;
+};
+
 struct GxmRecordState {
     // Programs.
     Ptr<const SceGxmFragmentProgram> fragment_program;
     Ptr<const SceGxmVertexProgram> vertex_program;
+
+    std::array<GXMStreamInfo, SCE_GXM_MAX_VERTEX_STREAMS> vertex_streams;
 
     SceGxmColorSurface color_surface;
     SceGxmDepthStencilSurface depth_stencil_surface;
@@ -141,6 +148,8 @@ struct ShaderProgram {
     std::string hash;
     UniformBufferSizes uniform_buffer_sizes; // Size of the buffer in 4-bytes unit
     UniformBufferSizes uniform_buffer_data_offsets; // Offset of the buffer in 4-bytes unit
+
+    std::size_t max_total_uniform_buffer_storage;
 };
 
 struct FragmentProgram : ShaderProgram {

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -41,7 +41,7 @@ COMMAND(handle_create_context) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL: {
-        result = gl::create(*ctx, config.hashless_taexture_cache);
+        result = gl::create(*ctx);
         break;
     }
 
@@ -82,6 +82,9 @@ COMMAND(handle_destroy_render_target) {
     complete_command(renderer, helper, 0);
 }
 
+COMMAND(handle_prepare_overall_buffer_storage) {
+}
+
 // Client
 bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id) {
     switch (state.current_backend) {
@@ -113,11 +116,11 @@ bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgra
     return false;
 }
 
-bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend) {
+bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config) {
     switch (backend) {
     case Backend::OpenGL:
         state = std::make_unique<gl::GLState>();
-        if (!gl::create(window, state))
+        if (!gl::create(window, state, config.hashless_texture_cache))
             return false;
         break;
 #ifdef USE_VULKAN

--- a/vita3k/renderer/src/gl/fence.cpp
+++ b/vita3k/renderer/src/gl/fence.cpp
@@ -1,0 +1,105 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// NOTE: I revised algorithm from RPCS3's GLHelpers.h. Please look at the class fence. Asked kd for advice.
+// I (pent0) mostly rewritten to understand it, other contributors in future can see the rpcs3 code.
+
+#include <renderer/gl/fence.h>
+#include <util/log.h>
+
+namespace renderer::gl {
+
+Fence::Fence()
+    : sync_(nullptr)
+    , signaled_(false) {
+}
+
+Fence::~Fence() {
+    if (sync_) {
+        glDeleteSync(sync_);
+    }
+}
+
+void Fence::insert() {
+    if (sync_ && !signaled_) {
+        if (!wait_for_signal()) {
+            LOG_ERROR("Unable to wait for previous sync to be done!");
+            return;
+        }
+    }
+
+    sync_ = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+    if (!sync_) {
+        LOG_ERROR("Unable to create fence sync object!");
+    }
+}
+
+bool Fence::wait_for_signal() {
+    if (signaled_) {
+        if (sync_) {
+            glDeleteSync(sync_);
+            sync_ = nullptr;
+        }
+
+        return true;
+    }
+
+    GLenum error = GL_WAIT_FAILED;
+    bool is_done = false;
+    bool check_status = false;
+
+    while (!is_done) {
+        if (!check_status) {
+            error = glClientWaitSync(sync_, GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+
+            switch (error) {
+            case GL_TIMEOUT_EXPIRED:
+                check_status = true;
+                continue;
+
+            case GL_ALREADY_SIGNALED:
+            case GL_CONDITION_SATISFIED:
+                is_done = true;
+                break;
+
+            default:
+                LOG_ERROR("Unknown error while retrieving wait sync result {}", error);
+                is_done = true;
+                break;
+            }
+        } else {
+            // Get the status
+            GLint length = 0;
+            GLint status = GL_UNSIGNALED;
+
+            glGetSynciv(sync_, GL_SYNC_STATUS, 1, &length, &status);
+
+            if (status == GL_SIGNALED) {
+                break;
+            }
+        }
+    }
+
+    signaled_ = ((error == GL_ALREADY_SIGNALED) || (error == GL_CONDITION_SATISFIED));
+
+    glDeleteSync(sync_);
+    sync_ = nullptr;
+
+    return signaled_;
+}
+
+} // namespace renderer::gl

--- a/vita3k/renderer/src/gl/ring_buffer.cpp
+++ b/vita3k/renderer/src/gl/ring_buffer.cpp
@@ -1,0 +1,86 @@
+// Vita3K emulator project
+// Copyright (C) 2021 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// NOTE: I revised algorithm from RPCS3's GLHelpers.h. Please look at the class ring_buffer. Asked kd for advice.
+// I (pent0) mostly rewritten to understand it, other contributors in future can see the rpcs3 code.
+
+#include <renderer/gl/ring_buffer.h>
+#include <util/align.h>
+#include <util/log.h>
+
+namespace renderer::gl {
+
+RingBuffer::RingBuffer(GLenum purpose, const std::size_t capacity)
+    : base_(nullptr)
+    , cursor_(0)
+    , capacity_(capacity)
+    , purpose_(purpose) {
+    buffer_.init(reinterpret_cast<renderer::Generator *>(glGenBuffers), reinterpret_cast<renderer::Deleter *>(glDeleteBuffers));
+}
+
+RingBuffer::~RingBuffer() {
+    if (base_) {
+        glBindBuffer(purpose_, buffer_[0]);
+        glUnmapBuffer(purpose_);
+    }
+}
+
+void RingBuffer::create_and_map() {
+    glBindBuffer(purpose_, buffer_[0]);
+    glBufferStorage(purpose_, capacity_, nullptr, GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
+
+    base_ = reinterpret_cast<std::uint8_t *>(glMapBufferRange(purpose_, 0, capacity_, GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT));
+
+    if (!base_) {
+        LOG_ERROR("Failed to map persistent buffer to host!");
+    }
+}
+
+std::pair<std::uint8_t *, std::size_t> RingBuffer::allocate(const std::size_t data_size) {
+    if (!base_) {
+        create_and_map();
+        if (!base_) {
+            return std::make_pair(nullptr, static_cast<std::size_t>(-1));
+        }
+    }
+
+    std::size_t offset = align(cursor_, 256);
+
+    if ((offset + data_size) >= capacity_) {
+        if (!safe_segment_consumed_fence_.empty()) {
+            safe_segment_consumed_fence_.wait_for_signal();
+        } else {
+            LOG_ERROR("Sync fence has not been inserted but the size of the ring buffer has already reached full!");
+            glFinish();
+        }
+
+        offset = 0;
+        cursor_ = 0;
+    }
+
+    cursor_ = align(offset + data_size, 256);
+    return std::make_pair(base_ + offset, offset);
+}
+
+void RingBuffer::draw_call_done() {
+    // Insert a fence when the buffer has been consumed about 25% (same as RPCS3)
+    if (safe_segment_consumed_fence_.empty() && (cursor_ >= (capacity_ >> 2))) {
+        safe_segment_consumed_fence_.insert();
+    }
+}
+
+} // namespace renderer::gl

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -128,4 +128,5 @@ std::uint8_t **set_uniform_buffer(State &state, Context *ctx, const bool is_vert
     renderer::add_state_set_command(ctx, renderer::GXMState::UniformBuffer, nullptr, is_vertex_uniform, block_number, bytes_to_copy_and_pad);
     return reinterpret_cast<std::uint8_t **>(ctx->command_list.last->data + 2);
 }
+
 } // namespace renderer

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -65,7 +65,7 @@ COMMAND(handle_set_context) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL: {
-        gl::set_context(*reinterpret_cast<gl::GLContext *>(render_context), mem, reinterpret_cast<const gl::GLRenderTarget *>(rt), features);
+        gl::set_context(static_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context), mem, reinterpret_cast<const gl::GLRenderTarget *>(rt), features);
         break;
     }
 
@@ -84,7 +84,7 @@ COMMAND(handle_sync_surface_data) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL: {
-        gl::get_surface_data(*reinterpret_cast<gl::GLContext *>(render_context), width, height,
+        gl::get_surface_data(static_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context), width, height,
             stride_in_pixels, pixels, render_context->record.color_surface.colorFormat);
 
         break;


### PR DESCRIPTION
# About:
Other split of graphics branch, tested and ready, improve perfomance on some game, get tales of inoncence run to 30 fps stable

- renderer/gl: Use persistent mapped buffer for continous data streaming.
- orphan a buffer is much more inefficient. Improve perf a bit.

# Result:
![image](https://cdn.discordapp.com/attachments/306945493764669440/974269208550600734/unknown.png)