### PR TITLE
kernel: Lock correct host mutex when deleting guest mutex

### DIFF
--- a/vita3k/kernel/src/sync_primitives.cpp
+++ b/vita3k/kernel/src/sync_primitives.cpp
@@ -522,7 +522,7 @@ int mutex_delete(KernelState &kernel, const char *export_name, SceUID thread_id,
     }
 
     if (mutex->waiting_threads->empty()) {
-        const std::lock_guard<std::mutex> mutex_lock(mutex->mutex);
+        const std::lock_guard<std::mutex> kernel_guard(kernel.mutex);
         mutexes->erase(mutexid);
     } else {
         // TODO:


### PR DESCRIPTION
Lock the kernel mutex instead of one that's going to be deleted when a guest mutex is deleted.

This fixes a crash I had in Freedom Wars.