### PR TITLE
modules/SceGxm: Fix sceGxmSetBackStencilFunc

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2591,17 +2591,25 @@ EXPORT(void, sceGxmSetBackPolygonMode, SceGxmContext *context, SceGxmPolygonMode
     }
 }
 
-EXPORT(void, sceGxmSetBackStencilFunc, SceGxmContext *context, SceGxmStencilFunc func, SceGxmStencilOp stencilFail, SceGxmStencilOp depthFail, SceGxmStencilOp depthPass, uint8_t compareMask, uint8_t writeMask) {
-    if ((context->state.back_stencil.func != func) || (context->state.back_stencil.stencil_fail != stencilFail) || (context->state.back_stencil.depth_fail != depthFail) || (context->state.back_stencil.depth_pass != depthPass) || (context->state.back_stencil.compare_mask != compareMask) || (context->state.back_stencil.write_mask != writeMask)) {
+EXPORT(void, sceGxmSetBackStencilFunc, SceGxmContext *context, SceGxmStencilFunc func, SceGxmStencilOp stencilFail, SceGxmStencilOp depthFail, SceGxmStencilOp depthPass, int32_t compareMask, uint32_t writeMask) {
+    // compareMask and depthMask should be uint8_t, however the compiler optimizes the call if this is the case...
+    const uint8_t compare_mask = static_cast<uint8_t>(compareMask);
+    const uint8_t write_mask = static_cast<uint8_t>(writeMask);
+    if ((context->state.back_stencil.func != func)
+        || (context->state.back_stencil.stencil_fail != stencilFail)
+        || (context->state.back_stencil.depth_fail != depthFail)
+        || (context->state.back_stencil.depth_pass != depthPass)
+        || (context->state.back_stencil.compare_mask != compare_mask)
+        || (context->state.back_stencil.write_mask != write_mask)) {
         context->state.back_stencil.func = func;
         context->state.back_stencil.stencil_fail = stencilFail;
         context->state.back_stencil.depth_fail = depthFail;
         context->state.back_stencil.depth_pass = depthPass;
-        context->state.back_stencil.compare_mask = compareMask;
-        context->state.back_stencil.write_mask = writeMask;
+        context->state.back_stencil.compare_mask = compare_mask;
+        context->state.back_stencil.write_mask = write_mask;
 
         if (context->alloc_space) {
-            renderer::set_stencil_func(*host.renderer, context->renderer.get(), false, func, stencilFail, depthFail, depthPass, compareMask, writeMask);
+            renderer::set_stencil_func(*host.renderer, context->renderer.get(), false, func, stencilFail, depthFail, depthPass, compare_mask, write_mask);
         }
     }
 }
@@ -2825,7 +2833,12 @@ EXPORT(void, sceGxmSetFrontStencilFunc, SceGxmContext *context, SceGxmStencilFun
     // compareMask and depthMask should be uint8_t, however the compiler optimizes the call if this is the case...
     const uint8_t compare_mask = static_cast<uint8_t>(compareMask);
     const uint8_t write_mask = static_cast<uint8_t>(writeMask);
-    if ((context->state.front_stencil.func != func) || (context->state.front_stencil.stencil_fail != stencilFail) || (context->state.front_stencil.depth_fail != depthFail) || (context->state.front_stencil.depth_pass != depthPass) || (context->state.front_stencil.compare_mask != compare_mask) || (context->state.front_stencil.write_mask != write_mask)) {
+    if ((context->state.front_stencil.func != func)
+        || (context->state.front_stencil.stencil_fail != stencilFail)
+        || (context->state.front_stencil.depth_fail != depthFail)
+        || (context->state.front_stencil.depth_pass != depthPass)
+        || (context->state.front_stencil.compare_mask != compare_mask)
+        || (context->state.front_stencil.write_mask != write_mask)) {
         context->state.front_stencil.func = func;
         context->state.front_stencil.depth_fail = depthFail;
         context->state.front_stencil.depth_pass = depthPass;
@@ -2834,7 +2847,7 @@ EXPORT(void, sceGxmSetFrontStencilFunc, SceGxmContext *context, SceGxmStencilFun
         context->state.front_stencil.write_mask = write_mask;
 
         if (context->alloc_space)
-            renderer::set_stencil_func(*host.renderer, context->renderer.get(), true, func, stencilFail, depthFail, depthPass, compareMask, writeMask);
+            renderer::set_stencil_func(*host.renderer, context->renderer.get(), true, func, stencilFail, depthFail, depthPass, compare_mask, write_mask);
     }
 }
 


### PR DESCRIPTION
Apply the fix from PR #1862 to `sceGxmSetBackStencilFunc`. Also break the long if condition into multiple lines.