### PR TITLE
Ask user to delete license after installing license from the license install dialog rather than always delete + fix typo

### DIFF
--- a/vita3k/gui/src/license_install_dialog.cpp
+++ b/vita3k/gui/src/license_install_dialog.cpp
@@ -27,6 +27,7 @@ namespace gui {
 
 static std::string state, title, zRIF;
 nfdchar_t *work_path;
+static bool delete_work_file;
 
 void draw_license_install_dialog(GuiState &gui, HostState &host) {
     const auto display_size = ImGui::GetIO().DisplaySize;
@@ -96,9 +97,15 @@ void draw_license_install_dialog(GuiState &gui, HostState &host) {
     } else if (state == "success") {
         title = !indicator["install_complete"].empty() ? indicator["install_complete"] : "Installation complete.";
         ImGui::Spacing();
-        ImGui::TextColored(GUI_COLOR_TEXT, "Succes install license.\nContent ID: %s\nTitle ID: %s", host.license_content_id.c_str(), host.license_title_id.c_str());
+        ImGui::TextColored(GUI_COLOR_TEXT, "Successfully installed license.\nContent ID: %s\nTitle ID: %s", host.license_content_id.c_str(), host.license_title_id.c_str());
+        if (work_path)
+            ImGui::Checkbox("Delete the work.bin/rif file?", &delete_work_file);
         ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - 20.f));
         if (ImGui::Button("OK", BUTTON_SIZE)) {
+            if (delete_work_file) {
+                fs::remove(fs::path(string_utils::utf_to_wide(std::string(work_path))));
+                delete_work_file = false;
+            }
             work_path = nullptr;
             gui.file_menu.license_install_dialog = false;
             state.clear();

--- a/vita3k/host/src/license.cpp
+++ b/vita3k/host/src/license.cpp
@@ -73,7 +73,6 @@ bool copy_license(HostState &host, const fs::path &license_path) {
         if (license_path != license_dst_path) {
             fs::copy_file(license_path, license_dst_path, fs::copy_option::overwrite_if_exists);
             if (fs::exists(license_dst_path)) {
-                fs::remove(license_path);
                 LOG_INFO("Success copy license file to: {}", license_dst_path.string());
                 return true;
             } else


### PR DESCRIPTION
I would not like Vita3K to try to delete the work.bin/rif file after installing using the license install dialog. I give the emulator read-only access to my dumps because I don't want to modify the archives, only install from it to the emulator. That results in a crash when trying to delete it.

The install pkg and install archive dialogs ask for this, so this PR makes the license dialog behave more consistently with the other dialogs.

Additionally, I fixed a typo in the successful installation message.