### PR TITLE
display: Start vsync thread during boot

### DIFF
--- a/vita3k/display/include/display/functions.h
+++ b/vita3k/display/include/display/functions.h
@@ -23,4 +23,5 @@
 struct DisplayState;
 struct KernelState;
 
+void start_sync_thread(DisplayState &display, KernelState &kernel);
 void wait_vblank(DisplayState &display, KernelState &kernel, const ThreadStatePtr &wait_thread, const int count, const bool is_cb);

--- a/vita3k/display/src/display.cpp
+++ b/vita3k/display/src/display.cpp
@@ -76,6 +76,10 @@ static void vblank_sync_thread(DisplayState &display, KernelState &kernel) {
     }
 }
 
+void start_sync_thread(DisplayState &display, KernelState &kernel) {
+    display.vblank_thread = std::make_unique<std::thread>(vblank_sync_thread, std::ref(display), std::ref(kernel));
+}
+
 void wait_vblank(DisplayState &display, KernelState &kernel, const ThreadStatePtr &wait_thread, int count, const bool is_cb) {
     if (!wait_thread) {
         return;
@@ -86,10 +90,6 @@ void wait_vblank(DisplayState &display, KernelState &kernel, const ThreadStatePt
 
     {
         const std::lock_guard<std::mutex> guard(display.mutex);
-
-        if (!display.vblank_thread) {
-            display.vblank_thread = std::make_unique<std::thread>(vblank_sync_thread, std::ref(display), std::ref(kernel));
-        }
 
         wait_thread->suspend();
         display.vblank_wait_infos.push_back({ wait_thread, count, is_cb });

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -18,6 +18,7 @@
 #include "interface.h"
 
 #include <ctrl/functions.h>
+#include <display/functions.h>
 #include <gui/functions.h>
 #include <host/functions.h>
 #include <host/pkg.h>
@@ -777,6 +778,8 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
         app::error_dialog("Failed to run main thread.", host.window.get());
         return RunThreadFailed;
     }
+
+    start_sync_thread(host.display, host.kernel);
 
     return Success;
 }


### PR DESCRIPTION
Right now, the vsync thread is started when the first waitVBlank or waitSetFrameBuf is called. 
However the vsync thread has more uses than this (like updating the framebuffer infos) and should be started when the application boots up.

This fixes the sample vitasdk program displaying a red square.

![image](https://user-images.githubusercontent.com/5671744/170894297-03851ed1-b5b7-43d8-90c3-67782ea4aa32.png)
