### PR TITLE
renderer: Add upscaling support

### DIFF
--- a/vita3k/app/src/app.cpp
+++ b/vita3k/app/src/app.cpp
@@ -59,8 +59,9 @@ void calculate_fps(HostState &host) {
 }
 
 void set_window_title(HostState &host) {
-    const std::string title_to_set = fmt::format("{} | {} ({}) | {} ms/frame ({} frames/sec)", window_title,
-        host.current_app_title, host.io.title_id, host.ms_per_frame, host.fps);
+    const std::string title_to_set = fmt::format("{} | {} ({}) | {} ms/frame ({} frames/sec) ({}x{})", window_title,
+        host.current_app_title, host.io.title_id, host.ms_per_frame, host.fps, 960 * host.cfg.current_config.resolution_multiplier,
+        544 * host.cfg.current_config.resolution_multiplier);
 
     SDL_SetWindowTitle(host.window.get(), title_to_set.c_str());
 }

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -58,6 +58,8 @@ enum PerfomanceOverleyPosition {
     code(bool, "show-live-area-screen", true, show_live_area_screen)                                    \
     code(int, "icon-size", 64, icon_size)                                                               \
     code(bool, "archive-log", false, archive_log)                                                       \
+    code(int, "resolution-multiplier", 1, resolution_multiplier)                                        \
+    code(bool, "disable-surface-sync", false, disable_surface_sync)                                     \
     code(bool, "texture-cache", true, texture_cache)                                                    \
     code(bool, "hashless-texture-cache", false, hashless_texture_cache)                                 \
     code(bool, "disable-ngs", false, disable_ngs)                                                       \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -122,6 +122,8 @@ public:
         std::vector<std::string> lle_modules = {};
         bool pstv_mode = false;
         bool disable_ngs = false;
+        int resolution_multiplier = 1;
+        bool disable_surface_sync = false;
     };
 
     /**

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -499,6 +499,7 @@ static ExitCode load_app_impl(Ptr<const void> &entry_point, HostState &host, con
     LOG_INFO("{}: {}", host.cfg[e_cpu_backend], host.cfg.current_config.cpu_backend);
     LOG_INFO_IF(host.kernel.cpu_backend == CPUBackend::Dynarmic, "CPU Optimisation state: {}", host.cfg.current_config.cpu_opt);
     LOG_INFO("ngs state: {}", !host.cfg.current_config.disable_ngs);
+    LOG_INFO("Resolution multiplier: {}", host.cfg.resolution_multiplier);
     refresh_controllers(host.ctrl);
     if (host.ctrl.controllers_num) {
         LOG_INFO("{} Controllers Connected", host.ctrl.controllers_num);

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -50,29 +50,28 @@ bool set_uniform_buffer(GLContext &context, MemState &mem, const bool vertex_sha
 
 bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const char *base_path, const bool hashless_texture_cache);
 bool create(std::unique_ptr<Context> &context);
-bool create(std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &params, const FeatureState &features);
+bool create(GLState &state, std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &params, const FeatureState &features);
 bool create(std::unique_ptr<FragmentProgram> &fp, GLState &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
 bool create(std::unique_ptr<VertexProgram> &vp, GLState &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
-void sync_rendertarget(const GLRenderTarget &rt);
 void set_context(GLState &state, GLContext &ctx, const MemState &mem, const GLRenderTarget *rt, const FeatureState &features);
-void get_surface_data(GLState &renderer, GLContext &context, size_t width, size_t height, size_t stride_in_pixels, uint32_t *pixels, SceGxmColorFormat format, SceGxmColorSurfaceType surface_type);
+void get_surface_data(GLState &renderer, GLContext &context, uint32_t *pixels, SceGxmColorSurface &surface);
 void lookup_and_get_surface_data(GLState &renderer, MemState &mem, SceGxmColorSurface &surface);
 void draw(GLState &renderer, GLContext &context, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format,
     void *indices, size_t count, uint32_t instance_count, MemState &mem, const char *base_path, const char *title_id, const char *self_name, const Config &config);
 
 // State
-void sync_viewport_flat(GLContext &context);
-void sync_viewport_real(GLContext &context, const float xOffset, const float yOffset, const float zOffset,
+void sync_viewport_flat(const GLState &state, GLContext &context);
+void sync_viewport_real(const GLState &state, GLContext &context, const float xOffset, const float yOffset, const float zOffset,
     const float xScale, const float yScale, const float zScale);
 
-void sync_clipping(GLContext &context);
+void sync_clipping(const GLState &state, GLContext &context);
 void sync_cull(const GxmRecordState &state);
 void sync_depth_func(const SceGxmDepthFunc func, const bool is_front);
 void sync_depth_write_enable(const SceGxmDepthWriteMode mode, const bool is_front);
 void sync_depth_data(const renderer::GxmRecordState &state);
 void sync_stencil_data(const renderer::GxmRecordState &state, const MemState &mem);
 void sync_stencil_func(const GxmStencilState &state, const MemState &mem, bool is_back_stencil);
-void sync_mask(GLContext &context, const MemState &mem);
+void sync_mask(const GLState &state, GLContext &context, const MemState &mem);
 void sync_polygon_mode(const SceGxmPolygonMode mode, const bool front);
 void sync_point_line_width(const std::uint32_t size, const bool front);
 void sync_depth_bias(const int factor, const int unit, const bool front);

--- a/vita3k/renderer/include/renderer/gl/surface_cache.h
+++ b/vita3k/renderer/include/renderer/gl/surface_cache.h
@@ -53,6 +53,8 @@ struct GLCastedTexture {
 struct GLColorSurfaceCacheInfo : public GLSurfaceCacheInfo {
     std::uint16_t width;
     std::uint16_t height;
+    uint16_t original_width;
+    uint16_t original_height;
     std::uint16_t pixel_stride;
     std::size_t total_bytes;
 
@@ -98,15 +100,15 @@ private:
 public:
     explicit GLSurfaceCache();
 
-    std::uint64_t retrieve_color_surface_texture_handle(const std::uint16_t width, const std::uint16_t height, const std::uint16_t pixel_stride,
+    std::uint64_t retrieve_color_surface_texture_handle(const State &state, std::uint16_t width, std::uint16_t height, const std::uint16_t pixel_stride,
         const SceGxmColorBaseFormat color_format, Ptr<void> address, SurfaceTextureRetrievePurpose purpose, std::uint32_t &swizzle,
         std::uint16_t *stored_height = nullptr, std::uint16_t *stored_width = nullptr) override;
     std::uint64_t retrieve_ping_pong_color_surface_texture_handle(Ptr<void> address) override;
 
     // We really can't sample this around... The only usage of this function is interally load/store from this texture.
-    std::uint64_t retrieve_depth_stencil_texture_handle(const MemState &mem, const SceGxmDepthStencilSurface &surface, std::int32_t force_width = -1,
+    std::uint64_t retrieve_depth_stencil_texture_handle(const State &state, const MemState &mem, const SceGxmDepthStencilSurface &surface, std::int32_t force_width = -1,
         std::int32_t force_height = -1, const bool is_reading = false) override;
-    std::uint64_t retrieve_framebuffer_handle(const MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
+    std::uint64_t retrieve_framebuffer_handle(const State &state, const MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
         std::uint64_t *color_texture_handle = nullptr, std::uint64_t *ds_texture_handle = nullptr,
         std::uint16_t *stored_height = nullptr) override;
 
@@ -114,6 +116,6 @@ public:
         target = new_target;
     }
 
-    std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, const std::uint32_t width, const std::uint32_t height, const std::uint32_t pitch, float *uvs) override;
+    std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier) override;
 };
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/gl/types.h
+++ b/vita3k/renderer/include/renderer/gl/types.h
@@ -80,6 +80,7 @@ struct GXMRenderFragUniformBlock {
     float writing_mask = 0;
     float use_raw_image = 0;
     float integral_texture_query_format[SCE_GXM_MAX_TEXTURE_UNITS];
+    int32_t res_multiplier = 0;
 };
 
 struct GLContext : public renderer::Context {

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -33,6 +33,8 @@ namespace renderer {
 struct State {
     Backend current_backend;
     FeatureState features;
+    int res_multiplier;
+    bool disable_surface_sync;
 
     GXPPtrMap gxp_ptr_map;
     Queue<CommandList> command_buffer_queue;

--- a/vita3k/renderer/include/renderer/surface_cache.h
+++ b/vita3k/renderer/include/renderer/surface_cache.h
@@ -26,29 +26,32 @@
 struct MemState;
 
 namespace renderer {
+
+struct State;
+
 enum SurfaceTextureRetrievePurpose {
     READING,
-    WRITING
+    WRITING,
 };
 
 class SurfaceCache {
 public:
-    virtual std::uint64_t retrieve_color_surface_texture_handle(const std::uint16_t width, const std::uint16_t height, const std::uint16_t pixel_stride,
+    virtual std::uint64_t retrieve_color_surface_texture_handle(const State &state, std::uint16_t width, std::uint16_t height, const std::uint16_t pixel_stride,
         const SceGxmColorBaseFormat color_format, Ptr<void> address, SurfaceTextureRetrievePurpose purpose, std::uint32_t &swizzle,
         std::uint16_t *stored_height = nullptr, std::uint16_t *stored_width = nullptr)
         = 0;
     virtual std::uint64_t retrieve_ping_pong_color_surface_texture_handle(Ptr<void> address) = 0;
 
     // We really can't sample this around... The only usage of this function is interally load/store from this texture.
-    virtual std::uint64_t retrieve_depth_stencil_texture_handle(const MemState &mem, const SceGxmDepthStencilSurface &surface, std::int32_t force_width = -1,
+    virtual std::uint64_t retrieve_depth_stencil_texture_handle(const State &state, const MemState &mem, const SceGxmDepthStencilSurface &surface, std::int32_t force_width = -1,
         std::int32_t force_height = -1, const bool is_reading = false)
         = 0;
-    virtual std::uint64_t retrieve_framebuffer_handle(const MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
+    virtual std::uint64_t retrieve_framebuffer_handle(const State &state, const MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
         std::uint64_t *color_texture_handle = nullptr, std::uint64_t *ds_texture_handle = nullptr,
         std::uint16_t *stored_height = nullptr)
         = 0;
 
-    virtual std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, const std::uint32_t width, const std::uint32_t height, const std::uint32_t pitch, float *uvs)
+    virtual std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier)
         = 0;
 };
 } // namespace renderer

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -69,7 +69,7 @@ COMMAND(handle_create_render_target) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL: {
-        result = gl::create(*render_target, *params, features);
+        result = gl::create(static_cast<gl::GLState &>(renderer), *render_target, *params, features);
         break;
     }
 

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -151,6 +151,7 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
     }
     frag_ublock.writing_mask = context.record.writing_mask;
     frag_ublock.use_raw_image = static_cast<float>(use_raw_image);
+    frag_ublock.res_multiplier = renderer.res_multiplier;
 
     if (memcmp(&context.previous_frag_info, &frag_ublock, sizeof(GXMRenderFragUniformBlock)) != 0) {
         std::pair<std::uint8_t *, std::size_t> allocated_buffer = context.fragment_info_uniform_buffer.allocate(sizeof(GXMRenderFragUniformBlock));

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -85,6 +85,13 @@ COMMAND(handle_sync_surface_data) {
             return;
         }
     }
+
+    if (renderer.disable_surface_sync) {
+        if (helper.cmd->status)
+            complete_command(renderer, helper, 0);
+        return;
+    }
+
     const size_t width = surface->width;
     const size_t height = surface->height;
     const size_t stride_in_pixels = surface->strideInPixels;
@@ -103,8 +110,7 @@ COMMAND(handle_sync_surface_data) {
         if (helper.cmd->status) {
             gl::lookup_and_get_surface_data(static_cast<gl::GLState &>(renderer), mem, *surface);
         } else {
-            gl::get_surface_data(static_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context), width, height,
-                stride_in_pixels, pixels, surface->colorFormat, surface->surfaceType);
+            gl::get_surface_data(static_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context), pixels, *surface);
         }
 
         break;

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -46,7 +46,7 @@ COMMAND_SET_STATE(region_clip) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL: {
-        gl::sync_clipping(*reinterpret_cast<gl::GLContext *>(render_context));
+        gl::sync_clipping(static_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context));
         break;
     }
 
@@ -138,7 +138,7 @@ COMMAND_SET_STATE(viewport) {
 
         switch (renderer.current_backend) {
         case Backend::OpenGL:
-            gl::sync_viewport_real(*reinterpret_cast<gl::GLContext *>(render_context), xOffset, yOffset, zOffset, xScale, yScale, zScale);
+            gl::sync_viewport_real(static_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context), xOffset, yOffset, zOffset, xScale, yScale, zScale);
             break;
 
         default:
@@ -148,7 +148,7 @@ COMMAND_SET_STATE(viewport) {
     } else {
         switch (renderer.current_backend) {
         case Backend::OpenGL:
-            gl::sync_viewport_flat(*reinterpret_cast<gl::GLContext *>(render_context));
+            gl::sync_viewport_flat(static_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context));
             break;
 
         default:


### PR DESCRIPTION
Add upscaling support to Vita3K.

The most important thing left to do is to implement surface readback to the cpu. It isn't hard but I need first to fix and merge #1770 in order for it not to kill performance.