### PR TITLE
shader: Handle 16-bit bitwise instructions

### DIFF
--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -497,12 +497,12 @@ bool USSETranslatorVisitor::vpck(
         source = utils::finalize(m_b, source1, source2, inst.opr.src1.swizzle, 0, dest_mask);
     }
 
-    // source is float destination is int
+    // source is int destination is float
     if (is_float_data_type(inst.opr.dest.type) && !is_float_data_type(inst.opr.src1.type)) {
         source = utils::convert_to_float(m_b, source, inst.opr.src1.type, scale);
     }
 
-    // source is int destination is float
+    // source is float destination is int
     if (!is_float_data_type(inst.opr.dest.type) && is_float_data_type(inst.opr.src1.type)) {
         source = utils::convert_to_int(m_b, source, inst.opr.dest.type, scale);
     }


### PR DESCRIPTION
Shader bitwise instructions have a flag to specify whether the registers are 16 or 32 bits.

This fixes the graphics in Dragon Quest Builder.