### PR TITLE
cpu: Also log thread id when an unicorn error occurs

### DIFF
--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -223,7 +223,7 @@ bool ThreadState::run_loop() {
                 continue;
 
             if (res < 0) {
-                LOG_ERROR("Thread {} experienced a unicorn error.", name);
+                LOG_ERROR("Thread {} ({}) experienced a unicorn error.", name, cpu->thread_id);
                 if (current_job->notify) {
                     current_job->notify(0xDEADDEAD);
                 }


### PR DESCRIPTION
Unicorn is still useful to debug some weird ass cpu problems, by providing the thread id it is possible to know exactly what instructions the thread that failed execute, watch code just says the thread id and instruction, its far better to say in logs what thread failed than to also print the thread id every cpu instruction