### PR TITLE
app: Fix main window not pumping events during loading

### DIFF
--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -355,7 +355,9 @@ int main(int argc, char *argv[]) {
     emuenv.renderer->title_id = emuenv.io.title_id.c_str();
     emuenv.renderer->self_name = emuenv.self_name.c_str();
     if (renderer::get_shaders_cache_hashs(*emuenv.renderer) && cfg.shader_cache) {
+        SDL_SetWindowTitle(emuenv.window.get(), fmt::format("{} | {} ({}) | Please wait, compiling shaders...", window_title, emuenv.current_app_title, emuenv.io.title_id).c_str());
         for (const auto &hash : emuenv.renderer->shaders_cache_hashs) {
+            handle_events(emuenv, gui);
             gui::draw_begin(gui, emuenv);
             draw_app_background(gui, emuenv);
 
@@ -364,14 +366,15 @@ int main(int argc, char *argv[]) {
 
             gui::draw_end(gui, emuenv.window.get());
             emuenv.renderer->swap_window(emuenv.window.get());
-            SDL_SetWindowTitle(emuenv.window.get(), fmt::format("{} | {} ({}) | Please wait, compiling shaders...", window_title, emuenv.current_app_title, emuenv.io.title_id).c_str());
         }
     }
 
     if (const auto err = run_app(emuenv, entry_point) != Success)
         return err;
 
-    while (emuenv.frame_count == 0 && !emuenv.load_exec) {
+    SDL_SetWindowTitle(emuenv.window.get(), fmt::format("{} | {} ({}) | Please wait, loading...", window_title, emuenv.current_app_title, emuenv.io.title_id).c_str());
+
+    while (handle_events(emuenv, gui) && (emuenv.frame_count == 0) && !emuenv.load_exec) {
         // Driver acto!
         renderer::process_batches(*emuenv.renderer.get(), emuenv.renderer->features, emuenv.mem, emuenv.cfg);
 
@@ -388,8 +391,6 @@ int main(int argc, char *argv[]) {
 
         gui::draw_end(gui, emuenv.window.get());
         emuenv.renderer->swap_window(emuenv.window.get());
-
-        SDL_SetWindowTitle(emuenv.window.get(), fmt::format("{} | {} ({}) | Please wait, loading...", window_title, emuenv.current_app_title, emuenv.io.title_id).c_str());
     }
 
     while (handle_events(emuenv, gui) && !emuenv.load_exec) {


### PR DESCRIPTION
Before this PR, the UI thread stops pumping events (i.e. no calls to `handle_events()`) when shaders are being compiled and while the application is "loading" (i.e. before the first frame is rendered). On Windows, this makes the window unresponsive: it cannot be minimized, maximized, resized, moved, or closed. I assume similar things may happen on other platforms but cannot confirm.

Fix by calling `handle_events()` in both loops to ensure events are pumped from the SDL event queue, making the window responsive again. Additionally, move the SDL_SetWindowTitle out of the loops - it doesn't need to be called every time as the title is static (no FPS counter/progess).

NOTE: Because shader cache precompilation is done synchronously on the UI thread, and it can block for a long time, the window may become unresponsive while it's being done. Moving the compilation on a dedicated worker thread would allow solving the issue, but I'm not familiar enough to know if that's possible, so I left as-is. This could be improved in a later PR by a person more knowledgeable.