### PR TITLE
gui: Add FXAA status to title bar

### DIFF
--- a/vita3k/app/src/app.cpp
+++ b/vita3k/app/src/app.cpp
@@ -59,9 +59,9 @@ void calculate_fps(HostState &host) {
 }
 
 void set_window_title(HostState &host) {
-    const std::string title_to_set = fmt::format("{} | {} ({}) | {} ms/frame ({} frames/sec) ({}x{})", window_title,
+    const std::string title_to_set = fmt::format("{} | {} ({}) | {} ms/frame ({} frames/sec) | {}x{} {}", window_title,
         host.current_app_title, host.io.title_id, host.ms_per_frame, host.fps, 960 * host.cfg.current_config.resolution_multiplier,
-        544 * host.cfg.current_config.resolution_multiplier);
+        544 * host.cfg.current_config.resolution_multiplier, host.cfg.current_config.enable_fxaa ? "| FXAA" : "");
 
     SDL_SetWindowTitle(host.window.get(), title_to_set.c_str());
 }


### PR DESCRIPTION
Add FXAA status to title bar.

Very minor, but it allows users to easily see whether or not FXAA is active in game since there's no indicator otherwise.
(Removes `title_to_set` const declaration)