### PR TITLE
vita3k: allow switch backend render & Reso multiplier when app run. 

### DIFF
--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -298,6 +298,13 @@ int main(int argc, char *argv[]) {
         }
     }
 
+    // When backend render is changed before boot app, reboot emu in new backend render and run app
+    if (emuenv.renderer->current_backend != emuenv.backend_renderer) {
+        emuenv.load_app_path = emuenv.io.app_path;
+        run_execv(argv, emuenv);
+        return Success;
+    }
+
     gui::set_config(gui, emuenv, emuenv.io.app_path);
 
     const auto APP_INDEX = gui::get_app_index(gui, emuenv.io.app_path);


### PR DESCRIPTION
# About
- Allow can switch backend render before boot app.
- Allow can swit-ch backend render & resolution multiplier when app run.
- refactror setting dialopg gpu tab and add arrow of change slider value.

# Result:
![image](https://user-images.githubusercontent.com/5261759/191289493-876e7c7a-7c13-476a-811f-d071071b702a.png)
