### PR TITLE
gui: Check first if livearea content is empty

### DIFF
--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -227,6 +227,11 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string app_pa
                 int32_t height = 0;
                 vfs::FileBuffer buffer;
 
+                if (contents.second.empty()) {
+                    LOG_WARN("Content '{}' is empty for title {} [{}].", contents.first, app_path, APP_INDEX->title);
+                    continue;
+                }
+
                 if (default_contents)
                     vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "data/internal/livearea/default/sce_sys/livearea/contents/" + contents.second);
                 else if (app_device == VitaIoDevice::vs0)


### PR DESCRIPTION
This happens with ARK Fast from https://github.com/Vita3K/Vita3K/issues/191

Without this it was checking the file size of the folder which boost hasn't implemented and crashed