### PR TITLE
renderer: Add anti-aliasing support (FXAA)

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -60,6 +60,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "archive-log", false, archive_log)                                                       \
     code(int, "resolution-multiplier", 1, resolution_multiplier)                                        \
     code(bool, "disable-surface-sync", false, disable_surface_sync)                                     \
+    code(bool, "enable-fxaa", false, enable_fxaa)                                                       \
     code(bool, "texture-cache", true, texture_cache)                                                    \
     code(bool, "hashless-texture-cache", false, hashless_texture_cache)                                 \
     code(bool, "disable-ngs", false, disable_ngs)                                                       \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -124,6 +124,7 @@ public:
         bool disable_ngs = false;
         int resolution_multiplier = 1;
         bool disable_surface_sync = false;
+        bool enable_fxaa = false;
     };
 
     /**

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -159,6 +159,7 @@ static bool get_custom_config(GuiState &gui, HostState &host, const std::string 
                 const auto gpu_child = config_child.child("gpu");
                 config.resolution_multiplier = gpu_child.attribute("resolution-multiplier").as_int();
                 config.disable_surface_sync = gpu_child.attribute("disable-surface-sync").as_bool();
+                config.enable_fxaa = gpu_child.attribute("enable-fxaa").as_bool();
             }
 
             // Load System Config
@@ -205,6 +206,7 @@ void init_config(GuiState &gui, HostState &host, const std::string &app_path) {
         config.lle_modules = host.cfg.lle_modules;
         config.resolution_multiplier = host.cfg.resolution_multiplier;
         config.disable_surface_sync = host.cfg.disable_surface_sync;
+        config.enable_fxaa = host.cfg.enable_fxaa;
         config.pstv_mode = host.cfg.pstv_mode;
         config.disable_ngs = host.cfg.disable_ngs;
     }
@@ -214,6 +216,7 @@ void init_config(GuiState &gui, HostState &host, const std::string &app_path) {
     host.display.imgui_render = true;
     host.renderer->res_multiplier = config.resolution_multiplier;
     host.renderer->disable_surface_sync = config.disable_surface_sync;
+    host.renderer->set_fxaa(config.enable_fxaa);
 }
 
 /**
@@ -259,6 +262,7 @@ static void save_config(GuiState &gui, HostState &host) {
         auto gpu_child = config_child.append_child("gpu");
         gpu_child.append_attribute("resolution-multiplier") = config.resolution_multiplier;
         gpu_child.append_attribute("disable-surface-sync") = config.disable_surface_sync;
+        gpu_child.append_attribute("enable-fxaa") = config.enable_fxaa;
 
         // System
         auto system_child = config_child.append_child("system");
@@ -280,6 +284,7 @@ static void save_config(GuiState &gui, HostState &host) {
         host.cfg.pstv_mode = config.pstv_mode;
         host.cfg.resolution_multiplier = config.resolution_multiplier;
         host.cfg.disable_surface_sync = config.disable_surface_sync;
+        host.cfg.enable_fxaa = config.enable_fxaa;
         host.cfg.disable_ngs = config.disable_ngs;
     }
     config::serialize_config(host.cfg, host.cfg.config_path);
@@ -306,6 +311,7 @@ void set_config(GuiState &gui, HostState &host, const std::string &app_path) {
         host.cfg.current_config.pstv_mode = config.pstv_mode;
         host.cfg.current_config.resolution_multiplier = config.resolution_multiplier;
         host.cfg.current_config.disable_surface_sync = config.disable_surface_sync;
+        host.cfg.current_config.enable_fxaa = config.enable_fxaa;
         host.cfg.current_config.disable_ngs = config.disable_ngs;
     } else {
         // Else inherit the values from the global emulator config
@@ -317,10 +323,12 @@ void set_config(GuiState &gui, HostState &host, const std::string &app_path) {
         host.cfg.current_config.pstv_mode = host.cfg.pstv_mode;
         host.cfg.current_config.resolution_multiplier = host.cfg.resolution_multiplier;
         host.cfg.current_config.disable_surface_sync = host.cfg.disable_surface_sync;
+        host.cfg.current_config.enable_fxaa = host.cfg.enable_fxaa;
         host.cfg.current_config.disable_ngs = host.cfg.disable_ngs;
     }
     // can be changed while ingame
     host.renderer->disable_surface_sync = host.cfg.current_config.disable_surface_sync;
+    host.renderer->set_fxaa(host.cfg.enable_fxaa);
     // No change it if app already running
     if (host.io.title_id.empty()) {
         host.kernel.cpu_backend = set_cpu_backend(host.cfg.current_config.cpu_backend);
@@ -472,6 +480,10 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
         ImGui::Checkbox("Disable surface sync", &config.disable_surface_sync);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Speed hack, disable surface syncing between cpu and gpu.\nSurface syncing is needed by a few games.\nGive a big performance boost if disabled (in particular when upscaling is on).");
+        ImGui::Spacing();
+        ImGui::Checkbox("Enable anti-aliasing (FXAA)", &config.enable_fxaa);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Anti-aliasing is a technique for smoothing out jagged edges.\n FXAA comes at almost no performance cost but makes the game look slightly blurry.");
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();

--- a/vita3k/renderer/include/renderer/gl/screen_render.h
+++ b/vita3k/renderer/include/renderer/gl/screen_render.h
@@ -28,7 +28,7 @@ public:
     ~ScreenRenderer();
 
     bool init(const std::string &base_path);
-    void render(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const float *uvs, const GLuint texture);
+    void render(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const float *uvs, const GLuint texture, const SceFVector2 texture_size);
 
     void destroy();
 
@@ -37,6 +37,8 @@ public:
     GLuint get_resident_texture() const {
         return m_screen_texture;
     }
+
+    bool enable_fxaa;
 
 private:
     struct screen_vertex {
@@ -51,13 +53,11 @@ private:
 
     GLuint m_vao{ 0 };
     GLuint m_vbo{ 0 };
-    SharedGLObject m_render_shader;
+    SharedGLObject m_render_shader_nofilter;
+    SharedGLObject m_render_shader_fxaa;
     GLuint m_screen_texture{ 0 };
 
     float last_uvs[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
-
-    GLint posAttrib;
-    GLint uvAttrib;
 };
 
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -51,6 +51,7 @@ struct GLState : public renderer::State {
     bool init(const char *base_path, const bool hashless_texture_cache) override;
     void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem) override;
+    void set_fxaa(bool enable_fxaa) override;
 };
 
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/gl/surface_cache.h
+++ b/vita3k/renderer/include/renderer/gl/surface_cache.h
@@ -116,6 +116,6 @@ public:
         target = new_target;
     }
 
-    std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier) override;
+    std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier, SceFVector2 &texture_size) override;
 };
 } // namespace renderer::gl

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -53,6 +53,7 @@ struct State {
     virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem)
         = 0;
+    virtual void set_fxaa(bool enable_fxaa) = 0;
 
     virtual ~State() = default;
 };

--- a/vita3k/renderer/include/renderer/surface_cache.h
+++ b/vita3k/renderer/include/renderer/surface_cache.h
@@ -51,7 +51,7 @@ public:
         std::uint16_t *stored_height = nullptr)
         = 0;
 
-    virtual std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier)
+    virtual std::uint64_t sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier, SceFVector2 &texture_size)
         = 0;
 };
 } // namespace renderer

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -741,9 +741,11 @@ void GLState::render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &v
         }
     }
 
+    SceFVector2 texture_size;
+
     if (check_for_cache)
         surface_handle = surface_cache.sourcing_color_surface_for_presentation(
-            display.frame.base, display.frame.image_size.x, display.frame.image_size.y, display.frame.pitch, uvs, this->res_multiplier);
+            display.frame.base, display.frame.image_size.x, display.frame.image_size.y, display.frame.pitch, uvs, this->res_multiplier, texture_size);
 
     GLint last_texture = 0;
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
@@ -771,6 +773,9 @@ void GLState::render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &v
             close_access_parent_protect_segment(mem, display.frame.base.address());
         }
 
+        texture_size.x = static_cast<float>(display.frame.image_size.x);
+        texture_size.y = static_cast<float>(display.frame.image_size.y);
+
         surface_handle = screen_renderer.get_resident_texture();
     } else {
         const GLint standard_swizzle[4] = { GL_RED, GL_GREEN, GL_BLUE, GL_ALPHA };
@@ -781,7 +786,11 @@ void GLState::render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &v
 
     glBindTexture(GL_TEXTURE_2D, last_texture);
 
-    screen_renderer.render(viewport_pos, viewport_size, need_uv ? uvs : nullptr, static_cast<GLuint>(surface_handle));
+    screen_renderer.render(viewport_pos, viewport_size, need_uv ? uvs : nullptr, static_cast<GLuint>(surface_handle), texture_size);
+}
+
+void GLState::set_fxaa(bool enable_fxaa) {
+    screen_renderer.enable_fxaa = enable_fxaa;
 }
 
 } // namespace renderer::gl

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -689,7 +689,7 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const State &state, co
     return fb[0];
 }
 
-std::uint64_t GLSurfaceCache::sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier) {
+std::uint64_t GLSurfaceCache::sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier, SceFVector2 &texture_size) {
     auto ite = color_surface_textures.lower_bound(address.address());
     if (ite == color_surface_textures.end()) {
         return 0;
@@ -723,6 +723,9 @@ std::uint64_t GLSurfaceCache::sourcing_color_surface_for_presentation(Ptr<const 
             uvs[1] = static_cast<float>(start_sourced_line) / info.height;
             uvs[2] = static_cast<float>(width) / info.width;
             uvs[3] = static_cast<float>(start_sourced_line + limited_height) / info.height;
+
+            texture_size.x = info.width;
+            texture_size.y = info.height;
 
             return info.gl_texture[0];
         }

--- a/vita3k/shaders-builtin/render_main_fxaa.frag
+++ b/vita3k/shaders-builtin/render_main_fxaa.frag
@@ -1,0 +1,63 @@
+// Vita3K emulator project
+// Code adapted from http://horde3d.org/wiki/index.php?title=Shading_Technique_-_FXAA
+
+#version 410 core
+
+uniform sampler2D fb;
+uniform vec2 inv_frame_size;
+in vec2 uv_frag;
+
+out vec3 color_frag;
+
+void main( void ) {
+        //gl_FragColor.xyz = texture2D(buf0,texCoords).xyz;
+        //return;
+
+        float FXAA_SPAN_MAX = 8.0;
+        float FXAA_REDUCE_MUL = 1.0/8.0;
+        float FXAA_REDUCE_MIN = 1.0/128.0;
+
+        vec3 rgbNW=texture2D(fb,uv_frag+(vec2(-1.0,-1.0)*inv_frame_size)).xyz;
+        vec3 rgbNE=texture2D(fb,uv_frag+(vec2(1.0,-1.0)*inv_frame_size)).xyz;
+        vec3 rgbSW=texture2D(fb,uv_frag+(vec2(-1.0,1.0)*inv_frame_size)).xyz;
+        vec3 rgbSE=texture2D(fb,uv_frag+(vec2(1.0,1.0)*inv_frame_size)).xyz;
+        vec3 rgbM=texture2D(fb,uv_frag).xyz;
+        
+        vec3 luma=vec3(0.299, 0.587, 0.114);
+        float lumaNW = dot(rgbNW, luma);
+        float lumaNE = dot(rgbNE, luma);
+        float lumaSW = dot(rgbSW, luma);
+        float lumaSE = dot(rgbSE, luma);
+        float lumaM  = dot(rgbM,  luma);
+        
+        float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
+        float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
+        
+        vec2 dir;
+        dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));
+        dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));
+        
+        float dirReduce = max(
+                (lumaNW + lumaNE + lumaSW + lumaSE) * (0.25 * FXAA_REDUCE_MUL),
+                FXAA_REDUCE_MIN);
+          
+        float rcpDirMin = 1.0/(min(abs(dir.x), abs(dir.y)) + dirReduce);
+        
+        dir = min(vec2( FXAA_SPAN_MAX,  FXAA_SPAN_MAX),
+                  max(vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX),
+                  dir * rcpDirMin)) * inv_frame_size;
+                
+        vec3 rgbA = (1.0/2.0) * (
+                texture2D(fb, uv_frag.xy + dir * (1.0/3.0 - 0.5)).xyz +
+                texture2D(fb, uv_frag.xy + dir * (2.0/3.0 - 0.5)).xyz);
+        vec3 rgbB = rgbA * (1.0/2.0) + (1.0/4.0) * (
+                texture2D(fb, uv_frag.xy + dir * (0.0/3.0 - 0.5)).xyz +
+                texture2D(fb, uv_frag.xy + dir * (3.0/3.0 - 0.5)).xyz);
+        float lumaB = dot(rgbB, luma);
+
+        if((lumaB < lumaMin) || (lumaB > lumaMax)){
+                color_frag.xyz=rgbA;
+        }else{
+                color_frag.xyz=rgbB;
+        }
+}


### PR DESCRIPTION
Add FXAA support to Vita3K. 
When upscaling it adds a nice touch. At native resolution, it is not looking as good as I thought it would be.
The PS Vita supports natively MSAA (which Vita3K does not yet), but this gives another option which is not as good but has almost no impact on performance.