### PR TITLE
kernel: Fix event flags

### DIFF
--- a/vita3k/kernel/include/kernel/sync_primitives.h
+++ b/vita3k/kernel/include/kernel/sync_primitives.h
@@ -39,6 +39,7 @@ struct WaitingThreadData {
         struct { // event flags
             int32_t wait;
             int32_t flags;
+            uint32_t *outBits;
         };
         // struct { }; // condvar
         struct { // msgpipe


### PR DESCRIPTION
Event Flags had multiple issues:

- When calling `_sceKernelPollEventFlag`, if the flag is not set, an error should be returned.
- The `pResultPat` should not be ANDed with the bitPattern
- `pResultPat` should be set after the wait has ended and not before

This should fix potential softlocks occuring in games using event flags. In particular, along with pr #1728 , it fixes sound effects and cutscene softlocks in Tales of Hearts R.