### PR TITLE
shader: Fix source load comp count not matching dest mask

### DIFF
--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1573,7 +1573,7 @@ bool USSETranslatorVisitor::vdual(
 
     auto do_dual_op = [&](Opcode code, std::vector<Operand> &ops, Operand &dest,
                           Imm4 write_mask_dest, const DualOpInfo &code_info) {
-        uint32_t write_mask_source = code_info.vector_load ? (0b1111u >> (uint32_t)!comp_count_type) : 0b0001;
+        uint32_t write_mask_source = code_info.vector_load ? write_mask_dest : 0b0001;
 
         spv::Id result;
 


### PR DESCRIPTION
# About:
- Fix source load comp count not matching dest mask.
  Just use it right away on vector operation

fix black texture on few game
- all black texture fixed on AC chronicle
![image](https://user-images.githubusercontent.com/5261759/169160343-2ccacabc-e618-4574-918b-672253b7a246.png)

- on atelier game too
![image](https://user-images.githubusercontent.com/5261759/169160535-5aa13e71-a49b-48b0-9f24-c416041e2a44.png)