### PR TITLE
shader: Do not compute data type size too early

### DIFF
--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -1090,8 +1090,6 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
     // register boundary, translate it to just a createStore
     auto total_comp_source = static_cast<std::uint8_t>(b.getNumComponents(source));
 
-    const std::size_t size_comp = get_data_type_size(dest.type);
-
     spv::Id source_elm_type_id = b.getTypeId(source);
     if (b.isVectorType(source_elm_type_id)) {
         source_elm_type_id = b.getContainedTypeId(source_elm_type_id);
@@ -1124,6 +1122,8 @@ void shader::usse::utils::store(spv::Builder &b, const SpirvShaderParameters &pa
         dest.num <<= 2;
         off <<= 2;
     }
+
+    const std::size_t size_comp = get_data_type_size(dest.type);
 
     spv::Id bank_base = *get_reg_bank(params, dest.bank);
 


### PR DESCRIPTION
This fixes Persona 3 Dancing graphic issues.

![image](https://user-images.githubusercontent.com/5671744/171947236-e344b470-f328-4a7b-b2e5-16414af2441c.png)
