### PR TITLE
interface: refresh immediately size of viewport.

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -596,6 +596,9 @@ static void switch_full_screen(HostState &host) {
     host.display.fullscreen = !host.display.fullscreen;
 
     SDL_SetWindowFullscreen(host.window.get(), host.display.fullscreen.load() ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+
+    // Refresh Viewport Size
+    app::update_viewport(host);
 }
 
 bool handle_events(HostState &host, GuiState &gui) {


### PR DESCRIPTION
# About
- fix wrong size of app background with refresh size of viewport immediately after go on full screen.