### PR TITLE
ngs: Fix softlock happening when calling update

### DIFF
--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -471,7 +471,7 @@ EXPORT(SceInt32, sceNgsVoiceGetInfo, SceNgsVoiceHandle handle, SceNgsVoiceInfo *
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
     }
 
-    const std::lock_guard<std::mutex> guard(*voice->voice_lock);
+    const std::lock_guard<std::mutex> guard(*voice->voice_mutex);
 
     info->voice_state = ngsVoiceStateFromHLEState(voice->state);
     info->num_modules = static_cast<SceUInt32>(voice->datas.size());
@@ -555,7 +555,7 @@ EXPORT(SceInt32, sceNgsVoiceKeyOff, SceNgsVoiceHandle voice_handle) {
     }
 
     voice->rack->system->voice_scheduler.off(voice);
-    voice->rack->system->voice_scheduler.stop(voice, thread_id);
+    voice->rack->system->voice_scheduler.stop(voice);
     return SCE_NGS_OK;
 }
 
@@ -570,7 +570,7 @@ EXPORT(int, sceNgsVoiceKill, SceNgsVoiceHandle voice_handle) {
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
     }
 
-    voice->rack->system->voice_scheduler.stop(voice, thread_id);
+    voice->rack->system->voice_scheduler.stop(voice);
     return 0;
 }
 
@@ -658,7 +658,7 @@ EXPORT(int, sceNgsVoicePause, SceNgsVoiceHandle handle) {
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
     }
 
-    if (!voice->rack->system->voice_scheduler.pause(voice, thread_id)) {
+    if (!voice->rack->system->voice_scheduler.pause(voice)) {
         return RET_ERROR(SCE_NGS_ERROR);
     }
 
@@ -732,7 +732,7 @@ EXPORT(SceInt32, sceNgsVoiceSetParamsBlock, SceNgsVoiceHandle voice_handle, cons
 
     ngs::Voice *voice = voice_handle.get(host.mem);
 
-    const std::lock_guard<std::mutex> guard(*voice->voice_lock);
+    const std::lock_guard<std::mutex> guard(*voice->voice_mutex);
 
     const SceUInt8 *data = reinterpret_cast<const SceUInt8 *>(header);
     const SceUInt8 *data_end = reinterpret_cast<const SceUInt8 *>(data + size);

--- a/vita3k/ngs/include/ngs/modules/atrac9.h
+++ b/vita3k/ngs/include/ngs/modules/atrac9.h
@@ -82,7 +82,7 @@ private:
 public:
     explicit Module();
 
-    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) override;
+    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) override;
     std::uint32_t module_id() const override { return 0x5CAA; }
     std::size_t get_buffer_parameter_size() const override;
     void on_state_change(ModuleData &v, const VoiceState previous) override;

--- a/vita3k/ngs/include/ngs/modules/equalizer.h
+++ b/vita3k/ngs/include/ngs/modules/equalizer.h
@@ -24,7 +24,7 @@ struct Module : public ngs::Module {
 public:
     explicit Module();
 
-    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) override;
+    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) override;
     std::uint32_t module_id() const override { return 0x5CEC; }
     std::size_t get_buffer_parameter_size() const override;
 };

--- a/vita3k/ngs/include/ngs/modules/master.h
+++ b/vita3k/ngs/include/ngs/modules/master.h
@@ -23,7 +23,7 @@ namespace ngs::master {
 struct Module : public ngs::Module {
 public:
     explicit Module();
-    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) override;
+    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) override;
     std::size_t get_buffer_parameter_size() const override {
         return 0;
     }

--- a/vita3k/ngs/include/ngs/modules/null.h
+++ b/vita3k/ngs/include/ngs/modules/null.h
@@ -23,7 +23,7 @@ namespace ngs::null {
 struct Module : public ngs::Module {
     Module();
 
-    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) override;
+    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) override;
     std::size_t get_buffer_parameter_size() const override;
 };
 } // namespace ngs::null

--- a/vita3k/ngs/include/ngs/modules/passthrough.h
+++ b/vita3k/ngs/include/ngs/modules/passthrough.h
@@ -23,7 +23,7 @@ namespace ngs::passthrough {
 struct Module : public ngs::Module {
     Module();
 
-    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) override;
+    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) override;
     std::size_t get_buffer_parameter_size() const override;
 };
 } // namespace ngs::passthrough

--- a/vita3k/ngs/include/ngs/modules/player.h
+++ b/vita3k/ngs/include/ngs/modules/player.h
@@ -96,7 +96,7 @@ private:
 
 public:
     explicit Module();
