### PR TITLE
codec, ngs: Fix race condition with swr and adpcm history

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -166,7 +166,8 @@ private:
     SwrContext *swr_stereo;
 
 public:
-    ADPCMHistory *adpcm_history;
+    // there are at most 2 channels
+    ADPCMHistory adpcm_history[2] = {};
 
     std::uint32_t source_channels;
 

--- a/vita3k/codec/src/pcm.cpp
+++ b/vita3k/codec/src/pcm.cpp
@@ -189,13 +189,6 @@ bool PCMDecoderState::send(const uint8_t *data, uint32_t size) {
             return false;
         }
 
-        if (!adpcm_history) {
-            adpcm_history = new ADPCMHistory[source_channels];
-
-            ADPCMHistory hist = {};
-            std::fill_n(adpcm_history, source_channels, hist);
-        }
-
         const std::uint32_t src_ch = source_channels;
 
         std::int32_t ch = 0;
@@ -305,8 +298,7 @@ PCMDecoderState::PCMDecoderState(const float dest_frequency)
     : dest_frequency(dest_frequency)
     , he_adpcm(false)
     , source_channels(2)
-    , source_frequency(48000.0f)
-    , adpcm_history(nullptr) {
+    , source_frequency(48000.0f) {
     // we are not resampling, we don't care about the sample rate
     swr_mono_to_stereo = swr_alloc_set_opts(nullptr,
         AV_CH_LAYOUT_STEREO, AV_SAMPLE_FMT_FLT, 48000,
@@ -324,10 +316,6 @@ PCMDecoderState::PCMDecoderState(const float dest_frequency)
 }
 
 PCMDecoderState::~PCMDecoderState() {
-    if (adpcm_history) {
-        delete[] adpcm_history;
-        adpcm_history = nullptr;
-    }
     swr_free(&swr_mono_to_stereo);
     swr_free(&swr_stereo);
 }

--- a/vita3k/ngs/include/ngs/modules/player.h
+++ b/vita3k/ngs/include/ngs/modules/player.h
@@ -57,9 +57,11 @@ struct State {
     std::uint32_t decoded_samples_pending = 0;
     std::uint32_t decoded_samples_passed = 0;
     // needed for he_adpcm because a same decoder can be used for many voices
-    ADPCMHistory *adpcm_history = nullptr;
+    ADPCMHistory adpcm_history[MAX_PCM_CHANNELS] = {};
     // used if the input must be resampled
     SwrContext *swr = nullptr;
+    // if we need at some point to reset the resampler params
+    bool reset_swr = false;
 };
 
 struct Parameters {


### PR DESCRIPTION
There was a race condition leading to a possible double free of the adpcm history or the resampler (mostly the adpcm history, the resampler was a bit more protected).

This should fix the random crash in Project Diva X.