### PR TITLE
net/ctl: Add loopback IP as default in case no other IP is found

### DIFF
--- a/vita3k/modules/SceNetCtl/SceNetCtl.cpp
+++ b/vita3k/modules/SceNetCtl/SceNetCtl.cpp
@@ -313,6 +313,7 @@ EXPORT(int, sceNetCtlInetGetInfo, int code, SceNetCtlInfo *info) {
 
     switch (code) {
     case SCE_NETCTL_INFO_GET_IP_ADDRESS:
+        strcpy(info->ip_address, "127.0.0.1"); // placeholder in case gethostbyname can't find another ip
         char devname[80];
         gethostname(devname, 80);
         struct hostent *resolved = gethostbyname(devname);


### PR DESCRIPTION
In linux system gethostbyname uses /etc/hosts to get its own ip, in the majority of cases it won't know it's LAN IP, instead it will fallback to loopback (127.0.0.1). This makes so that if it doesn't find any ip default it to loopback instead of an undefined string