### PR TITLE
renderer: Fix renderer for mesa drivers

### DIFF
--- a/vita3k/glutil/include/glutil/object_array.h
+++ b/vita3k/glutil/include/glutil/object_array.h
@@ -54,7 +54,6 @@ public:
     const GLuint operator[](size_t i) const {
         assert(i >= 0);
         assert(i < names.size());
-        assert(names[i] != 0);
         return names[i];
     }
 

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -988,7 +988,7 @@ EXPORT(int, sceGxmDestroyContext, Ptr<SceGxmContext> context) {
     if (!context)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
 
-    free(host.mem, context);
+    renderer::destroy_context(*host.renderer, context.get(host.mem)->renderer);
 
     return 0;
 }

--- a/vita3k/renderer/include/renderer/commands.h
+++ b/vita3k/renderer/include/renderer/commands.h
@@ -66,7 +66,8 @@ enum class CommandOpcode : std::uint8_t {
 
     SignalNotification = 10,
 
-    DestroyRenderTarget = 11
+    DestroyRenderTarget = 11,
+    DestroyContext = 12
 };
 
 enum CommandErrorCode {

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -90,6 +90,7 @@ void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndex
 void sync_surface_data(State &state, Context *ctx);
 
 bool create_context(State &state, std::unique_ptr<Context> &context);
+void destroy_context(State &state, std::unique_ptr<Context> &context);
 bool create_render_target(State &state, std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams *params);
 void destroy_render_target(State &state, std::unique_ptr<RenderTarget> &rt);
 

--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -58,7 +58,8 @@ void process_batch(renderer::State &state, const FeatureState &features, MemStat
         { CommandOpcode::SetState, cmd_handle_set_state },
         { CommandOpcode::SignalSyncObject, cmd_handle_signal_sync_object },
         { CommandOpcode::SignalNotification, cmd_handle_notification },
-        { CommandOpcode::DestroyRenderTarget, cmd_handle_destroy_render_target }
+        { CommandOpcode::DestroyRenderTarget, cmd_handle_destroy_render_target },
+        { CommandOpcode::DestroyContext, cmd_handle_destroy_context }
     };
 
     Command *cmd = command_list.first;

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -54,6 +54,13 @@ COMMAND(handle_create_context) {
     complete_command(renderer, helper, result);
 }
 
+COMMAND(handle_destroy_context) {
+    std::unique_ptr<Context> *ctx = helper.pop<std::unique_ptr<Context> *>();
+    ctx->reset();
+
+    complete_command(renderer, helper, 0);
+}
+
 COMMAND(handle_create_render_target) {
     std::unique_ptr<RenderTarget> *render_target = helper.pop<std::unique_ptr<RenderTarget> *>();
     SceGxmRenderTargetParams *params = helper.pop<SceGxmRenderTargetParams *>();

--- a/vita3k/renderer/src/driver_functions.h
+++ b/vita3k/renderer/src/driver_functions.h
@@ -52,6 +52,7 @@ COMMAND(handle_set_state);
 
 // Creation
 COMMAND(handle_create_context);
+COMMAND(handle_destroy_context);
 COMMAND(handle_create_render_target);
 COMMAND(handle_destroy_render_target);
 

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -109,6 +109,10 @@ bool create_context(State &state, std::unique_ptr<Context> &context) {
     return renderer::send_single_command(state, nullptr, renderer::CommandOpcode::CreateContext, &context);
 }
 
+void destroy_context(State &state, std::unique_ptr<Context> &context) {
+    renderer::send_single_command(state, nullptr, renderer::CommandOpcode::DestroyContext, &context);
+}
+
 bool create_render_target(State &state, std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams *params) {
     return renderer::send_single_command(state, nullptr, renderer::CommandOpcode::CreateRenderTarget, &rt, params);
 }


### PR DESCRIPTION
This fixes the yellow screen when using mesa drivers (mainly used by linux users).
Textures used for image load/store must be immutable (use glTexStorage2D) (otherwise mesa drivers will silently fail when executing shaders...). This was not the case for the mask texture. I haven't been able to find if this is required by the doc or only specific to mesa drivers.

Also fix sceGxmDestroyContext which was broken for many reasons:
- opengl buffers' deletion is not done on the same thread as other opengl calls
- it frees the memory used by the GxmContext, but it is not up to this function to do so (double free).

Also fix debug builds, opengl debug context and increase the opengl version requirement: we use glBufferStorage which requires openGL 4.4 anyway.