### PR TITLE
kernel: don't check status on msgpipe finish

### DIFF
--- a/vita3k/kernel/src/sync_primitives.cpp
+++ b/vita3k/kernel/src/sync_primitives.cpp
@@ -1385,7 +1385,7 @@ SceSize msgpipe_recv(KernelState &kernel, const char *export_name, SceUID thread
 
         const auto finish = [&] {
             msgpipe_lock.lock(); // Lock message pipe again
-            thread->update_status(ThreadStatus::run, ThreadStatus::wait); // Wake up
+            thread->update_status(ThreadStatus::run); // Wake up
 
             SceSize readSize = (SceSize)copyOut();
             // msgpipe->receivers->erase(wait_data); //we've already been erased by the sender
@@ -1485,7 +1485,7 @@ SceSize msgpipe_send(KernelState &kernel, const char *export_name, SceUID thread
 
         const auto finish = [&] {
             msgpipe_lock.lock(); // Lock message pipe again
-            thread->update_status(ThreadStatus::run, ThreadStatus::wait); // Wake up
+            thread->update_status(ThreadStatus::run); // Wake up
 
             SceSize insertedSize = (SceSize)msgpipe->data_buffer.Insert(pSendBuf, sendSize);
             // msgpipe->senders->erase(wait_data); //Don't erase ourselves - recv will do it


### PR DESCRIPTION
The `finish()` lambda used in msgpipe operation functions expected the thread to be in `wait`ing state and checked this using the `expected` argument of `thread->update_status()`.
However, the wakeup of threads sleeping on a message pipe is done by changing their status from `wait` to `run`, breaking this assumption.
This leads to an assertion failure and crash, preventing e.g. Ratchet & Clank from booting.

Fix (workaround) by no longer verifying the thread's status on `finish()`.