### PR TITLE
tracy: Fix cropped names

### DIFF
--- a/vita3k/module/include/module/bridge.h
+++ b/vita3k/module/include/module/bridge.h
@@ -53,7 +53,7 @@ ImportFn bridge(Ret (*export_fn)(HostState &, SceUID, const char *, Args...), co
 #ifdef TRACY_ENABLE
         ZoneNamed(___tracy_scoped_zone, host.cfg.tracy_primitive_impl); // Tracy - Track function scope
         ZoneColorV(___tracy_scoped_zone, 0xFFF34C); // Tracy - Change color to yellow
-        ZoneNameV(___tracy_scoped_zone, export_name, sizeof(export_name)); // Tracy - Edit scope name based on export_name
+        ZoneNameV(___tracy_scoped_zone, export_name, strlen(export_name)); // Tracy - Edit scope name based on export_name
 #endif
 
         using Indices = std::index_sequence_for<Args...>;


### PR DESCRIPTION
Tracy names were cropped to 8 characters because sizeof was used instead of strlen.