### PR TITLE
Shader: Fix VRCP decoding and cube textureGrad

### DIFF
--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -61,8 +61,9 @@ public:
     int repeat_multiplier[4];
 
     void do_texture_queries(const NonDependentTextureQueryCallInfos &texture_queries, const spv::Id translation_state_id);
+    // extra1 is either lod or ddx, extra2 is ddy
     spv::Id do_fetch_texture(const spv::Id tex, const Coord &coord, const DataType dest_type, const int lod_mode,
-        const spv::Id lod = spv::NoResult);
+        const spv::Id extra1 = spv::NoResult, const spv::Id extra2 = spv::NoResult);
 
     USSETranslatorVisitor() = delete;
     explicit USSETranslatorVisitor(spv::Builder &_b, USSERecompiler &_recompiler, const SceGxmProgram &program, const FeatureState &features,

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -748,10 +748,13 @@ bool USSETranslatorVisitor::vcomp(
         if (num_comp == 1) {
             one_v = one_const;
         } else {
-            std::vector<spv::Id> ones;
-            ones.insert(ones.begin(), num_comp, one_const);
+            std::vector<spv::Id> composite_values(num_comp);
 
-            one_v = m_b.makeCompositeConstant(type_f32_v[num_comp], ones);
+            std::fill_n(composite_values.begin(), num_comp, one_const);
+            one_v = m_b.makeCompositeConstant(type_f32_v[num_comp], composite_values);
+
+            std::fill_n(composite_values.begin(), num_comp, result);
+            result = m_b.createCompositeConstruct(type_f32_v[num_comp], composite_values);
         }
 
         result = m_b.createBinOp(spv::OpFDiv, m_b.getTypeId(result), one_v, result);


### PR DESCRIPTION
These fixes are ported from @korenkonder fixes in his glsl branch.

Fix VRCP decoding when the input and output are not the same size (SpirV-cross did it for us before but the generated spirV code was not valid).

Implement smp texture grad for cube textures.

This fix allow Hatsune Miku Project Diva X to run without shader errors and should fix some of its graphical issues.