### PR TITLE
renderer: Do not try to decompress swizzled f16f16f16f16

### DIFF
--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -96,6 +96,7 @@ bool can_texture_be_unswizzled_without_decode(SceGxmTextureBaseFormat fmt, bool 
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U1U5U5U5
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8
+        || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_F16F16F16F16
         || (is_vulkan && fmt == SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9);
 }
 
@@ -225,6 +226,8 @@ static size_t decompress_compressed_swizz_texture(SceGxmTextureBaseFormat fmt, v
         const std::uint32_t num_yword = (height + 3) / 4;
 
         return (size_t)num_xword * (size_t)num_yword * 8;
+    } else {
+        LOG_ERROR("Trying to decompress and unswizzle unknown format {}", log_hex(fmt));
     }
 
     return 0;


### PR DESCRIPTION
Do as the title says (uncharted uses a cube map of f16f16f16f16 textures, which are therefore swizzled).
Also add an error if we try to decompress an unknown texture because this is the second time it happens.

This fixes the big graphical issues in uncharted.