### PR TITLE
renderer: Fix blending

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -46,7 +46,7 @@ enum SceGxmContextType {
     SCE_GXM_CONTEXT_TYPE_DEFERRED
 };
 
-enum SceGxmColorMask {
+enum SceGxmColorMask : uint8_t {
     SCE_GXM_COLOR_MASK_NONE = 0,
     SCE_GXM_COLOR_MASK_A = (1 << 0),
     SCE_GXM_COLOR_MASK_R = (1 << 1),
@@ -55,7 +55,7 @@ enum SceGxmColorMask {
     SCE_GXM_COLOR_MASK_ALL = (SCE_GXM_COLOR_MASK_A | SCE_GXM_COLOR_MASK_B | SCE_GXM_COLOR_MASK_G | SCE_GXM_COLOR_MASK_R)
 };
 
-enum SceGxmBlendFunc {
+enum SceGxmBlendFunc : uint8_t {
     SCE_GXM_BLEND_FUNC_NONE,
     SCE_GXM_BLEND_FUNC_ADD,
     SCE_GXM_BLEND_FUNC_SUBTRACT,
@@ -64,7 +64,7 @@ enum SceGxmBlendFunc {
     SCE_GXM_BLEND_FUNC_MAX
 };
 
-enum SceGxmBlendFactor {
+enum SceGxmBlendFactor : uint8_t {
     SCE_GXM_BLEND_FACTOR_ZERO,
     SCE_GXM_BLEND_FACTOR_ONE,
     SCE_GXM_BLEND_FACTOR_SRC_COLOR,


### PR DESCRIPTION
You MUST never use different data types in a C structure that uses bit fields (and always use an integer type). Otherwise 9 time out of 10 it will work perfectly fine but the 10th it will give weird results that are really hard to understand.
Specifying a few enums to be uint8_t fixes this problem for `SceGxmBlendInfo`.

This fixes the blending in Persona 4 dancing (and it should be fixed in many other games that use blending).
![image](https://user-images.githubusercontent.com/5671744/171908235-f2b50ccf-3bc3-42ad-b906-c6fa5fd11624.png)
