### PR TITLE
shader: Improve texture instructions

### DIFF
--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -183,7 +183,6 @@ uint16_t get_upload_mip(const uint16_t true_mip, const uint16_t width, const uin
 
 void upload_bound_texture(const TextureCacheState &cache, const SceGxmTexture &gxm_texture, const MemState &mem);
 void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_texture, MemState &mem);
-float get_integral_query_format(const SceGxmTextureBaseFormat format);
 size_t bits_per_pixel(SceGxmTextureBaseFormat base_format);
 bool is_compressed_format(SceGxmTextureBaseFormat base_format);
 bool can_texture_be_unswizzled_without_decode(SceGxmTextureBaseFormat fmt, bool is_vulkan);

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -36,7 +36,7 @@ struct FeatureState;
 namespace renderer::gl {
 
 // Compile program.
-SharedGLObject compile_program(GLState &renderer, const GxmRecordState &state, const FeatureState &features, const MemState &mem, bool shader_cache, bool spirv, bool maskupdate, const char *base_path, const char *title_id, const char *self_name);
+SharedGLObject compile_program(GLState &renderer, GLContext &context, const GxmRecordState &state, const FeatureState &features, const MemState &mem, bool shader_cache, bool spirv, bool maskupdate, const char *base_path, const char *title_id, const char *self_name);
 void pre_compile_program(GLState &renderer, const char *base_path, const char *title_id, const char *self_name, const ShadersHash &hashs);
 
 // Uniforms.

--- a/vita3k/renderer/include/renderer/shaders.h
+++ b/vita3k/renderer/include/renderer/shaders.h
@@ -20,6 +20,10 @@
 #include <string>
 #include <vector>
 
+namespace shader {
+struct Hints;
+}
+
 struct SceGxmProgram;
 struct FeatureState;
 struct SceGxmVertexAttribute;
@@ -32,8 +36,8 @@ struct State;
 // Shaders.
 bool get_shaders_cache_hashs(State &renderer);
 void save_shaders_cache_hashs(State &renderer, std::vector<ShadersHash> &shaders_cache_hashs);
-std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const std::vector<SceGxmVertexAttribute> *hint_attributes, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
-std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const std::vector<SceGxmVertexAttribute> *hint_attributes, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
+std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
+std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const shader::Hints &hints, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
 std::string pre_load_shader_glsl(const char *hash_text, const char *shader_type_str, const char *base_path, const char *title_id, const char *self_name);
 std::vector<uint32_t> pre_load_shader_spirv(const char *hash_text, const char *shader_type_str, const char *base_path, const char *title_id, const char *self_name);
 } // namespace renderer

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -186,6 +186,8 @@ struct Context {
 
     std::map<int, std::vector<uint8_t>> ubo_data;
 
+    shader::Hints shader_hints;
+
     virtual ~Context() = default;
 };
 

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -74,6 +74,14 @@ COMMAND(handle_create_context) {
 
     renderer.context = ctx->get();
 
+    // fill with default values
+    renderer.context->shader_hints = {
+        .attributes = nullptr,
+        .color_format = SCE_GXM_COLOR_FORMAT_U8U8U8U8_ABGR
+    };
+    std::fill_n(renderer.context->shader_hints.vertex_textures, SCE_GXM_MAX_TEXTURE_UNITS, SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR);
+    std::fill_n(renderer.context->shader_hints.fragment_textures, SCE_GXM_MAX_TEXTURE_UNITS, SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR);
+
     complete_command(renderer, helper, result);
 }
 

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -68,16 +68,11 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
     const SceGxmProgram &fragment_program_gxp = *gxm_fragment_program.program.get(mem);
     const auto &gl_frag_program = reinterpret_cast<gl::GLFragmentProgram *>(gxm_fragment_program.renderer_data.get());
 
