### PR TITLE
Fix programmable blending and remove raw surfaces

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -60,7 +60,6 @@ enum PerfomanceOverleyPosition {
     code(bool, "archive-log", false, archive_log)                                                       \
     code(int, "resolution-multiplier", 1, resolution_multiplier)                                        \
     code(bool, "disable-surface-sync", false, disable_surface_sync)                                     \
-    code(bool, "enable-raw-surfaces", true, enable_raw_surfaces)                                        \
     code(bool, "enable-fxaa", false, enable_fxaa)                                                       \
     code(bool, "v-sync", true, v_sync)                                                                  \
     code(int, "anisotropic-filtering", 1, anisotropic_filtering)                                        \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -124,7 +124,6 @@ public:
         bool disable_ngs = false;
         int resolution_multiplier = 1;
         bool disable_surface_sync = false;
-        bool enable_raw_surfaces = true;
         bool enable_fxaa = false;
         bool v_sync = true;
         int anisotropic_filtering = 1;

--- a/vita3k/features/include/features/state.h
+++ b/vita3k/features/include/features/state.h
@@ -22,8 +22,9 @@ struct FeatureState {
     bool support_texture_barrier = false; ///< Second option for blending. Slower but work on 3 vendors.
     bool direct_fragcolor = false;
     bool spirv_shader = false;
-    bool preserve_f16_nan_as_u16 = true; ///< Emit store of 4xU16 to draw buffer 1. This buffer is expected to be U16U16U16U16, which can be casted to F16F16F16F16. This is to preserve some drivers's behaviour of casting NaN to default value when store in framebuffer, not keeping its original value.
+    bool preserve_f16_nan_as_u16 = false; ///< Emit store of 4xU16 to draw buffer 1. This buffer is expected to be U16U16U16U16, which can be casted to F16F16F16F16. This is to preserve some drivers's behaviour of casting NaN to default value when store in framebuffer, not keeping its original value.
     bool support_get_texture_sub_image = false;
+    bool support_unknown_format = false;
 
     bool is_programmable_blending_supported() const {
         return support_shader_interlock || support_texture_barrier || direct_fragcolor;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -160,7 +160,6 @@ static bool get_custom_config(GuiState &gui, EmuEnvState &emuenv, const std::str
                 const auto gpu_child = config_child.child("gpu");
                 config.resolution_multiplier = gpu_child.attribute("resolution-multiplier").as_int();
                 config.disable_surface_sync = gpu_child.attribute("disable-surface-sync").as_bool();
-                config.enable_raw_surfaces = gpu_child.attribute("enable-raw-surfaces").as_bool();
                 config.enable_fxaa = gpu_child.attribute("enable-fxaa").as_bool();
                 config.v_sync = gpu_child.attribute("v-sync").as_bool();
                 config.anisotropic_filtering = gpu_child.attribute("anisotropic-filtering").as_int();
@@ -211,7 +210,6 @@ void init_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
         config.lle_modules = emuenv.cfg.lle_modules;
         config.resolution_multiplier = emuenv.cfg.resolution_multiplier;
         config.disable_surface_sync = emuenv.cfg.disable_surface_sync;
-        config.enable_raw_surfaces = emuenv.cfg.enable_raw_surfaces;
         config.enable_fxaa = emuenv.cfg.enable_fxaa;
         config.v_sync = emuenv.cfg.v_sync;
         config.anisotropic_filtering = emuenv.cfg.anisotropic_filtering;
@@ -268,7 +266,6 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         auto gpu_child = config_child.append_child("gpu");
         gpu_child.append_attribute("resolution-multiplier") = config.resolution_multiplier;
         gpu_child.append_attribute("disable-surface-sync") = config.disable_surface_sync;
-        gpu_child.append_attribute("enable-raw-surfaces") = config.enable_raw_surfaces;
         gpu_child.append_attribute("enable-fxaa") = config.enable_fxaa;
         gpu_child.append_attribute("v-sync") = config.v_sync;
         gpu_child.append_attribute("anisotropic-filtering") = config.anisotropic_filtering;
@@ -292,7 +289,6 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         emuenv.cfg.pstv_mode = config.pstv_mode;
         emuenv.cfg.resolution_multiplier = config.resolution_multiplier;
         emuenv.cfg.disable_surface_sync = config.disable_surface_sync;
-        emuenv.cfg.enable_raw_surfaces = config.enable_raw_surfaces;
         emuenv.cfg.enable_fxaa = config.enable_fxaa;
         emuenv.cfg.v_sync = config.v_sync;
         emuenv.cfg.anisotropic_filtering = config.anisotropic_filtering;
@@ -333,7 +329,6 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.cfg.current_config.pstv_mode = config.pstv_mode;
         emuenv.cfg.current_config.resolution_multiplier = config.resolution_multiplier;
         emuenv.cfg.current_config.disable_surface_sync = config.disable_surface_sync;
-        emuenv.cfg.current_config.enable_raw_surfaces = config.enable_raw_surfaces;
         emuenv.cfg.current_config.enable_fxaa = config.enable_fxaa;
         emuenv.cfg.current_config.v_sync = config.v_sync;
         emuenv.cfg.current_config.anisotropic_filtering = config.anisotropic_filtering;
@@ -347,7 +342,6 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.cfg.current_config.pstv_mode = emuenv.cfg.pstv_mode;
         emuenv.cfg.current_config.resolution_multiplier = emuenv.cfg.resolution_multiplier;
         emuenv.cfg.current_config.disable_surface_sync = emuenv.cfg.disable_surface_sync;
-        emuenv.cfg.current_config.enable_raw_surfaces = emuenv.cfg.enable_raw_surfaces;
         emuenv.cfg.current_config.enable_fxaa = emuenv.cfg.enable_fxaa;
         emuenv.cfg.current_config.v_sync = emuenv.cfg.v_sync;
         emuenv.cfg.current_config.anisotropic_filtering = emuenv.cfg.anisotropic_filtering;
@@ -365,7 +359,6 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.kernel.cpu_backend = set_cpu_backend(emuenv.cfg.current_config.cpu_backend);
         emuenv.kernel.cpu_opt = emuenv.cfg.current_config.cpu_opt;
         emuenv.renderer->res_multiplier = emuenv.cfg.current_config.resolution_multiplier;
-        emuenv.renderer->enable_raw_surfaces = emuenv.cfg.enable_raw_surfaces;
     }
 }
 
@@ -516,13 +509,6 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Speed hack, check the box to disable surface syncing between CPU and GPU.\nSurface syncing is needed by a few games.\nGive a big performance boost if disabled (in particular when upscaling is on).");
         ImGui::Spacing();
-        if (!emuenv.io.title_id.empty())
-            ImGui::BeginDisabled();
-        ImGui::Checkbox("Enable raw surfaces", &config.enable_raw_surfaces);
-        if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("Store 16 bits component surfaces in a raw way.\n Disabling this option can fix blending in a few games but will break others.");
-        if (!emuenv.io.title_id.empty())
-            ImGui::EndDisabled();
         ImGui::Checkbox("Enable anti-aliasing (FXAA)", &config.enable_fxaa);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Anti-aliasing is a technique for smoothing out jagged edges.\n FXAA comes at almost no performance cost but makes games look slightly blurry.");

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -35,7 +35,6 @@ struct State {
     FeatureState features;
     int res_multiplier;
     bool disable_surface_sync;
-    bool enable_raw_surfaces;
 
     GXPPtrMap gxp_ptr_map;
     Queue<CommandList> command_buffer_queue;

--- a/vita3k/renderer/src/gl/color_formats.cpp
+++ b/vita3k/renderer/src/gl/color_formats.cpp
@@ -98,7 +98,7 @@ GLenum translate_internal_format(SceGxmColorBaseFormat base_format) {
         return GL_RGBA16F;
 
     case SCE_GXM_COLOR_BASE_FORMAT_U2U10U10U10:
-        return GL_RGBA;
+        return GL_RGB10_A2;
 
     case SCE_GXM_COLOR_BASE_FORMAT_F11F11F10:
         return GL_R11F_G11F_B10F;
@@ -107,7 +107,8 @@ GLenum translate_internal_format(SceGxmColorBaseFormat base_format) {
         return GL_RG32F;
 
     default:
-        return GL_RGBA;
+        LOG_ERROR("Unknown base format {}", log_hex(base_format));
+        return GL_RGBA8;
     }
 }
 

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -99,7 +99,7 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
 
     glUseProgram(program_id);
 
-    const bool use_raw_image = renderer.enable_raw_surfaces && color::is_write_surface_stored_rawly(gxm::get_base_format(context.record.color_surface.colorFormat));
+    const bool use_raw_image = color::is_write_surface_stored_rawly(gxm::get_base_format(context.record.color_surface.colorFormat));
 
     if (fragment_program_gxp.is_native_color() && features.is_programmable_blending_need_to_bind_color_attachment()) {
         if (use_raw_image) {

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -99,15 +99,21 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
 
     glUseProgram(program_id);
 
-    const bool use_raw_image = color::is_write_surface_stored_rawly(gxm::get_base_format(context.record.color_surface.colorFormat));
+    const bool use_raw_image = renderer.features.preserve_f16_nan_as_u16 && color::is_write_surface_stored_rawly(gxm::get_base_format(context.record.color_surface.colorFormat));
+
+    GLenum surface_format = GL_RGBA8;
+    if (renderer.features.support_unknown_format) {
+        const SceGxmColorBaseFormat base_format = gxm::get_base_format(context.record.color_surface.colorFormat);
+        surface_format = color::translate_internal_format(base_format);
+    }
 
     if (fragment_program_gxp.is_native_color() && features.is_programmable_blending_need_to_bind_color_attachment()) {
         if (use_raw_image) {
             glBindImageTexture(shader::COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE, context.current_color_attachment, 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA16UI);
-            glBindImageTexture(shader::COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE, 0, 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA8);
+            glBindImageTexture(shader::COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE, 0, 0, GL_FALSE, 0, GL_READ_WRITE, surface_format);
         } else {
             glBindImageTexture(shader::COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE, 0, 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA16UI);
-            glBindImageTexture(shader::COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE, context.current_color_attachment, 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA8);
+            glBindImageTexture(shader::COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE, context.current_color_attachment, 0, GL_FALSE, 0, GL_READ_WRITE, surface_format);
         }
     }
     glBindImageTexture(shader::MASK_TEXTURE_SLOT_IMAGE, context.render_target->masktexture[0], 0, GL_FALSE, 0, GL_READ_ONLY, GL_RGBA8);

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -641,7 +641,7 @@ void lookup_and_get_surface_data(GLState &renderer, MemState &mem, SceGxmColorSu
 
     GLenum gl_format = format_gl->second.first;
     GLenum gl_type = format_gl->second.second;
-    if (renderer.enable_raw_surfaces && color::is_write_surface_stored_rawly(base_format)) {
+    if (color::is_write_surface_stored_rawly(base_format)) {
         gl_format = color::get_raw_store_upload_format_type(base_format);
         gl_type = color::get_raw_store_upload_data_type(base_format);
     }
@@ -697,7 +697,7 @@ void get_surface_data(GLState &renderer, GLContext &context, uint32_t *pixels, S
     }
 
     const SceGxmColorBaseFormat base_format = gxm::get_base_format(format);
-    if (renderer.enable_raw_surfaces && color::is_write_surface_stored_rawly(base_format)) {
+    if (color::is_write_surface_stored_rawly(base_format)) {
         // we can't get the content of raw textures with glReadPixels
         GLint last_texture = 0;
 

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -160,7 +160,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
                 remake_and_apply_filters_to_current_binded();
             }
 
-            if (state.enable_raw_surfaces && color::is_write_surface_stored_rawly(base_format)) {
+            if (color::is_write_surface_stored_rawly(base_format)) {
                 surface_internal_format = color::get_raw_store_internal_type(base_format);
                 surface_upload_format = color::get_raw_store_upload_format_type(base_format);
                 surface_data_type = color::get_raw_store_upload_data_type(base_format);
@@ -250,7 +250,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
 
                     GLenum source_format, source_data_type = 0;
 
-                    if (state.enable_raw_surfaces && color::is_write_surface_stored_rawly(info.format)) {
+                    if (color::is_write_surface_stored_rawly(info.format)) {
                         source_format = color::get_raw_store_upload_format_type(info.format);
                         source_data_type = color::get_raw_store_upload_data_type(info.format);
                     } else {
@@ -396,7 +396,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
     GLint texture_handle_return = info_added->gl_texture[0];
     bool store_rawly = false;
 
-    if (state.enable_raw_surfaces && color::is_write_surface_stored_rawly(base_format)) {
+    if (color::is_write_surface_stored_rawly(base_format)) {
         surface_internal_format = color::get_raw_store_internal_type(base_format);
         surface_upload_format = color::get_raw_store_upload_format_type(base_format);
         surface_data_type = color::get_raw_store_upload_data_type(base_format);
@@ -660,7 +660,7 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const State &state, co
 
     glBindFramebuffer(GL_FRAMEBUFFER, fb[0]);
 
-    if (color && state.enable_raw_surfaces && renderer::gl::color::is_write_surface_stored_rawly(gxm::get_base_format(color->colorFormat))) {
+    if (color && renderer::gl::color::is_write_surface_stored_rawly(gxm::get_base_format(color->colorFormat))) {
         glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, color_handle, 0);
 
         const GLenum buffers[] = { GL_NONE, GL_COLOR_ATTACHMENT1 };

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -160,7 +160,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
                 remake_and_apply_filters_to_current_binded();
             }
 
-            if (color::is_write_surface_stored_rawly(base_format)) {
+            if (state.features.preserve_f16_nan_as_u16 && color::is_write_surface_stored_rawly(base_format)) {
                 surface_internal_format = color::get_raw_store_internal_type(base_format);
                 surface_upload_format = color::get_raw_store_upload_format_type(base_format);
                 surface_data_type = color::get_raw_store_upload_data_type(base_format);
@@ -250,7 +250,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
 
                     GLenum source_format, source_data_type = 0;
 
-                    if (color::is_write_surface_stored_rawly(info.format)) {
+                    if (state.features.preserve_f16_nan_as_u16 && color::is_write_surface_stored_rawly(info.format)) {
                         source_format = color::get_raw_store_upload_format_type(info.format);
                         source_data_type = color::get_raw_store_upload_data_type(info.format);
                     } else {
@@ -327,7 +327,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
 
                     return casted_info.texture[0];
                 } else {
-                    if (color::is_write_surface_stored_rawly(info.format)) {
+                    if (state.features.preserve_f16_nan_as_u16 && color::is_write_surface_stored_rawly(info.format)) {
                         // Create a texture view
                         if (!info.gl_expected_read_texture_view[0]) {
                             if (!info.gl_expected_read_texture_view.init(reinterpret_cast<renderer::Generator *>(glGenTextures), reinterpret_cast<renderer::Deleter *>(glDeleteTextures))) {
@@ -396,7 +396,7 @@ std::uint64_t GLSurfaceCache::retrieve_color_surface_texture_handle(const State 
     GLint texture_handle_return = info_added->gl_texture[0];
     bool store_rawly = false;
 
-    if (color::is_write_surface_stored_rawly(base_format)) {
+    if (state.features.preserve_f16_nan_as_u16 && color::is_write_surface_stored_rawly(base_format)) {
         surface_internal_format = color::get_raw_store_internal_type(base_format);
         surface_upload_format = color::get_raw_store_upload_format_type(base_format);
         surface_data_type = color::get_raw_store_upload_data_type(base_format);
@@ -660,7 +660,7 @@ std::uint64_t GLSurfaceCache::retrieve_framebuffer_handle(const State &state, co
 
     glBindFramebuffer(GL_FRAMEBUFFER, fb[0]);
 
-    if (color && renderer::gl::color::is_write_surface_stored_rawly(gxm::get_base_format(color->colorFormat))) {
+    if (color && state.features.preserve_f16_nan_as_u16 && renderer::gl::color::is_write_surface_stored_rawly(gxm::get_base_format(color->colorFormat))) {
         glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, color_handle, 0);
 
         const GLenum buffers[] = { GL_NONE, GL_COLOR_ATTACHMENT1 };

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -39,7 +39,7 @@ static constexpr float INTEGRAL_TEX_QUERY_TYPE_8BIT_SIGNED = 3.0;
 static constexpr float INTEGRAL_TEX_QUERY_TYPE_8BIT_UNSIGNED = 2.0;
 static constexpr float INTEGRAL_TEX_QUERY_TYPE_16BIT = 1.0;
 static constexpr float INTEGRAL_TEX_QUERY_TYPE_32BIT = 0.0;
-static constexpr std::uint32_t CURRENT_VERSION = 2;
+static constexpr std::uint32_t CURRENT_VERSION = 3;
 
 // Dump generated SPIR-V disassembly up to this point
 void spirv_disasm_print(const usse::SpirvCode &spirv_binary, std::string *spirv_dump = nullptr);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -315,8 +315,9 @@ static spv::Id create_input_variable(spv::Builder &b, SpirvShaderParameters &par
 static spv::Id create_builtin_sampler(spv::Builder &b, const FeatureState &features, TranslationState &translation_state, const std::string &name) {
     spv::Id sampled_type = b.makeFloatType(32);
 
+    // 2 = storage image
     int sampled = 2;
-    spv::ImageFormat img_format = spv::ImageFormatRgba8;
+    spv::ImageFormat img_format = features.support_unknown_format ? spv::ImageFormatUnknown : spv::ImageFormatRgba8;
 
     spv::Id image_type = b.makeImageType(sampled_type, spv::Dim2D, false, false, false, sampled, img_format);
     spv::Id sampler = b.createVariable(spv::NoPrecision, spv::StorageClassUniformConstant, image_type, name.c_str());
@@ -1451,6 +1452,8 @@ static SpirvCode convert_gxp_to_spirv_impl(const SceGxmProgram &program, const s
 
     // Capabilities
     b.addCapability(spv::Capability::CapabilityShader);
+    if (features.support_unknown_format)
+        b.addCapability(spv::Capability::CapabilityStorageImageReadWithoutFormat);
     b.addCapability(spv::Capability::CapabilityFloat16);
 
     NonDependentTextureQueryCallInfos texture_queries;


### PR DESCRIPTION
Programmable blending was broken when the surface was not rgba8. Raw surfaces were used as a way to prevent that for the special case of F16F16F16F16 surfaces (but not for the right reason and it broke classic blending).

Because this is fixed, raw textures are no longer needed. I keep them in the code because I now need another opengl extension ( not necessary but without it we would have to modify the shader code to generate one shader for each surface format used), so they are enabled only if this extension is missing (and direct frag color is not possible).

Also bump the shader version because disabling raw textures change shaders quite a lot.