### PR TITLE
ngs: Fix parse_params and add missing checks

### DIFF
--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -111,14 +111,15 @@ EXPORT(int, sceNgsPatchCreateRouting, ngs::PatchSetupInfo *patch_info, SceNgsPat
     if (host.cfg.current_config.disable_ngs) {
         return 0;
     }
-    assert(handle);
+
+    if (!patch_info || !handle)
+        return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
 
     // Make the scheduler order this right based on dependencies request
     ngs::Voice *source = patch_info->source.get(host.mem);
 
-    if (!source) {
+    if (!source)
         return RET_ERROR(SCE_NGS_ERROR);
-    }
 
     LOG_TRACE("Patching 0x{:X}:{}:{} to 0x{:X}:{}", patch_info->source.address(), patch_info->source_output_index,
         patch_info->source_output_index, patch_info->dest.address(), patch_info->dest_input_index);
@@ -296,6 +297,9 @@ EXPORT(SceInt32, sceNgsVoiceBypassModule, SceNgsVoiceHandle voice_handle, const 
     if (host.cfg.current_config.disable_ngs) {
         return 0;
     }
+
+    if (!voice_handle)
+        return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
 
     ngs::Voice *voice = voice_handle.get(host.mem);
 
@@ -795,6 +799,9 @@ EXPORT(SceInt32, sceNgsVoiceSetFinishedCallback, SceNgsVoiceHandle voice_handle,
 
     ngs::Voice *voice = voice_handle.get(host.mem);
 
+    if (!voice)
+        return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
+
     voice->finished_callback = callback;
     voice->finished_callback_user_data = user_data;
 
@@ -807,6 +814,10 @@ EXPORT(SceInt32, sceNgsVoiceSetModuleCallback, SceNgsVoiceHandle voice_handle, c
     }
 
     ngs::Voice *voice = voice_handle.get(host.mem);
+
+    if (!voice)
+        return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
+
     ngs::ModuleData *storage = voice->module_storage(module);
     if (!storage) {
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
@@ -860,6 +871,10 @@ EXPORT(SceInt32, sceNgsVoiceUnlockParams, SceNgsVoiceHandle handle, const SceUIn
     }
 
     ngs::Voice *voice = handle.get(host.mem);
+
+    if (!voice)
+        return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
+
     ngs::ModuleData *data = voice->module_storage(module_index);
 
     if (!data) {

--- a/vita3k/ngs/include/ngs/system.h
+++ b/vita3k/ngs/include/ngs/system.h
@@ -64,7 +64,6 @@ struct ParametersDescriptor {
 struct ModuleParameterHeader {
     SceInt32 module_id;
     SceInt32 channel;
-    ParametersDescriptor descriptor;
 };
 
 struct BufferParamsInfo {

--- a/vita3k/ngs/src/ngs.cpp
+++ b/vita3k/ngs/src/ngs.cpp
@@ -258,10 +258,11 @@ bool Voice::parse_params(const MemState &mem, const ModuleParameterHeader *heade
     if (storage->flags & ModuleData::PARAMS_LOCK)
         return false;
 
-    if (header->descriptor.size > storage->info.size)
+    const auto *descr = reinterpret_cast<const ParametersDescriptor *>(header + 1);
+    if (descr->size > storage->info.size)
         return false;
 
-    memcpy(storage->info.data.get(mem), &header->descriptor + 1, header->descriptor.size);
+    memcpy(storage->info.data.get(mem), descr, descr->size);
 
     return true;
 }
@@ -278,7 +279,7 @@ SceInt32 Voice::parse_params_block(const MemState &mem, const ModuleParameterHea
             num_error++;
 
         // increment by the size of the header alone + the descriptor size
-        data += 2 * sizeof(SceUInt32) + header->descriptor.size;
+        data += sizeof(ModuleParameterHeader) + reinterpret_cast<const ParametersDescriptor *>(header + 1)->size;
 
         // set new header for next module
         header = reinterpret_cast<const ngs::ModuleParameterHeader *>(data);


### PR DESCRIPTION
Return `ModuleParameterHeader` to its previous structure to match the sdk, and adapt `parse_params` (which was broken anyway).
Also add missing checks to ngs calls.