### PR TITLE
gui, renderer: Add option to disable raw surfaces

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -60,6 +60,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "archive-log", false, archive_log)                                                       \
     code(int, "resolution-multiplier", 1, resolution_multiplier)                                        \
     code(bool, "disable-surface-sync", false, disable_surface_sync)                                     \
+    code(bool, "enable-raw-surfaces", true, enable_raw_surfaces)                                        \
     code(bool, "enable-fxaa", false, enable_fxaa)                                                       \
     code(bool, "v-sync", true, v_sync)                                                                  \
     code(int, "anisotropic-filtering", 1, anisotropic_filtering)                                        \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -124,6 +124,7 @@ public:
         bool disable_ngs = false;
         int resolution_multiplier = 1;
         bool disable_surface_sync = false;
+        bool enable_raw_surfaces = true;
         bool enable_fxaa = false;
         bool v_sync = true;
         int anisotropic_filtering = 1;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -160,6 +160,7 @@ static bool get_custom_config(GuiState &gui, EmuEnvState &emuenv, const std::str
                 const auto gpu_child = config_child.child("gpu");
                 config.resolution_multiplier = gpu_child.attribute("resolution-multiplier").as_int();
                 config.disable_surface_sync = gpu_child.attribute("disable-surface-sync").as_bool();
+                config.enable_raw_surfaces = gpu_child.attribute("enable-raw-surfaces").as_bool();
                 config.enable_fxaa = gpu_child.attribute("enable-fxaa").as_bool();
                 config.v_sync = gpu_child.attribute("v-sync").as_bool();
                 config.anisotropic_filtering = gpu_child.attribute("anisotropic-filtering").as_int();
@@ -210,6 +211,7 @@ void init_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
         config.lle_modules = emuenv.cfg.lle_modules;
         config.resolution_multiplier = emuenv.cfg.resolution_multiplier;
         config.disable_surface_sync = emuenv.cfg.disable_surface_sync;
+        config.enable_raw_surfaces = emuenv.cfg.enable_raw_surfaces;
         config.enable_fxaa = emuenv.cfg.enable_fxaa;
         config.v_sync = emuenv.cfg.v_sync;
         config.anisotropic_filtering = emuenv.cfg.anisotropic_filtering;
@@ -266,6 +268,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         auto gpu_child = config_child.append_child("gpu");
         gpu_child.append_attribute("resolution-multiplier") = config.resolution_multiplier;
         gpu_child.append_attribute("disable-surface-sync") = config.disable_surface_sync;
+        gpu_child.append_attribute("enable-raw-surfaces") = config.enable_raw_surfaces;
         gpu_child.append_attribute("enable-fxaa") = config.enable_fxaa;
         gpu_child.append_attribute("v-sync") = config.v_sync;
         gpu_child.append_attribute("anisotropic-filtering") = config.anisotropic_filtering;
@@ -289,6 +292,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         emuenv.cfg.pstv_mode = config.pstv_mode;
         emuenv.cfg.resolution_multiplier = config.resolution_multiplier;
         emuenv.cfg.disable_surface_sync = config.disable_surface_sync;
+        emuenv.cfg.enable_raw_surfaces = config.enable_raw_surfaces;
         emuenv.cfg.enable_fxaa = config.enable_fxaa;
         emuenv.cfg.v_sync = config.v_sync;
         emuenv.cfg.anisotropic_filtering = config.anisotropic_filtering;
@@ -329,6 +333,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.cfg.current_config.pstv_mode = config.pstv_mode;
         emuenv.cfg.current_config.resolution_multiplier = config.resolution_multiplier;
         emuenv.cfg.current_config.disable_surface_sync = config.disable_surface_sync;
+        emuenv.cfg.current_config.enable_raw_surfaces = config.enable_raw_surfaces;
         emuenv.cfg.current_config.enable_fxaa = config.enable_fxaa;
         emuenv.cfg.current_config.v_sync = config.v_sync;
         emuenv.cfg.current_config.anisotropic_filtering = config.anisotropic_filtering;
@@ -342,6 +347,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.cfg.current_config.pstv_mode = emuenv.cfg.pstv_mode;
         emuenv.cfg.current_config.resolution_multiplier = emuenv.cfg.resolution_multiplier;
         emuenv.cfg.current_config.disable_surface_sync = emuenv.cfg.disable_surface_sync;
+        emuenv.cfg.current_config.enable_raw_surfaces = emuenv.cfg.enable_raw_surfaces;
         emuenv.cfg.current_config.enable_fxaa = emuenv.cfg.enable_fxaa;
         emuenv.cfg.current_config.v_sync = emuenv.cfg.v_sync;
         emuenv.cfg.current_config.anisotropic_filtering = emuenv.cfg.anisotropic_filtering;
@@ -359,6 +365,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.kernel.cpu_backend = set_cpu_backend(emuenv.cfg.current_config.cpu_backend);
         emuenv.kernel.cpu_opt = emuenv.cfg.current_config.cpu_opt;
         emuenv.renderer->res_multiplier = emuenv.cfg.current_config.resolution_multiplier;
+        emuenv.renderer->enable_raw_surfaces = emuenv.cfg.enable_raw_surfaces;
     }
 }
 
