### PR TITLE
util: Add missing include in fs.h

### DIFF
--- a/vita3k/util/include/util/fs.h
+++ b/vita3k/util/include/util/fs.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 
 namespace fs = boost::filesystem;
 


### PR DESCRIPTION
On GNU/Linux, compilation currently fails with the following error messages:
```
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/interface.cpp:377:9: error: no type named 'ifstream' in namespace 'boost::filesystem'; did you mean 'std::ifstream'?
        fs::ifstream f{ path, fs::ifstream::binary };
        ^~~~~~~~~~~~
        std::ifstream
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.1.0/../../../../include/c++/12.1.0/iosfwd:162:34: note: 'std::ifstream' declared here
  typedef basic_ifstream<char>          ifstream;
                                        ^
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/interface.cpp:377:31: error: no member named 'ifstream' in namespace 'boost::filesystem'; did you mean 'std::ifstream'?
        fs::ifstream f{ path, fs::ifstream::binary };
                              ^~~~~~~~~~~~
                              std::ifstream
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.1.0/../../../../include/c++/12.1.0/iosfwd:162:34: note: 'std::ifstream' declared here
  typedef basic_ifstream<char>          ifstream;
                                        ^
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/interface.cpp:381:18: error: no member named 'ifstream' in namespace 'boost::filesystem'; did you mean 'std::ifstream'?
        f.unsetf(fs::ifstream::skipws);
                 ^~~~~~~~~~~~
                 std::ifstream
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.1.0/../../../../include/c++/12.1.0/iosfwd:162:34: note: 'std::ifstream' declared here
  typedef basic_ifstream<char>          ifstream;
                                        ^
3 errors generated.
```
```
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/config/src/config.cpp:106:17: error: expected ';' after expression
    fs::ofstream fo(output);
                ^
                ;
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/config/src/config.cpp:106:9: error: no member named 'ofstream' in namespace 'boost::filesystem'
    fs::ofstream fo(output);
    ~~~~^
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/config/src/config.cpp:106:18: error: use of undeclared identifier 'fo'
    fs::ofstream fo(output);
                 ^
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/config/src/config.cpp:107:10: error: use of undeclared identifier 'fo'
    if (!fo) {
         ^
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/config/src/config.cpp:111:5: error: use of undeclared identifier 'fo'
    fo << emitter.c_str();
    ^
/mnt/tmp/vita3k-git/src/vita3k-git/vita3k/config/src/config.cpp:112:5: error: use of undeclared identifier 'fo'
    fo.close();
    ^
6 errors generated.
```
This appears to be caused by missing include for boost's `filesystem/fstream.h`, which is where `ofstream` and `ifstream` in the error messages are defined. This PR fixes the error by including the header in `util/fs.h`.