### PR TITLE
renderer: Compute format later in surface cache and do not try to read an u8u8u8 surface

### DIFF
--- a/vita3k/renderer/src/gl/color_formats.cpp
+++ b/vita3k/renderer/src/gl/color_formats.cpp
@@ -253,7 +253,7 @@ GLenum get_raw_store_upload_data_type(SceGxmColorBaseFormat base_format) {
 bool convert_base_texture_format_to_base_color_format(SceGxmTextureBaseFormat format, SceGxmColorBaseFormat &color_format) {
     static const std::map<std::uint32_t, std::uint32_t> TEXTURE_TO_COLOR_FORMAT_MAPPING = {
         { SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8, SCE_GXM_COLOR_BASE_FORMAT_U8U8U8U8 },
-        { SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8, SCE_GXM_COLOR_BASE_FORMAT_U8U8U8 },
+        // { SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8, SCE_GXM_COLOR_BASE_FORMAT_U8U8U8 },
         { SCE_GXM_TEXTURE_BASE_FORMAT_U5U6U5, SCE_GXM_COLOR_BASE_FORMAT_U5U6U5 },
         { SCE_GXM_TEXTURE_BASE_FORMAT_U1U5U5U5, SCE_GXM_COLOR_BASE_FORMAT_U1U5U5U5 },
         { SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4, SCE_GXM_COLOR_BASE_FORMAT_U4U4U4U4 },


### PR DESCRIPTION
Compute the openGL format later in the surface cache. 

Also don't try to read an U8U8U8 texture from a surface. Even though it exists, it is a packed format (so no game should use it as a render target) and we do not support it yet. If there is really a game that uses this format and samples from it this will need to be changed (and implemented), but I doubt this is the case.

This should fix the Unsupported format log error in most games which had it.