### PR TITLE
tracy: Fix libc setjmp

### DIFF
--- a/vita3k/modules/SceLibc/SceLibc.cpp
+++ b/vita3k/modules/SceLibc/SceLibc.cpp
@@ -1108,7 +1108,12 @@ EXPORT(int, setbuf) {
 }
 
 EXPORT(int, setjmp) {
+// setjmp can be defined as _setjmp on some systems
+#pragma push_macro("setjmp")
+#undef setjmp
     TRACY_FUNC(setjmp);
+#pragma pop_macro("setjmp")
+
     return UNIMPLEMENTED();
 }
 


### PR DESCRIPTION
Vita3K can't be built anymore if tracy is enabled on windows because setjmp is defined as _setjmp.