### PR TITLE
vita3k: Remove unnecessary dependencies between librairies and files

### DIFF
--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -127,7 +127,7 @@ add_subdirectory(packages)
 
 add_executable(vita3k MACOSX_BUNDLE main.cpp interface.cpp interface.h performance.cpp)
 
-target_link_libraries(vita3k PRIVATE app gui modules packages)
+target_link_libraries(vita3k PRIVATE app config ctrl display gdbstub gui gxm io miniz modules packages renderer shader touch)
 if(USE_DISCORD_RICH_PRESENCE)
 	target_link_libraries(vita3k PRIVATE discord-rpc)
 endif()

--- a/vita3k/app/CMakeLists.txt
+++ b/vita3k/app/CMakeLists.txt
@@ -9,8 +9,8 @@ add_library(
 )
 
 target_include_directories(app PUBLIC include)
-target_link_libraries(app PUBLIC emuenv)
+target_link_libraries(app PUBLIC emuenv mem)
 if(USE_DISCORD_RICH_PRESENCE)
   target_link_libraries(app PUBLIC discord-rpc)
 endif()
-target_link_libraries(app PRIVATE gui)
+target_link_libraries(app PRIVATE audio config display gdbstub gui io ngs renderer)

--- a/vita3k/app/src/app.cpp
+++ b/vita3k/app/src/app.cpp
@@ -17,8 +17,11 @@
 
 #include <app/functions.h>
 
+#include <config/state.h>
 #include <config/version.h>
+#include <display/state.h>
 #include <emuenv/state.h>
+#include <io/state.h>
 #include <util/log.h>
 
 #include <SDL.h>

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -19,10 +19,15 @@
 
 #include <audio/functions.h>
 #include <config/functions.h>
+#include <config/state.h>
 #include <config/version.h>
+#include <display/state.h>
 #include <emuenv/state.h>
 #include <gui/imgui_impl_sdl.h>
 #include <io/functions.h>
+#include <kernel/state.h>
+#include <ngs/state.h>
+#include <renderer/state.h>
 
 #include <nids/functions.h>
 #include <renderer/functions.h>

--- a/vita3k/ctrl/CMakeLists.txt
+++ b/vita3k/ctrl/CMakeLists.txt
@@ -9,3 +9,5 @@ add_library(
 
 target_include_directories(ctrl PUBLIC include)
 target_link_libraries(ctrl PUBLIC emuenv sdl2 util)
+target_link_libraries(ctrl PRIVATE config dialog)
+

--- a/vita3k/ctrl/src/ctrl.cpp
+++ b/vita3k/ctrl/src/ctrl.cpp
@@ -19,7 +19,12 @@
 #include <ctrl/functions.h>
 #include <ctrl/state.h>
 
+#include <config/state.h>
+#include <dialog/state.h>
+
 #include <SDL_keyboard.h>
+
+#include <array>
 
 static uint64_t timestamp;
 

--- a/vita3k/dialog/CMakeLists.txt
+++ b/vita3k/dialog/CMakeLists.txt
@@ -4,3 +4,4 @@ add_library(
 )
 
 target_include_directories(dialog INTERFACE include)
+target_link_libraries(dialog INTERFACE lang io)

--- a/vita3k/display/CMakeLists.txt
+++ b/vita3k/display/CMakeLists.txt
@@ -7,5 +7,5 @@ add_library(
 )
 
 target_include_directories(display PUBLIC include)
-target_link_libraries(display PUBLIC emuenv)
-target_link_libraries(display PRIVATE)
+target_link_libraries(display PUBLIC emuenv kernel)
+target_link_libraries(display PRIVATE kernel touch renderer)

--- a/vita3k/display/src/display.cpp
+++ b/vita3k/display/src/display.cpp
@@ -15,7 +15,12 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include <display/functions.h>
+
+#include <display/state.h>
 #include <emuenv/state.h>
+#include <kernel/state.h>
+#include <renderer/state.h>
 
 #include <chrono>
 #include <touch/functions.h>

--- a/vita3k/emuenv/CMakeLists.txt
+++ b/vita3k/emuenv/CMakeLists.txt
@@ -1,10 +1,8 @@
 add_library(
 	emuenv
-	INTERFACE
-	include/emuenv/app_util.h
-	include/emuenv/state.h
-	include/emuenv/window.h
-)
+	STATIC
+	src/emuenv.cpp)
 
 target_include_directories(emuenv INTERFACE include)
-target_link_libraries(emuenv INTERFACE app audio config ctrl dialog display ime io kernel lang miniz net ngs nids np renderer touch gdbstub codec packages)
+target_link_libraries(emuenv PUBLIC mem)
+target_link_libraries(emuenv PRIVATE app audio config ctrl dialog display ime io kernel lang miniz net ngs nids np renderer touch gdbstub codec packages)

--- a/vita3k/emuenv/include/emuenv/app_util.h
+++ b/vita3k/emuenv/include/emuenv/app_util.h
@@ -20,6 +20,9 @@
 #include <mem/ptr.h>
 #include <util/types.h>
 
+// forward declarations
+typedef uint32_t SceUInt32;
+
 typedef SceUInt32 SceAppUtilBootAttribute;
 typedef SceUInt32 SceAppUtilAppEventType;
 typedef SceUInt32 SceAppUtilSaveDataSlotId;

--- a/vita3k/emuenv/include/emuenv/state.h
+++ b/vita3k/emuenv/include/emuenv/state.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,54 +17,105 @@
 
 #pragma once
 
-#include <audio/state.h>
-#include <config/state.h>
-#include <ctrl/state.h>
-#include <dialog/state.h>
-#include <display/state.h>
 #include <emuenv/window.h>
-#include <gxm/state.h>
-#include <ime/state.h>
-#include <io/state.h>
-#include <kernel/state.h>
-#include <net/state.h>
-#include <ngs/state.h>
-#include <nids/types.h>
-#include <np/state.h>
-#include <packages/sfo.h>
-#include <renderer/state.h>
-#include <touch/state.h>
 
-// The GDB Stub requires winsock.h on windows (included in above headers). Keep it here to prevent build errors.
-#include <gdbstub/state.h>
-
-#include <atomic>
 #include <memory>
+#include <set>
 #include <string>
