### PR TITLE
shader: Fix Out-of-bound shader write

### DIFF
--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -922,7 +922,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
 
     for (const auto &buffer : program_input.uniform_buffers) {
         if (buffer.reg_block_size > 0) {
-            const uint32_t reg_block_size_in_f32v = (buffer.reg_block_size + 3) / 4;
+            const uint32_t reg_block_size_in_f32v = std::min<uint32_t>(buffer.reg_block_size + 3, REG_SA_COUNT) / 4;
             const auto spv_buffer = b.createAccessChain(spv::StorageClassStorageBuffer, spv_params.buffer_container,
                 { b.makeIntConstant(spv_params.buffers.at(buffer.index).index_in_container) });
             copy_uniform_block_to_register(b, spv_params.uniforms, spv_buffer, ite_copy, buffer.reg_start_offset, reg_block_size_in_f32v);


### PR DESCRIPTION
Fix an out-of-bound write that can happen while copying the uniform buffer to the sa register in the shader code.

It looks like OpenGL doesn't really care about this (at least on my computer), however with Vulkan on my Nvidia GPU it leads to vertex explosions and on my Intel iGPU it crashes my computer (yes, you read that right...).

This fixes the graphics / the computer crash of Trails of Cold Steel menu in the Vulkan renderer.