### PR TITLE
renderer: Set alpha value of default clear color to 0

### DIFF
--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -126,6 +126,8 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClearDepth(1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    // should not be needed, but just in case
+    glClearColor(0.968627450f, 0.776470588f, 0.0f, 0.0f);
 
     const auto &shader = enable_fxaa ? m_render_shader_fxaa : m_render_shader_nofilter;
 

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -673,7 +673,7 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const State &state, co
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
         LOG_ERROR("Framebuffer is not completed. Proceed anyway...");
 
-    glClearColor(0.968627450f, 0.776470588f, 0.0f, 1.0f);
+    glClearColor(0.968627450f, 0.776470588f, 0.0f, 0.0f);
     glClearDepth(1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);


### PR DESCRIPTION
Some games like to do blending on a framebuffer that was just initialized. The alpha value needs to be 0 for this to properly work.