### PR TITLE
workflow: Delete unused CI variable

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: CMake
         run: |
-          cmake -DCI=ON ${{ matrix.extra_cmake_args }} --preset ${{ matrix.cmake_preset }}
+          cmake ${{ matrix.extra_cmake_args }} --preset ${{ matrix.cmake_preset }}
           cmake --build build/${{ matrix.cmake_preset }} --config ${{ matrix.config }}
 
       - name: CTest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build
         run: |
-         cmake -DCI=ON --preset ${{ matrix.cmake_preset }}
+         cmake --preset ${{ matrix.cmake_preset }}
          cmake --build build/${{ matrix.cmake_preset }} --config ${{ matrix.config }}
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
the `CI` variable isn't used by vita3k nor any depend, cmake makes a warning because of it, literally its there for nothing lol
![image](https://user-images.githubusercontent.com/30161277/187686783-f66665c1-d0e3-42c6-842f-204d6c73eafd.png)