-    if (!features.support_unknown_format) {
-        // use the format of this surface as the color format of the shader
-        shader::last_color_format = gxm::get_base_format(context.record.color_surface.colorFormat);
-    }
-
     // Trying to cache: the last time vs this time shader pair. Does it different somehow?
     // If it's different, we need to switch. Else just stick to it.
     if (context.record.vertex_program.get(mem)->renderer_data->hash != context.last_draw_vertex_program_hash || context.record.fragment_program.get(mem)->renderer_data->hash != context.last_draw_fragment_program_hash) {
         // Need to recompile!
-        SharedGLObject program = gl::compile_program(renderer, context.record, features, mem, config.shader_cache, config.spirv_shader, gxm_fragment_program.is_maskupdate, base_path, title_id, self_name);
+        SharedGLObject program = gl::compile_program(renderer, context, context.record, features, mem, config.shader_cache, config.spirv_shader, gxm_fragment_program.is_maskupdate, base_path, title_id, self_name);
 
         LOG_ERROR_IF(!program, "Fail to get program!");
 

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -290,9 +290,9 @@ void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t
 
     if (index >= SCE_GXM_MAX_TEXTURE_UNITS) {
         // Vertex textures
-        context.current_vert_render_info.integral_texture_query_format[index - SCE_GXM_MAX_TEXTURE_UNITS] = renderer::texture::get_integral_query_format(base_format);
+        context.shader_hints.vertex_textures[index - SCE_GXM_MAX_TEXTURE_UNITS] = format;
     } else {
-        context.current_frag_render_info.integral_texture_query_format[index] = renderer::texture::get_integral_query_format(base_format);
+        context.shader_hints.fragment_textures[index] = format;
     }
 
     glActiveTexture(static_cast<GLenum>(static_cast<std::size_t>(GL_TEXTURE0) + index));

--- a/vita3k/renderer/src/shaders.cpp
+++ b/vita3k/renderer/src/shaders.cpp
@@ -154,7 +154,7 @@ R load_shader_generic(const char *hash_text, const char *base_path, const char *
     return source;
 }
 
-shader::GeneratedShader load_shader_generic(shader::Target target, const SceGxmProgram &program, const FeatureState &features, const std::vector<SceGxmVertexAttribute> *hint_attributes, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const char *shader_type_str, const std::string &shader_version, bool shader_cache) {
+shader::GeneratedShader load_shader_generic(shader::Target target, const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const char *shader_type_str, const std::string &shader_version, bool shader_cache) {
     // TODO: no need to recompute the hash here
     const std::string hash_text = hex_string(get_shader_hash(program));
     // Set Shader Hash with Version
@@ -202,7 +202,7 @@ shader::GeneratedShader load_shader_generic(shader::Target target, const SceGxmP
         return true;
     };
 
-    shader::GeneratedShader source = shader::convert_gxp(program, hash_text.data(), features, target, hint_attributes, maskupdate, false, write_data_with_ext);
+    shader::GeneratedShader source = shader::convert_gxp(program, hash_text.data(), features, target, hints, maskupdate, false, write_data_with_ext);
 
     // Copy shader generate to shaders cache
     const auto shaders_cache_path = fs::path("cache/shaders") / title_id / self_name;
@@ -232,7 +232,7 @@ shader::GeneratedShader load_shader_generic(shader::Target target, const SceGxmP
     return source;
 }
 
-std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const std::vector<SceGxmVertexAttribute> *hint_attributes, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache) {
+std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache) {
     SceGxmProgramType program_type = program.get_type();
 
     auto shader_type_to_str = [](SceGxmProgramType type) {
@@ -240,17 +240,17 @@ std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &f
     };
 
     const char *shader_type_str = shader_type_to_str(program_type);
-    return load_shader_generic(shader::Target::GLSLOpenGL, program, features, hint_attributes, maskupdate, base_path, title_id, self_name, shader_type_str, shader_version, shader_cache).glsl;
+    return load_shader_generic(shader::Target::GLSLOpenGL, program, features, hints, maskupdate, base_path, title_id, self_name, shader_type_str, shader_version, shader_cache).glsl;
 }
 
-std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const std::vector<SceGxmVertexAttribute> *hint_attributes, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache) {
+std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const shader::Hints &hints, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache) {
     const shader::Target target = is_vulkan ? shader::Target::SpirVVulkan : shader::Target::SpirVOpenGL;
     auto shader_type_to_str = [](SceGxmProgramType type) {
         return (type == SceGxmProgramType::Vertex) ? "vert.spv.txt" : ((type == SceGxmProgramType::Fragment) ? "frag.spv.txt" : "unknown.spv.txt");
     };
     const char *shader_type_str = shader_type_to_str(program.get_type());
 
-    return load_shader_generic(target, program, features, hint_attributes, maskupdate, base_path, title_id, self_name, shader_type_str, shader_version, shader_cache).spirv;
+    return load_shader_generic(target, program, features, hints, maskupdate, base_path, title_id, self_name, shader_type_str, shader_version, shader_cache).spirv;
 }
 
 std::string pre_load_shader_glsl(const char *hash_text, const char *shader_type_str, const char *base_path, const char *title_id, const char *self_name) {

--- a/vita3k/renderer/src/texture_format.cpp
+++ b/vita3k/renderer/src/texture_format.cpp
@@ -27,22 +27,6 @@
 
 namespace renderer::texture {
 
-float get_integral_query_format(const SceGxmTextureBaseFormat format) {
-    if ((format == SCE_GXM_TEXTURE_BASE_FORMAT_S8) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_S8S8) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8S8)) {
-        return shader::INTEGRAL_TEX_QUERY_TYPE_8BIT_SIGNED;
-    }
-
-    if ((format == SCE_GXM_TEXTURE_BASE_FORMAT_U16) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_U16U16) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_U16U16U16U16) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_S16) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_S16S16) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_S16S16S16S16)) {
-        return shader::INTEGRAL_TEX_QUERY_TYPE_16BIT;
-    }
-
-    if ((format == SCE_GXM_TEXTURE_BASE_FORMAT_U32) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_U32U32) || (format == SCE_GXM_TEXTURE_BASE_FORMAT_S32)) {
-        return shader::INTEGRAL_TEX_QUERY_TYPE_32BIT;
-    }
-
-    return shader::INTEGRAL_TEX_QUERY_TYPE_8BIT_UNSIGNED;
-}
-
 size_t bits_per_pixel(SceGxmTextureBaseFormat base_format) {
     switch (base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_U8:

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -296,10 +296,6 @@ static const vk::ComponentMapping translate_swizzle2(SceGxmColorSwizzle2Mode mod
         return swizzle_rg01;
     case SCE_GXM_COLOR_SWIZZLE2_RG:
         return swizzle_gr01;
-    case SCE_GXM_COLOR_SWIZZLE2_RA:
-        return swizzle_a00r;
-    case SCE_GXM_COLOR_SWIZZLE2_AR:
-        return swizzle_r00a;
     default:
         LOG_ERROR("Unknown swizzle mode {}", log_hex(mode));
         return swizzle_identity;
@@ -727,11 +723,11 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8:
         return vk::Format::eR8G8Unorm;
     case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8:
-        return vk::Format::eR8G8Unorm;
+        return vk::Format::eR8G8Snorm;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U16U16:
-        return vk::Format::eR8G8Unorm;
+        return vk::Format::eR16G16Unorm;
     case SCE_GXM_TEXTURE_BASE_FORMAT_S16S16:
-        return vk::Format::eR8G8Unorm;
+        return vk::Format::eR16G16Snorm;
     case SCE_GXM_TEXTURE_BASE_FORMAT_F16F16:
         return vk::Format::eR16G16Sfloat;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U32U32:

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -230,9 +230,6 @@ vk::PipelineShaderStageCreateInfo PipelineCache::retrieve_shader(const SceGxmPro
         return shader_stage_info;
     }
 
-    if (!state.features.support_unknown_format)
-        shader::last_color_format = gxm::get_base_format(current_context->record.color_surface.colorFormat);
-
     const char *base_path = state.base_path;
     const char *title_id = state.title_id;
     const char *self_name = state.self_name;
@@ -241,7 +238,12 @@ vk::PipelineShaderStageCreateInfo PipelineCache::retrieve_shader(const SceGxmPro
 
     LOG_INFO("Generating vulkan spv shader {}", hash_text.data());
     const std::string shader_version = fmt::format("vk{}", shader::CURRENT_VERSION);
-    shader::usse::SpirvCode source = load_spirv_shader(*program, state.features, true, hint_attributes, maskupdate, base_path, title_id, self_name, shader_version, true);
+
+    // update shader hints
+    current_context->shader_hints.color_format = current_context->record.color_surface.colorFormat;
+    current_context->shader_hints.attributes = hint_attributes;
+
+    shader::usse::SpirvCode source = load_spirv_shader(*program, state.features, true, current_context->shader_hints, maskupdate, base_path, title_id, self_name, shader_version, true);
 
     vk::ShaderModuleCreateInfo shader_info{
         .codeSize = sizeof(uint32_t) * source.size(),

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -42,11 +42,11 @@ void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTe
         return;
     }
 
-    if (is_vertex) {
+    if (index >= SCE_GXM_MAX_TEXTURE_UNITS) {
         // Vertex textures
-        context.current_vert_render_info.integral_texture_query_format[index - SCE_GXM_MAX_TEXTURE_UNITS] = renderer::texture::get_integral_query_format(base_format);
+        context.shader_hints.vertex_textures[index - SCE_GXM_MAX_TEXTURE_UNITS] = format;
     } else {
-        context.current_frag_render_info.integral_texture_query_format[index] = renderer::texture::get_integral_query_format(base_format);
+        context.shader_hints.fragment_textures[index] = format;
     }
 
     vkutil::Image *image = nullptr;

--- a/vita3k/shader/CMakeLists.txt
+++ b/vita3k/shader/CMakeLists.txt
@@ -34,8 +34,8 @@ add_library(
 )
 
 target_include_directories(shader PUBLIC include)
-target_link_libraries(shader PUBLIC features gxm util spirv-cross-glsl)
-target_link_libraries(shader PRIVATE SPIRV)
+target_link_libraries(shader PUBLIC features gxm util)
+target_link_libraries(shader PRIVATE SPIRV spirv-cross-glsl)
 
 # Marshmallow Tracy linking
 if(TRACY_ENABLE_ON_CORE_COMPONENTS)

--- a/vita3k/shader/include/shader/gxp_parser.h
+++ b/vita3k/shader/include/shader/gxp_parser.h
@@ -26,4 +26,6 @@ namespace shader {
 usse::GenericType translate_generic_type(const gxp::GenericParameterType &type);
 std::tuple<usse::DataType, std::string> get_parameter_type_store_and_name(const SceGxmParameterType &type);
 usse::ProgramInput get_program_input(const SceGxmProgram &program);
+usse::DataType get_texture_component_type(SceGxmTextureFormat format);
+
 } // namespace shader

--- a/vita3k/shader/include/shader/gxp_parser.h
+++ b/vita3k/shader/include/shader/gxp_parser.h
@@ -27,5 +27,6 @@ usse::GenericType translate_generic_type(const gxp::GenericParameterType &type);
 std::tuple<usse::DataType, std::string> get_parameter_type_store_and_name(const SceGxmParameterType &type);
 usse::ProgramInput get_program_input(const SceGxmProgram &program);
 usse::DataType get_texture_component_type(SceGxmTextureFormat format);
+uint8_t get_texture_component_count(SceGxmTextureFormat format);
 
 } // namespace shader

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -32,24 +32,30 @@ class Builder;
 }
 
 namespace shader {
+
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
-static constexpr float INTEGRAL_TEX_QUERY_TYPE_8BIT_SIGNED = 3.0;
-static constexpr float INTEGRAL_TEX_QUERY_TYPE_8BIT_UNSIGNED = 2.0;
-static constexpr float INTEGRAL_TEX_QUERY_TYPE_16BIT = 1.0;
-static constexpr float INTEGRAL_TEX_QUERY_TYPE_32BIT = 0.0;
-static constexpr std::uint32_t CURRENT_VERSION = 4;
+static constexpr std::uint32_t CURRENT_VERSION = 5;
 
 struct RenderVertUniformBlock {
     std::array<float, 4> viewport_flip;
     float viewport_flag;
     float screen_width;
     float screen_height;
-    float padding;
-    float integral_texture_query_format[SCE_GXM_MAX_TEXTURE_UNITS];
     float z_offset;
     float z_scale;
+};
+
+// used internally to identify the field by the shader recompiler
+// it is put next to the RenderVertUniformBlock so we don't forget to update both fields every time
+enum VertUniformFieldId : uint32_t {
+    VERT_UNIFORM_viewport_flip,
+    VERT_UNIFORM_viewport_flag,
+    VERT_UNIFORM_screen_width,
+    VERT_UNIFORM_screen_height,
+    VERT_UNIFORM_z_offset,
+    VERT_UNIFORM_z_scale
 };
 
 struct RenderFragUniformBlock {
@@ -57,8 +63,15 @@ struct RenderFragUniformBlock {
     float front_disabled = 0;
     float writing_mask = 0;
     float use_raw_image = 0;
-    float integral_texture_query_format[SCE_GXM_MAX_TEXTURE_UNITS];
     int32_t res_multiplier = 0;
+};
+
+enum FragUniformFieldId : uint32_t {
+    FRAG_UNIFORM_back_disabled,
+    FRAG_UNIFORM_front_disabled,
+    FRAG_UNIFORM_writing_mask,
+    FRAG_UNIFORM_use_raw_image,
+    FRAG_UNIFORM_res_multiplier
 };
 
 enum struct Target {
@@ -67,19 +80,33 @@ enum struct Target {
     SpirVVulkan
 };
 
+// Hints given while compiling the shader
+// For example, the gxp shader knows at runtime the swizzle of the color surface
+// or the format / number of components of the sampled images, but we can't
+struct Hints {
+    // used when symbols are stripped
+    const std::vector<SceGxmVertexAttribute> *attributes;
+    // color format of the surface, used for the opengl renderer when the GPU does not support features.support_unknown_format
+    // I'm asking for the format instead of the base format as the swizzle might be used in future updates for surfaces with only 1 or 2 components
+    SceGxmColorFormat color_format;
+
+    // we need to have the texture formats of the sampled textures in two cases:
+    // - when doing dependent texture queries with unknown format we need to know the format
+    // - when sampling, we need to know the component count of a texture
+    SceGxmTextureFormat vertex_textures[SCE_GXM_MAX_TEXTURE_UNITS];
+    SceGxmTextureFormat fragment_textures[SCE_GXM_MAX_TEXTURE_UNITS];
+};
+
 struct GeneratedShader {
     std::string glsl;
     usse::SpirvCode spirv;
 };
 
-// Used if the GPU does not support features.support_unknown_format
-extern SceGxmColorBaseFormat last_color_format;
-
 // Dump generated SPIR-V disassembly up to this point
 void spirv_disasm_print(const usse::SpirvCode &spirv_binary, std::string *spirv_dump = nullptr);
 
 // the returned object will only have its glsl or spirv field non-empty depending on the target
-GeneratedShader convert_gxp(const SceGxmProgram &program, const std::string &shader_hash, const FeatureState &features, const Target target, const std::vector<SceGxmVertexAttribute> *hint_attributes = nullptr, bool maskupdate = false,
+GeneratedShader convert_gxp(const SceGxmProgram &program, const std::string &shader_hash, const FeatureState &features, const Target target, const Hints &hints, bool maskupdate = false,
     bool force_shader_debug = false, std::function<bool(const std::string &ext, const std::string &dump)> dumper = nullptr);
 
 void convert_gxp_to_glsl_from_filepath(const std::string &shader_filepath);

--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -60,7 +60,7 @@ public:
     int repeat_increase[4][17];
     int repeat_multiplier[4];
 
-    void do_texture_queries(const NonDependentTextureQueryCallInfos &texture_queries, const spv::Id translation_state_id);
+    void do_texture_queries(const NonDependentTextureQueryCallInfos &texture_queries);
     // extra1 is either lod or ddx, extra2 is ddy
     spv::Id do_fetch_texture(const spv::Id tex, const Coord &coord, const DataType dest_type, const int lod_mode,
         const spv::Id extra1 = spv::NoResult, const spv::Id extra2 = spv::NoResult);
@@ -68,7 +68,7 @@ public:
     USSETranslatorVisitor() = delete;
     explicit USSETranslatorVisitor(spv::Builder &_b, USSERecompiler &_recompiler, const SceGxmProgram &program, const FeatureState &features,
         utils::SpirvUtilFunctions &utils, const uint64_t &_instr, const SpirvShaderParameters &spirv_params, const NonDependentTextureQueryCallInfos &queries,
-        const spv::Id render_info_id, bool is_secondary_program = false)
+        bool is_secondary_program = false)
         : m_util_funcs(utils)
         , m_second_program(is_secondary_program)
         , m_b(_b)
@@ -113,7 +113,7 @@ public:
             }
         }
 
-        do_texture_queries(queries, render_info_id);
+        do_texture_queries(queries);
     }
 
     /*

--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -63,7 +63,7 @@ public:
     void do_texture_queries(const NonDependentTextureQueryCallInfos &texture_queries);
     // extra1 is either lod or ddx, extra2 is ddy
     spv::Id do_fetch_texture(const spv::Id tex, const Coord &coord, const DataType dest_type, const int lod_mode,
-        const spv::Id extra1 = spv::NoResult, const spv::Id extra2 = spv::NoResult);
+        const spv::Id extra1 = spv::NoResult, const spv::Id extra2 = spv::NoResult, const int gather4_comp = -1);
 
     USSETranslatorVisitor() = delete;
     explicit USSETranslatorVisitor(spv::Builder &_b, USSERecompiler &_recompiler, const SceGxmProgram &program, const FeatureState &features,

--- a/vita3k/shader/include/shader/usse_translator_types.h
+++ b/vita3k/shader/include/shader/usse_translator_types.h
@@ -42,6 +42,7 @@ struct SpirvUniformBufferInfo {
 struct SamplerInfo {
     spv::Id id;
     DataType component_type;
+    uint8_t component_count;
 };
 using SamplerMap = std::unordered_map<std::uint32_t, SamplerInfo>;
 
@@ -95,6 +96,7 @@ struct NonDependentTextureQueryCallInfo {
     int prod_pos = -1;
 
     DataType component_type;
+    uint8_t component_count;
 };
 
 using NonDependentTextureQueryCallInfos = std::vector<NonDependentTextureQueryCallInfo>;

--- a/vita3k/shader/include/shader/usse_translator_types.h
+++ b/vita3k/shader/include/shader/usse_translator_types.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <spirv_glsl.hpp>
+#include <shader/usse_types.h>
 
 #include <map>
 #include <unordered_map>
@@ -25,7 +25,8 @@
 
 namespace spv {
 class Builder;
-}
+typedef unsigned int Id;
+} // namespace spv
 
 namespace shader::usse {
 
@@ -37,6 +38,12 @@ struct SpirvUniformBufferInfo {
     std::uint32_t size;
     std::uint32_t index_in_container;
 };
+
+struct SamplerInfo {
+    spv::Id id;
+    DataType component_type;
+};
+using SamplerMap = std::unordered_map<std::uint32_t, SamplerInfo>;
 
 struct SpirvShaderParameters {
     // Mapped to 'pa' (primary attribute) USSE registers
@@ -67,7 +74,7 @@ struct SpirvShaderParameters {
     SpirvVarRegBank predicates;
 
     // Sampler map. Since all banks are a flat array, sampler must be in an explicit bank.
-    std::unordered_map<std::uint32_t, spv::Id> samplers;
+    SamplerMap samplers;
 
     // Uniform buffer map contains layout info of a UBO inside the big SSBO.
     std::map<std::uint32_t, SpirvUniformBufferInfo> buffers;
@@ -86,9 +93,10 @@ struct NonDependentTextureQueryCallInfo {
     std::uint32_t dest_offset = 0;
     int store_type = 0; ///< For sampling method later
     int prod_pos = -1;
+
+    DataType component_type;
 };
 
 using NonDependentTextureQueryCallInfos = std::vector<NonDependentTextureQueryCallInfo>;
-using SamplerMap = std::unordered_map<std::uint32_t, spv::Id>;
 
 } // namespace shader::usse

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -21,7 +21,9 @@
 #include <util/align.h>
 #include <util/log.h>
 
-using namespace shader::usse;
+namespace shader {
+
+using namespace usse;
 
 GenericType shader::translate_generic_type(const gxp::GenericParameterType &type) {
     switch (type) {
@@ -367,3 +369,77 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
 
     return program_input;
 }
+
+DataType get_texture_component_type(SceGxmTextureFormat format) {
+    SceGxmTextureBaseFormat base_format = gxm::get_base_format(format);
+    // TODO: won't be surprised if some of them are wrong
+    switch (base_format) {
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U3U3U2:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U1U5U5U5:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U5U6U5:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S5S5U6:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_P4:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_P8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8:
+        return DataType::UINT8;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8S8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_X8S8S8U8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8:
+        return DataType::INT8;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U2U10U10U10:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U16U16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U16U16U16U16:
+        return DataType::UINT16;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S16S16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S16S16S16S16:
+        return DataType::INT16;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F16F16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F11F11F10:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F16F16F16F16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U2F10F10F10:
+        return DataType::F16;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F32M:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_X8U24:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F32F32:
+    // should these formats be left as F32?
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U32U32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S32:
+        return DataType::F32;
+
+    // TODO are these stored as U8, F16 or F32?
+    case SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_PVRT4BPP:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII2BPP:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC1:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC2:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC4:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P2:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P3:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_YUV422:
+        return DataType::UINT8;
+    }
+}
+
+} // namespace shader

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -442,4 +442,39 @@ DataType get_texture_component_type(SceGxmTextureFormat format) {
     }
 }
 
+uint8_t get_texture_component_count(SceGxmTextureFormat format) {
+    const SceGxmTextureBaseFormat base_format = gxm::get_base_format(format);
+    const uint32_t swizzle = format & SCE_GXM_TEXTURE_SWIZZLE_MASK;
+    switch (base_format) {
+    // 1 Component.
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F32M:
+        return (swizzle == SCE_GXM_TEXTURE_SWIZZLE1_R) ? 1U : 4U;
+
+    // 2 components
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U16U16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S16S16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F16F16:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U32U32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_F32F32:
+        return (swizzle == SCE_GXM_TEXTURE_SWIZZLE2_GR) ? 2U : 4U;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_X8U24:
+        return 1U;
+
+    // 3 and 4 components, always 4
+    default:
+        return 4U;
+    }
+}
+
 } // namespace shader

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1558,6 +1558,8 @@ static SpirvCode convert_gxp_to_spirv_impl(const SceGxmProgram &program, const s
 
     // Capabilities
     b.addCapability(spv::Capability::CapabilityShader);
+    if (translation_state.is_fragment)
+        b.addCapability(spv::Capability::CapabilityImageQuery);
     if (features.support_unknown_format)
         b.addCapability(spv::Capability::CapabilityStorageImageReadWithoutFormat);
 

--- a/vita3k/shader/src/translator/branch_cond.cpp
+++ b/vita3k/shader/src/translator/branch_cond.cpp
@@ -501,7 +501,7 @@ bool USSETranslatorVisitor::vtstmsk(
         break;
     }
 
-    pred_result = m_b.createOp(spv::OpSelect, output_type, { pred_result, zeros, ones });
+    pred_result = m_b.createOp(spv::OpSelect, output_type, { pred_result, ones, zeros });
 
     store(inst.opr.dest, pred_result);
 

--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -95,7 +95,9 @@ void shader::usse::USSETranslatorVisitor::do_texture_queries(const NonDependentT
         spv::Id fetch_result = do_fetch_texture(texture_query.sampler, coord_inst, store_op.type, proj ? 4 : 0, 0);
         store_op.num = texture_query.dest_offset;
 
-        store(store_op, fetch_result, 0b1111);
+        const Imm4 mask = (1U << texture_query.component_count) - 1;
+
+        store(store_op, fetch_result, mask);
     }
 }
 
@@ -225,15 +227,16 @@ bool USSETranslatorVisitor::smp(
 
     spv::Id result = do_fetch_texture(sampler.id, { coord, static_cast<int>(DataType::F32) }, DataType::F32, lod_mode, extra1, extra2);
 
+    const Imm4 dest_mask = (1U << sampler.component_count) - 1;
     switch (sb_mode) {
     case 0:
     case 1:
-        store(inst.opr.dest, result, 0b1111);
+        store(inst.opr.dest, result, dest_mask);
         break;
     case 3: {
         // TODO: figure out what to fill here
         // store(inst.opr.dest, stub, 0b1111);
-        store(inst.opr.dest, result, 0b1111);
+        store(inst.opr.dest, result, dest_mask);
         break;
     }
     default: {

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -832,7 +832,7 @@ USSERecompiler::USSERecompiler(spv::Builder &b, const SceGxmProgram &program, co
     : inst(nullptr)
     , count(0)
     , b(b)
-    , visitor(b, *this, program, features, utils, cur_instr, parameters, queries, render_info_id, true)
+    , visitor(b, *this, program, features, utils, cur_instr, parameters, queries, true)
     , end_hook_func(end_hook_func)
     , tree_block_node(nullptr, 0) {
 }


### PR DESCRIPTION
This PR contains 4 commits, each one containing different improvements to the shader recompiler and in particular texture sampling.

- First, rewrite the hint system used by the shader recompiler. The current system is not enough, for some instructions we need to know the texture format (to be more precise the component type and the component count).
- Apply the color swizzle in the shader. Our current implementation didn't work when writing to a texture with different swizzles and didn't support some swizzles like SWIZZLE1_A, this is now fixed.
- Take into account the component count of a texture when sampling. If the texture has only one component (SWIZZLE1_R, for example a depth buffer), do not overwrite the memory at locations that would have matched the 2nd to 4th components.
- Implement missing texture info and texture gather instructions.

This fixes the graphics of many games, to name a few: Persona 4, Freedom War, Dragon Quest Builder, Trails of Cold Steel, Urban Trial...

I'm putting it as a draft because it seems there are still some issues with the shadows.