### PR TITLE
modules/SceVideodec: Return one last frame when calling sceAvcdecDecodeStop

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -91,6 +91,8 @@ struct H264DecoderState : public DecoderState {
     uint64_t dts = ~0ull;
     uint64_t pts_out = ~0ull;
 
+    bool is_stopped = true;
+
     static uint32_t buffer_size(DecoderSize size);
 
     uint32_t get(DecoderQuery query) override;


### PR DESCRIPTION
I guess the PS vita expects us to be able to output one last frame when calling `sceAvcdecDecodeStop`, however ffmpeg does not allow us to do so (different decoder internals, maybe it is expecting a bit more data to generate the frame). 
Proper fix inspired by a hack from bookmist.

This fixes the softlocks occuring when skipping fmvs in Tales of games and also a lot of the AVAGAIN fmvs warnings in games like persona dancing where it is calling `sceAvcdecDecodeStop` until it gets its last frame.