### PR TITLE
renderer/gl: Reuse the cached surface if available and support casting.

### DIFF
--- a/vita3k/app/CMakeLists.txt
+++ b/vita3k/app/CMakeLists.txt
@@ -3,11 +3,9 @@ add_library(
 	STATIC
 	include/app/functions.h
 	include/app/discord.h
-	include/app/screen_render.h
 	src/app_init.cpp
 	src/app.cpp
 	src/discord.cpp
-	src/screen_render.cpp
 )
 
 target_include_directories(app PUBLIC include)

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -181,7 +181,7 @@ bool init(HostState &state, Config &cfg, const Root &root_paths) {
 #endif
 
     if (!cfg.console) {
-        if (renderer::init(state.window.get(), state.renderer, state.backend_renderer, state.cfg)) {
+        if (renderer::init(state.window.get(), state.renderer, state.backend_renderer, state.cfg, state.base_path.data())) {
             update_viewport(state);
             return true;
         } else {

--- a/vita3k/features/include/features/state.h
+++ b/vita3k/features/include/features/state.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ struct FeatureState {
     bool support_texture_barrier = false; ///< Second option for blending. Slower but work on 3 vendors.
     bool direct_fragcolor = false;
     bool spirv_shader = false;
+    bool preserve_f16_nan_as_u16 = true; ///< Emit store of 4xU16 to draw buffer 1. This buffer is expected to be U16U16U16U16, which can be casted to F16F16F16F16. This is to preserve some drivers's behaviour of casting NaN to default value when store in framebuffer, not keeping its original value.
 
     bool is_programmable_blending_supported() const {
         return support_shader_interlock || support_texture_barrier || direct_fragcolor;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -18,7 +18,6 @@
 #include "interface.h"
 
 #include <app/functions.h>
-#include <app/screen_render.h>
 #include <config/functions.h>
 #include <config/version.h>
 #include <gui/functions.h>
@@ -292,12 +291,7 @@ int main(int argc, char *argv[]) {
     gui::init_app_background(gui, host, host.io.app_path);
     gui::update_last_time_app_used(gui, host, host.io.app_path);
 
-    app::gl_screen_renderer gl_renderer;
-
-    if (!gl_renderer.init(host.base_path))
-        return RendererInitFailed;
-
-    const auto draw_app_background = [](GuiState &gui, HostState &host) {
+    const auto draw_app_background = [&](GuiState &gui, HostState &host) {
         if (gui.apps_background.find(host.io.app_path) != gui.apps_background.end())
             // Display application background
             ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background[host.io.app_path],
@@ -343,7 +337,7 @@ int main(int argc, char *argv[]) {
 
         {
             const std::lock_guard<std::mutex> guard(host.display.display_info_mutex);
-            gl_renderer.render(host);
+            host.renderer->render_frame(host.viewport_pos, host.viewport_size, host.display, host.mem);
         }
 
         gui::draw_begin(gui, host);
@@ -363,7 +357,7 @@ int main(int argc, char *argv[]) {
 
         {
             const std::lock_guard<std::mutex> guard(host.display.display_info_mutex);
-            gl_renderer.render(host);
+            host.renderer->render_frame(host.viewport_pos, host.viewport_size, host.display, host.mem);
         }
 
         // Calculate FPS

--- a/vita3k/renderer/CMakeLists.txt
+++ b/vita3k/renderer/CMakeLists.txt
@@ -29,16 +29,19 @@ add_library(
 	include/renderer/gl/types.h
 	include/renderer/gl/state.h
 	include/renderer/gl/ring_buffer.h
+	include/renderer/gl/screen_render.h
 	include/renderer/gl/surface_cache.h
 	include/renderer/gl/functions.h
 
 	src/gl/attribute_formats.cpp
+	src/gl/color_formats.cpp
 	src/gl/compile_program.cpp
 	src/gl/draw.cpp
 	src/gl/fence.cpp
 	src/gl/load_shaders.cpp
 	src/gl/renderer.cpp
 	src/gl/ring_buffer.cpp
+        src/gl/screen_render.cpp
 	src/gl/surface_cache.cpp
 	src/gl/sync_state.cpp
 	src/gl/texture_formats.cpp
@@ -63,7 +66,7 @@ add_library(
 )
 
 target_include_directories(renderer PUBLIC include)
-target_link_libraries(renderer PUBLIC mem crypto dlmalloc stb shader glutil threads config util ${RENDERER_VULKAN_LIBRARIES})
+target_link_libraries(renderer PUBLIC crypto display dlmalloc mem stb shader glutil threads config util ${RENDERER_VULKAN_LIBRARIES})
 target_link_libraries(renderer PRIVATE sdl2 stb ffmpeg xxHash::xxhash)
 
 # Marshmallow Tracy linking

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -65,7 +65,7 @@ void reset_command_list(CommandList &command_list);
 void submit_command_list(State &state, renderer::Context *context, CommandList &command_list);
 void process_batch(State &state, MemState &mem, Config &config, CommandList &command_list, const char *base_path, const char *title_id);
 void process_batches(State &state, const FeatureState &features, MemState &mem, Config &config, const char *base_path, const char *title_id, const char *self_name);
-bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config);
+bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config, const char *base_path);
 
 void set_depth_bias(State &state, Context *ctx, bool is_front, int factor, int units);
 void set_depth_func(State &state, Context *ctx, bool is_front, SceGxmDepthFunc depth_func);

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -48,7 +48,7 @@ std::string pre_load_glsl_shader(const char *hash_text, const char *shader_type_
 // Uniforms.
 bool set_uniform_buffer(GLContext &context, MemState &mem, const bool vertex_shader, const int block_num, const int size, const void *data, bool log_active_shader);
 
-bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const bool hashless_texture_cache);
+bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const char *base_path, const bool hashless_texture_cache);
 bool create(std::unique_ptr<Context> &context);
 bool create(std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &params, const FeatureState &features);
 bool create(std::unique_ptr<FragmentProgram> &fp, GLState &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
@@ -112,4 +112,21 @@ bool init(GLTextureCacheState &cache, const bool hashless_texture_cache);
 void dump(const SceGxmTexture &gxm_texture, const MemState &mem, const std::string &name, const std::string &base_path, const std::string &title_id, Sha256Hash hash);
 
 } // namespace texture
+
+namespace color {
+
+GLenum translate_format(SceGxmColorBaseFormat base_format);
+GLenum translate_internal_format(SceGxmColorBaseFormat base_format);
+GLenum translate_type(SceGxmColorBaseFormat base_format);
+const GLint *translate_swizzle(SceGxmColorFormat fmt);
+size_t bytes_per_pixel(SceGxmColorBaseFormat base_format);
+size_t bytes_per_pixel_in_gl_storage(SceGxmColorBaseFormat base_format);
+bool convert_texture_format_to_color_format(SceGxmTextureFormat format, SceGxmColorFormat &color_format);
+bool is_write_surface_stored_rawly(SceGxmColorBaseFormat base_format);
+GLenum get_raw_store_internal_type(SceGxmColorBaseFormat base_format);
+GLenum get_raw_store_upload_format_type(SceGxmColorBaseFormat base_format);
+GLenum get_raw_store_upload_data_type(SceGxmColorBaseFormat base_format);
+
+} // namespace color
+
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/gl/screen_render.h
+++ b/vita3k/renderer/include/renderer/gl/screen_render.h
@@ -18,19 +18,25 @@
 #pragma once
 
 #include <glutil/shader.h>
+#include <util/types.h>
 
-struct HostState;
+namespace renderer::gl {
 
-namespace app {
-
-class gl_screen_renderer {
+class ScreenRenderer {
 public:
-    gl_screen_renderer() = default;
-    ~gl_screen_renderer();
+    ScreenRenderer() = default;
+    ~ScreenRenderer();
 
     bool init(const std::string &base_path);
-    void render(const HostState &state);
+    void render(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const float *uvs, const GLuint texture);
+
     void destroy();
+
+    // Fallback in case surface cache does not contain what we want
+    // For homebrew that does not use GXM
+    GLuint get_resident_texture() const {
+        return m_screen_texture;
+    }
 
 private:
     struct screen_vertex {
@@ -48,8 +54,10 @@ private:
     SharedGLObject m_render_shader;
     GLuint m_screen_texture{ 0 };
 
+    float last_uvs[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
+
     GLint posAttrib;
     GLint uvAttrib;
 };
 
-} // namespace app
+} // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <renderer/gl/screen_render.h>
 #include <renderer/gl/surface_cache.h>
 #include <renderer/state.h>
 #include <renderer/texture_cache_state.h>
@@ -43,9 +44,13 @@ struct GLState : public renderer::State {
     GLSurfaceCache surface_cache;
 
     std::vector<ShadersHash> shaders_cache_hashs;
-    std::string shader_version = "v1";
+    std::string shader_version;
 
-    bool init(const bool hashless_texture_cache);
+    ScreenRenderer screen_renderer;
+
+    bool init(const char *base_path, const bool hashless_texture_cache) override;
+    void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
+        const MemState &mem) override;
 };
 
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -26,6 +26,7 @@
 #include <mutex>
 
 struct SDL_Cursor;
+struct DisplayState;
 
 namespace renderer {
 struct State {
@@ -44,6 +45,11 @@ struct State {
 
     std::atomic<std::uint32_t> average_scene_per_frame = 1;
     std::uint32_t scene_processed_since_last_frame = 0;
+
+    virtual bool init(const char *base_path, const bool hashless_texture_cache) = 0;
+    virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
+        const MemState &mem)
+        = 0;
 
     virtual ~State() = default;
 };

--- a/vita3k/renderer/include/renderer/surface_cache.h
+++ b/vita3k/renderer/include/renderer/surface_cache.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -33,8 +33,8 @@ enum SurfaceTextureRetrievePurpose {
 
 class SurfaceCache {
 public:
-    virtual std::uint64_t retrieve_color_surface_texture_handle(const std::uint16_t width, const std::uint16_t height,
-        Ptr<void> address, SurfaceTextureRetrievePurpose purpose, std::uint16_t *stored_height = nullptr)
+    virtual std::uint64_t retrieve_color_surface_texture_handle(const std::uint16_t width, const std::uint16_t height, const std::uint16_t pixel_stride,
+        const SceGxmColorFormat color_format, Ptr<void> address, SurfaceTextureRetrievePurpose purpose, std::uint16_t *stored_height = nullptr, std::uint16_t *stored_width = nullptr)
         = 0;
     virtual std::uint64_t retrieve_ping_pong_color_surface_texture_handle(Ptr<void> address) = 0;
 
@@ -43,6 +43,9 @@ public:
     virtual std::uint64_t retrieve_framebuffer_handle(const MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
         std::uint64_t *color_texture_handle = nullptr, std::uint64_t *ds_texture_handle = nullptr,
         std::uint16_t *stored_height = nullptr)
+        = 0;
+
+    virtual std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, const std::uint32_t width, const std::uint32_t height, const std::uint32_t pitch, float *uvs)
         = 0;
 };
 } // namespace renderer

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -116,11 +116,11 @@ bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgra
     return false;
 }
 
-bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config) {
+bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config, const char *base_path) {
     switch (backend) {
     case Backend::OpenGL:
         state = std::make_unique<gl::GLState>();
-        if (!gl::create(window, state, config.hashless_texture_cache))
+        if (!gl::create(window, state, base_path, config.hashless_texture_cache))
             return false;
         break;
 #ifdef USE_VULKAN

--- a/vita3k/renderer/src/gl/color_formats.cpp
+++ b/vita3k/renderer/src/gl/color_formats.cpp
@@ -1,0 +1,238 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <renderer/functions.h>
+#include <renderer/gl/functions.h>
+
+#include <gxm/functions.h>
+#include <map>
+#include <util/log.h>
+
+namespace renderer::color {
+size_t bits_per_pixel(SceGxmColorBaseFormat base_format);
+}
+
+namespace renderer::gl {
+namespace color {
+
+static const GLint swizzle_abgr[4] = { GL_RED, GL_GREEN, GL_BLUE, GL_ALPHA };
+static const GLint swizzle_argb[4] = { GL_BLUE, GL_GREEN, GL_RED, GL_ALPHA };
+static const GLint swizzle_rgba[4] = { GL_ALPHA, GL_BLUE, GL_GREEN, GL_RED };
+static const GLint swizzle_bgra[4] = { GL_GREEN, GL_BLUE, GL_ALPHA, GL_RED };
+
+static const GLint *translate_swizzle(SceGxmColorSwizzle4Mode mode) {
+    switch (mode) {
+    case SCE_GXM_COLOR_SWIZZLE4_ABGR:
+        return swizzle_abgr;
+    case SCE_GXM_COLOR_SWIZZLE4_ARGB:
+        return swizzle_argb;
+    case SCE_GXM_COLOR_SWIZZLE4_RGBA:
+        return swizzle_rgba;
+    case SCE_GXM_COLOR_SWIZZLE4_BGRA:
+        return swizzle_bgra;
+    default:
+        break;
+    }
+
+    return swizzle_abgr;
+}
+
+// Translate popular color base format that can be bit-casted for purposes
+GLenum translate_internal_format(SceGxmColorBaseFormat base_format) {
+    switch (base_format) {
+    case SCE_GXM_COLOR_BASE_FORMAT_U8U8U8U8:
+        return GL_RGBA8;
+
+    case SCE_GXM_COLOR_BASE_FORMAT_S8S8S8S8:
+        return GL_RGBA8_SNORM;
+
+    case SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16:
+        return GL_RGBA16F;
+
+    default:
+        return GL_RGBA;
+    }
+}
+
+GLenum translate_format(SceGxmColorBaseFormat base_format) {
+    switch (base_format) {
+    case SCE_GXM_COLOR_BASE_FORMAT_U8U8U8U8:
+        return GL_RGBA;
+
+    case SCE_GXM_COLOR_BASE_FORMAT_S8S8S8S8:
+        return GL_RGBA;
+
+    default:
+        return GL_RGBA;
+    }
+}
+
+GLenum translate_type(SceGxmColorBaseFormat base_format) {
+    switch (base_format) {
+    case SCE_GXM_COLOR_BASE_FORMAT_U8U8U8U8:
+        return GL_UNSIGNED_BYTE;
+
+    case SCE_GXM_COLOR_BASE_FORMAT_S8S8S8S8:
+        return GL_BYTE;
+
+    case SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16:
+        return GL_HALF_FLOAT;
+
+    default:
+        return GL_UNSIGNED_BYTE;
+    }
+}
+
+const GLint *translate_swizzle(SceGxmColorFormat fmt) {
+    const SceGxmColorBaseFormat base_format = gxm::get_base_format(fmt);
+    const uint32_t swizzle = fmt & SCE_GXM_COLOR_SWIZZLE_MASK;
+    switch (base_format) {
+    // 1 Component.
+    case SCE_GXM_COLOR_BASE_FORMAT_U8U8U8U8:
+    case SCE_GXM_COLOR_BASE_FORMAT_S8S8S8S8:
+    case SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16:
+        return translate_swizzle(static_cast<SceGxmColorSwizzle4Mode>(swizzle));
+
+    default:
+        break;
+    }
+
+    return swizzle_abgr;
+}
+
+size_t bytes_per_pixel(SceGxmColorBaseFormat base_format) {
+    return renderer::color::bits_per_pixel(base_format) >> 3;
+}
+
+size_t bytes_per_pixel_in_gl_storage(SceGxmColorBaseFormat base_format) {
+    switch (base_format) {
+    case SCE_GXM_COLOR_BASE_FORMAT_U8U8U8U8:
+    case SCE_GXM_COLOR_BASE_FORMAT_S8S8S8S8:
+        return 4;
+    case SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16:
+        return 8;
+    default:
+        break;
+    }
+
+    return 4;
+}
+
+bool is_write_surface_stored_rawly(SceGxmColorBaseFormat base_format) {
+    return (base_format == SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16);
+}
+
+GLenum get_raw_store_internal_type(SceGxmColorBaseFormat base_format) {
+    switch (base_format) {
+    case SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16:
+        return GL_RGBA16UI;
+
+    default:
+        break;
+    }
+
+    return GL_RGBA16UI;
+}
+
+GLenum get_raw_store_upload_format_type(SceGxmColorBaseFormat base_format) {
+    switch (base_format) {
+    case SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16:
+        return GL_RGBA_INTEGER;
+
+    default:
+        break;
+    }
+
+    return GL_RGBA_INTEGER;
+}
+
+GLenum get_raw_store_upload_data_type(SceGxmColorBaseFormat base_format) {
+    switch (base_format) {
+    case SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16:
+        return GL_UNSIGNED_SHORT;
+
+    default:
+        break;
+    }
+
+    return GL_RGBA_INTEGER;
+}
+
+bool convert_texture_format_to_color_format(SceGxmTextureFormat format, SceGxmColorFormat &color_format) {
+    static const std::map<std::uint32_t, std::uint32_t> TEXTURE_TO_COLOR_FORMAT_MAPPING = {
+        { SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR, SCE_GXM_COLOR_FORMAT_U8U8U8U8_ABGR },
+        { SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ARGB, SCE_GXM_COLOR_FORMAT_U8U8U8U8_ARGB },
+        { SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_RGBA, SCE_GXM_COLOR_FORMAT_U8U8U8U8_RGBA },
+        { SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_BGRA, SCE_GXM_COLOR_FORMAT_U8U8U8U8_BGRA },
+        { SCE_GXM_TEXTURE_FORMAT_U8U8U8_BGR, SCE_GXM_COLOR_FORMAT_U8U8U8_BGR },
+        { SCE_GXM_TEXTURE_FORMAT_U8U8U8_RGB, SCE_GXM_COLOR_FORMAT_U8U8U8_RGB },
+        { SCE_GXM_TEXTURE_FORMAT_U5U6U5_BGR, SCE_GXM_COLOR_FORMAT_U5U6U5_BGR },
+        { SCE_GXM_TEXTURE_FORMAT_U5U6U5_RGB, SCE_GXM_COLOR_FORMAT_U5U6U5_RGB },
+        { SCE_GXM_TEXTURE_FORMAT_U1U5U5U5_ABGR, SCE_GXM_COLOR_FORMAT_U1U5U5U5_ABGR },
+        { SCE_GXM_TEXTURE_FORMAT_U1U5U5U5_ARGB, SCE_GXM_COLOR_FORMAT_U1U5U5U5_ARGB },
+        { SCE_GXM_TEXTURE_FORMAT_U5U5U5U1_RGBA, SCE_GXM_COLOR_FORMAT_U5U5U5U1_RGBA },
+        { SCE_GXM_TEXTURE_FORMAT_U5U5U5U1_BGRA, SCE_GXM_COLOR_FORMAT_U5U5U5U1_BGRA },
+        { SCE_GXM_TEXTURE_FORMAT_U4U4U4U4_ABGR, SCE_GXM_COLOR_FORMAT_U4U4U4U4_ABGR },
+        { SCE_GXM_TEXTURE_FORMAT_U4U4U4U4_ARGB, SCE_GXM_COLOR_FORMAT_U4U4U4U4_ARGB },
+        { SCE_GXM_TEXTURE_FORMAT_U4U4U4U4_RGBA, SCE_GXM_COLOR_FORMAT_U4U4U4U4_RGBA },
+        { SCE_GXM_TEXTURE_FORMAT_U4U4U4U4_BGRA, SCE_GXM_COLOR_FORMAT_U4U4U4U4_BGRA },
+        { SCE_GXM_TEXTURE_FORMAT_U8U3U3U2_ARGB, SCE_GXM_COLOR_FORMAT_U8U3U3U2_ARGB },
+        { SCE_GXM_TEXTURE_FORMAT_F16_R, SCE_GXM_COLOR_FORMAT_F16_R },
+        { SCE_GXM_TEXTURE_FORMAT_F16F16_GR, SCE_GXM_COLOR_FORMAT_F16F16_GR },
+        { SCE_GXM_TEXTURE_FORMAT_F32_R, SCE_GXM_COLOR_FORMAT_F32_R },
+        { SCE_GXM_TEXTURE_FORMAT_S16_R, SCE_GXM_COLOR_FORMAT_S16_R },
+        { SCE_GXM_TEXTURE_FORMAT_S16S16_GR, SCE_GXM_COLOR_FORMAT_S16S16_GR },
+        { SCE_GXM_TEXTURE_FORMAT_U16_R, SCE_GXM_COLOR_FORMAT_U16_R },
+        { SCE_GXM_TEXTURE_FORMAT_U16U16_GR, SCE_GXM_COLOR_FORMAT_U16U16_GR },
+        { SCE_GXM_TEXTURE_FORMAT_U2U10U10U10_ABGR, SCE_GXM_COLOR_FORMAT_U2U10U10U10_ABGR },
+        { SCE_GXM_TEXTURE_FORMAT_U2U10U10U10_ARGB, SCE_GXM_COLOR_FORMAT_U2U10U10U10_ARGB },
+        { SCE_GXM_TEXTURE_FORMAT_U10U10U10U2_RGBA, SCE_GXM_COLOR_FORMAT_U10U10U10U2_RGBA },
+        { SCE_GXM_TEXTURE_FORMAT_U10U10U10U2_BGRA, SCE_GXM_COLOR_FORMAT_U10U10U10U2_BGRA },
+        { SCE_GXM_TEXTURE_FORMAT_U8_R, SCE_GXM_COLOR_FORMAT_U8_R },
+        { SCE_GXM_TEXTURE_FORMAT_S8_R, SCE_GXM_COLOR_FORMAT_S8_R },
+        { SCE_GXM_TEXTURE_FORMAT_U6S5S5_BGR, SCE_GXM_TEXTURE_FORMAT_U6S5S5_BGR },
+        { SCE_GXM_TEXTURE_FORMAT_S5S5U6_RGB, SCE_GXM_COLOR_FORMAT_S5S5U6_RGB },
+        { SCE_GXM_TEXTURE_FORMAT_U8U8_GR, SCE_GXM_COLOR_FORMAT_U8U8_GR },
+        { SCE_GXM_TEXTURE_FORMAT_S8S8_GR, SCE_GXM_COLOR_FORMAT_S8S8_RG },
+        { SCE_GXM_TEXTURE_FORMAT_S8S8S8S8_ABGR, SCE_GXM_COLOR_FORMAT_S8S8S8S8_ABGR },
+        { SCE_GXM_TEXTURE_FORMAT_S8S8S8S8_ARGB, SCE_GXM_COLOR_FORMAT_S8S8S8S8_ARGB },
+        { SCE_GXM_TEXTURE_FORMAT_S8S8S8S8_RGBA, SCE_GXM_COLOR_FORMAT_S8S8S8S8_RGBA },
+        { SCE_GXM_TEXTURE_FORMAT_S8S8S8S8_BGRA, SCE_GXM_COLOR_FORMAT_S8S8S8S8_BGRA },
+        { SCE_GXM_TEXTURE_FORMAT_F16F16F16F16_ABGR, SCE_GXM_COLOR_FORMAT_F16F16F16F16_ABGR },
+        { SCE_GXM_TEXTURE_FORMAT_F16F16F16F16_ARGB, SCE_GXM_COLOR_FORMAT_F16F16F16F16_ARGB },
+        { SCE_GXM_TEXTURE_FORMAT_F16F16F16F16_RGBA, SCE_GXM_COLOR_FORMAT_F16F16F16F16_RGBA },
+        { SCE_GXM_TEXTURE_FORMAT_F16F16F16F16_BGRA, SCE_GXM_COLOR_FORMAT_F16F16F16F16_BGRA },
+        { SCE_GXM_TEXTURE_FORMAT_F32F32_GR, SCE_GXM_COLOR_FORMAT_F32F32_GR },
+        { SCE_GXM_TEXTURE_FORMAT_F10F11F11_BGR, SCE_GXM_COLOR_FORMAT_F10F11F11_BGR },
+        { SCE_GXM_TEXTURE_FORMAT_F11F11F10_RGB, SCE_GXM_COLOR_FORMAT_F11F11F10_RGB },
+        { SCE_GXM_TEXTURE_FORMAT_SE5M9M9M9_BGR, SCE_GXM_COLOR_FORMAT_SE5M9M9M9_BGR },
+        { SCE_GXM_TEXTURE_FORMAT_SE5M9M9M9_RGB, SCE_GXM_COLOR_FORMAT_SE5M9M9M9_RGB },
+        { SCE_GXM_TEXTURE_FORMAT_U2F10F10F10_ABGR, SCE_GXM_COLOR_FORMAT_U2F10F10F10_ABGR },
+        { SCE_GXM_TEXTURE_FORMAT_U2F10F10F10_ARGB, SCE_GXM_COLOR_FORMAT_U2F10F10F10_ARGB },
+        { SCE_GXM_TEXTURE_FORMAT_F10F10F10U2_RGBA, SCE_GXM_COLOR_FORMAT_F10F10F10U2_RGBA },
+        { SCE_GXM_TEXTURE_FORMAT_F10F10F10U2_BGRA, SCE_GXM_COLOR_FORMAT_F10F10F10U2_BGRA }
+    };
+
+    auto ite = TEXTURE_TO_COLOR_FORMAT_MAPPING.find(format);
+    if (ite == TEXTURE_TO_COLOR_FORMAT_MAPPING.end())
+        return false;
+
+    color_format = static_cast<SceGxmColorFormat>(ite->second);
+    return true;
+}
+} // namespace color
+} // namespace renderer::gl

--- a/vita3k/renderer/src/gl/compile_program.cpp
+++ b/vita3k/renderer/src/gl/compile_program.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -117,7 +117,7 @@ static void save_shaders_cache_hashs(std::vector<ShadersHash> &shaders_cache_has
         shaders_hashs.write((char *)&size, sizeof(size));
 
         // Write version of cache
-        const uint32_t versionInFile = 1;
+        const uint32_t versionInFile = shader::CURRENT_VERSION;
         shaders_hashs.write((char *)&versionInFile, sizeof(uint32_t));
 
         // Write shader hash list

--- a/vita3k/renderer/src/gl/load_shaders.cpp
+++ b/vita3k/renderer/src/gl/load_shaders.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@ bool get_shaders_cache_hashs(GLState &renderer, const char *base_path, const cha
         // Check version of cache
         uint32_t versionInFile;
         shaders_hashs.read((char *)&versionInFile, sizeof(uint32_t));
-        if (versionInFile != 1) {
+        if (versionInFile != shader::CURRENT_VERSION) {
             shaders_hashs.close();
             fs::remove_all(shaders_path);
             fs::remove_all(fs::path(base_path) / "shaderlog" / title_id / self_name);
@@ -69,6 +69,8 @@ bool get_shaders_cache_hashs(GLState &renderer, const char *base_path, const cha
 
             renderer.shaders_cache_hashs.push_back({ hash.frag, hash.vert });
         }
+
+        shaders_hashs.close();
     }
 
     return !renderer.shaders_cache_hashs.empty();

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@
 #include <shader/spirv_recompiler.h>
 #include <shader/usse_program_analyzer.h>
 
+#include <display/state.h>
 #include <features/state.h>
 
 #include <gxm/functions.h>
@@ -198,7 +199,7 @@ static void debug_output_callback(GLenum source, GLenum type, GLuint id, GLenum 
     LOG_DEBUG("[OPENGL - {} - {}] {}", type_str, severity_fmt, message);
 }
 
-bool create(SDL_Window *window, std::unique_ptr<State> &state, const bool hashless_texture_cache) {
+bool create(SDL_Window *window, std::unique_ptr<State> &state, const char *base_path, const bool hashless_texture_cache) {
     auto &gl_state = dynamic_cast<GLState &>(*state);
 
     // Recursively create GL version until one accepts
@@ -284,14 +285,21 @@ bool create(SDL_Window *window, std::unique_ptr<State> &state, const bool hashle
         LOG_WARN("Consider updating your graphics drivers or upgrading your GPU.");
     }
 
-    return gl_state.init(hashless_texture_cache);
+    return gl_state.init(base_path, hashless_texture_cache);
 }
 
-bool GLState::init(const bool hashless_texture_cache) {
+bool GLState::init(const char *base_path, const bool hashless_texture_cache) {
     if (!texture::init(texture_cache, hashless_texture_cache)) {
         LOG_ERROR("Failed to initialize texture cache!");
         return false;
     }
+
+    if (!screen_renderer.init(base_path)) {
+        LOG_ERROR("Failed to initialize screen renderer");
+        return false;
+    }
+
+    shader_version = fmt::format("v{}", shader::CURRENT_VERSION);
 
     return true;
 }
@@ -591,6 +599,28 @@ void get_surface_data(GLState &renderer, GLContext &context, size_t width, size_
 
     glPixelStorei(GL_PACK_ROW_LENGTH, 0);
     ++renderer.texture_cache.timestamp;
+}
+
+void GLState::render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
+    const MemState &mem) {
+    // Check if the surface exists
+    float uvs[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    bool need_uv = true;
+    std::uint64_t surface_handle = surface_cache.sourcing_color_surface_for_presentation(display.frame.base, display.frame.image_size.x, display.frame.image_size.y, display.frame.pitch, uvs);
+
+    if (!surface_handle) {
+        // Fallback to a manual upload (likely a black !!!)
+        need_uv = false;
+
+        glBindTexture(GL_TEXTURE_2D, screen_renderer.get_resident_texture());
+        const auto pixels = display.frame.base.cast<void>().get(mem);
+
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, display.frame.pitch);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, display.frame.image_size.x, display.frame.image_size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    }
+
+    screen_renderer.render(viewport_pos, viewport_size, need_uv ? uvs : nullptr, static_cast<GLuint>(surface_handle));
 }
 
 } // namespace renderer::gl

--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,19 +15,20 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#include <app/screen_render.h>
+#include <display/state.h>
+#include <mem/state.h>
+#include <renderer/gl/screen_render.h>
 
-#include <host/state.h>
 #include <util/log.h>
 
-namespace app {
+namespace renderer::gl {
 
-bool gl_screen_renderer::init(const std::string &base_path) {
+bool ScreenRenderer::init(const std::string &base_path) {
     glGenTextures(1, &m_screen_texture);
 
     const auto builtin_shaders_path = base_path + "shaders-builtin/";
 
-    m_render_shader = gl::load_shaders(builtin_shaders_path + "render_main.vert", builtin_shaders_path + "render_main.frag");
+    m_render_shader = ::gl::load_shaders(builtin_shaders_path + "render_main.vert", builtin_shaders_path + "render_main.frag");
     if (!m_render_shader) {
         LOG_CRITICAL("Couldn't compile essential shaders for rendering. Exiting");
         return false;
@@ -45,7 +46,7 @@ bool gl_screen_renderer::init(const std::string &base_path) {
 
     glGenBuffers(1, &m_vbo);
     glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_buffer_data), vertex_buffer_data, GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_buffer_data), vertex_buffer_data, GL_DYNAMIC_DRAW);
 
     posAttrib = glGetAttribLocation(*m_render_shader, "position_vertex");
     uvAttrib = glGetAttribLocation(*m_render_shader, "uv_vertex");
@@ -78,10 +79,7 @@ bool gl_screen_renderer::init(const std::string &base_path) {
     return true;
 }
 
-void gl_screen_renderer::render(const HostState &host) {
-    const DisplayState &display = host.display;
-    const MemState &mem = host.mem;
-
+void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const float *uvs, const GLuint texture) {
     // Backup GL state
     glActiveTexture(GL_TEXTURE0);
     GLint last_texture;
@@ -99,50 +97,76 @@ void gl_screen_renderer::render(const HostState &host) {
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_CULL_FACE);
 
-    glViewport(static_cast<GLint>(host.viewport_pos.x), static_cast<GLint>(host.viewport_pos.y), static_cast<GLsizei>(host.viewport_size.x),
-        static_cast<GLsizei>(host.viewport_size.y));
+    glViewport(static_cast<GLint>(viewport_pos.x), static_cast<GLint>(viewport_pos.y), static_cast<GLsizei>(viewport_size.x),
+        static_cast<GLsizei>(viewport_size.y));
 
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    if ((display.frame.image_size.x > 0) && (display.frame.image_size.y > 0)) {
-        glUseProgram(*m_render_shader);
-        glBindVertexArray(m_vao);
-        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+    glUseProgram(*m_render_shader);
+    glBindVertexArray(m_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
 
-        // 1st attribute: positions
-        glVertexAttribPointer(
-            posAttrib, // attribute index
-            3, // size
-            GL_FLOAT, // type
-            GL_FALSE, // normalized?
-            screen_vertex_size, // stride
-            reinterpret_cast<void *>(0) // array buffer offset
-        );
-        glEnableVertexAttribArray(posAttrib);
+    const float default_uv[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
 
-        // 2nd attribute: uvs
-        glVertexAttribPointer(
-            uvAttrib, // attribute index
-            2, // size
-            GL_FLOAT, // type
-            GL_FALSE, // normalized?
-            screen_vertex_size, // stride
-            reinterpret_cast<void *>(3 * sizeof(GLfloat)) // array buffer offset
-        );
-        glEnableVertexAttribArray(uvAttrib);
-
-        glBindTexture(GL_TEXTURE_2D, m_screen_texture);
-        const auto pixels = display.frame.base.cast<void>().get(mem);
-
-        glPixelStorei(GL_UNPACK_ROW_LENGTH, display.frame.pitch);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, display.frame.image_size.x, display.frame.image_size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-        glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
-        glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+    if (!uvs) {
+        uvs = default_uv;
     }
+
+    if ((uvs[0] != last_uvs[0]) || (uvs[1] != last_uvs[1]) || (uvs[2] != last_uvs[2]) || (uvs[3] != last_uvs[3])) {
+        // Reupload the data again
+        screen_vertices_t vertex_buffer_data = {
+            { { -1.f, -1.f, 0.0f }, { 0.f, 1.f } },
+            { { 1.f, -1.f, 0.0f }, { 1.f, 1.f } },
+            { { 1.f, 1.f, 0.0f }, { 1.f, 0.f } },
+            { { -1.f, 1.f, 0.0f }, { 0.f, 0.f } }
+        };
+
+        vertex_buffer_data[0].uv[0] = uvs[0];
+        vertex_buffer_data[0].uv[1] = uvs[3];
+
+        vertex_buffer_data[1].uv[0] = uvs[2];
+        vertex_buffer_data[1].uv[1] = uvs[3];
+
+        vertex_buffer_data[2].uv[0] = uvs[2];
+        vertex_buffer_data[2].uv[1] = uvs[1];
+
+        vertex_buffer_data[3].uv[0] = uvs[0];
+        vertex_buffer_data[3].uv[1] = uvs[1];
+
+        last_uvs[0] = uvs[0];
+        last_uvs[1] = uvs[1];
+        last_uvs[2] = uvs[2];
+        last_uvs[3] = uvs[3];
+
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_buffer_data), nullptr, GL_DYNAMIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_buffer_data), vertex_buffer_data, GL_DYNAMIC_DRAW);
+    }
+
+    // 1st attribute: positions
+    glVertexAttribPointer(
+        posAttrib, // attribute index
+        3, // size
+        GL_FLOAT, // type
+        GL_FALSE, // normalized?
+        screen_vertex_size, // stride
+        reinterpret_cast<void *>(0) // array buffer offset
+    );
+    glEnableVertexAttribArray(posAttrib);
+
+    // 2nd attribute: uvs
+    glVertexAttribPointer(
+        uvAttrib, // attribute index
+        2, // size
+        GL_FLOAT, // type
+        GL_FALSE, // normalized?
+        screen_vertex_size, // stride
+        reinterpret_cast<void *>(3 * sizeof(GLfloat)) // array buffer offset
+    );
+    glEnableVertexAttribArray(uvAttrib);
+
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
     glBindTexture(GL_TEXTURE_2D, last_texture);
 
@@ -169,7 +193,7 @@ void gl_screen_renderer::render(const HostState &host) {
     glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2], (GLsizei)last_viewport[3]);
 }
 
-void gl_screen_renderer::destroy() {
+void ScreenRenderer::destroy() {
     glDeleteBuffers(1, &m_vbo);
     m_vbo = 0;
 
@@ -180,8 +204,8 @@ void gl_screen_renderer::destroy() {
     m_screen_texture = 0;
 }
 
-gl_screen_renderer::~gl_screen_renderer() {
+ScreenRenderer::~ScreenRenderer() {
     destroy();
 }
 
-} // namespace app
+} // namespace renderer::gl

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -15,86 +15,380 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include <gxm/functions.h>
+#include <renderer/gl/functions.h>
 #include <renderer/gl/surface_cache.h>
 #include <renderer/gl/types.h>
 #include <util/log.h>
 
+#include <chrono>
+
 namespace renderer::gl {
+static constexpr std::uint64_t CASTED_UNUSED_TEXTURE_PURGE_SECS = 40;
+
 GLSurfaceCache::GLSurfaceCache() {
 }
 
-std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const std::uint16_t width, const std::uint16_t height,
-    Ptr<void> address, SurfaceTextureRetrievePurpose purpose, std::uint16_t *stored_height) {
+void GLSurfaceCache::do_typeless_copy(const GLint dest_texture, const GLint source_texture, const GLenum dest_internal,
+    const GLenum dest_upload_format, const GLenum dest_type, const GLenum source_format, const GLenum source_type, const int offset_x,
+    const int offset_y, const int width, const int height, const int dest_width, const int dest_height, const std::size_t total_source_size) {
+    static constexpr GLsizei I32_SIGNED_MAX = 0x7FFFFFFF;
+
+    if (!typeless_copy_buffer[0]) {
+        if (!typeless_copy_buffer.init(reinterpret_cast<renderer::Generator *>(glGenBuffers), reinterpret_cast<renderer::Deleter *>(glDeleteBuffers))) {
+            LOG_ERROR("Unable to initialize a typeless copy buffer");
+            return;
+        }
+    }
+
+    if (total_source_size > typeless_copy_buffer_size) {
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, typeless_copy_buffer[0]);
+        glBufferData(GL_PIXEL_PACK_BUFFER, total_source_size, nullptr, GL_STATIC_COPY);
+
+        typeless_copy_buffer_size = total_source_size;
+    }
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, typeless_copy_buffer[0]);
+    glGetTextureSubImage(source_texture, 0, offset_x, offset_y, 0, width, height, 1, source_format, source_type, I32_SIGNED_MAX, nullptr);
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, GL_NONE);
+
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, typeless_copy_buffer[0]);
+    glBindTexture(GL_TEXTURE_2D, dest_texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, dest_internal, dest_width, dest_height, 0, dest_upload_format, dest_type, nullptr);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, GL_NONE);
+}
+
+std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const std::uint16_t width, const std::uint16_t height, const std::uint16_t pixel_stride,
+    const SceGxmColorFormat color_format, Ptr<void> address, SurfaceTextureRetrievePurpose purpose, std::uint16_t *stored_height, std::uint16_t *stored_width) {
     // Create the key to access the cache struct
     const std::uint64_t key = address.address();
-    auto used_iterator = std::find(last_use_color_surface_index.begin(), last_use_color_surface_index.end(), key);
 
-    if (used_iterator != last_use_color_surface_index.end()) {
-        last_use_color_surface_index.erase(used_iterator);
-        last_use_color_surface_index.push_back(key);
+    SceGxmColorBaseFormat base_format = gxm::get_base_format(color_format);
+    GLenum surface_internal_format = color::translate_internal_format(base_format);
+    GLenum surface_upload_format = color::translate_format(base_format);
+    GLenum surface_data_type = color::translate_type(base_format);
+    const GLint *surface_swizzle = color::translate_swizzle(color_format);
 
-        GLColorSurfaceCacheInfo &info = color_surface_textures[key];
-        if ((info.width < width) || (info.height < height)) {
-            // May clear one frame (hopefully!)
-            // This handles some situation where game may stores texture in a larger texture then rebind it
-            glBindTexture(GL_TEXTURE_2D, info.gl_texture[0]);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    std::size_t bytes_per_stride = pixel_stride * color::bytes_per_pixel(base_format);
+    std::size_t total_surface_size = bytes_per_stride * height;
 
-            if (info.gl_ping_pong_texture[0]) {
-                glBindTexture(GL_TEXTURE_2D, info.gl_ping_pong_texture[0]);
-                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-            }
+    // Of course, this works under the assumption that range must be unique :D
+    auto ite = color_surface_textures.lower_bound(key);
+    bool invalidated = false;
 
-            info.width = width;
-            info.height = height;
-        } else {
-            if (purpose == SurfaceTextureRetrievePurpose::READING) {
-                if (info.flags & GLSurfaceCacheInfo::FLAG_DIRTY) {
-                    // We can't use this texture sadly :( If it uses for writing of course it will be gud gud
-                    return 0;
-                }
-            }
-        }
+    if (ite != color_surface_textures.end()) {
+        GLColorSurfaceCacheInfo &info = *ite->second;
+        auto used_iterator = std::find(last_use_color_surface_index.begin(), last_use_color_surface_index.end(), ite->first);
 
         if (stored_height) {
             *stored_height = info.height;
         }
 
-        return info.gl_texture[0];
+        if (stored_width) {
+            *stored_width = info.width;
+        }
+
+        // There are four situations I think of:
+        // 1. Different base address, lookup for write, in this case, if the cached surface range contains the given address, then
+        // probably this cached surface has already been freed GPU-wise. So erase.
+        // 2. Same base address, but width and height change to be larger, or format change if write. Remake a new one for both read and write sitatation.
+        // 3. Out of cache range. In write case, create a new one, in read case, lul
+        // 4. Read situation with smaller width and height, probably need to extract the needed region out.
+        const bool addr_in_range_of_cache = ((key + total_surface_size) <= (ite->first + info.total_bytes));
+        const bool cache_probably_freed = ((ite->first != key) && addr_in_range_of_cache && (purpose == SurfaceTextureRetrievePurpose::WRITING));
+        const bool surface_extent_changed = (info.width < width) || (info.height < height);
+        bool surface_stat_changed = false;
+
+        if (ite->first == key) {
+            if (purpose == SurfaceTextureRetrievePurpose::WRITING) {
+                surface_stat_changed = surface_extent_changed || (base_format != info.format);
+            } else {
+                // If the extent changed but format is not the same, then the probability of it being a cast is high
+                surface_stat_changed = surface_extent_changed && (base_format == info.format);
+            }
+        }
+
+        if (cache_probably_freed) {
+            for (auto ite = framebuffer_array.begin(); ite != framebuffer_array.end();) {
+                if ((ite->first & 0xFFFFFFFF) == key) {
+                    ite = framebuffer_array.erase(ite);
+                } else {
+                    ite++;
+                }
+            }
+            // Clear out. We will recreate later
+            color_surface_textures.erase(ite);
+            invalidated = true;
+        } else if (surface_stat_changed) {
+            // Remake locally to avoid making changes to framebuffer array
+            info.width = width;
+            info.height = height;
+            info.pixel_stride = pixel_stride;
+            info.format = base_format;
+            info.total_bytes = total_surface_size;
+            info.flags = 0;
+
+            bool store_rawly = false;
+
+            if (color::is_write_surface_stored_rawly(base_format)) {
+                surface_internal_format = color::get_raw_store_internal_type(base_format);
+                surface_upload_format = color::get_raw_store_upload_format_type(base_format);
+                surface_data_type = color::get_raw_store_upload_data_type(base_format);
+
+                store_rawly = true;
+            }
+
+            auto remake_and_apply_filters_to_current_binded = [&]() {
+                glTexImage2D(GL_TEXTURE_2D, 0, surface_internal_format, width, height, 0, surface_upload_format, surface_data_type, nullptr);
+
+                if (!store_rawly) {
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+                } else {
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+                }
+            };
+
+            // This handles some situation where game may stores texture in a larger texture then rebind it
+            glBindTexture(GL_TEXTURE_2D, info.gl_texture[0]);
+            remake_and_apply_filters_to_current_binded();
+
+            if (info.gl_ping_pong_texture[0]) {
+                glBindTexture(GL_TEXTURE_2D, info.gl_ping_pong_texture[0]);
+                remake_and_apply_filters_to_current_binded();
+            }
+
+            info.casted_textures.clear();
+        }
+        if (!addr_in_range_of_cache) {
+            if (purpose == SurfaceTextureRetrievePurpose::WRITING) {
+                invalidated = true;
+            }
+        } else {
+            // If we read and it's still in range
+            if ((purpose == SurfaceTextureRetrievePurpose::READING) && addr_in_range_of_cache) {
+                if (used_iterator != last_use_color_surface_index.end()) {
+                    last_use_color_surface_index.erase(used_iterator);
+                }
+
+                last_use_color_surface_index.push_back(ite->first);
+
+                if (info.flags & GLSurfaceCacheInfo::FLAG_DIRTY) {
+                    // We can't use this texture sadly :( If it uses for writing of course it will be gud gud
+                    return 0;
+                }
+
+                bool castable = (info.pixel_stride == pixel_stride);
+
+                std::size_t bytes_per_pixel_requested = color::bytes_per_pixel(base_format);
+                std::size_t bytes_per_pixel_in_store = color::bytes_per_pixel(info.format);
+
+                // Check if castable. Technically the income format should be texture format, but this is for easier logic.
+                // When it's required. I may change :p
+                if (base_format != info.format) {
+                    if (bytes_per_pixel_requested > bytes_per_pixel_in_store) {
+                        castable = (((bytes_per_pixel_requested % bytes_per_pixel_in_store) == 0) && (info.pixel_stride % pixel_stride == 0) && ((info.pixel_stride / pixel_stride) == (bytes_per_pixel_requested / bytes_per_pixel_in_store)));
+                    } else {
+                        castable = (((bytes_per_pixel_in_store % bytes_per_pixel_requested) == 0) && (pixel_stride % info.pixel_stride == 0) && ((pixel_stride / info.pixel_stride) == (bytes_per_pixel_in_store / bytes_per_pixel_requested)));
+                    }
+
+                    if (castable) {
+                        // Check if the GL implementation actually store raw like this (a safe check)
+                        if ((bytes_per_pixel_requested != color::bytes_per_pixel_in_gl_storage(base_format)) || (bytes_per_pixel_in_store != color::bytes_per_pixel_in_gl_storage(info.format))) {
+                            LOG_ERROR("One or both two surface formats requested=0x{:X} and inStore=0x{:X} does not support bit-casting. Please report to developers!",
+                                base_format, info.format);
+
+                            return 0;
+                        }
+                    } else {
+                        LOG_ERROR("Two surface formats requested=0x{:X} and inStore=0x{:X} are not castable!", base_format, info.format);
+                        return 0;
+                    }
+                }
+
+                if (castable) {
+                    const std::size_t data_delta = address.address() - ite->first;
+                    std::size_t start_sourced_line = data_delta / bytes_per_stride;
+                    std::size_t start_x = (data_delta % bytes_per_stride) / color::bytes_per_pixel(base_format);
+
+                    if (static_cast<std::uint16_t>(start_sourced_line + height) > info.height) {
+                        LOG_ERROR("Trying to present non-existen segment in cached color surface!");
+                        return 0;
+                    }
+
+                    if ((start_sourced_line != 0) || (start_x != 0) || (info.width != width) || (info.height != height) || (info.format != base_format)) {
+                        std::uint64_t current_time = std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::steady_clock::now().time_since_epoch())
+                                                         .count();
+
+                        std::vector<std::unique_ptr<GLCastedTexture>> &casted_vec = info.casted_textures;
+
+                        GLenum source_format, source_data_type = 0;
+
+                        if (color::is_write_surface_stored_rawly(info.format)) {
+                            source_format = color::get_raw_store_upload_format_type(info.format);
+                            source_data_type = color::get_raw_store_upload_data_type(info.format);
+                        } else {
+                            source_format = color::translate_format(info.format);
+                            source_data_type = color::translate_type(info.format);
+                        }
+
+                        if ((base_format != info.format) || (info.height != height) || (info.width != width) || (ite->first != address.address())) {
+                            // Look in cast cache and grab one. The cache really does not store immediate grab on now, but rather to reduce the synchronization in the pipeline (use different texture)
+                            for (std::size_t i = 0; i < casted_vec.size();) {
+                                if ((casted_vec[i]->cropped_height == height) && (casted_vec[i]->cropped_width == width) && (casted_vec[i]->cropped_y == start_sourced_line) && (casted_vec[i]->cropped_x == start_x) && (casted_vec[i]->format == base_format)) {
+                                    glBindTexture(GL_TEXTURE_2D, casted_vec[i]->texture[0]);
+                                    glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, surface_swizzle);
+
+                                    if (color::bytes_per_pixel_in_gl_storage(base_format) == color::bytes_per_pixel_in_gl_storage(info.format)) {
+                                        glCopyImageSubData(info.gl_texture[0], GL_TEXTURE_2D, 0, static_cast<int>(start_x), static_cast<int>(start_sourced_line), 0, casted_vec[i]->texture[0], GL_TEXTURE_2D,
+                                            0, 0, 0, 0, width, height, 1);
+                                    } else {
+                                        do_typeless_copy(casted_vec[i]->texture[0], info.gl_texture[0], surface_internal_format, surface_upload_format,
+                                            surface_data_type, source_format, source_data_type, static_cast<int>(start_x), static_cast<int>(start_sourced_line), info.width,
+                                            height, width, height, info.total_bytes);
+                                    }
+
+                                    casted_vec[i]->last_used_time = current_time;
+                                    return casted_vec[i]->texture[0];
+                                } else {
+                                    if (current_time - info.casted_textures[i]->last_used_time >= CASTED_UNUSED_TEXTURE_PURGE_SECS) {
+                                        casted_vec.erase(casted_vec.begin() + i);
+                                        continue;
+                                    }
+                                }
+
+                                i++;
+                            }
+                        }
+
+                        // Try to crop + cast
+                        std::unique_ptr<GLCastedTexture> casted_info_unq = std::make_unique<GLCastedTexture>();
+                        GLCastedTexture &casted_info = *casted_info_unq;
+
+                        if (!casted_info.texture.init(reinterpret_cast<renderer::Generator *>(glGenTextures), reinterpret_cast<renderer::Deleter *>(glDeleteTextures))) {
+                            LOG_ERROR("Failed to initialise cast color surface texture!");
+                            return 0;
+                        }
+
+                        glBindTexture(GL_TEXTURE_2D, casted_info.texture[0]);
+
+                        if (color::bytes_per_pixel_in_gl_storage(base_format) == color::bytes_per_pixel_in_gl_storage(info.format)) {
+                            glTexImage2D(GL_TEXTURE_2D, 0, surface_internal_format, width, height, 0, surface_upload_format, surface_data_type, nullptr);
+
+                            // Make it a complete texture (what kind of requirement is this)?
+                            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+                            glCopyImageSubData(info.gl_texture[0], GL_TEXTURE_2D, 0, 0, start_sourced_line, 0, casted_info.texture[0], GL_TEXTURE_2D,
+                                0, 0, 0, 0, width, height, 1);
+                        } else {
+                            // TODO: Copy sub region of typeless copy is still not handled ((
+                            // We must do a typeless copy (RPCS3)
+                            do_typeless_copy(casted_info.texture[0], info.gl_texture[0], surface_internal_format, surface_upload_format,
+                                surface_data_type, source_format, source_data_type, static_cast<int>(start_x), static_cast<int>(start_sourced_line), info.width,
+                                height, width, height, info.total_bytes);
+
+                            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+                        }
+
+                        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, surface_swizzle);
+
+                        casted_info.format = base_format;
+                        casted_info.cropped_x = start_x;
+                        casted_info.cropped_y = start_sourced_line;
+                        casted_info.cropped_width = width;
+                        casted_info.cropped_height = height;
+                        casted_info.last_used_time = current_time;
+                        casted_vec.push_back(std::move(casted_info_unq));
+
+                        return casted_info.texture[0];
+                    } else {
+                        if (color::is_write_surface_stored_rawly(info.format)) {
+                            // Create a texture view
+                            if (!info.gl_expected_read_texture_view[0]) {
+                                if (!info.gl_expected_read_texture_view.init(reinterpret_cast<renderer::Generator *>(glGenTextures), reinterpret_cast<renderer::Deleter *>(glDeleteTextures))) {
+                                    LOG_ERROR("Unable to initialize texture view for casting texture!");
+                                    return 0;
+                                }
+
+                                glTextureView(info.gl_expected_read_texture_view[0], GL_TEXTURE_2D, info.gl_texture[0], surface_internal_format, 0, 1, 0, 1);
+                            }
+
+                            return info.gl_expected_read_texture_view[0];
+                        }
+
+                        return info.gl_texture[0];
+                    }
+                }
+            }
+        }
+
+        if (!invalidated) {
+            if (purpose == SurfaceTextureRetrievePurpose::WRITING) {
+                if (used_iterator != last_use_color_surface_index.end()) {
+                    last_use_color_surface_index.erase(used_iterator);
+                }
+
+                last_use_color_surface_index.push_back(ite->first);
+                return info.gl_texture[0];
+            } else {
+                return 0;
+            }
+        } else if (invalidated) {
+            if (used_iterator != last_use_color_surface_index.end()) {
+                last_use_color_surface_index.erase(used_iterator);
+            }
+        }
     }
 
-    if (purpose == SurfaceTextureRetrievePurpose::READING) {
-        return 0;
-    }
+    std::unique_ptr<GLColorSurfaceCacheInfo> info_added = std::make_unique<GLColorSurfaceCacheInfo>();
 
-    GLColorSurfaceCacheInfo &info_added = color_surface_textures[key];
-    info_added.width = width;
-    info_added.height = height;
-    info_added.data = address;
-    info_added.flags = 0;
+    info_added->width = width;
+    info_added->height = height;
+    info_added->pixel_stride = pixel_stride;
+    info_added->data = address;
+    info_added->total_bytes = bytes_per_stride * height;
+    info_added->format = base_format;
+    info_added->flags = 0;
 
-    if (!info_added.gl_texture.init(reinterpret_cast<renderer::Generator *>(glGenTextures), reinterpret_cast<renderer::Deleter *>(glDeleteTextures))) {
+    if (!info_added->gl_texture.init(reinterpret_cast<renderer::Generator *>(glGenTextures), reinterpret_cast<renderer::Deleter *>(glDeleteTextures))) {
         LOG_ERROR("Failed to initialise color surface texture!");
         color_surface_textures.erase(key);
 
         return 0;
     }
 
-    glBindTexture(GL_TEXTURE_2D, info_added.gl_texture[0]);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GLint texture_handle_return = info_added->gl_texture[0];
+    bool store_rawly = false;
+
+    if (color::is_write_surface_stored_rawly(base_format)) {
+        surface_internal_format = color::get_raw_store_internal_type(base_format);
+        surface_upload_format = color::get_raw_store_upload_format_type(base_format);
+        surface_data_type = color::get_raw_store_upload_data_type(base_format);
+
+        store_rawly = true;
+    }
+
+    glBindTexture(GL_TEXTURE_2D, texture_handle_return);
+    glTexImage2D(GL_TEXTURE_2D, 0, surface_internal_format, width, height, 0, surface_upload_format, surface_data_type, nullptr);
+
+    if (!store_rawly) {
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    } else {
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    }
+
+    color_surface_textures.emplace(address.address(), std::move(info_added));
 
     // Now that everything goes well, we can start rearranging
     if (last_use_color_surface_index.size() >= MAX_CACHE_SIZE_PER_CONTAINER) {
         // We have to purge a cache along with framebuffer
         // So choose the one that is last used
         const std::uint64_t first_key = last_use_color_surface_index.front();
-        GLuint texture_handle = color_surface_textures[first_key].gl_texture[0];
+        GLuint texture_handle = color_surface_textures.find(first_key)->second->gl_texture[0];
 
         for (auto it = framebuffer_array.cbegin(); it != framebuffer_array.cend();) {
             if ((it->first & 0xFFFFFFFF) == texture_handle) {
@@ -114,7 +408,11 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const std::u
         *stored_height = height;
     }
 
-    return info_added.gl_texture[0];
+    if (stored_width) {
+        *stored_width = width;
+    }
+
+    return texture_handle_return;
 }
 
 std::uint64_t GLSurfaceCache::retrieve_ping_pong_color_surface_texture_handle(Ptr<void> address) {
@@ -123,7 +421,12 @@ std::uint64_t GLSurfaceCache::retrieve_ping_pong_color_surface_texture_handle(Pt
         return 0;
     }
 
-    GLColorSurfaceCacheInfo &info = ite->second;
+    GLColorSurfaceCacheInfo &info = *ite->second;
+
+    GLenum surface_internal_format = color::translate_internal_format(info.format);
+    GLenum surface_upload_format = color::translate_format(info.format);
+    GLenum surface_data_type = color::translate_type(info.format);
+
     if (!info.gl_ping_pong_texture[0]) {
         if (!info.gl_ping_pong_texture.init(reinterpret_cast<renderer::Generator *>(glGenTextures), reinterpret_cast<renderer::Deleter *>(glDeleteTextures))) {
             LOG_ERROR("Failed to initialise ping pong surface texture!");
@@ -131,7 +434,7 @@ std::uint64_t GLSurfaceCache::retrieve_ping_pong_color_surface_texture_handle(Pt
         }
 
         glBindTexture(GL_TEXTURE_2D, info.gl_ping_pong_texture[0]);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, info.width, info.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+        glTexImage2D(GL_TEXTURE_2D, 0, surface_internal_format, info.width, info.height, 0, surface_upload_format, surface_data_type, nullptr);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     } else {
@@ -246,7 +549,8 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const MemState &mem, S
 
     if (color) {
         color_handle = static_cast<GLuint>(retrieve_color_surface_texture_handle(color->width,
-            color->height, color->data, renderer::SurfaceTextureRetrievePurpose::WRITING, stored_height));
+            color->height, color->strideInPixels, color->colorFormat, color->data,
+            renderer::SurfaceTextureRetrievePurpose::WRITING, stored_height));
     } else {
         color_handle = target->attachments[0];
     }
@@ -280,9 +584,17 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const MemState &mem, S
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, fb[0]);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, color_handle, 0);
-    glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, ds_handle, 0);
 
+    if (color && renderer::gl::color::is_write_surface_stored_rawly(gxm::get_base_format(color->colorFormat))) {
+        glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, color_handle, 0);
+
+        const GLenum buffers[] = { GL_NONE, GL_COLOR_ATTACHMENT1 };
+        glDrawBuffers(2, buffers);
+    } else {
+        glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, color_handle, 0);
+    }
+
+    glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, ds_handle, 0);
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
         LOG_ERROR("Framebuffer is not completed. Proceed anyway...");
 
@@ -301,4 +613,37 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const MemState &mem, S
 
     return fb[0];
 }
+
+std::uint64_t GLSurfaceCache::sourcing_color_surface_for_presentation(Ptr<const void> address, const std::uint32_t width, const std::uint32_t height, const std::uint32_t pitch, float *uvs) {
+    auto ite = color_surface_textures.lower_bound(address.address());
+    if (ite == color_surface_textures.end()) {
+        return 0;
+    }
+
+    const GLColorSurfaceCacheInfo &info = *ite->second;
+
+    if (info.pixel_stride == pitch) {
+        // In assumption the format is RGBA8
+        const std::size_t data_delta = address.address() - ite->first;
+        if ((data_delta % (pitch * 4)) == 0) {
+            std::uint32_t start_sourced_line = (data_delta / (pitch * 4));
+            if ((start_sourced_line + height) > info.height) {
+                LOG_ERROR("Trying to present non-existen segment in cached color surface!");
+                return 0;
+            }
+
+            // Calculate uvs
+            // First two top left, the two others bottom right
+            uvs[0] = 0.0f;
+            uvs[1] = static_cast<float>(start_sourced_line) / info.height;
+            uvs[2] = static_cast<float>(width) / info.width;
+            uvs[3] = static_cast<float>(start_sourced_line + height) / info.height;
+
+            return info.gl_texture[0];
+        }
+    }
+
+    return 0;
+}
+
 } // namespace renderer::gl

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -341,10 +341,20 @@ void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t
             context.self_sampling_indices.erase(res);
         }
 
-        texture_as_surface = state.surface_cache.retrieve_color_surface_texture_handle(
-            static_cast<std::uint16_t>(gxm::get_width(&texture)),
-            static_cast<std::uint16_t>(gxm::get_height(&texture)),
-            Ptr<void>(data_addr), renderer::SurfaceTextureRetrievePurpose::READING);
+        SceGxmColorFormat format_target_of_texture;
+        if (color::convert_texture_format_to_color_format(format, format_target_of_texture)) {
+            std::uint16_t width = static_cast<std::uint16_t>(gxm::get_width(&texture));
+            std::uint16_t stride_in_pixels = width;
+
+            if (texture.texture_type() == SCE_GXM_TEXTURE_LINEAR_STRIDED) {
+                stride_in_pixels = static_cast<std::uint16_t>(gxm::get_stride_in_bytes(&texture)) / ((renderer::texture::bits_per_pixel(base_format) + 7) >> 3);
+            }
+
+            texture_as_surface = state.surface_cache.retrieve_color_surface_texture_handle(
+                width, static_cast<std::uint16_t>(gxm::get_height(&texture)),
+                stride_in_pixels, format_target_of_texture, Ptr<void>(data_addr),
+                renderer::SurfaceTextureRetrievePurpose::READING);
+        }
     }
 
     if (texture_as_surface != 0) {

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -34,6 +34,7 @@ class Builder;
 namespace shader {
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
+static constexpr std::uint32_t CURRENT_VERSION = 2;
 
 // Dump generated SPIR-V disassembly up to this point
 void spirv_disasm_print(const usse::SpirvCode &spirv_binary, std::string *spirv_dump = nullptr);

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -1073,7 +1073,7 @@ void convert_gxp_usse_to_spirv(spv::Builder &b, const SceGxmProgram &program, co
     b.createFunctionCall(end_hook_func, {});
 
     std::vector<spv::Id> empty_args;
-    if (features.should_use_shader_interlock() && program.is_fragment() && program.is_native_color())
+    if (features.should_use_shader_interlock() && program.is_fragment() && program.is_frag_color_used())
         b.createNoResultOp(spv::OpEndInvocationInterlockEXT);
 }
 


### PR DESCRIPTION
# About
- renderer/gl: Reuse the cached surface if available and support surface casting.
- Move screen render to renderer module. It does not make much sense to be in app module now.

# Result:
When combine with #1761 
- Before
![image](https://user-images.githubusercontent.com/5261759/170692835-7b9d655d-6a98-4bc6-adb6-21cbf73706b3.png)
- After
![image](https://user-images.githubusercontent.com/5261759/170692814-1029d9cc-68da-4a77-98c6-52d163dcf2a6.png)

- fix also ingame to it, for first time go ingame
![image](https://user-images.githubusercontent.com/5261759/170700676-39dd3920-a63b-4f43-9dba-135c862e4666.png)

