### PR TITLE
display, renderer: Sync guest and host fps

### DIFF
--- a/vita3k/display/src/display.cpp
+++ b/vita3k/display/src/display.cpp
@@ -43,9 +43,10 @@ static void vblank_sync_thread(EmuEnvState &emuenv) {
                 display.vblank_count++;
                 // register framebuf change made by _sceDisplaySetFrameBuf
                 if (display.has_next_frame) {
-                    display.frame = display.next_frame;
                     display.has_next_frame = false;
-                    emuenv.renderer->should_display = true;
+                    // do not set it here as it as already been set in _sceDisplaySetFrameBuf
+                    // display.frame = display.next_frame;
+                    // emuenv.renderer->should_display = true;
                 }
             }
 

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -22,6 +22,7 @@
 #include <io/state.h>
 #include <kernel/state.h>
 #include <packages/functions.h>
+#include <renderer/state.h>
 
 #include <util/safe_time.h>
 
@@ -1035,6 +1036,8 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
                 update_time_app_used(gui, emuenv, app_path);
                 emuenv.kernel.exit_delete_all_threads();
                 emuenv.load_exec = true;
+                // make sure we are not stuck waiting for a gpu command
+                emuenv.renderer->should_display = true;
             } else {
                 gui.apps_list_opened.erase(get_app_open_list_index(gui, app_path));
                 if (gui.current_app_selected == 0) {

--- a/vita3k/modules/SceAppMgr/SceAppMgr.cpp
+++ b/vita3k/modules/SceAppMgr/SceAppMgr.cpp
@@ -20,6 +20,7 @@
 #include <io/state.h>
 #include <kernel/state.h>
 #include <packages/sfo.h>
+#include <renderer/state.h>
 #include <util/tracy.h>
 
 #ifdef TRACY_ENABLE
@@ -422,6 +423,8 @@ EXPORT(SceInt32, _sceAppMgrLoadExec, const char *appPath, Ptr<char> const argv[]
         emuenv.load_app_path = emuenv.io.app_path;
         emuenv.load_exec_path = exec_path;
         emuenv.load_exec = true;
+        // make sure we are not stuck waiting for a gpu command
+        emuenv.renderer->should_display = true;
 
         return SCE_KERNEL_OK;
     }

--- a/vita3k/modules/SceDisplay/SceDisplay.cpp
+++ b/vita3k/modules/SceDisplay/SceDisplay.cpp
@@ -25,6 +25,7 @@
 #include <display/state.h>
 #include <kernel/state.h>
 #include <packages/functions.h>
+#include <renderer/state.h>
 #include <util/lock_and_find.h>
 #include <util/types.h>
 
@@ -128,6 +129,14 @@ EXPORT(SceInt32, _sceDisplaySetFrameBuf, const SceDisplayFrameBuf *pFrameBuf, Sc
         info.image_size.x = pFrameBuf->width;
         info.image_size.y = pFrameBuf->height;
         emuenv.display.last_setframe_vblank_count = emuenv.display.vblank_count.load();
+
+        // hack (kind of)
+        // we can assume the framebuffer is already fully rendered
+        // (always the case when using gxm, and should also be the case when it is not used)
+        // so set this buffer as ready to be displayed
+        // this should decrease the latency
+        emuenv.display.frame = emuenv.display.next_frame;
+        emuenv.renderer->should_display = true;
     }
 
     emuenv.frame_count++;

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -41,8 +41,10 @@ void finish(State &state, Context *context);
 
 /**
  * \brief Wait for all subjects to be done with the given sync object.
+ * 
+ * Return true if the wait didn't timeout
  */
-void wishlist(SceGxmSyncObject *sync_object, const uint32_t timestamp);
+bool wishlist(SceGxmSyncObject *sync_object, const uint32_t timestamp, const int32_t timeout_micros = -1);
 
 /**
  * \brief Set list of subject with sync object to done.

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -59,7 +59,7 @@ struct State {
     uint32_t shaders_count_compiled = 0;
     uint32_t programs_count_pre_compiled = 0;
 
-    std::atomic<bool> should_display;
+    bool should_display;
 
     virtual bool init(const char *base_path, const bool hashless_texture_cache) = 0;
     virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -667,6 +667,8 @@ void get_surface_data(GLState &renderer, GLContext &context, uint32_t *pixels, S
 
 void GLState::render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
     const GxmState &gxm, MemState &mem) {
+    should_display = false;
+
     if (!display.frame.base)
         return;
 

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -388,6 +388,9 @@ void VKState::cleanup() {
 
 void VKState::render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
     const GxmState &gxm, MemState &mem) {
+    // we are displaying this frame, wait for a new one
+    should_display = false;
+
     if (!display.frame.base)
         return;
 


### PR DESCRIPTION
Synchronise the guest and the host fps : if there is no frame ready, do not re-render the last frame. This should slightly improve the performance of games, allow external fps counters to work properly and prevent the emulator from rendering at 300 fps with vsync off when there is nothing to display.

The only downside is that the gui's fps will also be the same as the game fps but I can't really do a lot about it because of the way it is integrated in Vita3K.