### PR TITLE
renderer: Fix wrong parameter type for texture filter

### DIFF
--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -150,7 +150,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
                 } else {
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
                 }
             };

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -410,8 +410,8 @@ void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t
         glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture_as_surface));
 
         if (only_nearest) {
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         }
 
         if (base_format != SCE_GXM_TEXTURE_BASE_FORMAT_X8U24) {


### PR DESCRIPTION
OpenGL texture filter parameters should be integers, not floats. Also fix a typo for raw textures.