### PR TITLE
ngs: Pass proper argument to buffer swap callback

### DIFF
--- a/vita3k/ngs/src/modules/atrac9.cpp
+++ b/vita3k/ngs/src/modules/atrac9.cpp
@@ -108,12 +108,12 @@ bool Module::decode_more_data(KernelState &kern, const MemState &mem, const SceU
                 // TODO: Free all occupied input routes
                 // unroute_occupied(mem, voice);
             } else {
-                data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_SWAPPED_BUFFER, state->current_loop_count,
+                data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_SWAPPED_BUFFER, prev_index,
                     params->buffer_params[state->current_buffer].buffer.address());
             }
         } else {
             // from what I understand, SCE_NGS_AT9_SWAPPED_BUFFER must be called even when it's just the current buffer looping
-            data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_SWAPPED_BUFFER, state->current_loop_count,
+            data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_SWAPPED_BUFFER, prev_index,
                 params->buffer_params[state->current_buffer].buffer.address());
             data.invoke_callback(kern, mem, thread_id, SCE_NGS_AT9_LOOPED_BUFFER, state->current_loop_count,
                 params->buffer_params[state->current_buffer].buffer.address());


### PR DESCRIPTION
Fix regression from #1795 which caused the audio to loop on a small sample.