### PR TITLE
ngs: Implement playback rate in the Atrac9 player

### DIFF
--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -952,7 +952,7 @@ EXPORT(SceInt32, sceNgsVoiceUnlockParams, SceNgsVoiceHandle handle, const SceUIn
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
     }
 
-    if (!data->unlock_params()) {
+    if (!data->unlock_params(host.mem)) {
         return RET_ERROR(SCE_NGS_ERROR);
     }
 

--- a/vita3k/ngs/include/ngs/modules/player.h
+++ b/vita3k/ngs/include/ngs/modules/player.h
@@ -102,5 +102,6 @@ public:
     std::uint32_t module_id() const override { return 0x5CE6; }
     std::size_t get_buffer_parameter_size() const override;
     void on_state_change(ModuleData &v, const VoiceState previous) override;
+    void on_param_change(const MemState &mem, ModuleData &data) override;
 };
 } // namespace ngs::player

--- a/vita3k/ngs/include/ngs/system.h
+++ b/vita3k/ngs/include/ngs/system.h
@@ -130,7 +130,7 @@ struct ModuleData {
         const std::uint32_t reason2, Address reason_ptr);
 
     BufferParamsInfo *lock_params(const MemState &mem);
-    bool unlock_params();
+    bool unlock_params(const MemState &mem);
 };
 
 struct Module {
@@ -144,6 +144,7 @@ struct Module {
     virtual std::uint32_t module_id() const { return 0; }
     virtual std::size_t get_buffer_parameter_size() const = 0;
     virtual void on_state_change(ModuleData &v, const VoiceState previous) {}
+    virtual void on_param_change(const MemState &mem, ModuleData &data) {}
 };
 
 static constexpr std::uint32_t MAX_VOICE_OUTPUT = 8;

--- a/vita3k/ngs/src/modules/player.cpp
+++ b/vita3k/ngs/src/modules/player.cpp
@@ -49,6 +49,17 @@ void Module::on_state_change(ModuleData &data, const VoiceState previous) {
     }
 }
 
+void Module::on_param_change(const MemState &mem, ModuleData &data) {
+    State *state = data.get_state<State>();
+    const Parameters *old_params = reinterpret_cast<Parameters *>(data.last_info.data());
+    const Parameters *new_params = reinterpret_cast<Parameters *>(data.info.data.get(mem));
+
+    // if playback scaling changed, reset the resampler
+    if (state->swr && (old_params->playback_frequency != new_params->playback_frequency || old_params->playback_scalar != new_params->playback_scalar)) {
+        swr_free(&state->swr);
+    }
+}
+
 bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) {
     Parameters *params = data.get_parameters<Parameters>(mem);
     State *state = data.get_state<State>();


### PR DESCRIPTION
Implement playback rate in the Atrac9 player and add improvement to the atrac9 and normal player in case the playback settings of a voice change.
Also fix a regression in the atrac9 player if a frame is across two buffers.