### PR TITLE
ngs: Fix broken Atrac9

### DIFF
--- a/vita3k/codec/src/atrac9.cpp
+++ b/vita3k/codec/src/atrac9.cpp
@@ -141,6 +141,6 @@ Atrac9DecoderState::Atrac9DecoderState(uint32_t config_data)
 
 Atrac9DecoderState::~Atrac9DecoderState() {
     Atrac9ReleaseHandle(decoder_handle);
-    delete atrac9_info;
+    delete reinterpret_cast<Atrac9CodecInfo *>(atrac9_info);
     context = nullptr;
 }

--- a/vita3k/ngs/src/modules/atrac9.cpp
+++ b/vita3k/ngs/src/modules/atrac9.cpp
@@ -200,6 +200,7 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                         reinterpret_cast<float *>(data.extra_storage.data() + curr_pos), decoder_size.samples, sample_rate);
 
                     curr_pos += decoder->get(DecoderQuery::AT9_SAMPLE_PER_FRAME) * sizeof(float) * 2;
+                    input += decoder->get_es_size();
                 }
 
                 if (got_decode_error) {


### PR DESCRIPTION
PR #1715 had a line missing in `ngs/atrac9.cpp` which broke ngs Atrac9 audio.
I also use this PR to fix a compiler warning error in Atrac9.