### PR TITLE
gxm: Correct definition of empty shader

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1428,7 +1428,9 @@ struct SceGxmProgram {
     }
     bool is_empty() const {
         // if the primary program is empty, it will still only contain a PHAS instruction
-        return !is_secondary_program_available() && primary_program_instr_count <= 1;
+        return !is_secondary_program_available()
+            && primary_program_instr_count <= 1
+            && parameter_count == 0;
     }
 };
 


### PR DESCRIPTION
A fragment shader can have no primary or secondary program but still write to the output by copying directly an attribute or using an independent texture read. Update the definition of an empty shader to take this behavior into account.

This should fix the regressions caused by #2104 .