### PR TITLE
renderer: improve render frame from surface cache.

### DIFF
--- a/vita3k/gxm/include/gxm/state.h
+++ b/vita3k/gxm/include/gxm/state.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <gxm/types.h>
 #include <mem/ptr.h>
 #include <threads/queue.h>
 
@@ -24,6 +25,9 @@
 #include <mutex>
 
 typedef void SceGxmDisplayQueueCallback(Ptr<const void> callbackData);
+static constexpr std::uint64_t SCENE_TIME_UNDEF = 0xFFFFFFFFFFFFFFFF;
+static constexpr std::uint64_t GPU_SYNCING_DISABLE_SCENE_DELTA = 40;
+static constexpr std::uint64_t GPU_INSERT_FENCE_SCENE_DELTA = 30;
 
 struct SceGxmInitializeParams {
     uint32_t flags = 0;
@@ -46,11 +50,33 @@ struct MemoryMapInfo {
     std::uint32_t perm;
 };
 
+struct SurfaceSyncingInfo {
+    Address addr = 0;
+    std::size_t size = 0;
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    std::uint32_t stride = 0;
+    SceGxmColorFormat sync_format;
+    SceGxmColorSurfaceType surface_type;
+    std::uint64_t scene_time_last_memaccess = SCENE_TIME_UNDEF;
+    std::uint64_t scene_time_passed = 0;
+    bool reprotect_needed = false;
+
+    bool should_insert_protect_fence() const {
+        return ((scene_time_last_memaccess == SCENE_TIME_UNDEF) || (scene_time_passed - scene_time_last_memaccess >= GPU_INSERT_FENCE_SCENE_DELTA));
+    }
+
+    bool syncing_disabled() const {
+        return ((scene_time_last_memaccess == SCENE_TIME_UNDEF) || (scene_time_passed - scene_time_last_memaccess >= GPU_SYNCING_DISABLE_SCENE_DELTA));
+    }
+};
+
 struct GxmState {
     SceGxmInitializeParams params;
     Queue<DisplayCallback> display_queue;
     Ptr<uint32_t> notification_region;
     SceUID display_queue_thread;
     std::map<Address, MemoryMapInfo> memory_mapped_regions;
+    std::array<SurfaceSyncingInfo, 40> surface_syncing_infoes;
     std::mutex callback_lock;
 };

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -337,7 +337,7 @@ int main(int argc, char *argv[]) {
 
         {
             const std::lock_guard<std::mutex> guard(host.display.display_info_mutex);
-            host.renderer->render_frame(host.viewport_pos, host.viewport_size, host.display, host.mem);
+            host.renderer->render_frame(host.viewport_pos, host.viewport_size, host.display, host.gxm, host.mem);
         }
 
         gui::draw_begin(gui, host);
@@ -357,7 +357,7 @@ int main(int argc, char *argv[]) {
 
         {
             const std::lock_guard<std::mutex> guard(host.display.display_info_mutex);
-            host.renderer->render_frame(host.viewport_pos, host.viewport_size, host.display, host.mem);
+            host.renderer->render_frame(host.viewport_pos, host.viewport_size, host.display, host.gxm, host.mem);
         }
 
         // Calculate FPS

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -50,7 +50,7 @@ struct GLState : public renderer::State {
 
     bool init(const char *base_path, const bool hashless_texture_cache) override;
     void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
-        const MemState &mem) override;
+        const GxmState &gxm, MemState &mem) override;
 };
 
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -27,6 +27,7 @@
 
 struct SDL_Cursor;
 struct DisplayState;
+struct GxmState;
 
 namespace renderer {
 struct State {
@@ -48,7 +49,7 @@ struct State {
 
     virtual bool init(const char *base_path, const bool hashless_texture_cache) = 0;
     virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
-        const MemState &mem)
+        const GxmState &gxm, MemState &mem)
         = 0;
 
     virtual ~State() = default;


### PR DESCRIPTION
# About:
- renderer: improve render frame from surface cache.
- renderer: Fix special converse format cause sigsegv.
We must reserve temporary storage for it!