### PR TITLE
renderer, shader: Fix uniform copies, specify a uniform as unbounded and disable empty shaders

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1426,6 +1426,10 @@ struct SceGxmProgram {
     bool is_secondary_program_available() const {
         return secondary_program_offset < secondary_program_offset_end + 4;
     }
+    bool is_empty() const {
+        // if the primary program is empty, it will still only contain a PHAS instruction
+        return !is_secondary_program_available() && primary_program_instr_count <= 1;
+    }
 };
 
 struct SceGxmProgramParameter {

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -522,7 +522,8 @@ vk::Pipeline PipelineCache::retrieve_pipeline(VKContext &context, SceGxmPrimitiv
     const vk::PipelineShaderStageCreateInfo vertex_shader = retrieve_shader(vertex_program_gxm.program.get(mem), vertex_program.hash, true, fragment_program_gxm.is_maskupdate, mem, &vertex_program_gxm.attributes);
     const vk::PipelineShaderStageCreateInfo fragment_shader = retrieve_shader(fragment_program_gxm.program.get(mem), fragment_program.hash, false, fragment_program_gxm.is_maskupdate, mem, nullptr);
     const vk::PipelineShaderStageCreateInfo shader_stages[] = { vertex_shader, fragment_shader };
-    const uint32_t shader_stage_count = (record.front_side_fragment_program_mode == SCE_GXM_FRAGMENT_PROGRAM_DISABLED) ? 1U : 2U;
+    const bool is_fragment_disabled = (record.front_side_fragment_program_mode == SCE_GXM_FRAGMENT_PROGRAM_DISABLED) || fragment_program_gxm.program.get(mem)->is_empty();
+    const uint32_t shader_stage_count = is_fragment_disabled ? 1U : 2U;
 
     const vk::PipelineInputAssemblyStateCreateInfo input_assembly{
         .topology = translate_primitive(type)
@@ -553,7 +554,7 @@ vk::Pipeline PipelineCache::retrieve_pipeline(VKContext &context, SceGxmPrimitiv
     };
 
     vk::PipelineColorBlendStateCreateInfo color_blending{};
-    if (record.front_side_fragment_program_mode == SCE_GXM_FRAGMENT_PROGRAM_DISABLED) {
+    if (is_fragment_disabled) {
         // The write mask must be empty as the lack of a fragment shader results in undefined values
         static const vk::PipelineColorBlendAttachmentState blending = {
             .blendEnable = VK_FALSE,

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -164,6 +164,12 @@ ProgramInput get_program_input(const SceGxmProgram &program) {
                         buffer.reg_start_offset = std::min(buffer.reg_start_offset, static_cast<uint32_t>(offset));
                     }
                 }
+
+                // hack (kind of) : Uncharted declares a uniform containing only a vec4 g_mSkinTransforms[96]
+                // however it accesses  g_mSkinTransforms[147] (for some default value I guess)
+                // so set the size to unbounded in the shader
+                if (var_name == "g_mSkinTransforms")
+                    uniform_buffers[parameter.container_index].size = SCE_GXM_MAX_UB_IN_FLOAT_UNIT;
             }
             break;
         }
@@ -209,7 +215,7 @@ ProgramInput get_program_input(const SceGxmProgram &program) {
         if ((((investigated_ub & (1 << index)) == 0) && seems_symbols_stripped) || (buffer.size == MAXIMUM_GXP_ARRAY_SIZE)) {
             // Symbols stripped shader with uniform buffer not referencing any uniform parameters, or
             // buffer that has the potential of outsizing 1024 (due to limits on the size variable), will
-            // got their buffer turns to MAX_UB_IN_VEC4_UNIT here. Their upload amount will be controlled!
+            // get their buffer turns to MAX_UB_IN_VEC4_UNIT here. Their upload amount will be controlled!
             buffer.size = SCE_GXM_MAX_UB_IN_FLOAT_UNIT;
         }
 


### PR DESCRIPTION
A few commits to partially fix the graphics of Uncharted:

- Uncharted specifies a uniform of size 960 but accesses elements far beyond. This is technically allowed, although no expected. This uniform must be detected (the other option would be to set all uniforms as unbound which would be slower).
- The PS Vita graphics API is able to detect when a fragment shader does not write to output and disable it. Do it for empty fragment shaders for now.
- The generated spirv code to copy unaligned uniform buffers was broken. Fix it and optimize it (it was using four times more loads than what was necessary).