### PR TITLE
kernel: Rewrite the way svc and callbacks are handled

### DIFF
--- a/vita3k/cpu/include/cpu/common.h
+++ b/vita3k/cpu/include/cpu/common.h
@@ -33,6 +33,7 @@ struct CPUState;
 struct MemState;
 struct CPUContext;
 struct CPUInterface;
+struct ThreadState;
 
 typedef std::function<void(CPUState &cpu, uint32_t, Address)> CallSVC;
 
@@ -42,7 +43,7 @@ typedef std::unique_ptr<CPUInterface> CPUInterfacePtr;
 typedef void *ExclusiveMonitorPtr;
 
 struct CPUProtocolBase {
-    virtual void call_svc(CPUState &cpu, uint32_t svc, Address pc, SceUID thread_id) = 0;
+    virtual void call_svc(CPUState &cpu, uint32_t svc, Address pc, ThreadState &thread) = 0;
     virtual Address get_watch_memory_addr(Address addr) = 0;
     virtual ExclusiveMonitorPtr get_exlusive_monitor() = 0;
     virtual ~CPUProtocolBase() = default;

--- a/vita3k/cpu/include/cpu/state.h
+++ b/vita3k/cpu/include/cpu/state.h
@@ -33,4 +33,6 @@ struct CPUState {
     Address halt_instruction_pc; // thumb mode pc
 
     CPUInterfacePtr cpu;
+    bool svc_called;
+    uint32_t svc;
 };

--- a/vita3k/cpu/src/dynarmic_cpu.cpp
+++ b/vita3k/cpu/src/dynarmic_cpu.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -265,10 +265,9 @@ public:
     }
 
     void CallSVC(uint32_t svc) override {
-        parent->protocol->call_svc(*parent, svc, cpu->get_pc(), get_thread_id(*parent));
-        if (cpu->exit_request) {
-            cpu->jit->HaltExecution();
-        }
+        parent->svc_called = true;
+        parent->svc = svc;
+        cpu->jit->HaltExecution(Dynarmic::HaltReason::UserDefined8);
     }
 
     void AddTicks(uint64_t ticks) override {}
