### PR TITLE
shader: Fix pa offset and NaN hack

### DIFF
--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -105,7 +105,7 @@ ProgramInput shader::get_program_input(const SceGxmProgram &program) {
             auto container = gxp::get_container_by_index(program, parameter.container_index);
             std::uint32_t offset = parameter.resource_index;
 
-            if (container) {
+            if (container && is_uniform) {
                 offset = container->base_sa_offset + parameter.resource_index;
             }
 

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1009,7 +1009,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
             auto container = gxp::get_container_by_index(program, parameter.container_index);
             std::uint32_t offset = parameter.resource_index;
 
-            if (container) {
+            if (container && is_uniform) {
                 offset = container->base_sa_offset + parameter.resource_index;
             }
 


### PR DESCRIPTION
- Fix the pa offset in the shader (do not take into account the sa offset variable)

- In Freedom wars, the shaders does the following computation in shadowed areas:
`exp(log(0) * 0)`
This gets evaluated to NaN, but I'm 90% sure it should be evaluated to 1.0f. Maybe because this is because it is done on F16 which may have a different behavior on some functions concerning NaN? I am really not sure. To fix this, I define in the shader exp(Nan) to be equal to 1.0. This hack should not impact other games anyway.

This PR fixes almost all the graphical glitches in Freedom Wars US and EU versions.