### PR TITLE
shader, renderer: use format of current surface if gpu does not support unknown format

### DIFF
--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -275,11 +275,6 @@ bool create(SDL_Window *window, std::unique_ptr<State> &state, const char *base_
     } else if (gl_state.features.support_texture_barrier) {
         LOG_INFO("Your GPU only supports texture barrier, performance may not be good on programmable blending games.");
         LOG_WARN("Consider upgrading to a GPU that has shader interlock.");
-
-        if (!gl_state.features.support_unknown_format) {
-            // Activate raw textures only for this case
-            gl_state.features.preserve_f16_nan_as_u16 = true;
-        }
     } else {
         LOG_INFO("Your GPU doesn't support extensions that make programmable blending possible. Some games may have broken graphics.");
         LOG_WARN("Consider updating your graphics drivers or upgrading your GPU.");

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -41,6 +41,9 @@ static constexpr float INTEGRAL_TEX_QUERY_TYPE_16BIT = 1.0;
 static constexpr float INTEGRAL_TEX_QUERY_TYPE_32BIT = 0.0;
 static constexpr std::uint32_t CURRENT_VERSION = 3;
 
+// Used if the GPU does not support features.support_unknown_format
+extern SceGxmColorBaseFormat last_color_format;
+
 // Dump generated SPIR-V disassembly up to this point
 void spirv_disasm_print(const usse::SpirvCode &spirv_binary, std::string *spirv_dump = nullptr);
 


### PR DESCRIPTION
If the GPU does not support `GL_EXT_shader_image_load_formatted` (mostly some AMD GPUs), use a better workaround than using rbga8 format and raw textures, instead give the format of the current surface to the builtin sampler.

This should almost always work, the only case where it won't is if a shader reading from it own color attachment and is used on surfaces with different color formats (Hopefully no game ever does that).