### PR TITLE
shader/spirv recompiler: handle default sampler value when no exist.

### DIFF
--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -569,9 +569,12 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
 
             tex_query_info.coord_index = tex_coord_index;
 
-            if (anonymous) {
+            if (anonymous && (samplers.find(sampler_resource_index) == samplers.end())) {
                 // Probably not gonna be used in future, just for non-dependent queries
                 tex_query_info.sampler = create_param_sampler(b, (program.is_vertex() ? "vertTex_" : "fragTex_") + tex_name, dim_type);
+
+                b.addDecoration(tex_query_info.sampler, spv::DecorationBinding, sampler_resource_index);
+                samplers[sampler_resource_index] = tex_query_info.sampler;
             } else {
                 tex_query_info.sampler = samplers[sampler_resource_index];
             }


### PR DESCRIPTION
# About:
- add part of commit missing from #1761 