### PR TITLE
cmake: Only apply important warning on linux

### DIFF
--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -59,9 +59,7 @@ endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-if(MSVC)
-	add_compile_options(/W4 /we4774)
-else()
+if(NOT MSVC)
 	add_compile_options(-Wformat -Werror=format-security)
 endif()
 


### PR DESCRIPTION
Enabling W4 was a mistake, it bottlenecks due to huge logging and makes the log file absurdly large (~50k lines). So its better to just enable the important warning into error only for linux so the ubuntu build and analyze fails so it doesn't get approved