### PR TITLE
cmake: Always use find_package for openssl and copy dlls if available

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -266,18 +266,10 @@ set_property(TARGET psvpfsparser PROPERTY FOLDER externals)
 set_property(TARGET libzRIF PROPERTY FOLDER externals)
 set_property(TARGET libb64 PROPERTY FOLDER externals)
 
-# Only include the openssl submodule on windows as in linux we can use the headers from /usr/include/openssl
-if(WIN32)
-	find_package(OpenSSL)
+find_package(OpenSSL QUIET)
 
-	if(OPENSSL_FOUND)
-		message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
-		message("OpenSSL root dir: ${OPENSSL_ROOT_DIR}")
-		message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")
-
-		add_library(ssl INTERFACE)
-		target_link_libraries(ssl INTERFACE OpenSSL::SSL)
-	else()
+if(NOT OPENSSL_FOUND)
+	if(MSVC)
 		message("OpenSSL not found, using prebuilt version")
 
 		if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/openssl.zip")
@@ -292,13 +284,17 @@ if(WIN32)
 				WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/openssl")
 		endif()
 
-		add_library(ssl INTERFACE)
-		target_include_directories(ssl INTERFACE "${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64/include")
-		target_link_libraries(ssl INTERFACE
-			"${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64/lib/libcrypto.lib"
-			"${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64/lib/libssl.lib")
+		set(OPENSSL_ROOT_DIR "${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64")
 	endif()
+
+	find_package(OpenSSL REQUIRED)
 endif()
+
+message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
+message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+
+add_library(ssl INTERFACE)
+target_link_libraries(ssl INTERFACE OpenSSL::SSL)
 
 file(GLOB LIBATRAC9_SOURCES
 	LibAtrac9/C/src/*.c

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -208,8 +208,6 @@ elseif(WIN32)
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/script/update-windows.bat" "$<TARGET_FILE_DIR:vita3k>/update-vita3k.bat"
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "$<TARGET_FILE_DIR:vita3k>/shaders-builtin"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/external/sdl/windows/lib/x64/SDL2.dll" "$<TARGET_FILE_DIR:vita3k>"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64/bin/libssl-3-x64.dll" "$<TARGET_FILE_DIR:vita3k>"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64/bin/libcrypto-3-x64.dll" "$<TARGET_FILE_DIR:vita3k>"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/unicorn.dll" "$<TARGET_FILE_DIR:vita3k>"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/libgcc_s_seh-1.dll" "$<TARGET_FILE_DIR:vita3k>"
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/libwinpthread-1.dll" "$<TARGET_FILE_DIR:vita3k>")
@@ -218,6 +216,13 @@ elseif(WIN32)
 		TARGET vita3k
 		POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dll" "$<TARGET_FILE_DIR:vita3k>")
+	endif()
+	if(EXISTS "${CMAKE_BINARY_DIR}/external/openssl")
+		add_custom_command(
+		TARGET vita3k
+		POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64/bin/libssl-3-x64.dll" "$<TARGET_FILE_DIR:vita3k>"
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64/bin/libcrypto-3-x64.dll" "$<TARGET_FILE_DIR:vita3k>")
 	endif()
 endif()
 


### PR DESCRIPTION
Always use find_package (even in Linux, as it's a bad habit to assume that a header is present without checking it), also copy the dlls for Windows when using prebuilt as it requires both a lib file when linking and a dll while running.