### PR TITLE
renderer: Fix lod bias underflow and unswizzled compressed textures

### DIFF
--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -86,7 +86,7 @@ void configure_bound_texture(const SceGxmTexture &gxm_texture) {
 
     glTexParameteri(texture_bind_type, GL_TEXTURE_WRAP_S, translate_wrap_mode(uaddr));
     glTexParameteri(texture_bind_type, GL_TEXTURE_WRAP_T, translate_wrap_mode(vaddr));
-    glTexParameterf(texture_bind_type, GL_TEXTURE_LOD_BIAS, (gxm_texture.lod_bias - 31) / 8.f);
+    glTexParameterf(texture_bind_type, GL_TEXTURE_LOD_BIAS, (static_cast<float>(gxm_texture.lod_bias) - 31.f) / 8.f);
     glTexParameteri(texture_bind_type, GL_TEXTURE_MIN_LOD, gxm_texture.lod_min0 | (gxm_texture.lod_min1 << 2));
     glTexParameteri(texture_bind_type, GL_TEXTURE_MIN_FILTER, translate_minmag_filter((SceGxmTextureFilter)gxm_texture.min_filter));
     glTexParameteri(texture_bind_type, GL_TEXTURE_MAG_FILTER, translate_minmag_filter((SceGxmTextureFilter)gxm_texture.mag_filter));

--- a/vita3k/renderer/src/texture_format.cpp
+++ b/vita3k/renderer/src/texture_format.cpp
@@ -202,12 +202,13 @@ bool is_compressed_format(SceGxmTextureBaseFormat base_format, std::uint32_t wid
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC1:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
-        return ((width + 3) / 4) * ((height + 3) / 4) * ((base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC1) ? 8 : 16);
+        source_size = ((width + 3) / 4) * ((height + 3) / 4) * ((base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC1) ? 8 : 16);
+        return true;
     default:
         break;
     }
 
-    return 0;
+    return false;
 }
 
 // =========================== COMPRESSION ============================


### PR DESCRIPTION
Fix an unsigned underflow that occured when computing the load bias (a load bias of 5e8 is a bit too much).

Also fix the function which was used to compute the size of compressed formats. This should fix the textures in games that are using unswizzled compressed textures.