### PR TITLE
 shader: Correct buffer copy to register offset. 

### DIFF
--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -149,13 +149,16 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
                     buffer.index = parameter.container_index;
                     buffer.reg_block_size = reg_block_size;
                     buffer.rw = false;
-                    buffer.reg_start_offset = offset;
+                    buffer.reg_start_offset = container ? container->base_sa_offset : offset;
                     buffer.size = parameter.resource_index + parameter_size_in_f32;
                     uniform_buffers.emplace(parameter.container_index, buffer);
                 } else {
                     auto &buffer = uniform_buffers.at(parameter.container_index);
                     buffer.size = std::max(parameter.resource_index + parameter_size_in_f32, buffer.size);
-                    buffer.reg_start_offset = std::min(buffer.reg_start_offset, static_cast<uint32_t>(offset));
+
+                    if (!container) {
+                        buffer.reg_start_offset = std::min(buffer.reg_start_offset, static_cast<uint32_t>(offset));
+                    }
                 }
             }
             break;


### PR DESCRIPTION
# About:
- Improve render of gravity rush with fix green, lsd and some effect visible
- fix black screen of super stardust ultra and resident evil revelation 2

# Result:
- Before
![image](https://cdn.discordapp.com/attachments/442344583293304833/980642065157341255/unknown.png)
![image](https://user-images.githubusercontent.com/5261759/170901293-bc75ae0d-489e-4489-9147-246c2ce615fc.png)
![image](https://user-images.githubusercontent.com/5261759/170901309-fcdce8ce-5f6e-4d73-908d-9ede79550dc4.png)

- After
- Alone
![image](https://cdn.discordapp.com/attachments/966671333373124628/980812481276551188/unknown.png)
- Combined with #1779  
![image](https://user-images.githubusercontent.com/5261759/170901322-ff03097a-9009-46c3-8cfc-7ac89ba668ef.png)
![image](https://user-images.githubusercontent.com/5261759/170901338-a70c5dfd-cf8a-49ef-97f0-3a8ceb12db96.png)
![image](https://user-images.githubusercontent.com/5261759/170901349-67c7041c-c558-4cf1-b5a2-eef7e420a2e7.png)


- Black screen fixed
![image](https://user-images.githubusercontent.com/5261759/170902441-13c72212-c846-41ea-ba39-a372ef03bb25.png)
![image](https://user-images.githubusercontent.com/5261759/170902774-222ac997-4c84-40ee-9268-f3f91212a0f3.png)