### PR TITLE
modules/SceSysmodule: prevent random crash when calling sceSysmoduleLoadModule

### DIFF
--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -35,6 +35,7 @@
 #include <mutex>
 #include <optional>
 #include <queue>
+#include <shared_mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -137,6 +138,7 @@ struct KernelState {
     SceKernelModuleInfoPtrs loaded_modules;
     LoadedSysmodules loaded_sysmodules;
     ExportNids export_nids;
+    std::shared_mutex export_nids_mutex;
     NidFromExport nid_from_export;
 
     bool cpu_opt;

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -82,6 +82,7 @@ const std::array<VarExport, var_exports_size> &get_var_exports() {
  * \return Resolved address, 0 if not found
  */
 Address resolve_export(KernelState &kernel, uint32_t nid) {
+    const std::shared_lock<std::shared_mutex> lock(kernel.export_nids_mutex);
     const ExportNids::iterator export_address = kernel.export_nids.find(nid);
     if (export_address == kernel.export_nids.end()) {
         return 0;


### PR DESCRIPTION
`sceSysmoduleLoadModule` can be called ingame and load a lle module.
However this function modifies `export_nids_mutex` without any mutex locking mechanism. Therefore if another thread calls a firmware function at the same time, it can lead to a crash when accessing `export_nids_mutex ` (it already happened a few times for me).

I used a shared_lock because writers are really rare (almost none after the beginning of the game) while there are lots of readers (every time a fw function is called), so it should be faster.

I still assumed in this PR that only one `sceSysmoduleLoadModule` would be called at a given time. Otherwise there will be a lot more things to make thread safe.