### PR TITLE
kernel: Partially implement command for sceIoDevctl

### DIFF
--- a/vita3k/io/include/io/types.h
+++ b/vita3k/io/include/io/types.h
@@ -103,3 +103,9 @@ struct SceIoDirent {
     Ptr<void> d_private;
     int dummy;
 };
+
+struct SceIoDevInfo {
+    SceInt64 max_size;
+    SceInt64 free_size;
+    SceSize cluster_size;
+};


### PR DESCRIPTION
wish that there was a list or a clue of what commands exist, i could only find the one the VITAident uses which uses to get the device capacity status. Implementing cluster size doesn't look very important and it requieres os specific code so i left it out stubbed to 4096 which is the default for an NTFS FS, which is the most commonly used

showing correctly
![image](https://user-images.githubusercontent.com/30161277/180474160-cc9734c1-2e34-43d7-9712-0ed632aa3139.png)
![image](https://user-images.githubusercontent.com/30161277/180474219-662329d6-7a05-4672-a540-10154cf460ae.png)
