### PR TITLE
renderer: Implement partial force load.

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -881,18 +881,13 @@ EXPORT(uint8_t, sceGxmDepthStencilSurfaceGetBackgroundStencil, const SceGxmDepth
 
 EXPORT(SceGxmDepthStencilForceLoadMode, sceGxmDepthStencilSurfaceGetForceLoadMode, const SceGxmDepthStencilSurface *surface) {
     assert(surface);
-    // TODO: Implement on the renderer side
-    // return static_cast<SceGxmDepthStencilForceLoadMode>(surface->zlsControl & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED);
-    STUBBED("SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_DISABLED");
-    return SceGxmDepthStencilForceLoadMode::SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_DISABLED;
+    return static_cast<SceGxmDepthStencilForceLoadMode>(surface->zlsControl & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED);
 }
 
 EXPORT(SceGxmDepthStencilForceStoreMode, sceGxmDepthStencilSurfaceGetForceStoreMode, const SceGxmDepthStencilSurface *surface) {
     assert(surface);
     // TODO: Implement on the renderer side
-    // return static_cast<SceGxmDepthStencilForceStoreMode>(surface->zlsControl & SCE_GXM_DEPTH_STENCIL_FORCE_STORE_ENABLED);
-    STUBBED("SCE_GXM_DEPTH_STENCIL_FORCE_STORE_DISABLED");
-    return SceGxmDepthStencilForceStoreMode::SCE_GXM_DEPTH_STENCIL_FORCE_STORE_DISABLED;
+    return static_cast<SceGxmDepthStencilForceStoreMode>(surface->zlsControl & SCE_GXM_DEPTH_STENCIL_FORCE_STORE_ENABLED);
 }
 
 EXPORT(int, sceGxmDepthStencilSurfaceGetFormat, const SceGxmDepthStencilSurface *surface) {
@@ -964,16 +959,12 @@ EXPORT(void, sceGxmDepthStencilSurfaceSetBackgroundStencil, SceGxmDepthStencilSu
 
 EXPORT(void, sceGxmDepthStencilSurfaceSetForceLoadMode, SceGxmDepthStencilSurface *surface, SceGxmDepthStencilForceLoadMode forceLoad) {
     assert(surface);
-    // TODO: Implement on the renderer side
-    // surface->zlsControl = (forceLoad & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED) | (surface->zlsControl & ~SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED);
-    UNIMPLEMENTED();
+    surface->zlsControl = (forceLoad & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED) | (surface->zlsControl & ~SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED);
 }
 
 EXPORT(void, sceGxmDepthStencilSurfaceSetForceStoreMode, SceGxmDepthStencilSurface *surface, SceGxmDepthStencilForceStoreMode forceStore) {
     assert(surface);
-    // TODO: Implement on the renderer side
-    // surface->zlsControl = (forceStore & SCE_GXM_DEPTH_STENCIL_FORCE_STORE_ENABLED) | (surface->zlsControl & ~SCE_GXM_DEPTH_STENCIL_FORCE_STORE_ENABLED);
-    UNIMPLEMENTED();
+    surface->zlsControl = (forceStore & SCE_GXM_DEPTH_STENCIL_FORCE_STORE_ENABLED) | (surface->zlsControl & ~SCE_GXM_DEPTH_STENCIL_FORCE_STORE_ENABLED);
 }
 
 EXPORT(int, sceGxmDestroyContext, Ptr<SceGxmContext> context) {

--- a/vita3k/renderer/include/renderer/gl/surface_cache.h
+++ b/vita3k/renderer/include/renderer/gl/surface_cache.h
@@ -74,8 +74,8 @@ public:
     std::uint64_t retrieve_ping_pong_color_surface_texture_handle(Ptr<void> address) override;
 
     // We really can't sample this around... The only usage of this function is interally load/store from this texture.
-    std::uint64_t retrieve_depth_stencil_texture_handle(const SceGxmDepthStencilSurface &surface) override;
-    std::uint64_t retrieve_framebuffer_handle(SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
+    std::uint64_t retrieve_depth_stencil_texture_handle(const MemState &mem, const SceGxmDepthStencilSurface &surface) override;
+    std::uint64_t retrieve_framebuffer_handle(const MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
         std::uint64_t *color_texture_handle = nullptr, std::uint64_t *ds_texture_handle = nullptr,
         std::uint16_t *stored_height = nullptr) override;
 

--- a/vita3k/renderer/include/renderer/surface_cache.h
+++ b/vita3k/renderer/include/renderer/surface_cache.h
@@ -23,6 +23,8 @@
 #include <mem/ptr.h>
 #include <renderer/gxm_types.h>
 
+struct MemState;
+
 namespace renderer {
 enum SurfaceTextureRetrievePurpose {
     READING,
@@ -37,8 +39,8 @@ public:
     virtual std::uint64_t retrieve_ping_pong_color_surface_texture_handle(Ptr<void> address) = 0;
 
     // We really can't sample this around... The only usage of this function is interally load/store from this texture.
-    virtual std::uint64_t retrieve_depth_stencil_texture_handle(const SceGxmDepthStencilSurface &surface) = 0;
-    virtual std::uint64_t retrieve_framebuffer_handle(SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
+    virtual std::uint64_t retrieve_depth_stencil_texture_handle(const MemState &mem, const SceGxmDepthStencilSurface &surface) = 0;
+    virtual std::uint64_t retrieve_framebuffer_handle(const MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
         std::uint64_t *color_texture_handle = nullptr, std::uint64_t *ds_texture_handle = nullptr,
         std::uint16_t *stored_height = nullptr)
         = 0;

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -447,7 +447,7 @@ void set_context(GLState &state, GLContext &context, const MemState &mem, const 
     std::uint16_t current_framebuffer_height = 0;
 
     context.current_framebuffer = static_cast<GLuint>(state.surface_cache.retrieve_framebuffer_handle(
-        color_surface_fin, ds_surface_fin, &current_color_attachment_handle, nullptr, &current_framebuffer_height));
+        mem, color_surface_fin, ds_surface_fin, &current_color_attachment_handle, nullptr, &current_framebuffer_height));
     context.current_color_attachment = static_cast<GLuint>(current_color_attachment_handle);
     context.current_framebuffer_height = current_framebuffer_height;
 

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -240,8 +240,12 @@ void sync_depth_data(const renderer::GxmRecordState &state) {
     // Depth test.
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);
-    glClearDepth(state.depth_stencil_surface.backgroundDepth);
-    glClear(GL_DEPTH_BUFFER_BIT);
+
+    // If force load is enabled to load saved depth and depth data memory exists (the second condition is just for safe, may sometimes contradict its usefulness, hopefully won't)
+    if (((state.depth_stencil_surface.zlsControl & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED) == 0) && (state.depth_stencil_surface.depthData)) {
+        glClearDepth(state.depth_stencil_surface.backgroundDepth);
+        glClear(GL_DEPTH_BUFFER_BIT);
+    }
 }
 
 void sync_stencil_func(const GxmStencilState &state, const MemState &mem, const bool is_back_stencil) {
@@ -256,9 +260,10 @@ void sync_stencil_func(const GxmStencilState &state, const MemState &mem, const 
 }
 
 void sync_stencil_data(const GxmRecordState &state, const MemState &mem) {
+    // Stencil test.
     glEnable(GL_STENCIL_TEST);
     glStencilMask(GL_TRUE);
-    if (state.depth_stencil_surface.control) {
+    if (((state.depth_stencil_surface.zlsControl & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED) == 0) && state.depth_stencil_surface.control) {
         glClearStencil(state.depth_stencil_surface.control.get(mem)->backgroundStencil);
         glClear(GL_STENCIL_BUFFER_BIT);
     }


### PR DESCRIPTION
# About:
- Does not support force load from memory. Use from stored FB.
  Hope no game is crazy to make its own depth
- fix transparant issue on all psvita game have it before


# Result:
![image](https://user-images.githubusercontent.com/5261759/168634808-cd342ff8-b8e3-4c2f-8625-c8dd0672d938.png)
![image](https://user-images.githubusercontent.com/5261759/168634982-07961631-9397-4980-b267-8ef0fa835e99.png)
![image](https://user-images.githubusercontent.com/5261759/168634894-6a9c9cd3-1cfb-4995-ad3c-88860d0924bb.png)