### PR TITLE
util: Add TimeLogger utility

### DIFF
--- a/vita3k/util/include/util/time.h
+++ b/vita3k/util/include/util/time.h
@@ -1,0 +1,45 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <chrono>
+#include <util/log.h>
+
+namespace TimeLogger {
+struct TimeLogger {
+private:
+    std::string _name;
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<long, std::ratio<1, 1000000000>>>::duration
+        init_time
+        = std::chrono::high_resolution_clock::now().time_since_epoch();
+
+public:
+    ~TimeLogger() {
+        auto destroy_time = std::chrono::high_resolution_clock::now().time_since_epoch();
+        auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(destroy_time - init_time).count();
+        auto micros = std::chrono::duration_cast<std::chrono::microseconds>(destroy_time - init_time).count();
+        auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(destroy_time - init_time).count();
+
+        LOG_TRACE("{} took {} ns | {} μs | {} ms", _name, nanos, micros, millis);
+    };
+
+    inline TimeLogger(std::string name) {
+        _name = name;
+    }
+};
+} // namespace TimeLogger


### PR DESCRIPTION
With this you can now time exactly how long it takes a code block, meaning in the case below, it will create a logger right before the push, and when the push is done it will exit the code block so that the logger gets destroyed, when a `TimeLogger` gets destroyed it outputs the time it spent alive, in this case its measuring how long it takes to push `display_callback` to `display_queue`

Example from SceGxm.cpp sceGxmDisplayQueueAddEntry
```cpp
// code here
{
        TimeLogger::TimeLogger a("cool name");

        // function may be blocking here (expected behavior)
        emuenv.gxm.display_queue.push(display_callback);
}
// more code here
```

will result in output:
```
[19:54:53.214] |T| [~TimeLogger]: cool name took 42002107 ns | 42002 μs | 42 ms
[19:54:53.281] |T| [~TimeLogger]: cool name took 63875140 ns | 63875 μs | 63 ms
[19:54:53.348] |T| [~TimeLogger]: cool name took 65378501 ns | 65378 μs | 65 ms
[19:54:53.414] |T| [~TimeLogger]: cool name took 59479457 ns | 59479 μs | 59 ms
[19:54:53.481] |T| [~TimeLogger]: cool name took 63971241 ns | 63971 μs | 63 ms
[19:54:53.531] |T| [~TimeLogger]: cool name took 43266148 ns | 43266 μs | 43 ms
[19:54:53.598] |T| [~TimeLogger]: cool name took 65338986 ns | 65338 μs | 65 ms
[19:54:53.698] |T| [~TimeLogger]: cool name took 97192579 ns | 97192 μs | 97 ms
[19:54:53.814] |T| [~TimeLogger]: cool name took 115428331 ns | 115428 μs | 115 ms
[19:54:53.881] |T| [~TimeLogger]: cool name took 62163230 ns | 62163 μs | 62 ms
[19:54:53.964] |T| [~TimeLogger]: cool name took 81919704 ns | 81919 μs | 81 ms
[19:54:53.990] |T| [~TimeLogger]: cool name took 20943481 ns | 20943 μs | 20 ms
```