@@ -509,6 +516,13 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Speed hack, check the box to disable surface syncing between CPU and GPU.\nSurface syncing is needed by a few games.\nGive a big performance boost if disabled (in particular when upscaling is on).");
         ImGui::Spacing();
+        if (!emuenv.io.title_id.empty())
+            ImGui::BeginDisabled();
+        ImGui::Checkbox("Enable raw surfaces", &config.enable_raw_surfaces);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Store 16 bits component surfaces in a raw way.\n Disabling this option can fix blending in a few games but will break others.");
+        if (!emuenv.io.title_id.empty())
+            ImGui::EndDisabled();
         ImGui::Checkbox("Enable anti-aliasing (FXAA)", &config.enable_fxaa);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Anti-aliasing is a technique for smoothing out jagged edges.\n FXAA comes at almost no performance cost but makes games look slightly blurry.");

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -35,6 +35,7 @@ struct State {
     FeatureState features;
     int res_multiplier;
     bool disable_surface_sync;
+    bool enable_raw_surfaces;
 
     GXPPtrMap gxp_ptr_map;
     Queue<CommandList> command_buffer_queue;

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -99,7 +99,7 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
 
     glUseProgram(program_id);
 
-    const bool use_raw_image = color::is_write_surface_stored_rawly(gxm::get_base_format(context.record.color_surface.colorFormat));
+    const bool use_raw_image = renderer.enable_raw_surfaces && color::is_write_surface_stored_rawly(gxm::get_base_format(context.record.color_surface.colorFormat));
 
     if (fragment_program_gxp.is_native_color() && features.is_programmable_blending_need_to_bind_color_attachment()) {
         if (use_raw_image) {

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -641,7 +641,7 @@ void lookup_and_get_surface_data(GLState &renderer, MemState &mem, SceGxmColorSu
 
     GLenum gl_format = format_gl->second.first;
     GLenum gl_type = format_gl->second.second;
-    if (color::is_write_surface_stored_rawly(base_format)) {
+    if (renderer.enable_raw_surfaces && color::is_write_surface_stored_rawly(base_format)) {
         gl_format = color::get_raw_store_upload_format_type(base_format);
         gl_type = color::get_raw_store_upload_data_type(base_format);
     }
@@ -697,7 +697,7 @@ void get_surface_data(GLState &renderer, GLContext &context, uint32_t *pixels, S
     }
 
     const SceGxmColorBaseFormat base_format = gxm::get_base_format(format);
-    if (color::is_write_surface_stored_rawly(base_format)) {
+    if (renderer.enable_raw_surfaces && color::is_write_surface_stored_rawly(base_format)) {
         // we can't get the content of raw textures with glReadPixels
         GLint last_texture = 0;
 

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -160,7 +160,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
                 remake_and_apply_filters_to_current_binded();
             }
 
-            if (color::is_write_surface_stored_rawly(base_format)) {
+            if (state.enable_raw_surfaces && color::is_write_surface_stored_rawly(base_format)) {
                 surface_internal_format = color::get_raw_store_internal_type(base_format);
                 surface_upload_format = color::get_raw_store_upload_format_type(base_format);
                 surface_data_type = color::get_raw_store_upload_data_type(base_format);
@@ -250,7 +250,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
 
                     GLenum source_format, source_data_type = 0;
 
-                    if (color::is_write_surface_stored_rawly(info.format)) {
+                    if (state.enable_raw_surfaces && color::is_write_surface_stored_rawly(info.format)) {
                         source_format = color::get_raw_store_upload_format_type(info.format);
                         source_data_type = color::get_raw_store_upload_data_type(info.format);
                     } else {
@@ -396,7 +396,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
     GLint texture_handle_return = info_added->gl_texture[0];
     bool store_rawly = false;
 
-    if (color::is_write_surface_stored_rawly(base_format)) {
+    if (state.enable_raw_surfaces && color::is_write_surface_stored_rawly(base_format)) {
         surface_internal_format = color::get_raw_store_internal_type(base_format);
         surface_upload_format = color::get_raw_store_upload_format_type(base_format);
         surface_data_type = color::get_raw_store_upload_data_type(base_format);
@@ -660,7 +660,7 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const State &state, co
 
     glBindFramebuffer(GL_FRAMEBUFFER, fb[0]);
 
-    if (color && renderer::gl::color::is_write_surface_stored_rawly(gxm::get_base_format(color->colorFormat))) {
+    if (color && state.enable_raw_surfaces && renderer::gl::color::is_write_surface_stored_rawly(gxm::get_base_format(color->colorFormat))) {
         glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, color_handle, 0);
 
         const GLenum buffers[] = { GL_NONE, GL_COLOR_ATTACHMENT1 };


### PR DESCRIPTION
As @korenkonder pointed out, raw textures prevent classic blending from working correctly. However, they are still needed for some games (like Gravity Rush) which rely on NaN floating values.

Add an option in the gui to disable raw texture, doing so fixes blending in Project Diva X.