### PR TITLE
renderer/vulkan: Implement gamma correction

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -932,7 +932,7 @@ enum SceGxmColorSurfaceType {
     SCE_GXM_COLOR_SURFACE_SWIZZLED = 0x08000000u
 };
 
-enum SceGxmColorSurfaceGammaMode {
+enum SceGxmColorSurfaceGammaMode : uint32_t {
     SCE_GXM_COLOR_SURFACE_GAMMA_NONE = 0x00000000u,
     SCE_GXM_COLOR_SURFACE_GAMMA_R = 0x00001000u,
     SCE_GXM_COLOR_SURFACE_GAMMA_GR = 0x00003000u,

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -422,6 +422,7 @@ static int init_texture_base(const char *export_name, SceGxmTexture *texture, Pt
     texture->mip_count = std::min<std::uint32_t>(15, mipCount - 1);
     texture->format0 = (tex_format & 0x80000000) >> 31;
     texture->lod_bias = 31;
+    texture->gamma_mode = 0;
 
     if ((texture_type == SCE_GXM_TEXTURE_SWIZZLED) || (texture_type == SCE_GXM_TEXTURE_CUBE)) {
         // Find highest set bit of width and height. It's also the 2^? for width and height
@@ -776,8 +777,7 @@ EXPORT(SceGxmColorFormat, sceGxmColorSurfaceGetFormat, const SceGxmColorSurface 
 
 EXPORT(SceGxmColorSurfaceGammaMode, sceGxmColorSurfaceGetGammaMode, const SceGxmColorSurface *surface) {
     assert(surface);
-    STUBBED("SCE_GXM_COLOR_SURFACE_GAMMA_NONE");
-    return SceGxmColorSurfaceGammaMode::SCE_GXM_COLOR_SURFACE_GAMMA_NONE;
+    return static_cast<SceGxmColorSurfaceGammaMode>(surface->gamma << 12);
 }
 
 EXPORT(SceGxmColorSurfaceScaleMode, sceGxmColorSurfaceGetScaleMode, const SceGxmColorSurface *surface) {
@@ -808,7 +808,7 @@ EXPORT(int, sceGxmColorSurfaceInit, SceGxmColorSurface *surface, SceGxmColorForm
     if ((strideInPixels < width) || ((data.address() & 3) != 0))
         return RET_ERROR(SCE_GXM_ERROR_INVALID_VALUE);
 
-    memset(surface, 0, sizeof(*surface));
+    memset(surface, 0, sizeof(SceGxmColorSurface));
     surface->disabled = 0;
     surface->downscale = scaleMode == SCE_GXM_COLOR_SURFACE_SCALE_MSAA_DOWNSCALE;
     surface->width = width;
@@ -895,7 +895,9 @@ EXPORT(int, sceGxmColorSurfaceSetGammaMode, SceGxmColorSurface *surface, SceGxmC
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
     }
 
-    return UNIMPLEMENTED();
+    surface->gamma = static_cast<uint32_t>(gammaMode) >> 12;
+
+    return 0;
 }
 
 EXPORT(void, sceGxmColorSurfaceSetScaleMode, SceGxmColorSurface *surface, SceGxmColorSurfaceScaleMode scaleMode) {

--- a/vita3k/renderer/include/renderer/gxm_types.h
+++ b/vita3k/renderer/include/renderer/gxm_types.h
@@ -36,9 +36,12 @@ struct VertexProgram;
 
 struct SceGxmColorSurface {
     // opaque start
-    uint32_t disabled : 1;
-    uint32_t downscale : 1;
-    uint32_t pad : 30;
+    struct {
+        uint32_t disabled : 1;
+        uint32_t downscale : 1;
+        uint32_t gamma : 2;
+        uint32_t : 28;
+    };
     uint32_t width;
     uint32_t height;
     uint32_t strideInPixels;

--- a/vita3k/renderer/include/renderer/vulkan/surface_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/surface_cache.h
@@ -103,7 +103,7 @@ public:
 
     // when writing, the swizzled given to this function is inversed
     vkutil::Image *retrieve_color_surface_texture_handle(uint16_t width, uint16_t height, const uint16_t pixel_stride,
-        const SceGxmColorBaseFormat base_format, Ptr<void> address, SurfaceTextureRetrievePurpose purpose, vk::ComponentMapping &swizzle,
+        const SceGxmColorBaseFormat base_format, const bool is_srgb, Ptr<void> address, SurfaceTextureRetrievePurpose purpose, vk::ComponentMapping &swizzle,
         uint16_t *stored_height = nullptr, uint16_t *stored_width = nullptr);
 
     vkutil::Image *retrieve_depth_stencil_texture_handle(const MemState &mem, const SceGxmDepthStencilSurface &surface, int32_t force_width = -1,

--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -44,6 +44,10 @@ void set_context(VKContext &context, const MemState &mem, VKRenderTarget *rt, co
     context.record.height = context.render_target->height;
     vk::Format vk_format = color::translate_format(context.record.color_base_format);
 
+    if (color_surface_fin->gamma && (vk_format == vk::Format::eR8G8B8A8Unorm)) {
+        vk_format = vk::Format::eR8G8B8A8Srgb;
+    }
+
     if (color_surface_fin->data.address() == 0) {
         color_surface_fin = nullptr;
         vk_format = vk::Format::eR8G8B8A8Unorm;

--- a/vita3k/vkutil/include/vkutil/objects.h
+++ b/vita3k/vkutil/include/vkutil/objects.h
@@ -49,7 +49,7 @@ struct Image {
     Image(const Image &) = delete;
     Image &operator=(Image const &) = delete;
 
-    void init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping = default_comp_mapping);
+    void init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping = default_comp_mapping, const vk::ImageCreateFlags image_create_flags = vk::ImageCreateFlags());
     // called by ~Image
     void destroy();
 

--- a/vita3k/vkutil/src/objects.cpp
+++ b/vita3k/vkutil/src/objects.cpp
@@ -70,8 +70,9 @@ Image::~Image() {
     destroy();
 }
 
-void Image::init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping) {
+void Image::init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping, const vk::ImageCreateFlags image_create_flags) {
     vk::ImageCreateInfo image_info{
+        .flags = image_create_flags,
         .imageType = vk::ImageType::e2D,
         .format = format,
         .extent = vk::Extent3D{


### PR DESCRIPTION
Implement gamma correction (only for Vulkan for now).
It is not perfect as there are many srgb texture formats and surfaces formats that are not supported in Vulkan compared to the PS Vita.
This fixes the brightness of many games.