### PR TITLE
vita3k: Change frames/sec to FPS and refactor a little

### DIFF
--- a/vita3k/app/src/app.cpp
+++ b/vita3k/app/src/app.cpp
@@ -60,9 +60,14 @@ void calculate_fps(EmuEnvState &emuenv) {
 
 void set_window_title(EmuEnvState &emuenv) {
     const auto af = emuenv.cfg.current_config.anisotropic_filtering > 1 ? fmt ::format(" | AF {}x", emuenv.cfg.current_config.anisotropic_filtering) : "";
-    const std::string title_to_set = fmt::format("{} | {} ({}) | {} | {} ms/frame ({} frames/sec) | {}x{}{} {}", window_title,
-        emuenv.current_app_title, emuenv.io.title_id, emuenv.cfg.backend_renderer, emuenv.ms_per_frame, emuenv.fps, emuenv.display.frame.image_size.x * emuenv.cfg.current_config.resolution_multiplier,
-        emuenv.display.frame.image_size.y * emuenv.cfg.current_config.resolution_multiplier, af, emuenv.cfg.current_config.enable_fxaa ? "| FXAA" : "");
+    const auto x = emuenv.display.frame.image_size.x * emuenv.cfg.current_config.resolution_multiplier;
+    const auto y = emuenv.display.frame.image_size.y * emuenv.cfg.current_config.resolution_multiplier;
+    const std::string title_to_set = fmt::format("{} | {} ({}) | {} | {} FPS ({} ms) | {}x{}{} {}",
+        window_title,
+        emuenv.current_app_title, emuenv.io.title_id,
+        emuenv.cfg.backend_renderer,
+        emuenv.fps, emuenv.ms_per_frame,
+        x, y, af, emuenv.cfg.current_config.enable_fxaa ? "| FXAA" : "");
 
     SDL_SetWindowTitle(emuenv.window.get(), title_to_set.c_str());
 }


### PR DESCRIPTION
this changes the frames/sec string into FPS which is more readable, also makes the window title format more readable, a new line every `|` to make the code not burn eyes