@@ -311,11 +310,13 @@ int DynarmicCPU::run() {
     halted = false;
     break_ = false;
     exit_request = false;
+    parent->svc_called = false;
     jit->Run();
     return halted;
 }
 
 int DynarmicCPU::step() {
+    parent->svc_called = false;
     jit->Step();
     return 0;
 }

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -717,8 +717,8 @@ ExitCode run_app(EmuEnvState &emuenv, Ptr<const void> &entry_point) {
 
         // TODO: why does fios need separate thread its stack freed anyways?
         const ThreadStatePtr module_thread = emuenv.kernel.create_thread(emuenv.mem, module_name);
-        const auto ret = module_thread->run_guest_function(module_start.address(), { 0, 0 });
-        emuenv.kernel.exit_delete_thread(module_thread);
+        const auto ret = module_thread->run_guest_function(emuenv.kernel, module_start.address());
+        module_thread->exit_delete();
 
         LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(ret));
     }

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -814,6 +814,8 @@ SceUID create_overlay(IOState &io, SceFiosProcessOverlay *fios_overlay) {
         overlay_index++;
 
     io.overlays.insert(io.overlays.begin() + overlay_index, std::move(overlay));
+
+    return overlay.id;
 }
 
 std::string resolve_path(IOState &io, const char *input, const bool is_write, const SceUInt32 min_order, const SceUInt32 max_order) {

--- a/vita3k/kernel/include/kernel/cpu_protocol.h
+++ b/vita3k/kernel/include/kernel/cpu_protocol.h
@@ -26,7 +26,7 @@ typedef std::function<void(CPUState &cpu, uint32_t nid, SceUID thread_id)> CallI
 struct CPUProtocol : public CPUProtocolBase {
     CPUProtocol(KernelState &kernel, MemState &mem, const CallImportFunc &func);
     ~CPUProtocol() override = default;
-    void call_svc(CPUState &cpu, uint32_t svc, Address pc, SceUID thread_id) override;
+    void call_svc(CPUState &cpu, uint32_t svc, Address pc, ThreadState &thread) override;
     Address get_watch_memory_addr(Address addr) override;
     ExclusiveMonitorPtr get_exlusive_monitor() override;
 

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -135,7 +135,6 @@ struct KernelState {
     CallbackPtrs callbacks;
 
     ThreadStatePtrs threads;
-    ThreadStatePtr guest_func_runner;
 
     SceKernelModuleInfoPtrs loaded_modules;
     LoadedSysmodules loaded_sysmodules;
@@ -166,16 +165,12 @@ struct KernelState {
 
     bool init(MemState &mem, CallImportFunc call_import, CPUBackend cpu_backend, bool cpu_opt);
     void load_process_param(MemState &mem, Ptr<uint32_t> ptr);
-    ThreadStatePtr create_thread(MemState &mem, const char *name);
+    ThreadStatePtr create_thread(MemState &mem, const char *name, Ptr<const void> entry_point = Ptr<const void>(0));
     ThreadStatePtr create_thread(MemState &mem, const char *name, Ptr<const void> entry_point, int init_priority, SceInt32 affinity_mask, int stack_size, const SceKernelThreadOptParam *option);
-    void exit_thread(ThreadStatePtr thread);
-    void exit_delete_thread(ThreadStatePtr thread);
 
     ThreadStatePtr get_thread(SceUID thread_id);
     Ptr<Ptr<void>> get_thread_tls_addr(MemState &mem, SceUID thread_id, int key);
     void exit_delete_all_threads();
-
-    int run_guest_function(SceUID thread_id, Address callback_address, const std::vector<uint32_t> &args);
 
     void set_memory_watch(bool enabled);
     void invalidate_jit_cache(Address start, size_t length);

--- a/vita3k/kernel/src/cpu_protocol.cpp
+++ b/vita3k/kernel/src/cpu_protocol.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ CPUProtocol::CPUProtocol(KernelState &kernel, MemState &mem, const CallImportFun
     , mem(&mem) {
 }
 
-void CPUProtocol::call_svc(CPUState &cpu, uint32_t svc, Address pc, SceUID thread_id) {
+void CPUProtocol::call_svc(CPUState &cpu, uint32_t svc, Address pc, ThreadState &thread) {
     // Handle trampoline
     // 1. Handle trampoline jumper
     // to save the space we use interrupt to implement jumper
@@ -50,14 +50,9 @@ void CPUProtocol::call_svc(CPUState &cpu, uint32_t svc, Address pc, SceUID threa
 
     // This is usual service call
     uint32_t nid = *Ptr<uint32_t>(pc + 4).get(*mem);
-    call_import(cpu, nid, thread_id);
-
     // TODO: just supply ThreadStatePtr to call_import
-    // the only benefit of using thread_id instead--namely less locking--is now gone.
-    ThreadStatePtr thread = lock_and_find(thread_id, kernel->threads, kernel->mutex);
-
-    // Add callback jobs requested inside hle implementation
-    thread->flush_callback_requests();
+    // the only benefit of using thread_id instead--namely less locking-- has been gone for long
+    call_import(cpu, nid, thread.id);
 
     // ARM recommends claering exclusive state inside interrupt handler
     clear_exclusive(kernel->exclusive_monitor, get_processor_id(cpu));

--- a/vita3k/modules/SceIme/SceIme.cpp
+++ b/vita3k/modules/SceIme/SceIme.cpp
@@ -27,9 +27,8 @@ EXPORT(void, SceImeEventHandler, Ptr<void> arg, const SceImeEvent *e) {
     Ptr<SceImeEvent> e1 = Ptr<SceImeEvent>(alloc(emuenv.mem, sizeof(SceImeEvent), "ime2"));
     memcpy(e1.get(emuenv.mem), e, sizeof(SceImeEvent));
     auto thread = lock_and_find(thread_id, emuenv.kernel.threads, emuenv.kernel.mutex);
-    thread->request_callback(emuenv.ime.param.handler.address(), { arg.address(), e1.address() }, [&emuenv, e1](int res) {
-        free(emuenv.mem, e1.address());
-    });
+    thread->run_callback(emuenv.ime.param.handler.address(), { arg.address(), e1.address() });
+    free(emuenv.mem, e1.address());
 }
 
 EXPORT(SceInt32, sceImeClose) {

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -909,7 +909,7 @@ EXPORT(int, sceKernelDeleteThread, SceUID thid) {
     if (!thread || thread->status != ThreadStatus::dormant) {
         return SCE_KERNEL_ERROR_NOT_DORMANT;
     }
-    emuenv.kernel.exit_delete_thread(thread);
+    thread->exit_delete();
     return 0;
 }
 
@@ -921,7 +921,7 @@ EXPORT(int, sceKernelDeleteTimer, SceUID timer_handle) {
 
 EXPORT(int, sceKernelExitDeleteThread, int status) {
     const ThreadStatePtr thread = lock_and_find(thread_id, emuenv.kernel.threads, emuenv.kernel.mutex);
-    emuenv.kernel.exit_delete_thread(thread);
+    thread->exit_delete();
 
     return status;
 }

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
@@ -21,7 +21,7 @@
 
 EXPORT(int, sceKernelExitThread, int status) {
     const ThreadStatePtr thread = emuenv.kernel.get_thread(thread_id);
-    emuenv.kernel.exit_thread(thread);
+    thread->exit_delete();
 
     return status;
 }

--- a/vita3k/modules/SceNetCtl/SceNetCtl.cpp
+++ b/vita3k/modules/SceNetCtl/SceNetCtl.cpp
@@ -251,13 +251,13 @@ EXPORT(int, sceNetCtlCheckCallback) {
 
     for (auto &callback : emuenv.netctl.callbacks) {
         if (callback.pc != NULL) {
-            thread->request_callback(callback.pc, { 1, callback.arg });
+            thread->run_callback(callback.pc, { 1, callback.arg });
         }
     }
 
     for (auto &callback : emuenv.netctl.adhocCallbacks) {
         if (callback.pc != NULL) {
-            thread->request_callback(callback.pc, { 1, callback.arg });
+            thread->run_callback(callback.pc, { 1, callback.arg });
         }
     }
 

--- a/vita3k/modules/SceNpCommon/SceNpCommon.cpp
+++ b/vita3k/modules/SceNpCommon/SceNpCommon.cpp
@@ -41,7 +41,7 @@ EXPORT(int, sceNpAuthCreateStartRequest, const SceNpAuthRequestParameter *param)
     const ThreadStatePtr thread = emuenv.kernel.get_thread(thread_id);
     // todo: this callback function should be called from sceNpCheckCallback
     STUBBED("Immediately call ticket callback");
-    thread->request_callback(param->ticketCb.address(), { 1, 1, param->cbArg.address() });
+    thread->run_callback(param->ticketCb.address(), { 1, 1, param->cbArg.address() });
     return 1;
 }
 

--- a/vita3k/modules/SceNpManager/SceNpManager.cpp
+++ b/vita3k/modules/SceNpManager/SceNpManager.cpp
@@ -49,7 +49,7 @@ EXPORT(int, sceNpCheckCallback) {
 
     const ThreadStatePtr thread = lock_and_find(thread_id, emuenv.kernel.threads, emuenv.kernel.mutex);
     for (auto &callback : emuenv.np.cbs) {
-        thread->request_callback(callback.second.pc, { (uint32_t)emuenv.np.state, 0, callback.second.data });
+        thread->run_callback(callback.second.pc, { (uint32_t)emuenv.np.state, 0, callback.second.data });
     }
 
     return STUBBED("Stub");

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -196,7 +196,8 @@ bool load_module(EmuEnvState &emuenv, SceUID thread_id, SceSysmoduleModuleId mod
                 LOG_DEBUG("Running module_start of module: {}", module_name);
 
                 Ptr<void> argp = Ptr<void>();
-                const auto ret = emuenv.kernel.run_guest_function(thread_id, lib_entry_point.address(), { 0, argp.address() });
+                const auto thread = emuenv.kernel.get_thread(thread_id);
+                const auto ret = thread->run_callback(lib_entry_point.address(), { 0, argp.address() });
                 LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(ret));
             }
 

--- a/vita3k/ngs/src/ngs.cpp
+++ b/vita3k/ngs/src/ngs.cpp
@@ -340,7 +340,7 @@ void Voice::invoke_callback(KernelState &kernel, const MemState &mem, const SceU
     info->callback_ptr = Ptr<void>(reason_ptr);
     info->userdata = user_data;
 
-    kernel.run_guest_function(thread_id, callback.address(), { callback_info_addr });
+    thread->run_callback(callback.address(), { callback_info_addr });
     stack_free(*thread->cpu, sizeof(CallbackInfo));
 }
 

--- a/vita3k/ngs/src/scheduler.cpp
+++ b/vita3k/ngs/src/scheduler.cpp
@@ -186,7 +186,7 @@ void VoiceScheduler::update(KernelState &kern, const MemState &mem, const SceUID
         case PendingType::ReleaseRack:
             release_rack(*op.release_data.state, mem, op.system, op.release_data.rack);
             // run callback (we know it is defined)
-            kern.run_guest_function(thread_id, op.release_data.callback, { Ptr<void>(op.release_data.rack, mem).address() });
+            kern.get_thread(thread_id)->run_callback(op.release_data.callback, { Ptr<void>(op.release_data.rack, mem).address() });
             break;
         }
 


### PR DESCRIPTION
Rewrite the SVC calls to stop the CPU. This allows hle functions to call callbacks in the same thread without having to use a guest function or a job queue. This is needed in order to have multiple levels of callbacks (like allocating callbacked gxm memory inside a kernel callback).

This allows Trails in the sky games to go ingame.
![image](https://user-images.githubusercontent.com/5671744/190449731-2cd839e3-842d-4862-812d-abcecedae17b.png)
