### PR TITLE
renderer: Improve saving and restoring the opengl state

### DIFF
--- a/vita3k/gui/src/imgui_impl_sdl_gl3.cpp
+++ b/vita3k/gui/src/imgui_impl_sdl_gl3.cpp
@@ -66,8 +66,10 @@ void ImGui_ImplSdlGL3_RenderDrawData(ImGui_GLState &state) {
     draw_data->ScaleClipRects(io.DisplayFramebufferScale);
 
     // Backup GL state
-    GLenum last_active_texture;
-    glGetIntegerv(GL_ACTIVE_TEXTURE, (GLint *)&last_active_texture);
+    GLint last_framebuffer;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &last_framebuffer);
+    GLint last_active_texture;
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &last_active_texture);
     glActiveTexture(GL_TEXTURE0);
     GLint last_program;
     glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
@@ -103,6 +105,8 @@ void ImGui_ImplSdlGL3_RenderDrawData(ImGui_GLState &state) {
     GLboolean last_enable_cull_face = glIsEnabled(GL_CULL_FACE);
     GLboolean last_enable_depth_test = glIsEnabled(GL_DEPTH_TEST);
     GLboolean last_enable_scissor_test = glIsEnabled(GL_SCISSOR_TEST);
+    GLboolean last_color_mask[4];
+    glGetBooleanv(GL_COLOR_WRITEMASK, last_color_mask);
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
@@ -114,6 +118,7 @@ void ImGui_ImplSdlGL3_RenderDrawData(ImGui_GLState &state) {
     glDisable(GL_DEPTH_TEST);
     glEnable(GL_SCISSOR_TEST);
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
     if (state.do_clear_screen)
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -171,6 +176,7 @@ void ImGui_ImplSdlGL3_RenderDrawData(ImGui_GLState &state) {
 
     // Restore modified GL state
     glUseProgram(last_program);
+    glBindFramebuffer(GL_FRAMEBUFFER, last_framebuffer);
     glBindTexture(GL_TEXTURE_2D, last_texture);
     glBindSampler(0, last_sampler);
     glActiveTexture(last_active_texture);
@@ -198,6 +204,7 @@ void ImGui_ImplSdlGL3_RenderDrawData(ImGui_GLState &state) {
     glPolygonMode(GL_FRONT_AND_BACK, (GLenum)last_polygon_mode[0]);
     glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2], (GLsizei)last_viewport[3]);
     glScissor(last_scissor_box[0], last_scissor_box[1], (GLsizei)last_scissor_box[2], (GLsizei)last_scissor_box[3]);
+    glColorMask(last_color_mask[0], last_color_mask[1], last_color_mask[2], last_color_mask[3]);
 }
 
 static const char *ImGui_ImplSdlGL3_GetClipboardText(void *) {

--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -85,8 +85,10 @@ bool ScreenRenderer::init(const std::string &base_path) {
 void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const float *uvs, const GLuint texture, const SceFVector2 texture_size) {
     // Code for backup and restore is taken from ImGui project ImGui_ImplSdlGL3_RenderDrawData
     // Backup GL state
-    GLenum last_active_texture;
-    glGetIntegerv(GL_ACTIVE_TEXTURE, (GLint *)&last_active_texture);
+    GLint last_framebuffer;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &last_framebuffer);
+    GLint last_active_texture;
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &last_active_texture);
     glActiveTexture(GL_TEXTURE0);
     GLint last_program;
     glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
@@ -104,30 +106,19 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
     glGetIntegerv(GL_POLYGON_MODE, last_polygon_mode);
     GLint last_viewport[4];
     glGetIntegerv(GL_VIEWPORT, last_viewport);
-    GLint last_scissor_box[4];
-    glGetIntegerv(GL_SCISSOR_BOX, last_scissor_box);
-    GLenum last_blend_src_rgb;
-    glGetIntegerv(GL_BLEND_SRC_RGB, (GLint *)&last_blend_src_rgb);
-    GLenum last_blend_dst_rgb;
-    glGetIntegerv(GL_BLEND_DST_RGB, (GLint *)&last_blend_dst_rgb);
-    GLenum last_blend_src_alpha;
-    glGetIntegerv(GL_BLEND_SRC_ALPHA, (GLint *)&last_blend_src_alpha);
-    GLenum last_blend_dst_alpha;
-    glGetIntegerv(GL_BLEND_DST_ALPHA, (GLint *)&last_blend_dst_alpha);
-    GLenum last_blend_equation_rgb;
-    glGetIntegerv(GL_BLEND_EQUATION_RGB, (GLint *)&last_blend_equation_rgb);
-    GLenum last_blend_equation_alpha;
-    glGetIntegerv(GL_BLEND_EQUATION_ALPHA, (GLint *)&last_blend_equation_alpha);
     GLboolean last_enable_blend = glIsEnabled(GL_BLEND);
     GLboolean last_enable_cull_face = glIsEnabled(GL_CULL_FACE);
     GLboolean last_enable_depth_test = glIsEnabled(GL_DEPTH_TEST);
     GLboolean last_enable_scissor_test = glIsEnabled(GL_SCISSOR_TEST);
+    GLboolean last_color_mask[4];
+    glGetBooleanv(GL_COLOR_WRITEMASK, last_color_mask);
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDisable(GL_SCISSOR_TEST);
     glDisable(GL_BLEND);
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_CULL_FACE);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
     glViewport(static_cast<GLint>(viewport_pos.x), static_cast<GLint>(viewport_pos.y), static_cast<GLsizei>(viewport_size.x),
         static_cast<GLsizei>(viewport_size.y));
@@ -213,14 +204,13 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
 
     // Restore modified GL state
     glUseProgram(last_program);
+    glBindFramebuffer(GL_FRAMEBUFFER, last_framebuffer);
     glBindTexture(GL_TEXTURE_2D, last_texture);
     glBindSampler(0, last_sampler);
     glActiveTexture(last_active_texture);
     glBindVertexArray(last_vertex_array);
     glBindBuffer(GL_ARRAY_BUFFER, last_array_buffer);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, last_element_array_buffer);
-    glBlendEquationSeparate(last_blend_equation_rgb, last_blend_equation_alpha);
-    glBlendFuncSeparate(last_blend_src_rgb, last_blend_dst_rgb, last_blend_src_alpha, last_blend_dst_alpha);
     if (last_enable_blend)
         glEnable(GL_BLEND);
     else
@@ -239,7 +229,7 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
         glDisable(GL_SCISSOR_TEST);
     glPolygonMode(GL_FRONT_AND_BACK, (GLenum)last_polygon_mode[0]);
     glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2], (GLsizei)last_viewport[3]);
-    glScissor(last_scissor_box[0], last_scissor_box[1], (GLsizei)last_scissor_box[2], (GLsizei)last_scissor_box[3]);
+    glColorMask(last_color_mask[0], last_color_mask[1], last_color_mask[2], last_color_mask[3]);
 }
 
 void ScreenRenderer::destroy() {


### PR DESCRIPTION
Save the color mask before rendering to the screen, also remove unnecessary saves and restores (we disable the blending and scissor test anyway in the screen renderer).

This fixes the intro in Trillion.