### PR TITLE
modules/SceFios2User: Partial implementation of fios overlays

### DIFF
--- a/vita3k/io/include/io/functions.h
+++ b/vita3k/io/include/io/functions.h
@@ -82,3 +82,7 @@ SceUID read_dir(IOState &io, SceUID fd, SceIoDirent *dent, const std::wstring &p
 int create_dir(IOState &io, const char *dir, int mode, const std::wstring &pref_path, const char *export_name, const bool recursive = false);
 int close_dir(IOState &io, SceUID fd, const char *export_name);
 int remove_dir(IOState &io, const char *dir, const std::wstring &pref_path, const char *export_name);
+
+// SceFios functions
+SceUID create_overlay(IOState &io, SceFiosProcessOverlay *fios_overlay);
+std::string resolve_path(IOState &io, const char *input, const bool is_write, const SceUInt32 min_order = 0, const SceUInt32 max_order = 0x7F);

--- a/vita3k/io/include/io/state.h
+++ b/vita3k/io/include/io/state.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <io/filesystem.h>
+#include <io/types.h>
 #include <io/util.h>
 
 #include <map>
@@ -121,4 +122,9 @@ struct IOState {
 
     std::unordered_map<std::string, std::string> cachemap;
     bool case_isens_find_enabled = false;
+
+    std::mutex overlay_mutex;
+    SceUID next_overlay_id = 1;
+    // overlay in the order they should be applied
+    std::vector<FiosOverlay> overlays;
 };

--- a/vita3k/io/include/io/types.h
+++ b/vita3k/io/include/io/types.h
@@ -109,3 +109,37 @@ struct SceIoDevInfo {
     SceInt64 free_size;
     SceSize cluster_size;
 };
+
+enum SceFiosOverlayType : uint8_t {
+    SCE_FIOS_OVERLAY_TYPE_OPAQUE,
+    SCE_FIOS_OVERLAY_TYPE_TRANSLUCENT,
+    SCE_FIOS_OVERLAY_TYPE_NEWER,
+    SCE_FIOS_OVERLAY_TYPE_WRITABLE
+};
+
+enum SceFiosOverlayLimits {
+    SCE_FIOS_OVERLAY_MAX_OVERLAYS = 64,
+    SCE_FIOS_OVERLAY_POINT_MAX = 292
+};
+
+struct SceFiosProcessOverlay {
+    SceFiosOverlayType type;
+    uint8_t order;
+    int16_t src_size;
+    int16_t dst_size;
+    SceUID process_id;
+    uint32_t reserved;
+    char dst[SCE_FIOS_OVERLAY_POINT_MAX];
+    char src[SCE_FIOS_OVERLAY_POINT_MAX];
+};
+
+static_assert(offsetof(SceFiosProcessOverlay, src) == 308);
+
+struct FiosOverlay {
+    SceUID id;
+    SceFiosOverlayType type;
+    uint8_t order;
+    SceUID process_id;
+    std::string dst;
+    std::string src;
+};

--- a/vita3k/modules/SceDriverUser/SceFios2User.h
+++ b/vita3k/modules/SceDriverUser/SceFios2User.h
@@ -19,6 +19,17 @@
 
 #include <module/module.h>
 
+enum SceFiosErrorCode {
+    SCE_FIOS_OK = 0
+};
+
+typedef SceUID SceFiosOverlayID;
+
+enum SceFiosOverlayResolveMode {
+    SCE_FIOS_OVERLAY_RESOLVE_FOR_READ = 0,
+    SCE_FIOS_OVERLAY_RESOLVE_FOR_WRITE = 1
+};
+
 BRIDGE_DECL(sceFiosOverlayAddForProcess02)
 BRIDGE_DECL(sceFiosOverlayGetInfoForProcess02)
 BRIDGE_DECL(sceFiosOverlayGetList02)


### PR DESCRIPTION
Implement some of the Fios overlays functions, which can't be LLEd.
This allows Trails in the sky games to get to the menu, however they are still stuck after because of kernel issues.

![image](https://user-images.githubusercontent.com/5671744/189501034-629a139d-c4ce-4826-b4bc-576565497ebe.png)
