### PR TITLE
settings dialog: app option for boot apps in full screen.

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -63,6 +63,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "enable-fxaa", false, enable_fxaa)                                                       \
     code(bool, "texture-cache", true, texture_cache)                                                    \
     code(bool, "hashless-texture-cache", false, hashless_texture_cache)                                 \
+    code(bool, "boot-apps-full-screen", false, boot_apps_full_screen)                                   \
     code(bool, "disable-ngs", false, disable_ngs)                                                       \
     code(int, "sys-button", static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS), sys_button)          \
     code(int, "sys-lang", static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US), sys_lang)                 \

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -338,7 +338,7 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
     auto &settings_dialog = is_custom_config ? gui.configuration_menu.custom_settings_dialog : gui.configuration_menu.settings_dialog;
     ImGui::Begin("##settings", &settings_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings);
     ImGui::PushFont(gui.vita_font);
-    ImGui::SetWindowFontScale(0.65f);
+    ImGui::SetWindowFontScale(0.8f);
     const auto title = is_custom_config ? fmt::format("Settings: {} [{}]", get_app_index(gui, host.app_path)->title, host.app_path) : "Settings";
     ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title.c_str()).x / 2.f));
     ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title.c_str());
@@ -528,6 +528,8 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
     if (ImGui::BeginTabItem("Emulator")) {
         ImGui::PopStyleColor();
         ImGui::Spacing();
+        ImGui::Checkbox("Boot apps in full screen", &host.cfg.boot_apps_full_screen);
+        ImGui::Spacing();
         ImGui::Checkbox("Disable ngs support", &config.disable_ngs);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Disable support for advanced audio library ngs");
@@ -574,6 +576,7 @@ void draw_settings_dialog(GuiState &gui, HostState &host) {
             ImGui::SetTooltip("Allows emulator to attempt searching for files regardless of case on non-Windows platforms");
 #endif
         ImGui::Separator();
+        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize("Emulated System Storage Folder").x / 2.f));
         ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "Emulated System Storage Folder");
         ImGui::Spacing();
         ImGui::PushItemWidth(320);

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -592,6 +592,12 @@ static void handle_window_event(HostState &state, const SDL_WindowEvent event) {
     }
 }
 
+static void switch_full_screen(HostState &host) {
+    host.display.fullscreen = !host.display.fullscreen;
+
+    SDL_SetWindowFullscreen(host.window.get(), host.display.fullscreen.load() ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+}
+
 bool handle_events(HostState &host, GuiState &gui) {
     SDL_Event event;
     while (SDL_PollEvent(&event)) {
@@ -632,14 +638,9 @@ bool handle_events(HostState &host, GuiState &gui) {
             }
             if (event.key.keysym.sym == SDLK_t)
                 toggle_touchscreen();
-            if (event.key.keysym.sym == SDLK_F11) {
-                host.display.fullscreen = !host.display.fullscreen;
+            if (event.key.keysym.sym == SDLK_F11)
+                switch_full_screen(host);
 
-                if (host.display.fullscreen.load())
-                    SDL_MaximizeWindow(host.window.get());
-
-                SDL_SetWindowFullscreen(host.window.get(), host.display.fullscreen.load() ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
-            }
             break;
 
         case SDL_WINDOWEVENT:
@@ -771,6 +772,9 @@ ExitCode run_app(HostState &host, Ptr<const void> &entry_point) {
     }
 
     start_sync_thread(host.display, host.kernel);
+
+    if (host.cfg.boot_apps_full_screen && !host.display.fullscreen.load())
+        switch_full_screen(host);
 
     return Success;
 }


### PR DESCRIPTION
# About:
- settings dialog: app option for boot apps in full screen.
- change pos of title for emulated storage