### PR TITLE
audio: Fix ADPCM decoding

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -151,6 +151,13 @@ struct Mp3DecoderState : public DecoderState {
     ~Mp3DecoderState() override;
 };
 
+struct ADPCMHistory {
+    int32_t hist1;
+    int32_t hist2;
+    int32_t hist3;
+    int32_t hist4;
+};
+
 struct PCMDecoderState : public DecoderState {
 private:
     std::vector<std::uint8_t> final_result;
@@ -159,7 +166,7 @@ private:
     SwrContext *swr_stereo;
 
 public:
-    std::int32_t adpcm_history[4];
+    ADPCMHistory *adpcm_history;
 
     std::uint32_t source_channels;
 

--- a/vita3k/codec/src/pcm.cpp
+++ b/vita3k/codec/src/pcm.cpp
@@ -189,6 +189,13 @@ bool PCMDecoderState::send(const uint8_t *data, uint32_t size) {
             return false;
         }
 
+        if (!adpcm_history) {
+            adpcm_history = new ADPCMHistory[source_channels];
+
+            ADPCMHistory hist = {};
+            std::fill_n(adpcm_history, source_channels, hist);
+        }
+
         const std::uint32_t src_ch = source_channels;
 
         std::int32_t ch = 0;

--- a/vita3k/codec/src/pcm.cpp
+++ b/vita3k/codec/src/pcm.cpp
@@ -176,15 +176,27 @@ bool PCMDecoderState::send(const uint8_t *data, uint32_t size) {
         const std::uint32_t samples_per_frame = (bytes_per_frame - 2) * 2;
 
         if (size % bytes_per_frame != 0) {
-            LOG_ERROR("Unaligned HEADPCM frame size");
+            LOG_ERROR("Unaligned HE ADPCM frame size");
             return false;
         }
 
+        // Allocate whole buffer now so we don't need to constantly increase it with push_back
+        transformed.resize((size / bytes_per_frame) * samples_per_frame);
+        std::int16_t *buffer = transformed.data();
+
+        if (source_channels > 1 && ((size / bytes_per_frame) % source_channels != 0)) {
+            LOG_ERROR("Wrong number of HE ADPCM frames");
+            return false;
+        }
+
+        const std::uint32_t src_ch = source_channels;
+
+        std::int32_t ch = 0;
         for (std::uint32_t i = 0; i < size / bytes_per_frame; i++) {
-            int32_t hist1 = adpcm_history[0];
-            int32_t hist2 = adpcm_history[1];
-            int32_t hist3 = adpcm_history[2];
-            int32_t hist4 = adpcm_history[3];
+            int32_t hist1 = adpcm_history[ch].hist1;
+            int32_t hist2 = adpcm_history[ch].hist2;
+            int32_t hist3 = adpcm_history[ch].hist3;
+            int32_t hist4 = adpcm_history[ch].hist4;
 
             const std::uint8_t *frame = reinterpret_cast<const std::uint8_t *>(data + bytes_per_frame * i);
 
@@ -195,14 +207,16 @@ bool PCMDecoderState::send(const uint8_t *data, uint32_t size) {
             const std::uint8_t flag = (frame[1] >> 0) & 0xf;
 
             if ((coef_index > 127) || (shift_factor > 12)) {
-                LOG_WARN("HEVAG: in+correct coefs/shift at frame {}", i);
+                LOG_WARN("HE ADPCM: in+correct coefs/shift at frame {}", i);
             }
 
+            // Better to reset to 0
             if (coef_index > 127)
-                coef_index = 127; /* ? */
+                coef_index = 0; /* ? */
 
-            if (shift_factor > 12)
-                shift_factor = 9; /* ? */
+            // Don't care about it. We don't need that stuff in HEVAG
+            //if (shift_factor > 12)
+            //    shift_factor = 9; /* ? */
 
             shift_factor = 20 - shift_factor;
 
@@ -216,11 +230,12 @@ bool PCMDecoderState::send(const uint8_t *data, uint32_t size) {
                                      nibble_lookup[nibbles >> 4]
                                     : nibble_lookup[nibbles & 0xF])
                         << shift_factor; /*scale*/
-                    sample = ((hist1 * hevag_coefs[coef_index][0] + hist2 * hevag_coefs[coef_index][1] + hist3 * hevag_coefs[coef_index][2] + hist4 * hevag_coefs[coef_index][3]) >> 5) + sample;
+                    sample += ((hist1 * hevag_coefs[coef_index][0] + hist2 * hevag_coefs[coef_index][1] + hist3 * hevag_coefs[coef_index][2] + hist4 * hevag_coefs[coef_index][3]) >> 5);
                     sample >>= 8;
                 }
 
-                transformed.push_back(static_cast<std::int16_t>(std::clamp(sample, -32768, 32767)));
+                // Multichannel interleaving
+                buffer[i * src_ch + ch] = static_cast<std::int16_t>(std::clamp(sample, -32768, 32767));
 
                 hist4 = hist3;
                 hist3 = hist2;
@@ -228,10 +243,16 @@ bool PCMDecoderState::send(const uint8_t *data, uint32_t size) {
                 hist1 = sample;
             }
 
-            adpcm_history[0] = hist1;
-            adpcm_history[1] = hist2;
-            adpcm_history[2] = hist3;
-            adpcm_history[3] = hist4;
+            adpcm_history[ch].hist1 = hist1;
+            adpcm_history[ch].hist2 = hist2;
+            adpcm_history[ch].hist3 = hist3;
+            adpcm_history[ch].hist4 = hist4;
+
+            ch++;
+            ch %= src_ch;
+
+            if (ch == 0)
+                buffer += samples_per_frame * src_ch;
         }
 
         source_transformed = reinterpret_cast<std::uint8_t *>(transformed.data());
@@ -278,7 +299,7 @@ PCMDecoderState::PCMDecoderState(const float dest_frequency)
     , he_adpcm(false)
     , source_channels(2)
     , source_frequency(48000.0f)
-    , adpcm_history{ 0, 0, 0, 0 } {
+    , adpcm_history(nullptr) {
     // we are not resampling, we don't care about the sample rate
     swr_mono_to_stereo = swr_alloc_set_opts(nullptr,
         AV_CH_LAYOUT_STEREO, AV_SAMPLE_FMT_FLT, 48000,
@@ -296,6 +317,10 @@ PCMDecoderState::PCMDecoderState(const float dest_frequency)
 }
 
 PCMDecoderState::~PCMDecoderState() {
+    if (adpcm_history) {
+        delete[] adpcm_history;
+        adpcm_history = nullptr;
+    }
     swr_free(&swr_mono_to_stereo);
     swr_free(&swr_stereo);
 }

--- a/vita3k/ngs/include/ngs/modules/player.h
+++ b/vita3k/ngs/include/ngs/modules/player.h
@@ -57,7 +57,7 @@ struct State {
     std::uint32_t decoded_samples_pending = 0;
     std::uint32_t decoded_samples_passed = 0;
     // needed for he_adpcm because a same decoder can be used for many voices
-    std::int32_t adpcm_history[4] = { 0, 0, 0, 0 };
+    ADPCMHistory *adpcm_history = nullptr;
     // used if the input must be resampled
     SwrContext *swr = nullptr;
 };

--- a/vita3k/ngs/src/modules/player.cpp
+++ b/vita3k/ngs/src/modules/player.cpp
@@ -43,7 +43,11 @@ void Module::on_state_change(ModuleData &data, const VoiceState previous) {
         state->samples_generated_since_key_on = 0;
         state->bytes_consumed_since_key_on = 0;
 
-        std::fill_n(state->adpcm_history, 4, 0);
+        if (state->adpcm_history) {
+            delete[] state->adpcm_history;
+            state->adpcm_history = nullptr;
+        }
+
         if (state->swr)
             swr_free(&state->swr);
     }
@@ -55,8 +59,14 @@ void Module::on_param_change(const MemState &mem, ModuleData &data) {
     const Parameters *new_params = reinterpret_cast<Parameters *>(data.info.data.get(mem));
 
     // if playback scaling changed, reset the resampler
-    if (state->swr && (old_params->playback_frequency != new_params->playback_frequency || old_params->playback_scalar != new_params->playback_scalar)) {
-        swr_free(&state->swr);
+    if (old_params->playback_frequency != new_params->playback_frequency || old_params->playback_scalar != new_params->playback_scalar) {
+        if (state->adpcm_history) {
+            delete[] state->adpcm_history;
+            state->adpcm_history = nullptr;
+        }
+
+        if (state->swr)
+            swr_free(&state->swr);
     }
 }
 
@@ -172,33 +182,49 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                 decoder->source_frequency = params->playback_frequency;
                 // Enable ADPCM mode on the decoder if needed, and restore state
                 decoder->he_adpcm = static_cast<bool>(params->type);
-                if (decoder->he_adpcm)
-                    std::copy_n(state->adpcm_history, 4, decoder->adpcm_history);
+                if (decoder->he_adpcm) {
+                    if (!decoder->adpcm_history) {
+                        decoder->adpcm_history = new ADPCMHistory[decoder->source_channels]; 
+
+                        ADPCMHistory hist = {};
+                        std::fill_n(decoder->adpcm_history, decoder->source_channels, hist);
+                    }
+
+                    if (!state->adpcm_history) {
+                        state->adpcm_history = new ADPCMHistory[decoder->source_channels];
+
+                        ADPCMHistory hist = {};
+                        std::fill_n(state->adpcm_history, decoder->source_channels, hist);
+                    }
+
+                    if (state->adpcm_history && decoder->adpcm_history)
+                        std::copy_n(state->adpcm_history, decoder->source_channels, decoder->adpcm_history);
+                }
 
                 // Get audio buffer
                 auto *input = params->buffer_params[state->current_buffer].buffer.cast<uint8_t>().get(mem);
 
                 DecoderSize samples_count;
 
-                // we need to know how many bytes we need to send (just enough for the system granularity)
+                // we need to know how many samples (not bytes!) we need to send (just enough for the system granularity)
                 uint32_t samples_needed = granularity - state->decoded_samples_pending;
                 uint32_t bytes_to_send;
 
+                if (params->playback_scalar != 1.0) {
+                    samples_needed = static_cast<uint32_t>(samples_needed * params->playback_scalar);
+                }
+                if (static_cast<int>(params->playback_frequency) != sample_rate) {
+                    samples_needed = static_cast<uint32_t>((samples_needed * params->playback_frequency) / sample_rate);
+                }
+
+                // Convert samples count to actual bytes count that we need
                 if (decoder->he_adpcm) {
-                    bytes_to_send = (samples_needed * params->channels * 16 + 27) / 28;
+                    bytes_to_send = (samples_needed + 27) / 28 * params->channels * 16;
                 } else {
                     bytes_to_send = samples_needed * params->channels * sizeof(int16_t);
                 }
 
-                if (params->playback_scalar != 1.0) {
-                    bytes_to_send = static_cast<uint32_t>(bytes_to_send * params->playback_scalar + 0x10);
-                }
-                if (static_cast<int>(params->playback_frequency) != sample_rate) {
-                    bytes_to_send = static_cast<uint32_t>((bytes_to_send * params->playback_frequency) / sample_rate + 0x10);
-                }
-
                 // makes the value 4 bits aligned so we have no issue with decoding, adpcm or not and whether the sound is mono or stereo
-                bytes_to_send = (bytes_to_send + 0xF) & ~0xF;
                 bytes_to_send = std::min<uint32_t>(bytes_to_send, params->buffer_params[state->current_buffer].bytes_count - state->current_byte_position_in_buffer);
 
                 // Send buffered audio data to decoder
@@ -209,7 +235,7 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                 state->total_bytes_consumed += bytes_to_send;
                 // save he_adpcm state
                 if (decoder->he_adpcm)
-                    std::copy_n(decoder->adpcm_history, 4, state->adpcm_history);
+                    std::copy_n(decoder->adpcm_history, decoder->source_channels, state->adpcm_history);
 
                 // Get the amount of samples about to be received from the decoder and dump the value in samples_count
                 decoder->receive(nullptr, &samples_count);
@@ -229,7 +255,7 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                     // resample the audio
                     int src_sample_rate = static_cast<int>(params->playback_frequency);
                     if (params->playback_scalar != 1.0)
-                        src_sample_rate *= params->playback_scalar;
+                        src_sample_rate = static_cast<int>(src_sample_rate * params->playback_scalar);
 
                     if (!state->swr) {
                         state->swr = swr_alloc_set_opts(nullptr,
@@ -295,7 +321,11 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
         state->samples_generated_since_key_on = 0;
         state->bytes_consumed_since_key_on = 0;
 
-        std::fill_n(state->adpcm_history, 4, 0);
+        if (state->adpcm_history) {
+            delete[] state->adpcm_history;
+            state->adpcm_history = nullptr;
+        }
+
         if (state->swr)
             swr_free(&state->swr);
     }


### PR DESCRIPTION
Mono audio is playing fine. However that doesn't apply to any multichannel sound. In HEVAG audio is packed in frames that contain 28 samples each. But they're not interleaved in frame. Instead channel interleaving is done on frame level. frame `n` has channel 0 data and frame `n+1` has channel 1 data and so on. If we reach last channel, `n` is wrapped back to 0. Each channel has `adpcm_history` and it must be separate for each channel