### PR TITLE
modules/SceGxm: Improve handling of front buffer sync object

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1178,8 +1178,12 @@ EXPORT(int, sceGxmDisplayQueueAddEntry, Ptr<SceGxmSyncObject> oldBuffer, Ptr<Sce
 
     // needed the first time the sync object is used as the old front buffer
     if (oldBufferSync->last_display == 0) {
-        oldBufferSync->timestamp_ahead++;
-        oldBufferSync->last_display = oldBufferSync->timestamp_ahead;
+        // resogun draws to the front buffer using the fact that the sync object prevents
+        // it from doing so until it is swapped, the first time it happens must be handled
+        // as a special case
+        renderer::wishlist(oldBufferSync, oldBufferSync->timestamp_ahead);
+
+        oldBufferSync->last_display = ++oldBufferSync->timestamp_ahead;
     }
 
     // function may be blocking here (expected behavior)


### PR DESCRIPTION
When drawing to the front buffer before it was used for any display entry, it could lead to a softlock.

This fixes the regression in Resogun and allows it to go back ingame.