### PR TITLE
shader: Fix input variables with integer type

### DIFF
--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -313,6 +313,9 @@ static spv::Id create_input_variable(spv::Builder &b, SpirvShaderParameters &par
             var = utils::finalize(b, var, var, SWIZZLE_CHANNEL_4_DEFAULT, 0, dest_mask);
         }
 
+        if (is_integer_data_type(dest.type) && b.isFloatType(utils::unwrap_type(b, b.getTypeId(var))))
+            var = utils::convert_to_int(b, var, dest.type, true);
+
         utils::store(b, parameters, utils, features, dest, var, dest_mask, 0);
     }
 

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -1370,7 +1370,7 @@ spv::Id shader::usse::utils::convert_to_int(spv::Builder &b, spv::Id opr, DataTy
         const auto constant_range = get_int_normalize_range_constants(type);
         const auto normalizer = b.makeFloatConstant(constant_range.second);
         const auto normalizer_vec = create_constant_vector_or_scalar(b, normalizer, comp_count);
-        const auto range_begin_vec = create_constant_vector_or_scalar(b, b.makeFloatConstant(is_uint ? -1.f : 0.f), comp_count);
+        const auto range_begin_vec = create_constant_vector_or_scalar(b, b.makeFloatConstant(is_uint ? 0.f : -1.f), comp_count);
         const auto range_end_vec = create_constant_vector_or_scalar(b, b.makeFloatConstant(1.f), comp_count);
         const auto zero_vec = create_constant_vector_or_scalar(b, b.makeFloatConstant(0.f), comp_count);
         const auto b_vec_type = b.makeVectorType(b.makeBoolType(), comp_count);


### PR DESCRIPTION
Add a missing float to integer conversion when reading integer input variables in the shader.
Also fix the start range when converting floats to integers which was reversed between signed and unsigned integer.

The first part fixes the minimap in Tales of Hearts R, the second part should fix any game that is using negative signed integers, as they were clamped to 0 previously.

![image](https://user-images.githubusercontent.com/5671744/182602270-e14e120e-ebc7-4205-ada0-71c7c14fa86b.png)
