### PR TITLE
ngs: Clear voice memory location when initializing it

### DIFF
--- a/vita3k/ngs/src/ngs.cpp
+++ b/vita3k/ngs/src/ngs.cpp
@@ -438,6 +438,7 @@ bool init_rack(State &ngs, const MemState &mem, System *system, BufferParamsInfo
         }
 
         Voice *v = voice.get(mem);
+        new (v) Voice();
         v->init(rack);
 
         // Allocate parameter buffer info for each voice


### PR DESCRIPTION
The data passed to initialize a rack can contain garbage (it can match a previous deleted voice if RackRelease was called). It needs to be cleared when creating a new Voice.

This fixes a crash in Valkyria Revolution, allowing to progress (slightly) further.