+
+// forward declare everything used in EmuEnvState
+namespace sfo {
+struct SfoAppInfo;
+}
+
+namespace renderer {
+enum class Backend : uint32_t;
+struct State;
+} // namespace renderer
+
+namespace ngs {
+struct State;
+};
+
+struct Config;
+struct CPUProtocolBase;
+struct MemState;
+struct CtrlState;
+struct TouchState;
+struct KernelState;
+struct AudioState;
+struct GxmState;
+struct IOState;
+struct NetState;
+struct NetCtlState;
+struct NpState;
+struct DisplayState;
+struct DialogState;
+struct Ime;
+struct SfoFile;
+struct GDBState;
+
+typedef int32_t SceInt;
+struct IVector2 {
+    SceInt x;
+    SceInt y;
+};
+
+typedef float SceFloat;
+struct FVector2 {
+    SceFloat x;
+    SceFloat y;
+};
+
+typedef int SceUID;
+
+using NIDSet = std::set<uint32_t>;
 
 /**
  * @brief State of the emulated PlayStation Vita environment
  */
 struct EmuEnvState {
+    // declare this first as the unique_ptr need to be initialized before the references
+private:
+    std::unique_ptr<sfo::SfoAppInfo> _app_info;
+    std::unique_ptr<Config> _cfg;
+    std::unique_ptr<MemState> _mem;
+    std::unique_ptr<CtrlState> _ctrl;
+    std::unique_ptr<TouchState> _touch;
+    std::unique_ptr<KernelState> _kernel;
+    std::unique_ptr<AudioState> _audio;
+    std::unique_ptr<GxmState> _gxm;
+    std::unique_ptr<IOState> _io;
+    std::unique_ptr<NetState> _net;
+    std::unique_ptr<NetCtlState> _netctl;
+    std::unique_ptr<ngs::State> _ngs;
+    std::unique_ptr<NpState> _np;
+    std::unique_ptr<DisplayState> _display;
+    std::unique_ptr<DialogState> _common_dialog;
+    std::unique_ptr<Ime> _ime;
+    std::unique_ptr<SfoFile> _sfo_handle;
+    std::unique_ptr<GDBState> _gdb;
+
+public:
     // App info contained in its `param.sfo` file
-    sfo::SfoAppInfo app_info;
-    std::string app_path;
-    int32_t app_sku_flag;
-    std::string license_content_id;
-    std::string license_title_id;
-    std::string current_app_title;
-    std::string base_path;
-    std::string default_path;
-    std::wstring pref_path;
-    bool load_exec = false;
-    std::string load_app_path;
-    std::string load_exec_argv;
-    std::string load_exec_path;
-    std::string self_name;
-    std::string self_path;
-    Config cfg;
-    std::unique_ptr<CPUProtocolBase> cpu_protocol;
-    SceUID main_thread_id;
+    sfo::SfoAppInfo &app_info;
+    std::string app_path{};
+    int32_t app_sku_flag{};
+    std::string license_content_id{};
+    std::string license_title_id{};
+    std::string current_app_title{};
+    std::string base_path{};
+    std::string default_path{};
+    std::wstring pref_path{};
+    bool load_exec{};
+    std::string load_app_path{};
+    std::string load_exec_argv{};
+    std::string load_exec_path{};
+    std::string self_name{};
+    std::string self_path{};
+    Config &cfg;
+    std::unique_ptr<CPUProtocolBase> cpu_protocol{};
+    SceUID main_thread_id{};
     size_t frame_count = 0;
     uint32_t sdl_ticks = 0;
     uint32_t fps = 0;
@@ -75,30 +126,38 @@ struct EmuEnvState {
     uint32_t current_fps_offset = 0;
     uint32_t ms_per_frame = 0;
     WindowPtr window = WindowPtr(nullptr, nullptr);
-    renderer::Backend backend_renderer;
-    RendererPtr renderer;
-    SceIVector2 drawable_size = { 0, 0 };
-    SceFVector2 viewport_pos = { 0, 0 };
-    SceFVector2 viewport_size = { 0, 0 };
-    MemState mem;
-    CtrlState ctrl;
-    TouchState touch;
-    KernelState kernel;
-    AudioState audio;
-    GxmState gxm;
-    bool renderer_focused;
-    IOState io;
-    NetState net;
-    NetCtlState netctl;
-    ngs::State ngs;
-    NpState np;
-    DisplayState display;
-    DialogState common_dialog;
-    Ime ime;
-    SfoFile sfo_handle;
+    renderer::Backend backend_renderer{};
+    RendererPtr renderer{};
+    IVector2 drawable_size = { 0, 0 };
+    FVector2 viewport_pos = { 0, 0 };
+    FVector2 viewport_size = { 0, 0 };
+    MemState &mem;
+    CtrlState &ctrl;
+    TouchState &touch;
+    KernelState &kernel;
+    AudioState &audio;
+    GxmState &gxm;
+    bool renderer_focused{};
+    IOState &io;
+    NetState &net;
+    NetCtlState &netctl;
+    ngs::State &ngs;
+    NpState &np;
+    DisplayState &display;
+    DialogState &common_dialog;
+    Ime &ime;
+    SfoFile &sfo_handle;
     NIDSet missing_nids;
     float dpi_scale = 1.0f;
-    float res_width_dpi_scale;
-    float res_height_dpi_scale;
-    GDBState gdb;
+    float res_width_dpi_scale{};
+    float res_height_dpi_scale{};
+    GDBState &gdb;
+
+    EmuEnvState();
+    // declaring a destructor is necessary to forward declare unique_ptrs
+    ~EmuEnvState();
+
+    // disable copy
+    EmuEnvState(const EmuEnvState &) = delete;
+    EmuEnvState &operator=(EmuEnvState const &) = delete;
 };

--- a/vita3k/emuenv/include/emuenv/window.h
+++ b/vita3k/emuenv/include/emuenv/window.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
 
 struct SDL_Window;

--- a/vita3k/emuenv/src/emuenv.cpp
+++ b/vita3k/emuenv/src/emuenv.cpp
@@ -1,0 +1,82 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <emuenv/state.h>
+
+#include <audio/state.h>
+#include <config/state.h>
+#include <ctrl/state.h>
+#include <dialog/state.h>
+#include <display/state.h>
+#include <emuenv/window.h>
+#include <gxm/state.h>
+#include <ime/state.h>
+#include <io/state.h>
+#include <kernel/state.h>
+#include <net/state.h>
+#include <ngs/state.h>
+#include <nids/types.h>
+#include <np/state.h>
+#include <packages/sfo.h>
+#include <renderer/state.h>
+#include <touch/state.h>
+
+#include <gdbstub/state.h>
+
+// initialize the unique_ptr then the reference each time
+// this is VERY repetitive
+EmuEnvState::EmuEnvState()
+    : _app_info(new sfo::SfoAppInfo)
+    , app_info(*_app_info)
+    , _cfg(new Config)
+    , cfg(*_cfg)
+    , _mem(new MemState)
+    , mem(*_mem)
+    , _ctrl(new CtrlState)
+    , ctrl(*_ctrl)
+    , _touch(new TouchState)
+    , touch(*_touch)
+    , _kernel(new KernelState)
+    , kernel(*_kernel)
+    , _audio(new AudioState)
+    , audio(*_audio)
+    , _gxm(new GxmState)
+    , gxm(*_gxm)
+    , _io(new IOState)
+    , io(*_io)
+    , _net(new NetState)
+    , net(*_net)
+    , _netctl(new NetCtlState)
+    , netctl(*_netctl)
+    , _ngs(new ngs::State)
+    , ngs(*_ngs)
+    , _np(new NpState)
+    , np(*_np)
+    , _display(new DisplayState)
+    , display(*_display)
+    , _common_dialog(new DialogState)
+    , common_dialog(*_common_dialog)
+    , _ime(new Ime)
+    , ime(*_ime)
+    , _sfo_handle(new SfoFile)
+    , sfo_handle(*_sfo_handle)
+    , _gdb(new GDBState)
+    , gdb(*_gdb) {
+}
+
+// this is necessary to forward declare unique_ptrs (so that they can call the appropriate destructor)
+EmuEnvState::~EmuEnvState() {}

--- a/vita3k/gdbstub/CMakeLists.txt
+++ b/vita3k/gdbstub/CMakeLists.txt
@@ -8,3 +8,4 @@ add_library(
 
 target_include_directories(gdbstub PUBLIC include)
 target_link_libraries(gdbstub PUBLIC cpu emuenv)
+target_link_libraries(gdbstub PRIVATE kernel)

--- a/vita3k/gdbstub/include/gdbstub/state.h
+++ b/vita3k/gdbstub/include/gdbstub/state.h
@@ -22,6 +22,10 @@
 #include <thread>
 
 #ifdef _WIN32
+#include <winsock.h>
+#endif
+
+#ifdef _WIN32
 typedef SOCKET socket_t;
 constexpr socket_t BAD_SOCK = (socket_t)~0;
 #else

--- a/vita3k/gdbstub/src/gdb.cpp
+++ b/vita3k/gdbstub/src/gdb.cpp
@@ -21,15 +21,19 @@
 #include <util/log.h>
 
 #include <gdbstub/functions.h>
+#include <gdbstub/state.h>
 
 #include <cpu/functions.h>
 
+#include <kernel/state.h>
 #include <mem/state.h>
 #include <spdlog/fmt/bundled/printf.h>
 #include <sstream>
 
 // Sockets
-#ifndef _WIN32
+#ifdef _WIN32
+#include <winsock.h>
+#else
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -692,11 +696,11 @@ constexpr bool cmp_less(T t, U u) noexcept {
         return u < 0 ? false : t < UU(u);
 }
 
-static bool command_begins_with(PacketCommand &command, const std::string &small) {
-    if (!cmp_less(small.size(), command.content_length))
+static bool command_begins_with(PacketCommand &command, const std::string &small_str) {
+    if (!cmp_less(small_str.size(), command.content_length))
         return false;
 
-    return std::memcmp(command.content_start, small.c_str(), small.size()) == 0;
+    return std::memcmp(command.content_start, small_str.c_str(), small_str.size()) == 0;
 }
 
 static int64_t server_next(EmuEnvState &state) {

--- a/vita3k/gui/CMakeLists.txt
+++ b/vita3k/gui/CMakeLists.txt
@@ -59,6 +59,6 @@ add_library(
 )
 
 target_include_directories(gui PUBLIC include ${CMAKE_SOURCE_DIR}/vita3k)
-target_link_libraries(gui PUBLIC app emuenv imgui glutil lang)
-target_link_libraries(gui PRIVATE nativefiledialog pugixml::pugixml stb renderer packages)
+target_link_libraries(gui PUBLIC app config dialog emuenv ime imgui glutil lang np)
+target_link_libraries(gui PRIVATE ctrl kernel miniz nativefiledialog psvpfsparser pugixml::pugixml stb renderer packages sdl2)
 target_link_libraries(gui PUBLIC tracy)

--- a/vita3k/gui/include/gui/imgui_impl_sdl.h
+++ b/vita3k/gui/include/gui/imgui_impl_sdl.h
@@ -22,6 +22,8 @@
 #include <emuenv/window.h>
 #include <gui/imgui_impl_sdl_state.h>
 
+#include <string>
+
 union SDL_Event;
 struct SDL_Window;
 struct SDL_Cursor;

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -17,7 +17,9 @@
 
 #include "private.h"
 
+#include <config/state.h>
 #include <gui/functions.h>
+#include <io/state.h>
 
 #include <util/log.h>
 #include <util/safe_time.h>

--- a/vita3k/gui/src/archive_install_dialog.cpp
+++ b/vita3k/gui/src/archive_install_dialog.cpp
@@ -19,6 +19,7 @@
 #include "private.h"
 
 #include <gui/functions.h>
+#include <packages/sfo.h>
 
 #include <util/string_utils.h>
 

--- a/vita3k/gui/src/common_dialog.cpp
+++ b/vita3k/gui/src/common_dialog.cpp
@@ -19,6 +19,7 @@
 
 #include <gui/functions.h>
 
+#include <config/state.h>
 #include <gui/imgui_impl_sdl.h>
 #include <util/string_utils.h>
 

--- a/vita3k/gui/src/compile_shaders.cpp
+++ b/vita3k/gui/src/compile_shaders.cpp
@@ -16,6 +16,8 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <gui/functions.h>
+#include <io/state.h>
+#include <renderer/state.h>
 
 #include "private.h"
 

--- a/vita3k/gui/src/condvars_dialog.cpp
+++ b/vita3k/gui/src/condvars_dialog.cpp
@@ -17,6 +17,8 @@
 
 #include "private.h"
 
+#include <kernel/state.h>
+
 namespace gui {
 
 void draw_condvars_dialog(GuiState &gui, EmuEnvState &emuenv) {

--- a/vita3k/gui/src/content_manager.cpp
+++ b/vita3k/gui/src/content_manager.cpp
@@ -23,6 +23,7 @@
 
 #include <gui/functions.h>
 
+#include <config/state.h>
 #include <packages/sfo.h>
 
 #include <io/VitaIoDevice.h>

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -18,6 +18,7 @@
 #include "private.h"
 
 #include <config/functions.h>
+#include <config/state.h>
 #include <emuenv/state.h>
 #include <gui/functions.h>
 #include <interface.h>

--- a/vita3k/gui/src/disassembly_dialog.cpp
+++ b/vita3k/gui/src/disassembly_dialog.cpp
@@ -20,6 +20,7 @@
 #include "private.h"
 
 #include <cpu/functions.h>
+#include <kernel/state.h>
 
 #include <spdlog/fmt/fmt.h>
 

--- a/vita3k/gui/src/eventflags_dialog.cpp
+++ b/vita3k/gui/src/eventflags_dialog.cpp
@@ -17,6 +17,8 @@
 
 #include "private.h"
 
+#include <kernel/state.h>
+
 namespace gui {
 
 void draw_event_flags_dialog(GuiState &gui, EmuEnvState &emuenv) {

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -17,6 +17,7 @@
 
 #include "private.h"
 
+#include <config/state.h>
 #include <gui/functions.h>
 #include <packages/functions.h>
 #include <util/log.h>

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -23,8 +23,11 @@
 #include <gui/state.h>
 
 #include <boost/algorithm/string/trim.hpp>
+#include <config/state.h>
+#include <display/state.h>
 #include <glutil/gl.h>
 #include <io/VitaIoDevice.h>
+#include <io/state.h>
 #include <io/vfs.h>
 #include <lang/functions.h>
 #include <packages/sfo.h>

--- a/vita3k/gui/src/home_screen.cpp
+++ b/vita3k/gui/src/home_screen.cpp
@@ -19,7 +19,11 @@
 
 #include <config/functions.h>
 
+#include <config/state.h>
+#include <display/state.h>
 #include <gui/functions.h>
+#include <io/state.h>
+#include <kernel/state.h>
 
 #include <io/VitaIoDevice.h>
 

--- a/vita3k/gui/src/ime.cpp
+++ b/vita3k/gui/src/ime.cpp
@@ -18,6 +18,7 @@
 #include "private.h"
 
 #include <config/functions.h>
+#include <config/state.h>
 #include <mem/functions.h>
 #include <util/string_utils.h>
 

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -19,7 +19,11 @@
 
 #include <gui/functions.h>
 
+#include <config/state.h>
+#include <display/state.h>
+#include <io/state.h>
 #include <packages/functions.h>
+#include <packages/sfo.h>
 #include <util/safe_time.h>
 
 #include <io/VitaIoDevice.h>

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -17,6 +17,7 @@
 
 #include "private.h"
 
+#include <config/state.h>
 #include <gui/functions.h>
 #include <lang/functions.h>
 

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -17,7 +17,10 @@
 
 #include "private.h"
 
+#include <config/state.h>
 #include <gui/functions.h>
+#include <io/state.h>
+#include <kernel/state.h>
 #include <packages/functions.h>
 
 #include <util/safe_time.h>
@@ -718,7 +721,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
                 std::vector<ImVec4> str_color;
 
                 if (!str_tag.color.empty()) {
-                    uint color = 0xFFFFFFFF;
+                    unsigned int color = 0xFFFFFFFF;
 
                     if (frame.autoflip)
                         sscanf(str[app_path][frame.id][current_item[app_path][frame.id]].color.c_str(), "#%x", &color);

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -15,7 +15,9 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include <config/state.h>
 #include <gui/functions.h>
+#include <io/state.h>
 
 #include <util/string_utils.h>
 

--- a/vita3k/gui/src/manual.cpp
+++ b/vita3k/gui/src/manual.cpp
@@ -19,6 +19,7 @@
 
 #include <gui/functions.h>
 
+#include <config/state.h>
 #include <io/vfs.h>
 
 #include <util/log.h>

--- a/vita3k/gui/src/mutexes_dialog.cpp
+++ b/vita3k/gui/src/mutexes_dialog.cpp
@@ -19,6 +19,7 @@
 
 #include <emuenv/state.h>
 
+#include <kernel/state.h>
 #include <kernel/thread/thread_state.h>
 
 namespace gui {

--- a/vita3k/gui/src/perf_overlay.cpp
+++ b/vita3k/gui/src/perf_overlay.cpp
@@ -17,6 +17,8 @@
 
 #include "private.h"
 
+#include <config/state.h>
+
 namespace gui {
 static const ImVec2 PERF_OVERLAY_PAD = ImVec2(12.f, 12.f);
 static const ImVec4 PERF_OVERLAY_BG_COLOR = ImVec4(0.282f, 0.239f, 0.545f, 0.8f);

--- a/vita3k/gui/src/pkg_install_dialog.cpp
+++ b/vita3k/gui/src/pkg_install_dialog.cpp
@@ -21,6 +21,7 @@
 #include <misc/cpp/imgui_stdlib.h>
 #include <packages/functions.h>
 #include <packages/pkg.h>
+#include <packages/sfo.h>
 #include <rif2zrif.h>
 #include <util/log.h>
 #include <util/string_utils.h>

--- a/vita3k/gui/src/reinstall.cpp
+++ b/vita3k/gui/src/reinstall.cpp
@@ -19,6 +19,7 @@
 #include <gui/functions.h>
 
 #include <imgui.h>
+#include <packages/sfo.h>
 
 namespace gui {
 

--- a/vita3k/gui/src/semaphores_dialog.cpp
+++ b/vita3k/gui/src/semaphores_dialog.cpp
@@ -17,6 +17,8 @@
 
 #include "private.h"
 
+#include <kernel/state.h>
+
 namespace gui {
 
 void draw_semaphores_dialog(GuiState &gui, EmuEnvState &emuenv) {

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -18,9 +18,11 @@
 #include "private.h"
 
 #include <config/functions.h>
+#include <config/state.h>
 #include <gui/functions.h>
 #include <ime/functions.h>
 #include <io/device.h>
+#include <io/state.h>
 #include <lang/functions.h>
 #include <numeric>
 #include <util/safe_time.h>

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -20,6 +20,10 @@
 
 #include <config/functions.h>
 #include <config/state.h>
+#include <display/state.h>
+#include <io/state.h>
+#include <kernel/state.h>
+#include <renderer/state.h>
 
 #include <gui/functions.h>
 #include <gui/state.h>

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -17,6 +17,7 @@
 
 #include "private.h"
 
+#include <config/state.h>
 #include <gui/functions.h>
 #include <io/device.h>
 #include <util/safe_time.h>

--- a/vita3k/gui/src/threads_dialog.cpp
+++ b/vita3k/gui/src/threads_dialog.cpp
@@ -19,6 +19,7 @@
 
 #include <cpu/functions.h>
 
+#include <kernel/state.h>
 #include <kernel/thread/thread_state.h>
 
 #include <spdlog/fmt/fmt.h>

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -22,6 +22,7 @@
 #include <util/log.h>
 #include <util/safe_time.h>
 
+#include <config/state.h>
 #include <io/device.h>
 #include <io/functions.h>
 

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -18,7 +18,10 @@
 #include "private.h"
 
 #include <config/functions.h>
+#include <config/state.h>
+#include <display/state.h>
 #include <gui/functions.h>
+#include <io/state.h>
 #include <misc/cpp/imgui_stdlib.h>
 #include <util/log.h>
 #include <util/string_utils.h>

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -17,6 +17,7 @@
 
 #include "private.h"
 
+#include <config/state.h>
 #include <config/version.h>
 #include <gui/functions.h>
 

--- a/vita3k/gui/src/welcome_dialog.cpp
+++ b/vita3k/gui/src/welcome_dialog.cpp
@@ -17,6 +17,7 @@
 
 #include <config/functions.h>
 
+#include <config/state.h>
 #include <gui/functions.h>
 
 #include "private.h"

--- a/vita3k/gxm/include/gxm/state.h
+++ b/vita3k/gxm/include/gxm/state.h
@@ -24,6 +24,8 @@
 #include <map>
 #include <mutex>
 
+struct SDL_Thread;
+
 typedef void SceGxmDisplayQueueCallback(Ptr<const void> callbackData);
 static constexpr std::uint64_t SCENE_TIME_UNDEF = 0xFFFFFFFFFFFFFFFF;
 static constexpr std::uint64_t GPU_SYNCING_DISABLE_SCENE_DELTA = 40;

--- a/vita3k/ime/include/ime/types.h
+++ b/vita3k/ime/include/ime/types.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <mem/ptr.h>
+#include <util/types.h>
 
 #define SCE_IME_MAX_PREEDIT_LENGTH 30
 #define SCE_IME_MAX_TEXT_LENGTH 2048

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -17,13 +17,17 @@
 
 #include "interface.h"
 
+#include <config/state.h>
 #include <ctrl/functions.h>
 #include <display/functions.h>
+#include <display/state.h>
 #include <gui/functions.h>
+#include <gxm/state.h>
 #include <io/device.h>
 #include <io/functions.h>
 #include <io/vfs.h>
 #include <kernel/load_self.h>
+#include <kernel/state.h>
 #include <packages/functions.h>
 #include <packages/pkg.h>
 #include <packages/sfo.h>

--- a/vita3k/lang/CMakeLists.txt
+++ b/vita3k/lang/CMakeLists.txt
@@ -7,5 +7,5 @@ add_library(
 )
 
 target_include_directories(lang PUBLIC include)
-target_link_libraries(lang PUBLIC emuenv)
-target_link_libraries(lang PRIVATE pugixml::pugixml)
+target_link_libraries(lang PUBLIC emuenv ime)
+target_link_libraries(lang PRIVATE config gui ime pugixml::pugixml util)

--- a/vita3k/lang/src/lang.cpp
+++ b/vita3k/lang/src/lang.cpp
@@ -18,6 +18,11 @@
 #include <lang/functions.h>
 #include <lang/state.h>
 
+#include <config/state.h>
+#include <gui/state.h>
+#include <ime/state.h>
+#include <util/fs.h>
+
 #include <pugixml.hpp>
 
 namespace lang {

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -20,12 +20,16 @@
 #include <app/functions.h>
 #include <config/functions.h>
 #include <config/version.h>
+#include <display/state.h>
 #include <emuenv/state.h>
 #include <gui/functions.h>
 #include <gui/state.h>
+#include <io/state.h>
+#include <kernel/state.h>
 #include <modules/module_parent.h>
 #include <packages/functions.h>
 #include <packages/pkg.h>
+#include <packages/sfo.h>
 #include <renderer/functions.h>
 #include <renderer/gl/functions.h>
 #include <shader/spirv_recompiler.h>
@@ -370,7 +374,9 @@ int main(int argc, char *argv[]) {
 
         {
             const std::lock_guard<std::mutex> guard(emuenv.display.display_info_mutex);
-            emuenv.renderer->render_frame(emuenv.viewport_pos, emuenv.viewport_size, emuenv.display, emuenv.gxm, emuenv.mem);
+            const SceFVector2 viewport_pos = { emuenv.viewport_pos.x, emuenv.viewport_pos.y };
+            const SceFVector2 viewport_size = { emuenv.viewport_size.x, emuenv.viewport_size.y };
+            emuenv.renderer->render_frame(viewport_pos, viewport_size, emuenv.display, emuenv.gxm, emuenv.mem);
         }
 
         gui::draw_begin(gui, emuenv);
@@ -390,7 +396,9 @@ int main(int argc, char *argv[]) {
 
         {
             const std::lock_guard<std::mutex> guard(emuenv.display.display_info_mutex);
-            emuenv.renderer->render_frame(emuenv.viewport_pos, emuenv.viewport_size, emuenv.display, emuenv.gxm, emuenv.mem);
+            const SceFVector2 viewport_pos = { emuenv.viewport_pos.x, emuenv.viewport_pos.y };
+            const SceFVector2 viewport_size = { emuenv.viewport_size.x, emuenv.viewport_size.y };
+            emuenv.renderer->render_frame(viewport_pos, viewport_size, emuenv.display, emuenv.gxm, emuenv.mem);
         }
 
         // Calculate FPS

--- a/vita3k/module/CMakeLists.txt
+++ b/vita3k/module/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
 )
 
 target_include_directories(module PUBLIC include)
-target_link_libraries(module PUBLIC emuenv dlmalloc printf util)
+target_link_libraries(module PUBLIC config cpu emuenv dlmalloc kernel printf util)
 if(TRACY_ENABLE_ON_CORE_COMPONENTS)
 	target_link_libraries(module PUBLIC tracy)
 endif()

--- a/vita3k/module/include/module/bridge.h
+++ b/vita3k/module/include/module/bridge.h
@@ -27,6 +27,7 @@
 #include "write_return_value.h"
 
 #include <config/functions.h>
+#include <config/state.h>
 #include <emuenv/state.h>
 
 using ImportFn = std::function<void(EmuEnvState &emuenv, CPUState &cpu, SceUID thread_id)>;

--- a/vita3k/module/include/module/load_module.h
+++ b/vita3k/module/include/module/load_module.h
@@ -16,7 +16,9 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <emuenv/state.h>
+#include <kernel/types.h>
 
+#include <array>
 #include <vector>
 
 static constexpr auto SYSMODULE_COUNT = 0x56;

--- a/vita3k/module/src/load_module.cpp
+++ b/vita3k/module/src/load_module.cpp
@@ -17,8 +17,10 @@
 
 #include <module/load_module.h>
 
+#include <config/state.h>
 #include <emuenv/state.h>
 #include <kernel/load_self.h>
+#include <kernel/state.h>
 
 bool is_lle_module(SceSysmoduleModuleId module_id, EmuEnvState &emuenv) {
     const auto paths = sysmodule_paths[module_id];

--- a/vita3k/modules/CMakeLists.txt
+++ b/vita3k/modules/CMakeLists.txt
@@ -210,6 +210,6 @@ set(SOURCE_LIST
 
 add_library(modules STATIC ${SOURCE_LIST})
 target_include_directories(modules PUBLIC include)
-target_link_libraries(modules PRIVATE xxHash::xxhash packages)
+target_link_libraries(modules PRIVATE audio codec ctrl dialog display gui gxm kernel mem net ngs np packages renderer rtc sdl2 touch xxHash::xxhash)
 target_link_libraries(modules PUBLIC module)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_LIST})

--- a/vita3k/modules/SceAppMgr/SceAppMgr.cpp
+++ b/vita3k/modules/SceAppMgr/SceAppMgr.cpp
@@ -17,8 +17,11 @@
 
 #include "SceAppMgr.h"
 
+#include <io/state.h>
 #include <kernel/load_self.h>
+#include <kernel/state.h>
 #include <packages/functions.h>
+#include <packages/sfo.h>
 
 #include <modules/module_parent.h>
 #include <util/find.h>

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -24,6 +24,12 @@
 #include <io/vfs.h>
 #include <util/safe_time.h>
 
+#ifdef WIN32
+#include <winsock.h>
+#else
+#include <unistd.h>
+#endif
+
 #include <cstring>
 
 EXPORT(int, sceAppUtilAddCookieWebBrowser) {

--- a/vita3k/modules/SceAudio/SceAudio.cpp
+++ b/vita3k/modules/SceAudio/SceAudio.cpp
@@ -19,6 +19,8 @@
 #include "SceAudio_tracy.h"
 #include "Tracy.hpp"
 
+#include <audio/state.h>
+#include <kernel/state.h>
 #include <util/lock_and_find.h>
 
 EXPORT(int, sceAudioOutGetAdopt, SceAudioOutPortType type) {

--- a/vita3k/modules/SceAudioIn/SceAudioIn.cpp
+++ b/vita3k/modules/SceAudioIn/SceAudioIn.cpp
@@ -17,6 +17,7 @@
 
 #include "SceAudioIn.h"
 
+#include <audio/state.h>
 #include <util/lock_and_find.h>
 
 #define PORT_ID 0

--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
@@ -17,7 +17,9 @@
 
 #include "SceAudiodecUser.h"
 
+#include <audio/state.h>
 #include <codec/state.h>
+#include <kernel/state.h>
 #include <util/lock_and_find.h>
 
 enum {

--- a/vita3k/modules/SceAvPlayer/SceAvPlayer.cpp
+++ b/vita3k/modules/SceAvPlayer/SceAvPlayer.cpp
@@ -19,6 +19,7 @@
 
 #include <codec/state.h>
 #include <io/functions.h>
+#include <kernel/state.h>
 
 #include <util/lock_and_find.h>
 #include <util/log.h>
@@ -353,7 +354,7 @@ EXPORT(bool, sceAvPlayerGetAudioData, SceUID player_handle, SceAvPlayerFrameInfo
     return true;
 }
 
-EXPORT(uint32_t, sceAvPlayerGetStreamInfo, SceUID player_handle, uint stream_no, SceAvPlayerStreamInfo *stream_info) {
+EXPORT(uint32_t, sceAvPlayerGetStreamInfo, SceUID player_handle, SceUInt32 stream_no, SceAvPlayerStreamInfo *stream_info) {
     if (!stream_info) {
         return SCE_AVPLAYER_ERROR_ILLEGAL_ADDR;
     }

--- a/vita3k/modules/SceCodecEngine/SceCodecEngineUser.cpp
+++ b/vita3k/modules/SceCodecEngine/SceCodecEngineUser.cpp
@@ -18,6 +18,8 @@
 #include "SceCodecEngineUser.h"
 #include <../SceSysmem/SceSysmem.h>
 
+#include <kernel/state.h>
+
 EXPORT(int32_t, sceCodecEngineAllocMemoryFromUnmapMemBlock, SceUID uid, uint32_t size, uint32_t alignment) {
     STUBBED("fake vaddr");
     auto guard = std::lock_guard<std::mutex>(emuenv.kernel.mutex);

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -19,6 +19,7 @@
 
 #include <dialog/types.h>
 #include <emuenv/app_util.h>
+#include <gui/state.h>
 #include <io/device.h>
 #include <io/functions.h>
 #include <io/vfs.h>

--- a/vita3k/modules/SceCtrl/SceCtrl.cpp
+++ b/vita3k/modules/SceCtrl/SceCtrl.cpp
@@ -19,6 +19,7 @@
 
 #include <ctrl/ctrl.h>
 #include <ctrl/functions.h>
+#include <kernel/types.h>
 
 #include <util/log.h>
 

--- a/vita3k/modules/SceDisplay/SceDisplay.cpp
+++ b/vita3k/modules/SceDisplay/SceDisplay.cpp
@@ -22,6 +22,8 @@
 #include "SceDisplay.h"
 
 #include <display/functions.h>
+#include <display/state.h>
+#include <kernel/state.h>
 #include <packages/functions.h>
 #include <util/lock_and_find.h>
 #include <util/types.h>

--- a/vita3k/modules/SceDisplay/SceDisplay.h
+++ b/vita3k/modules/SceDisplay/SceDisplay.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <display/state.h>
 #include <module/module.h>
 
 enum SceDisplaySetBufSync {

--- a/vita3k/modules/SceFiber/SceFiber.cpp
+++ b/vita3k/modules/SceFiber/SceFiber.cpp
@@ -17,7 +17,8 @@
 
 #include "SceFiber.h"
 
-#include "cpu/functions.h"
+#include <cpu/functions.h>
+#include <kernel/state.h>
 
 #include <sstream>
 #include <util/lock_and_find.h>

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -22,12 +22,18 @@
 #include <xxh3.h>
 
 #include <gxm/functions.h>
+#include <gxm/state.h>
 #include <gxm/types.h>
 #include <immintrin.h>
+#include <kernel/state.h>
+#include <mem/state.h>
 
+#include <SDL.h>
+#include <io/state.h>
 #include <mem/allocator.h>
 #include <mem/mempool.h>
 #include <renderer/functions.h>
+#include <renderer/state.h>
 #include <renderer/types.h>
 #include <util/bytes.h>
 #include <util/lock_and_find.h>

--- a/vita3k/modules/SceIme/SceIme.cpp
+++ b/vita3k/modules/SceIme/SceIme.cpp
@@ -19,6 +19,7 @@
 
 #include <ime/functions.h>
 #include <ime/types.h>
+#include <kernel/state.h>
 
 #include <util/lock_and_find.h>
 

--- a/vita3k/modules/SceIofilemgr/SceIofilemgr.cpp
+++ b/vita3k/modules/SceIofilemgr/SceIofilemgr.cpp
@@ -18,6 +18,7 @@
 #include "SceIofilemgr.h"
 
 #include <io/functions.h>
+#include <kernel/types.h>
 
 EXPORT(int, _sceIoChstat) {
     return UNIMPLEMENTED();

--- a/vita3k/modules/SceIofilemgr/SceIofilemgr.h
+++ b/vita3k/modules/SceIofilemgr/SceIofilemgr.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <io/types.h>
 #include <module/module.h>
 
 typedef struct _sceIoLseekOpt {

--- a/vita3k/modules/SceJpeg/SceJpegUser.cpp
+++ b/vita3k/modules/SceJpeg/SceJpegUser.cpp
@@ -18,6 +18,7 @@
 #include "SceJpegUser.h"
 
 #include <codec/state.h>
+#include <kernel/state.h>
 
 typedef std::shared_ptr<DecoderState> DecoderPtr;
 

--- a/vita3k/modules/SceKernelModulemgr/SceModulemgr.h
+++ b/vita3k/modules/SceKernelModulemgr/SceModulemgr.h
@@ -19,6 +19,8 @@
 
 #include <module/module.h>
 
+#include <kernel/types.h>
+
 EXPORT(SceUID, _sceKernelLoadModule, char *path, int flags, SceKernelLMOption *option);
 EXPORT(SceUID, _sceKernelLoadStartModule, const char *moduleFileName, SceSize args, const Ptr<void> argp, SceUInt32 flags, const SceKernelLMOption *pOpt, int *pRes);
 EXPORT(int, _sceKernelStartModule, SceUID uid, SceSize args, const Ptr<void> argp, SceUInt32 flags, const Ptr<SceKernelStartModuleOpt> pOpt, int *pRes);

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -19,7 +19,9 @@
 #include <modules/module_parent.h>
 
 #include <kernel/callback.h>
+#include <kernel/state.h>
 #include <kernel/sync_primitives.h>
+#include <kernel/types.h>
 #include <packages/functions.h>
 
 #include <util/lock_and_find.h>
@@ -420,7 +422,7 @@ EXPORT(int, _sceKernelGetTimerTime) {
 
 EXPORT(int, _sceKernelLockLwMutex, Ptr<SceKernelLwMutexWork> workarea, int lock_count, unsigned int *ptimeout) {
     if (!workarea)
-        return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
+        return RET_ERROR(SCE_KERNEL_ERROR_INVALID_ARGUMENT);
 
     const auto lwmutexid = workarea.get(emuenv.mem)->uid;
     return mutex_lock(emuenv.kernel, emuenv.mem, export_name, thread_id, lwmutexid, lock_count, ptimeout, SyncWeight::Light);

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
@@ -19,6 +19,8 @@
 
 #include <module/module.h>
 
+#include <kernel/types.h>
+
 EXPORT(SceUID, _sceKernelCreateCond, const char *pName, SceUInt32 attr, SceUID mutexId, const SceKernelCondOptParam *pOptParam);
 EXPORT(SceInt32, _sceKernelGetCondInfo, SceUID condId, Ptr<SceKernelCondInfo> pInfo);
 EXPORT(SceUID, _sceKernelCreateSimpleEvent, const char *name, SceUInt32 attr, SceUInt32 init_pattern, const SceKernelSimpleEventOptParam *pOptParam);

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
@@ -17,7 +17,7 @@
 
 #include "SceThreadmgrCoredumpTime.h"
 
-#include <util/lock_and_find.h>
+#include <kernel/state.h>
 
 EXPORT(int, sceKernelExitThread, int status) {
     const ThreadStatePtr thread = emuenv.kernel.get_thread(thread_id);

--- a/vita3k/modules/SceLibDbg/SceDbg.cpp
+++ b/vita3k/modules/SceLibDbg/SceDbg.cpp
@@ -17,6 +17,7 @@
 
 #include "SceDbg.h"
 
+#include <kernel/state.h>
 #include <util/lock_and_find.h>
 #include <v3kprintf.h>
 

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -27,6 +27,7 @@
 #include <dlmalloc.h>
 #include <io/functions.h>
 #include <kernel/load_self.h>
+#include <kernel/state.h>
 #include <kernel/sync_primitives.h>
 #include <packages/functions.h>
 

--- a/vita3k/modules/SceLibKernel/SceLibRng.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibRng.cpp
@@ -18,6 +18,7 @@
 #include "SceLibRng.h"
 
 #include <algorithm>
+#include <kernel/types.h>
 #include <random>
 
 #define SCE_RNG_ERROR_INVALID_ARGUMENT 0x810C0000

--- a/vita3k/modules/SceLibc/SceLibc.cpp
+++ b/vita3k/modules/SceLibc/SceLibc.cpp
@@ -18,6 +18,7 @@
 #include "SceLibc.h"
 
 #include <io/functions.h>
+#include <kernel/state.h>
 #include <util/lock_and_find.h>
 #include <util/log.h>
 

--- a/vita3k/modules/SceNet/SceNet.cpp
+++ b/vita3k/modules/SceNet/SceNet.cpp
@@ -17,7 +17,9 @@
 
 #include "SceNet.h"
 
+#include <kernel/state.h>
 #include <net/functions.h>
+#include <net/state.h>
 #include <net/types.h>
 #include <util/lock_and_find.h>
 

--- a/vita3k/modules/SceNetCtl/SceNetCtl.cpp
+++ b/vita3k/modules/SceNetCtl/SceNetCtl.cpp
@@ -17,6 +17,9 @@
 
 #include "SceNetCtl.h"
 
+#include <kernel/state.h>
+#include <net/state.h>
+#include <rtc/rtc.h>
 #include <util/lock_and_find.h>
 
 #define SCE_NETCTL_INFO_SSID_LEN_MAX 32

--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -16,6 +16,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <ngs/modules/atrac9.h>
+#include <ngs/state.h>
 #include <ngs/system.h>
 #include <util/log.h>
 

--- a/vita3k/modules/SceNpCommon/SceNpCommon.cpp
+++ b/vita3k/modules/SceNpCommon/SceNpCommon.cpp
@@ -17,6 +17,10 @@
 
 #include "SceNpCommon.h"
 
+#include <io/state.h>
+#include <kernel/state.h>
+#include <np/common.h>
+
 EXPORT(int, sceNpAuthAbortRequest) {
     return UNIMPLEMENTED();
 }

--- a/vita3k/modules/SceNpManager/SceNpManager.cpp
+++ b/vita3k/modules/SceNpManager/SceNpManager.cpp
@@ -17,6 +17,9 @@
 
 #include "SceNpManager.h"
 
+#include <io/state.h>
+#include <kernel/state.h>
+#include <np/state.h>
 #include <util/lock_and_find.h>
 #include <util/log.h>
 

--- a/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
+++ b/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
@@ -16,6 +16,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <np/functions.h>
+#include <np/state.h>
 #include <np/trophy/context.h>
 #include <util/log.h>
 

--- a/vita3k/modules/SceNpTrophy/SceNpTrophy.h
+++ b/vita3k/modules/SceNpTrophy/SceNpTrophy.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <module/module.h>
+#include <rtc/rtc.h>
 
 using SceNpTrophyHandle = std::int32_t;
 using SceNpTrophyID = std::int32_t;

--- a/vita3k/modules/SceProcessmgr/SceProcessmgr.cpp
+++ b/vita3k/modules/SceProcessmgr/SceProcessmgr.cpp
@@ -18,6 +18,7 @@
 #include "SceProcessmgr.h"
 
 #include <io/functions.h>
+#include <kernel/state.h>
 #include <rtc/rtc.h>
 
 #include <util/safe_time.h>

--- a/vita3k/modules/SceRtc/SceRtc.cpp
+++ b/vita3k/modules/SceRtc/SceRtc.cpp
@@ -17,6 +17,7 @@
 
 #include "SceRtc.h"
 
+#include <kernel/state.h>
 #include <rtc/rtc.h>
 
 #include <util/safe_time.h>

--- a/vita3k/modules/SceRtc/SceRtc.h
+++ b/vita3k/modules/SceRtc/SceRtc.h
@@ -19,6 +19,9 @@
 
 #include <module/module.h>
 
+struct SceRtcTick;
+struct SceDateTime;
+
 EXPORT(int, _sceRtcConvertLocalTimeToUtc, const SceRtcTick *pLocalTime, SceRtcTick *pUtc);
 EXPORT(int, _sceRtcConvertUtcToLocalTime, const SceRtcTick *pUtc, SceRtcTick *pLocalTime);
 EXPORT(int, _sceRtcGetCurrentClock, SceDateTime *datePtr, int iTimeZone);

--- a/vita3k/modules/SceSblSsMgr/SceSblRng.cpp
+++ b/vita3k/modules/SceSblSsMgr/SceSblRng.cpp
@@ -18,6 +18,7 @@
 #include "SceSblRng.h"
 
 #include <algorithm>
+#include <kernel/types.h>
 #include <random>
 
 #define SCE_RNG_ERROR_INVALID_ARGUMENT 0x810C0000

--- a/vita3k/modules/SceTouch/SceTouch.cpp
+++ b/vita3k/modules/SceTouch/SceTouch.cpp
@@ -18,6 +18,7 @@
 #include "SceTouch.h"
 
 #include <touch/functions.h>
+#include <touch/state.h>
 #include <touch/touch.h>
 
 EXPORT(int, sceTouchActivateRegion) {

--- a/vita3k/modules/SceVideodec/SceVideodecUser.cpp
+++ b/vita3k/modules/SceVideodec/SceVideodecUser.cpp
@@ -16,7 +16,9 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "SceVideodecUser.h"
+
 #include <codec/state.h>
+#include <kernel/state.h>
 #include <util/lock_and_find.h>
 
 typedef std::shared_ptr<H264DecoderState> H264DecoderPtr;

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -22,6 +22,7 @@
 #include <io/device.h>
 #include <io/vfs.h>
 #include <kernel/load_self.h>
+#include <kernel/state.h>
 #include <module/load_module.h>
 #include <nids/functions.h>
 #include <util/arm.h>

--- a/vita3k/packages/CMakeLists.txt
+++ b/vita3k/packages/CMakeLists.txt
@@ -10,5 +10,5 @@ add_library(packages STATIC
             include/packages/sfo.h
 )
 target_include_directories(packages PUBLIC include)
-
-target_link_libraries(packages PUBLIC emuenv miniz crypto FAT16 vita-toolchain psvpfsparser io)
+target_link_libraries(packages PUBLIC emuenv util)
+target_link_libraries(packages PRIVATE config crypto emuenv FAT16 io miniz psvpfsparser vita-toolchain)

--- a/vita3k/packages/include/packages/functions.h
+++ b/vita3k/packages/include/packages/functions.h
@@ -28,6 +28,9 @@
 #include <string>
 #include <vector>
 
+// TODO: remove
+#include <util/fs.h>
+
 struct SfoFile;
 
 void install_pup(const std::wstring &pref_path, const std::string &pup_path, const std::function<void(uint32_t)> &progress_callback = nullptr);

--- a/vita3k/packages/src/pkg.cpp
+++ b/vita3k/packages/src/pkg.cpp
@@ -29,6 +29,7 @@
 #include <io/device.h>
 #include <io/functions.h>
 
+#include <config/state.h>
 #include <emuenv/state.h>
 #include <packages/functions.h>
 #include <packages/pkg.h>

--- a/vita3k/packages/src/sfo.cpp
+++ b/vita3k/packages/src/sfo.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <fmt/format.h>
 
 namespace sfo {
 

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -52,7 +52,7 @@ typedef std::map<Sha256Hash, const SceGxmProgram *> GXPPtrMap;
 
 struct CommandBuffer;
 
-enum class Backend {
+enum class Backend : uint32_t {
     OpenGL,
 #ifdef USE_VULKAN
     Vulkan,

--- a/vita3k/touch/CMakeLists.txt
+++ b/vita3k/touch/CMakeLists.txt
@@ -9,3 +9,4 @@ add_library(
 
 target_include_directories(touch PUBLIC include)
 target_link_libraries(touch PUBLIC emuenv)
+target_link_libraries(touch PRIVATE display sdl2)

--- a/vita3k/touch/src/touch.cpp
+++ b/vita3k/touch/src/touch.cpp
@@ -16,8 +16,11 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <display/functions.h>
+#include <display/state.h>
 #include <emuenv/state.h>
+#include <kernel/state.h>
 #include <touch/functions.h>
+#include <touch/state.h>
 #include <touch/touch.h>
 
 #include <SDL_events.h>


### PR DESCRIPTION
Vita3K has a really annoying design flaw in that almost all files include `emuenv/state.h` and this file include more than half of all the headers of vita3k (and many external librairies). This leads for exemple ngs headers to include `spirv_recompiler.h`. So when I modify one line in `spirv_recompiler.h` (or in a lot of headers), I have to wait 15 minutes for the whole project to recompile.

This PR forwards declare all the dependencies in `emuenv/state.h` so each header should only include headers it needs (or at least less than before), so I should not have to wait 15 minutes every time I change a line in a header. This has also the side effect to divide by 2 the time to build Vita3K from scratch.

If anyone has a suggestion to make the content of `emuenv/state.h` and `emuenv/emuenv.cpp` cleaner, I will take it.