### PR TITLE
kernel: Do not delete thread when calling SceKernelExitThread

### DIFF
--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -61,7 +61,7 @@ private:
 
 // Internal
 enum class ThreadToDo {
-    exit,
+    remove,
     run,
     step,
     suspend,

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -175,7 +175,7 @@ bool ThreadState::run_loop() {
     std::unique_lock<std::mutex> lock(mutex);
     while (true) {
         switch (to_do) {
-        case ThreadToDo::exit:
+        case ThreadToDo::remove:
             if (run_level == 1)
                 update_status(ThreadStatus::dormant);
 
@@ -209,7 +209,7 @@ bool ThreadState::run_loop() {
             lock.lock();
 
             // Handle errors
-            if (to_do == ThreadToDo::exit)
+            if (to_do == ThreadToDo::remove)
                 continue;
 
             if (res < 0) {
@@ -313,7 +313,7 @@ uint32_t ThreadState::run_guest_function(KernelState &kernel, Address callback_a
 void ThreadState::stop_loop() {
     std::lock_guard<std::mutex> lock(mutex);
     const ThreadToDo last_to_do = to_do;
-    to_do = ThreadToDo::exit;
+    to_do = ThreadToDo::remove;
     if (last_to_do == ThreadToDo::wait) {
         something_to_do.notify_one();
     } else {

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
@@ -21,9 +21,10 @@
 
 EXPORT(int, sceKernelExitThread, int status) {
     const ThreadStatePtr thread = emuenv.kernel.get_thread(thread_id);
-    thread->exit_delete();
+    thread->exit(status);
 
-    return status;
+    // the thread exits, the return value is not read anyway
+    return 0;
 }
 
 BRIDGE_IMPL(sceKernelExitThread)


### PR DESCRIPTION
Fix a regression in my previous commit which caused SceKernelExitThread to delete the thread. Also rename ThreadToDo::exit into ThreadToDo::remove because that's what it does now (delete would be better but it's a c++ keyword).

This allows Tales of Innocence to go back ingame and should fix other regressions.