### PR TITLE
tracy: Use binary search when possible

### DIFF
--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -26,6 +26,7 @@
 #include <CLI11.hpp>
 #include <vector>
 
+#include <algorithm>
 #include <exception>
 #include <iostream>
 
@@ -275,7 +276,14 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
 
 #ifdef TRACY_ENABLE
 bool is_tracy_advanced_profiling_active_for_module(std::vector<std::string> &active_modules, std::string module, int *index) {
+    // If we dont care about the index that means that its getting executed from an export
+    // And because of that we know its sorted so we can use binary search so it
+    // doesn't hurt performance as a standard std::find, also we just care for the result
+    if (!index)
+        return std::binary_search(active_modules.begin(), active_modules.end(), module);
+
     bool result = false;
+
     // Retrieve index for module name in the list of enabled modules
     auto iterator = std::find(active_modules.begin(), active_modules.end(), module);
 

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -997,6 +997,8 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
                         // Activate module by appending the name of the module to the vector
                         emuenv.cfg.tracy_advanced_profiling_modules.push_back(module);
                     }
+                    // Sort the list everytime it changes, this is so that we can use binary search on sce functions
+                    std::sort(emuenv.cfg.tracy_advanced_profiling_modules.begin(), emuenv.cfg.tracy_advanced_profiling_modules.end());
                 }
             }
             ImGui::EndListBox();


### PR DESCRIPTION
as the comments say, if the user has some tracy modules enabled, ALL the modules that just support tracy will get some performance hit because of std::find, but if the list is ordered then we can use binary search so the time it takes to find if a specific module is enabled or not is considerably low, there aren't many tracy modules but in some near future there may be +50 and that may put some overhead, especially on kernel or gxm exports