### PR TITLE
renderer: Use rgba16 surfaces when rgba8 is requested when needed

### DIFF
--- a/vita3k/features/include/features/state.h
+++ b/vita3k/features/include/features/state.h
@@ -26,6 +26,12 @@ struct FeatureState {
     bool preserve_f16_nan_as_u16 = false; ///< Emit store of 4xU16 to draw buffer 1. This buffer is expected to be U16U16U16U16, which can be casted to F16F16F16F16. This is to preserve some drivers's behaviour of casting NaN to default value when store in framebuffer, not keeping its original value.
     bool support_unknown_format = false;
     bool use_mask_bit = false; ///< Is the mask bit (1 per sample) emulated ? It is only used in homebrews afaik
+    // even though the image being rendered has 8-bit components,
+    // the component width while each sample is stored in the tile renderer
+    // can be wider and used as a buffer using direct fragcolor access
+    // Tearaway does this and the only way to emulate this on an immediate
+    // renderer is to use a texture with a big enough component size
+    bool use_rgba16_for_rgba8 = false;
 
     bool is_programmable_blending_supported() const {
         return support_shader_interlock || support_texture_barrier || direct_fragcolor;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -351,9 +351,7 @@ int main(int argc, char *argv[]) {
     gui.live_area.information_bar = false;
 
     // Pre-Compile Shaders
-    emuenv.renderer->base_path = emuenv.base_path.c_str();
-    emuenv.renderer->title_id = emuenv.io.title_id.c_str();
-    emuenv.renderer->self_name = emuenv.self_name.c_str();
+    emuenv.renderer->game_start(emuenv.base_path.c_str(), emuenv.io.title_id.c_str(), emuenv.self_name.c_str());
     if (renderer::get_shaders_cache_hashs(*emuenv.renderer) && cfg.shader_cache) {
         SDL_SetWindowTitle(emuenv.window.get(), fmt::format("{} | {} ({}) | Please wait, compiling shaders...", window_title, emuenv.current_app_title, emuenv.io.title_id).c_str());
         for (const auto &hash : emuenv.renderer->shaders_cache_hashs) {

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -62,6 +62,8 @@ struct State {
     std::atomic<bool> should_display;
 
     virtual bool init(const char *base_path, const bool hashless_texture_cache) = 0;
+    // called after a game has been chosen and right before it is started
+    virtual void game_start(const char *base_path, const char *title_id, const char *self_name);
     virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem)
         = 0;

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -35,6 +35,34 @@
 
 namespace renderer {
 
+void State::game_start(const char *base_path, const char *title_id, const char *self_name) {
+    this->base_path = base_path;
+    this->title_id = title_id;
+    this->self_name = self_name;
+
+    static const std::string tearaway_games[] = {
+        "PCSC00048",
+        "PCSC00064",
+        "PCSF00214",
+        "PCSF00476",
+        "PCSF00463",
+        "PCSD00072",
+        "PCSD00077",
+        "PCSA00099",
+        "PCSA00141",
+        "PCSA00142",
+        "PCSA00144"
+    };
+
+    const std::string title_string = std::string(title_id);
+    for (const auto &tearaway_game : tearaway_games) {
+        if (title_string.find(tearaway_game) != std::string::npos) {
+            features.use_rgba16_for_rgba8 = true;
+            LOG_INFO("Tearaway game detected, using improved tiled renderer emulation.");
+        }
+    }
+}
+
 static void layout_ssbo_offset_from_uniform_buffer_sizes(UniformBufferSizes &sizes, UniformBufferSizes &offsets, std::size_t &total_hold) {
     std::uint32_t last_offset = 0;
 

--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -51,6 +51,8 @@ void set_context(VKContext &context, const MemState &mem, VKRenderTarget *rt, co
     if (color_surface_fin->data.address() == 0) {
         color_surface_fin = nullptr;
         vk_format = vk::Format::eR8G8B8A8Unorm;
+    } else if (features.use_rgba16_for_rgba8 && vk_format == vk::Format::eR8G8B8A8Unorm) {
+        vk_format = vk::Format::eR16G16B16A16Sfloat;
     }
 
     SceGxmDepthStencilSurface *ds_surface_fin = &context.record.depth_stencil_surface;

--- a/vita3k/renderer/src/vulkan/surface_cache.cpp
+++ b/vita3k/renderer/src/vulkan/surface_cache.cpp
@@ -117,6 +117,9 @@ vkutil::Image *VKSurfaceCache::retrieve_color_surface_texture_handle(uint16_t wi
         }
     }
 
+    if (state.features.use_rgba16_for_rgba8 && vk_format == vk::Format::eR8G8B8A8Unorm)
+        vk_format = vk::Format::eR16G16B16A16Sfloat;
+
     uint32_t bytes_per_stride = pixel_stride * gxm::bits_per_pixel(base_format) / 8;
     uint32_t total_surface_size = bytes_per_stride * original_height;
 
@@ -787,6 +790,10 @@ vk::ImageView VKSurfaceCache::sourcing_color_surface_for_presentation(Ptr<const 
             texture_size.y = info.height;
 
             if (info.swizzle == vkutil::rgba_mapping && info.texture.format == vk::Format::eR8G8B8A8Unorm)
+                return info.texture.view;
+
+            // wrong swizzle not supported in this case, if use_rgba16_for_rgba8 is enabled, the texture will be rgba16
+            if (state.features.use_rgba16_for_rgba8 && info.texture.format == vk::Format::eR16G16B16A16Sfloat)
                 return info.texture.view;
 
             if (!info.sampled_image.view) {


### PR DESCRIPTION
Tearaway uses a feature of tiles renderer, which is that the format on the tiled renderer may be different compared to the format used to store the surface. The only way to emulate it accurately with a desktop GPU (immediate renderer) is to use a wider surface format.

As Tearaway is the only game that uses the renderer this way as far as I'm aware and that this causes an increase in memory usage, a decrease in performances and would break many games. I don't think adding it as a setting is a good idea and doing a check for Tearaway only is better.

This partially fixes the graphics in Tearaway.