### PR TITLE
shader/alu/dual: Adjust config 3 layout of dual.

### DIFF
--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1316,9 +1316,8 @@ static optional<DualSrcLayout> get_dual_op2_src_layout(uint8_t op1_count, uint8_
             switch (src_config) {
             case 0: return optional<DualSrcLayout>({ DualSrcId::INTERAL0, DualSrcId::INTERNAL1, DualSrcId::NONE });
             case 1: return optional<DualSrcLayout>({ DualSrcId::UNIFIED, DualSrcId::INTERNAL1, DualSrcId::NONE });
-            case 2:
-            case 3:
-                return optional<DualSrcLayout>({ DualSrcId::INTERAL0, DualSrcId::UNIFIED, DualSrcId::NONE });
+            case 2: return optional<DualSrcLayout>({ DualSrcId::INTERAL0, DualSrcId::UNIFIED, DualSrcId::NONE });
+            case 3: return optional<DualSrcLayout>({ DualSrcId::INTERNAL1, DualSrcId::UNIFIED, DualSrcId::NONE });
             default: return {};
             }
         case 3:


### PR DESCRIPTION
# About:
- shader/alu/dual: Adjust config 3 layout of dual.
  Based on some tests that is visible on assasin's creed chronicles.
  All 3 text shaders all have src_config = 3. And it uses internals1 x unified.

# Result:
![image](https://user-images.githubusercontent.com/5261759/169282049-87aa8189-e782-4f29-a9c9-19cd023cb52c.png)
![image](https://user-images.githubusercontent.com/5261759/169282073-db70d237-9bf2-4758-be15-68aa320aa805.png)
