### PR TITLE
renderer: Change border color to black when aspect ratio doesn't match

### DIFF
--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -123,6 +123,8 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
     glViewport(static_cast<GLint>(viewport_pos.x), static_cast<GLint>(viewport_pos.y), static_cast<GLsizei>(viewport_size.x),
         static_cast<GLsizei>(viewport_size.y));
 
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClearDepth(1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     const auto &shader = enable_fxaa ? m_render_shader_fxaa : m_render_shader_nofilter;


### PR DESCRIPTION
Currently, when the aspect ratio does not match the PS Vita's one, the borders are yellow as the color is inherited from the default framebuffer clear color.
However while the yellow colors is useful for debugging purposes for the framebuffers, it doesn't make any sense for the borders in which we won't draw anything anyway.

![image](https://user-images.githubusercontent.com/5671744/175606419-4ecad372-4a10-4a0c-9556-ce0ea612d052.png)