-    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) override;
+    bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) override;
     std::uint32_t module_id() const override { return 0x5CE6; }
     std::size_t get_buffer_parameter_size() const override;
     void on_state_change(ModuleData &v, const VoiceState previous) override;

--- a/vita3k/ngs/include/ngs/scheduler.h
+++ b/vita3k/ngs/include/ngs/scheduler.h
@@ -38,11 +38,11 @@ struct VoiceScheduler {
     std::vector<Voice *> queue;
     std::vector<Voice *> pending_deque;
 
-    std::mutex lock;
+    std::recursive_mutex mutex;
     SceUID updater;
 
 protected:
-    bool deque_voice(Voice *voice, const SceUID thread_id);
+    bool deque_voice(Voice *voice);
     bool deque_voice_impl(Voice *voice);
 
     bool resort_to_respect_dependencies(const MemState &mem, Voice *source);
@@ -51,9 +51,9 @@ protected:
 
 public:
     bool play(const MemState &mem, Voice *voice);
-    bool pause(Voice *voice, const SceUID thread_id);
+    bool pause(Voice *voice);
     bool resume(const MemState &mem, Voice *voice);
-    bool stop(Voice *voice, const SceUID thread_id);
+    bool stop(Voice *voice);
     bool off(Voice *voice);
 
     void update(KernelState &kern, const MemState &mem, const SceUID thread_id);

--- a/vita3k/ngs/include/ngs/system.h
+++ b/vita3k/ngs/include/ngs/system.h
@@ -134,7 +134,7 @@ struct Module {
         : buss_type(buss_type) {}
     virtual ~Module() = default;
 
-    virtual bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) = 0;
+    virtual bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) = 0;
     virtual std::uint32_t module_id() const { return 0; }
     virtual std::size_t get_buffer_parameter_size() const = 0;
     virtual void on_state_change(ModuleData &v, const VoiceState previous) {}
@@ -218,7 +218,7 @@ struct Voice {
 
     VoiceInputManager inputs;
 
-    std::unique_ptr<std::mutex> voice_lock;
+    std::unique_ptr<std::mutex> voice_mutex;
     VoiceProduct products[MAX_VOICE_OUTPUT];
 
     void init(Rack *mama);

--- a/vita3k/ngs/src/modules/atrac9.cpp
+++ b/vita3k/ngs/src/modules/atrac9.cpp
@@ -65,7 +65,7 @@ void Module::on_state_change(ModuleData &data, const VoiceState previous) {
     }
 }
 
-bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) {
+bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) {
     const Parameters *params = data.get_parameters<Parameters>(mem);
     State *state = data.get_state<State>();
 
@@ -94,7 +94,8 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                     state->current_loop_count = 0;
                     state->current_byte_position_in_buffer = 0;
 
-                    data.parent->voice_lock->unlock();
+                    voice_lock.unlock();
+                    scheduler_lock.unlock();
 
                     if (state->current_buffer == -1) {
                         data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_CALLBACK_REASON_DONE_ALL, 0, 0);
@@ -106,13 +107,18 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                             params->buffer_params[state->current_buffer].buffer.address());
                     }
 
-                    data.parent->voice_lock->lock();
+                    scheduler_lock.lock();
+                    voice_lock.lock();
                 }
             } else {
-                data.parent->voice_lock->unlock();
+                voice_lock.unlock();
+                scheduler_lock.unlock();
+
                 data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_CALLBACK_REASON_START_LOOP, state->current_loop_count,
                     params->buffer_params[state->current_buffer].buffer.address());
-                data.parent->voice_lock->lock();
+
+                scheduler_lock.lock();
+                voice_lock.lock();
             }
 
             state->current_byte_position_in_buffer = 0;
@@ -204,10 +210,14 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                 }
 
                 if (got_decode_error) {
-                    data.parent->voice_lock->unlock();
+                    voice_lock.unlock();
+                    scheduler_lock.unlock();
+
                     data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_CALLBACK_REASON_DECODE_ERROR, state->current_byte_position_in_buffer,
                         params->buffer_params[state->current_buffer].buffer.address());
-                    data.parent->voice_lock->lock();
+
+                    scheduler_lock.lock();
+                    voice_lock.lock();
 
                     // clear the context or we'll get en error next time we cant to decode
                     decoder->clear_context();

--- a/vita3k/ngs/src/modules/equalizer.cpp
+++ b/vita3k/ngs/src/modules/equalizer.cpp
@@ -26,7 +26,7 @@ std::size_t Module::get_buffer_parameter_size() const {
     return default_normal_parameter_size;
 }
 
-bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) {
+bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) {
     // TODO: Proper implement it, for now just lower volume lol
     float *product_before = reinterpret_cast<float *>(data.parent->products[0].data);
 

--- a/vita3k/ngs/src/modules/master.cpp
+++ b/vita3k/ngs/src/modules/master.cpp
@@ -26,7 +26,7 @@ Module::Module()
     : ngs::Module(ngs::BussType::BUSS_MASTER) {
 }
 
-bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) {
+bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) {
     // Merge all voices. This buss manually outputs 2 channels
     if (data.voice_state_data.empty()) {
         data.voice_state_data.resize(data.parent->rack->system->granularity * sizeof(std::uint16_t) * 2);

--- a/vita3k/ngs/src/modules/null.cpp
+++ b/vita3k/ngs/src/modules/null.cpp
@@ -25,7 +25,7 @@ std::size_t Module::get_buffer_parameter_size() const {
     return 0;
 }
 
-bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) {
+bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) {
     return false;
 }
 } // namespace ngs::null

--- a/vita3k/ngs/src/modules/passthrough.cpp
+++ b/vita3k/ngs/src/modules/passthrough.cpp
@@ -26,7 +26,7 @@ std::size_t Module::get_buffer_parameter_size() const {
     return default_passthrough_parameter_size;
 }
 
-bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data) {
+bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) {
     if (data.parent->inputs.inputs.empty()) {
         return false;
     }

--- a/vita3k/ngs/src/ngs.cpp
+++ b/vita3k/ngs/src/ngs.cpp
@@ -97,7 +97,7 @@ ModuleData::ModuleData()
 }
 
 BufferParamsInfo *ModuleData::lock_params(const MemState &mem) {
-    const std::lock_guard<std::mutex> guard(*parent->voice_lock);
+    const std::lock_guard<std::mutex> guard(*parent->voice_mutex);
 
     // Save a copy of previous set of data
     if (flags & PARAMS_LOCK) {
@@ -116,7 +116,7 @@ BufferParamsInfo *ModuleData::lock_params(const MemState &mem) {
 }
 
 bool ModuleData::unlock_params() {
-    const std::lock_guard<std::mutex> guard(*parent->voice_lock);
+    const std::lock_guard<std::mutex> guard(*parent->voice_mutex);
 
     if (flags & PARAMS_LOCK) {
         flags &= ~PARAMS_LOCK;
@@ -168,11 +168,11 @@ void Voice::init(Rack *mama) {
         patches[i].resize(mama->patches_per_output);
 
     inputs.init(rack->system->granularity, 1);
-    voice_lock = std::make_unique<std::mutex>();
+    voice_mutex = std::make_unique<std::mutex>();
 }
 
 Ptr<Patch> Voice::patch(const MemState &mem, const std::int32_t index, std::int32_t subindex, std::int32_t dest_index, Voice *dest) {
-    const std::lock_guard<std::mutex> guard(*voice_lock);
+    const std::lock_guard<std::mutex> guard(*voice_mutex);
 
     if (index >= MAX_OUTPUT_PORT) {
         // We don't have enough port for you!
@@ -221,7 +221,7 @@ Ptr<Patch> Voice::patch(const MemState &mem, const std::int32_t index, std::int3
 }
 
 bool Voice::remove_patch(const MemState &mem, const Ptr<Patch> patch) {
-    const std::lock_guard<std::mutex> guard(*voice_lock);
+    const std::lock_guard<std::mutex> guard(*voice_mutex);
     bool found = false;
 
     for (std::uint8_t i = 0; i < patches.size(); i++) {

--- a/vita3k/ngs/src/route.cpp
+++ b/vita3k/ngs/src/route.cpp
@@ -35,7 +35,7 @@ bool deliver_data(const MemState &mem, Voice *source, const std::uint8_t output_
         }
 
         if (data_to_deliver.data != nullptr) {
-            const std::lock_guard<std::mutex> guard(*patch->dest->voice_lock);
+            const std::lock_guard<std::mutex> guard(*patch->dest->voice_mutex);
             patch->dest->inputs.receive(patch, data_to_deliver);
         }
     }


### PR DESCRIPTION
Mutexes should be locked for a fixed and known amount of time, they should not be locked while calling callback. This pr makes it so that all mutexes are unlocked before calling a callback, and also makes the scheduler mutex a recursive mutex to prevent any issue while stopping a voice in update. Also rename locks mutexes because they are mutexes, not locks.

This fixes freezes in chronovolt and Rayman origins and should fix many more games.