### PR TITLE
gxm/renderer: Fix 3 warnings of txt format

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -794,7 +794,7 @@ EXPORT(int, sceGxmColorSurfaceSetFormat, SceGxmColorSurface *surface, SceGxmColo
         LOG_WARN("Unable to convert color surface type 0x{:X} to texture format enum for background texture of color surface!", static_cast<std::uint32_t>(format));
     }
 
-    CALL_EXPORT(sceGxmTextureSetFormat, &surface->backgroundTex, tex_format);
+    return CALL_EXPORT(sceGxmTextureSetFormat, &surface->backgroundTex, tex_format);
 }
 
 EXPORT(int, sceGxmColorSurfaceSetGammaMode, SceGxmColorSurface *surface, SceGxmColorSurfaceGammaMode gammaMode) {

--- a/vita3k/renderer/src/gl/texture_formats.cpp
+++ b/vita3k/renderer/src/gl/texture_formats.cpp
@@ -274,6 +274,9 @@ GLenum translate_internal_format(SceGxmTextureBaseFormat base_format) {
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
         return GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+    default:
+        LOG_ERROR("Missing case texture base format {}, fallback to GL_RGBA", base_format);
+        return GL_RGBA;
     }
 }
 
@@ -347,6 +350,9 @@ GLenum translate_format(SceGxmTextureBaseFormat base_format) {
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
         return GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+    default:
+        LOG_ERROR("Missing case texture base format {}, fallback to GL_RGBA", base_format);
+        return GL_RGBA;
     }
 }
 


### PR DESCRIPTION
Please comment if the fallback format is OK, i used RGBA because its the one that has the most cases and its very common