### PR TITLE
ngs: Fix VoiceState and sceNgsVoiceKeyOff

### DIFF
--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -443,13 +443,13 @@ static SceUInt32 ngsVoiceStateFromHLEState(const ngs::VoiceState state) {
         return SCE_NGS_VOICE_STATE_FINALIZE;
 
     case ngs::VoiceState::VOICE_STATE_KEY_OFF:
-        return SCE_NGS_VOICE_STATE_KEY_OFF;
+        return SCE_NGS_VOICE_STATE_FINALIZE | SCE_NGS_VOICE_STATE_KEY_OFF;
 
     case ngs::VoiceState::VOICE_STATE_PAUSED:
-        return SCE_NGS_VOICE_STATE_PAUSED;
+        return SCE_NGS_VOICE_STATE_ACTIVE | SCE_NGS_VOICE_STATE_PAUSED;
 
     case ngs::VoiceState::VOICE_STATE_PENDING:
-        return SCE_NGS_VOICE_STATE_PENDING;
+        return SCE_NGS_VOICE_STATE_AVAILABLE | SCE_NGS_VOICE_STATE_PENDING;
 
     case ngs::VoiceState::VOICE_STATE_UNLOADING:
         return SCE_NGS_VOICE_STATE_UNLOADING;
@@ -555,6 +555,7 @@ EXPORT(SceInt32, sceNgsVoiceKeyOff, SceNgsVoiceHandle voice_handle) {
     }
 
     voice->rack->system->voice_scheduler.off(voice);
+    voice->rack->system->voice_scheduler.stop(voice, thread_id);
     return SCE_NGS_OK;
 }
 

--- a/vita3k/ngs/include/ngs/system.h
+++ b/vita3k/ngs/include/ngs/system.h
@@ -38,13 +38,13 @@ constexpr size_t default_passthrough_parameter_size = 140;
 constexpr size_t default_normal_parameter_size = 100;
 
 enum VoiceState {
-    VOICE_STATE_AVAILABLE = 1 << 0,
-    VOICE_STATE_ACTIVE = 1 << 1,
-    VOICE_STATE_FINALIZING = 1 << 2,
-    VOICE_STATE_UNLOADING = 1 << 3,
-    VOICE_STATE_PENDING = 1 << 4,
-    VOICE_STATE_PAUSED = 1 << 5,
-    VOICE_STATE_KEY_OFF = 1 << 6
+    VOICE_STATE_AVAILABLE,
+    VOICE_STATE_ACTIVE,
+    VOICE_STATE_FINALIZING,
+    VOICE_STATE_UNLOADING,
+    VOICE_STATE_PENDING,
+    VOICE_STATE_PAUSED,
+    VOICE_STATE_KEY_OFF
 };
 
 struct ModuleParameterHeader {


### PR DESCRIPTION
`ngs::VoiceState` does not exactly match ngs voice state representation, there should be 4 main states and additional flags that can be ORed with the main state. This is not an issue (for now) but it needs to be accounted for when returning the voice state.

Also fix `sceNgsVoiceKeyOff` which should kill the voice after finalizing it.

This fixes the startup menu sound effects in Chronovolt.