### PR TITLE
vita3k: fix repo author when is in SSH.

### DIFF
--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -27,7 +27,12 @@ execute_process(
 	OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if (NOT GIT_REPO STREQUAL "")
-	string(REPLACE "https://github.com/" "" GIT_REPO ${GIT_REPO})
+	string(FIND ${GIT_REPO} "git@github.com:" IS_GIT_SSH)
+	if (IS_GIT_SSH EQUAL 0)
+		string(REPLACE "git@github.com:" "" GIT_REPO ${GIT_REPO})
+	else()
+		string(REPLACE "https://github.com/" "" GIT_REPO ${GIT_REPO})
+	endif()
 	string(REPLACE "/" ";" GIT_REPO ${GIT_REPO})
 	list(POP_BACK GIT_REPO)
 endif()


### PR DESCRIPTION
# About
- fix repo author when git is clonned in ssh mode

# Result
- before
![image](https://user-images.githubusercontent.com/5261759/182610785-921f0294-5248-412f-9eba-299bbcb4c8e1.png)
- after
![image](https://user-images.githubusercontent.com/5261759/182610737-3f099f3e-31b8-4a9a-8987-55713f2ecff0.png)
