### PR TITLE
ci: Use zlib boost version for Windows

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Set up build environment (windows-latest)
         run: |
-          vcpkg install boost-system:x64-windows boost-filesystem:x64-windows boost-program-options:x64-windows boost-icl:x64-windows boost-variant:x64-windows
+          vcpkg install zlib:x64-windows boost-system:x64-windows boost-filesystem:x64-windows boost-program-options:x64-windows boost-icl:x64-windows boost-variant:x64-windows
         if: matrix.os == 'windows-latest'
 
       - name: Set up SDL 2.24.0 (ubuntu-latest)


### PR DESCRIPTION
When psvpfstools does not find a version of zlib already available, it uses its own included binaries. However these are debug binaries which are very slow. Use boost zlib which will link against its release binaries instead.

This should really speed up any operation that involves using zlib on Windows.