### PR TITLE
Fix sceGxmTerminate

### DIFF
--- a/vita3k/gxm/include/gxm/state.h
+++ b/vita3k/gxm/include/gxm/state.h
@@ -81,4 +81,5 @@ struct GxmState {
     std::map<Address, MemoryMapInfo> memory_mapped_regions;
     std::array<SurfaceSyncingInfo, 40> surface_syncing_infoes;
     std::mutex callback_lock;
+    SDL_Thread *sdl_thread;
 };

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -133,7 +133,7 @@ struct SceGxmContext {
         auto *copy_info = command_list->copy_info;
         while (copy_info) {
             auto *next = copy_info->next;
-            memset(copy_info, 0, sizeof(copy_info));
+            memset(copy_info, 0, sizeof(*copy_info));
             free(copy_info);
             copy_info = next;
         }

--- a/vita3k/threads/include/threads/queue.h
+++ b/vita3k/threads/include/threads/queue.h
@@ -101,7 +101,8 @@ public:
     }
 
     void reset() {
-        queue_.clear();
+        std::queue<T> empty;
+        std::swap(queue_, empty);
         aborted = false;
     }
 


### PR DESCRIPTION
These patches make sure that sceGxmTerminate doesn't trigger a segmentation fault in SDL thread by emptying the work queue first and by aborting it.
Then, the thread is waited for before killing the SceGxm thread.

This PR also includes a fix on a warning raised by clang about memset being called with an improper size.
Finally, the reset() implementation of Queue is fixed to properly build.