### PR TITLE
shader: Fix behavior of vpck on large repeat count

### DIFF
--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -57,7 +57,7 @@ public:
     spv::Id out;
 
     // Contains repeat increasement offset
-    int repeat_increase[4][4];
+    int repeat_increase[4][17];
     int repeat_multiplier[4];
 
     void do_texture_queries(const NonDependentTextureQueryCallInfos &texture_queries, const spv::Id translation_state_id);
@@ -189,7 +189,7 @@ private:
 
     void reset_repeat_increase() {
         for (int i = 0; i < 4; i++) {
-            for (int j = 0; j < 4; j++) {
+            for (int j = 0; j < 17; j++) {
                 repeat_increase[i][j] = j;
             }
         }

--- a/vita3k/shader/src/translator/special.cpp
+++ b/vita3k/shader/src/translator/special.cpp
@@ -87,8 +87,8 @@ bool USSETranslatorVisitor::smlsi(
 
             disasm_str += ") ";
         } else {
-            // Parse value as immidiate
-            for (int i = 0; i < 4; i++) {
+            // Parse value as immediate
+            for (int i = 0; i < 17; i++) {
                 repeat_increase[idx][i] = i * static_cast<std::int8_t>(inc_value);
             }
 

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -288,8 +288,7 @@ static std::optional<const USSEMatcher<V>> DecodeUSSE(uint64_t instruction) {
                                                 e = end (1 bit)
                                                  r = src1_bank_ext (1 bit)
                                                   c = src2_bank_ext (1 bit)
-                                                   - = don't care
-                                                    aaa = repeat_count (3 bits, RepeatCount)
+                                                   aaaa = repeat_count (4 bits, RepeatCount)
                                                        fff = src_fmt (3 bits)
                                                           ttt = dest_fmt (3 bits)
                                                              mmmm = dest_mask (4 bits)
@@ -306,7 +305,7 @@ static std::optional<const USSEMatcher<V>> DecodeUSSE(uint64_t instruction) {
                                                                                             wwwwww = src2_n (6 bits)
                                                                                                   x = comp_sel_0_bit0 (1 bit)
         */
-        INST(&V::vpck, "VPCK ()", "01000pppsnuyderc-aaaffftttmmmmbbkkllgggggggoohiijjqqqqqqvwwwwwwx"),
+        INST(&V::vpck, "VPCK ()", "01000pppsnuydercaaaaffftttmmmmbbkkllgggggggoohiijjqqqqqqvwwwwwwx"),
         // Test Instructions
         /*
                                    01001 = op1


### PR DESCRIPTION
VPCK can have a really big repeat count (can go up to 15, meaning 16 repetitions), Increase the possible values of `repeat_increase` (and correct the definition of vpck) to account for it.

This fixes the blur effect during gameplay on persona 4 dancing.