### PR TITLE
http: Also return 0 on connection when disabled

### DIFF
--- a/vita3k/modules/SceHttp/SceHttp.cpp
+++ b/vita3k/modules/SceHttp/SceHttp.cpp
@@ -178,6 +178,12 @@ EXPORT(SceInt, sceHttpCreateConnectionWithURL, SceInt tmplId, const char *url, S
         return RET_ERROR(SCE_HTTP_ERROR_UNKNOWN);
     }
 
+    if (!emuenv.cfg.http_enable) {
+        // Need to push the connection here so the id exists when "sending" the request
+        emuenv.http.connections.emplace(connId, SceConnection{ tmplId, urlStr, enableKeepalive, isSecure, sockfd });
+        return 0;
+    }
+
     const addrinfo hints = {
         AI_PASSIVE, /* For wildcard IP address */
         AF_UNSPEC, /* Allow IPv4 or IPv6 */


### PR DESCRIPTION
If the game servers are down the connect would literally take 2 minutes and end up returning an error, its far better to be able of just toggling this and just return ok when http is disabled, its not like its needed when its disabled