### PR TITLE
renderer: Fix depth stencil surface not caching.

### DIFF
--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -251,7 +251,7 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const MemState &mem, S
         color_handle = target->attachments[0];
     }
 
-    if (ds_handle) {
+    if (depth_stencil) {
         ds_handle = static_cast<GLuint>(retrieve_depth_stencil_texture_handle(mem, *depth_stencil));
     } else {
         ds_handle = target->attachments[1];


### PR DESCRIPTION
# Result
- fix missing piece of uncharted loading
![image](https://user-images.githubusercontent.com/5261759/168822337-eca1c79b-6ae4-41c4-b153-972f312054db.png)