### PR TITLE
vita3k/interface: fix race and crash on application close again

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -574,7 +574,9 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             emuenv.kernel.exit_delete_all_threads();
             emuenv.gxm.display_queue.abort();
             emuenv.display.abort = true;
-            emuenv.display.vblank_thread->join();
+            if (emuenv.display.vblank_thread) {
+                emuenv.display.vblank_thread->join();
+            }
             return false;
 
         case SDL_KEYDOWN:


### PR DESCRIPTION
I forget the case when thread finished too fast (or not yet created)