### PR TITLE
vita3k update: add some lang string and fix.

### DIFF
--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -313,4 +313,19 @@ Are you sure you want to continue?</user_delete_warn>
 		<no>No</no>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K Update">
+ 		<new_version_available>A new version of the Vita3K is available.</new_version_available>
+		<back>Back</back>
+		<downloading>Downloading...
+After the download is complete, Vita3K will restart automatically and then install the new Vita3K.</downloading>
+		<not_complete_update>Could not complete the update.</not_complete_update>
+		<next>Next</next>
+		<update_vita3k>Do you want to update Vita3K?</update_vita3k>
+		<later_version_already_installed>The later version of the Vita3K software is already installed.</later_version_already_installed>
+		<latest_version_already_installed>The latest version of the Vita3K is already installed.</latest_version_already_installed>
+		<new_features>New Features in Version {}</new_features>
+		<update>Update</update>
+		<version>Version {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -315,13 +315,15 @@ Are you sure you want to continue?</user_delete_warn>
 	</user_management>
 
 	<vita3k_update name="Vita3K Update">
-		<back>Back</back>
  		<new_version_available>A new version of the Vita3K is available.</new_version_available>
+		<back>Back</back>
+		<downloading>Downloading...
+After the download is complete, Vita3K will restart automatically and then install the new Vita3K.</downloading>
+		<not_complete_update>Could not complete the update.</not_complete_update>
 		<next>Next</next>
 		<update_vita3k>Do you want to update Vita3K?</update_vita3k>
+		<later_version_already_installed>The later version of the Vita3K software is already installed.</later_version_already_installed>
 		<latest_version_already_installed>The latest version of the Vita3K is already installed.</latest_version_already_installed>
-		<downloading>Downloading...
-After the download is complete, Vita3K will restart automatically and then install the new version.</downloading>
 		<new_features>New Features in Version {}</new_features>
 		<update>Update</update>
 		<version>Version {}</version>

--- a/lang/es.xml
+++ b/lang/es.xml
@@ -280,4 +280,19 @@ Podrás conseguir trofeos si usas una aplicación compatible con la función de 
 		<user>Usuario</user>
 		<confirm>Confirmar</confirm>
 	</user_management>
+
+	<vita3k_update name="Actualización Vita3K">
+ 		<new_version_available>Está disponible una nueva versión de Vita3k.</new_version_available>
+		<back>Atrás</back>
+		<downloading>Descargando...
+Cuando la descarga se haya completado, Vita3K se reiniciará automáticamente e instalará el nuevo Vita3K.</downloading>
+		<not_complete_update>No se ha podido completar la actualización.</not_complete_update>
+		<next>Siguiente</next>
+		<update_vita3k>¿Quieres actualizar Vita3K?</update_vita3k>
+		<later_version_already_installed>Ya está instalada la versión posterior de Vita3K.</later_version_already_installed>
+		<latest_version_already_installed>Ya está instalada la versión más reciente de Vita3K.</latest_version_already_installed>
+		<new_features>Nuevas funciones de la versión {}</new_features>
+		<update>Actualizar</update>
+		<version>Versión {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/fr.xml
+++ b/lang/fr.xml
@@ -283,13 +283,15 @@ Pour obtenir des trophées, utilisez une application compatible avec cette fonct
 	</user_management>
 
 	<vita3k_update name="Mise à jour Vita3K">
-		<back>Précédent</back>
  		<new_version_available>Une nouvelle version de Vita3K est disponible.</new_version_available>
+		<back>Précédent</back>
+		<downloading>Téléchargement en cours...
+Une fois le téléchargement terminé, Vita3K redémarrera automatiquement et installera le nouveau Vita3K.</downloading>
+		<not_complete_update>La mise à jour n'a pas pu être terminée.</not_complete_update>
 		<next>Suivant</next>
 		<update_vita3k>Mettre à jour Vita3K ?</update_vita3k>
+		<later_version_already_installed>Une version plus récente de Vita3K est déjà installée.</later_version_already_installed>
 		<latest_version_already_installed>La dernière version de Vita3K est déjà installée.</latest_version_already_installed>
-		<downloading>Téléchargement en cours...
-Une fois le téléchargement terminé, Vita3K redémarrera automatiquement et installera la nouvelle version.</downloading>
 		<new_features>Nouveautés de la version {}</new_features>
 		<update>Mettre à jour</update>
 		<version>Version {}</version>

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -101,7 +101,7 @@ static void draw_help_menu(GuiState &gui) {
     auto lang = gui.lang.main_menubar.help;
     if (ImGui::BeginMenu(lang["title"].c_str())) {
         ImGui::MenuItem(lang["about"].c_str(), nullptr, &gui.help_menu.about_dialog);
-        if (ImGui::MenuItem("Vita3K Update", nullptr, &gui.help_menu.vita3k_update))
+        if (ImGui::MenuItem(gui.lang.vita3k_update["title"].c_str(), nullptr, &gui.help_menu.vita3k_update))
             init_vita3k_update(gui);
         ImGui::MenuItem(lang["welcome"].c_str(), nullptr, &gui.help_menu.welcome_dialog);
         ImGui::EndMenu();

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -270,12 +270,14 @@ struct LangState {
     };
     std::map<std::string, std::string> vita3k_update = {
         { "title", "Vita3K Update" },
-        { "back", "Back" },
         { "new_version_available", "A new version of the Vita3K is available." },
+        { "back", "Back" },
+        { "downloading", "Downloading...\nAfter the download is complete, Vita3K will restart automatically and then install the new Vita3K." },
+        { "not_complete_update", "Could not complete the update." },
         { "next", "Next" },
         { "update_vita3k", "Do you want to update Vita3K" },
+        { "later_version_already_installed", "The later version of the Vita3K software is already installed." },
         { "latest_version_already_installed", "The latest version of the Vita3K is already installed." },
-        { "downloading", "Downloading...\nAfter the download is complete, Vita3K will restart automatically and then install the new version." },
         { "new_features", "New Features in Version {}" },
         { "update", "Update" },
         { "version", "Version {}" }


### PR DESCRIPTION
# About
- Add spanish/en-gb lang
-  Add screen if install update fail for allow cancel and back in emu home screen
- add text if version of vit'a3k is upper compare current
- fix warn compile on line find for windows
- check if powershell version is upper to 3 for can using rest-method
- add timeout of 4 sec on check versionn, if github down  etc...