### PR TITLE
gui: Make FPS overlay update each frame

### DIFF
--- a/vita3k/emuenv/include/emuenv/state.h
+++ b/vita3k/emuenv/include/emuenv/state.h
@@ -122,7 +122,7 @@ public:
     uint32_t avg_fps = 0;
     uint32_t min_fps = 0;
     uint32_t max_fps = 0;
-    float fps_values[20] = {};
+    float fps_values[60] = {};
     uint32_t current_fps_offset = 0;
     uint32_t ms_per_frame = 0;
     WindowPtr window = WindowPtr(nullptr, nullptr);

--- a/vita3k/gui/src/perf_overlay.cpp
+++ b/vita3k/gui/src/perf_overlay.cpp
@@ -18,13 +18,13 @@
 #include "private.h"
 
 #include <config/state.h>
+#include <display/state.h>
 
 namespace gui {
-static const ImVec2 PERF_OVERLAY_PAD = ImVec2(12.f, 12.f);
-static const ImVec4 PERF_OVERLAY_BG_COLOR = ImVec4(0.282f, 0.239f, 0.545f, 0.8f);
-
 static ImVec2 get_perf_pos(ImVec2 window_size, EmuEnvState &emuenv) {
-    const auto TOP = emuenv.viewport_pos.y - PERF_OVERLAY_PAD.y;
+    static const ImVec2 PERF_OVERLAY_PAD = ImVec2(12.f, 12.f);
+
+    const auto TOP = emuenv.viewport_pos.y - PERF_OVERLAY_PAD.y + emuenv.display.imgui_render * 27.f;
     const auto LEFT = emuenv.viewport_pos.x - PERF_OVERLAY_PAD.x;
     const auto CENTER = emuenv.viewport_pos.x + (emuenv.viewport_size.x / 2.f) - (window_size.x / 2.f);
     const auto RIGHT = emuenv.viewport_pos.x + emuenv.viewport_size.x - window_size.x + PERF_OVERLAY_PAD.x;
@@ -45,20 +45,22 @@ static ImVec2 get_perf_pos(ImVec2 window_size, EmuEnvState &emuenv) {
 
 static float get_perf_height(EmuEnvState &emuenv) {
     switch (emuenv.cfg.performance_overlay_detail) {
-    case MAXIMUM: return 138.f;
-    case MEDIUM: return 80.f;
+    case MAXIMUM: return 128.f;
+    case MEDIUM: return 70.f;
     case LOW:
     case MINIMUM:
     default: break;
     }
 
-    return 57.f;
+    return 47.f;
 }
 
 void draw_perf_overlay(GuiState &gui, EmuEnvState &emuenv) {
-    const auto MAIN_WINDOW_SIZE = ImVec2((emuenv.cfg.performance_overlay_detail == MINIMUM ? 95.5f : 152.f) * emuenv.dpi_scale, get_perf_height(emuenv) * emuenv.dpi_scale);
+    static const ImVec4 PERF_OVERLAY_BG_COLOR = ImVec4(0.282f, 0.239f, 0.545f, 0.8f);
+    const auto MAIN_WINDOW_SIZE = ImVec2((emuenv.cfg.performance_overlay_detail == MINIMUM ? 151.5f : 286.5f) * emuenv.dpi_scale, get_perf_height(emuenv) * emuenv.dpi_scale);
+    const auto WINDOW_SIZE = ImVec2((emuenv.cfg.performance_overlay_detail == MINIMUM ? 135.f : 270.f) * emuenv.dpi_scale, (emuenv.cfg.performance_overlay_detail <= LOW ? 35.f : 58.f) * emuenv.dpi_scale);
     const auto WINDOW_POS = get_perf_pos(MAIN_WINDOW_SIZE, emuenv);
-    const auto WINDOW_SIZE = ImVec2((emuenv.cfg.performance_overlay_detail == MINIMUM ? 72.5f : 130.f) * emuenv.dpi_scale, (emuenv.cfg.performance_overlay_detail <= LOW ? 35.f : 58.f) * emuenv.dpi_scale);
+    const auto SCALE_MAX = emuenv.max_fps < 300 ? emuenv.max_fps : 300;
 
     ImGui::SetNextWindowSize(MAIN_WINDOW_SIZE);
     ImGui::SetNextWindowPos(WINDOW_POS);
@@ -68,19 +70,19 @@ void draw_perf_overlay(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 5.f * emuenv.dpi_scale);
     ImGui::BeginChild("#perf_stats", WINDOW_SIZE, true, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (emuenv.cfg.performance_overlay_detail == PerfomanceOverleyDetail::MINIMUM)
-        ImGui::Text("FPS: %d", emuenv.fps);
+        ImGui::Text("Avg: %u (%u ms)", emuenv.avg_fps, (uint16_t)(1000 / (emuenv.avg_fps ? emuenv.avg_fps : 1)));
     else
-        ImGui::Text("FPS: %d Avg: %d", emuenv.fps, emuenv.avg_fps);
+        ImGui::Text("FPS: %u (%u ms) Avg: %u (%u ms)", emuenv.fps, (uint16_t)(1000 / (emuenv.fps ? emuenv.fps : 1)), emuenv.avg_fps, (uint16_t)(1000 / (emuenv.avg_fps ? emuenv.avg_fps : 1)));
     if (emuenv.cfg.performance_overlay_detail >= PerfomanceOverleyDetail::MEDIUM) {
         ImGui::Separator();
-        ImGui::Text("Min: %d Max: %d", emuenv.min_fps, emuenv.max_fps);
+        ImGui::Text("Min: %u (%u ms) Max: %u (%u ms)", emuenv.min_fps, (uint16_t)(1000 / (emuenv.min_fps ? emuenv.min_fps : 1)), emuenv.max_fps, (uint16_t)(1000 / (emuenv.max_fps ? emuenv.max_fps : 1)));
     }
     ImGui::EndChild();
     ImGui::PopStyleVar();
     ImGui::PopStyleColor();
     if (emuenv.cfg.performance_overlay_detail == PerfomanceOverleyDetail::MAXIMUM) {
         ImGui::SetCursorPosY(ImGui::GetCursorPosY() - (5.f * emuenv.dpi_scale));
-        ImGui::PlotLines("##fps_graphic", emuenv.fps_values, IM_ARRAYSIZE(emuenv.fps_values), emuenv.current_fps_offset, nullptr, 0.f, float(emuenv.max_fps), WINDOW_SIZE);
+        ImGui::PlotLines("##fps_graphic", emuenv.fps_values, IM_ARRAYSIZE(emuenv.fps_values), emuenv.current_fps_offset, nullptr, 0.f, SCALE_MAX, WINDOW_SIZE);
     }
     ImGui::End();
     ImGui::PopStyleVar();


### PR DESCRIPTION
### FPS value changes to be based on the last frame, meaning more responsive to sudden fps changes
### AVGFPS value remains the same, an average among the last 20 to the last 60 frames

### The overlay made gui buttons IMPOSSIBLE to click, so now it moves down a bit to make those buttons clickable again

* Window title FPS -> use avg fps because its TOO FAST and unreadable
* FPS/Min -> Show "Avg: <AVGFPS> (<avg frametime> ms)" instead of "FPS: (FPS)"
* FPS/Low -> Show both fps and average with its frametimes
* FPS/Max -> Same as above but also change the graph to react to changes in FPS, meaning if you get 60 fps it will go fast, but on low fps, like 15 it goes a lot slower, this way it works like optifine's and osu frame graph, which makes seeing exactly when a spike happened a lot easier


* Before this changes the only way to notice a sudden lag spike that lasted for less than some milliseconds was impossible, with this it just shows all the spikes in the graph.
