### PR TITLE
io: Fix case sensitive path when it doesn't exist

### DIFF
--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -176,6 +176,9 @@ bool find_case_isens_path(IOState &io, VitaIoDevice &device, const fs::path &tra
     }
     }
 
+    if (!fs::exists(final_path))
+        return false;
+
     for (const auto &file : fs::recursive_directory_iterator(final_path)) {
         io.cachemap.insert(std::make_pair(string_utils::tolower(file.path().string()), file.path().string()));
     }


### PR DESCRIPTION
Check first if the root (from the game's perspective) folder even exists in the first place