### PR TITLE
modules/SceGxm: Remove unnecessary copies to the renderer

### DIFF
--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -74,10 +74,10 @@ void set_viewport_flat(State &state, Context *ctx);
 void set_region_clip(State &state, Context *ctx, SceGxmRegionClipMode mode, unsigned int xMin, unsigned int xMax, unsigned int yMin, unsigned int yMax);
 void set_two_sided_enable(State &state, Context *ctx, SceGxmTwoSidedMode mode);
 void set_side_fragment_program_enable(State &state, Context *ctx, const bool is_front, SceGxmFragmentProgramMode mode);
-std::uint8_t **set_uniform_buffer(State &state, Context *ctx, const bool is_vertex_uniform, const int block_num, const std::uint16_t buffer_size);
+void set_uniform_buffer(State &state, Context *ctx, const bool is_vertex_uniform, const int block_num, const std::uint16_t buffer_size, const Ptr<const void> buffer);
 
 void set_context(State &state, Context *ctx, RenderTarget *target, SceGxmColorSurface *color_surface, SceGxmDepthStencilSurface *depth_stencil_surface);
-std::uint8_t **set_vertex_stream(State &state, Context *ctx, const std::size_t index, const std::size_t data_len);
+void set_vertex_stream(State &state, Context *ctx, const std::size_t index, const std::size_t data_len, const Ptr<const void> stream);
 void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndexFormat index_type, const void *index_data, const std::uint32_t index_count, const std::uint32_t instance_count);
 void transfer_copy(State &state, uint32_t colorKeyValue, uint32_t colorKeyMask, SceGxmTransferColorKeyMode colorKeyMode, const SceGxmTransferImage *images, SceGxmTransferType srcType, SceGxmTransferType destType);
 void transfer_downscale(State &state, const SceGxmTransferImage *src, const SceGxmTransferImage *dest);

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -61,31 +61,30 @@ enum class Backend : uint32_t {
 };
 
 enum class GXMState : std::uint16_t {
-    RegionClip = 0,
-    Program = 1,
-    Viewport = 2,
-    DepthBias = 3,
-    DepthFunc = 4,
-    DepthWriteEnable = 5,
-    PolygonMode = 6,
-    PointLineWidth = 7,
-    StencilFunc = 8,
-    Texture = 9,
-    StencilRef = 10,
-    VertexStream = 11,
-    TwoSided = 12,
-    CullMode = 13,
-    Uniform = 14,
-    UniformBuffer = 15,
-    FragmentProgramEnable = 16,
+    RegionClip,
+    Program,
+    Viewport,
+    DepthBias,
+    DepthFunc,
+    DepthWriteEnable,
+    PolygonMode,
+    PointLineWidth,
+    StencilFunc,
+    Texture,
+    StencilRef,
+    VertexStream,
+    TwoSided,
+    CullMode,
+    UniformBuffer,
+    FragmentProgramEnable,
     TotalState
 };
 
 struct RenderTarget;
 
 struct GXMStreamInfo {
-    std::uint8_t *data = nullptr;
-    std::size_t size = 0;
+    const uint8_t *data = nullptr;
+    size_t size = 0;
 };
 
 // We seperate the following two parts of the stencil state because the first is part of the pipeline creation
@@ -171,9 +170,6 @@ struct Context {
 
     int render_finish_status = 0;
     int notification_finish_status = 0;
-
-    std::vector<UniformSetRequest> vertex_set_requests;
-    std::vector<UniformSetRequest> fragment_set_requests;
 
     Sha256Hash last_draw_fragment_program_hash;
     Sha256Hash last_draw_vertex_program_hash;

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -167,9 +167,6 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
         glBindBufferRange(GL_UNIFORM_BUFFER, 3, context.fragment_info_uniform_buffer.handle(), allocated_buffer.second, sizeof(shader::RenderFragUniformBlock));
     }
 
-    context.vertex_set_requests.clear();
-    context.fragment_set_requests.clear();
-
     // Upload vertex stream
     sync_vertex_streams_and_attributes(context, context.record, mem);
 
@@ -185,9 +182,6 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
 
     std::memcpy(index_gpu_ptr.first, indices, index_buffer_size);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, context.index_stream_ring_buffer.handle());
-
-    std::uint8_t *indices_u8 = reinterpret_cast<std::uint8_t *>(indices);
-    delete[] indices_u8;
 
     if (fragment_program_gxp.is_native_color()) {
         if (features.should_use_shader_interlock() && !config.spirv_shader) {

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -480,8 +480,6 @@ void sync_vertex_streams_and_attributes(GLContext &context, GxmRecordState &stat
                 offset_in_buffer[i] = result.second;
             }
 
-            delete[] state.vertex_streams[i].data;
-
             state.vertex_streams[i].data = nullptr;
             state.vertex_streams[i].size = 0;
         } else {

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -89,9 +89,8 @@ void set_context(State &state, Context *ctx, RenderTarget *target, SceGxmColorSu
     renderer::add_command(ctx, renderer::CommandOpcode::SetContext, nullptr, target, color_surface, depth_stencil_surface);
 }
 
-std::uint8_t **set_vertex_stream(State &state, Context *ctx, const std::size_t index, const std::size_t data_len) {
-    renderer::add_state_set_command(ctx, renderer::GXMState::VertexStream, nullptr, index, data_len);
-    return reinterpret_cast<std::uint8_t **>(ctx->command_list.last->data + 2);
+void set_vertex_stream(State &state, Context *ctx, const std::size_t index, const std::size_t data_len, const Ptr<const void> stream) {
+    renderer::add_state_set_command(ctx, renderer::GXMState::VertexStream, stream, index, data_len);
 }
 
 void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndexFormat index_type, const void *index_data, const std::uint32_t index_count, const std::uint32_t instance_count) {
@@ -130,16 +129,11 @@ void destroy_render_target(State &state, std::unique_ptr<RenderTarget> &rt) {
     renderer::send_single_command(state, nullptr, renderer::CommandOpcode::DestroyRenderTarget, true, &rt);
 }
 
-void set_uniform(State &state, Context *ctx, const bool is_vertex_uniform, const SceGxmProgramParameter *parameter, const void *data) {
-    renderer::add_state_set_command(ctx, renderer::GXMState::Uniform, is_vertex_uniform, parameter, data);
-}
-
-std::uint8_t **set_uniform_buffer(State &state, Context *ctx, const bool is_vertex_uniform, const int block_number, const std::uint16_t block_size) {
+void set_uniform_buffer(State &state, Context *ctx, const bool is_vertex_uniform, const int block_number, const std::uint16_t block_size, const Ptr<const void> buffer) {
     // Calculate the number of bytes
     std::uint32_t bytes_to_copy_and_pad = (((block_size + 15) / 16)) * 16;
 
-    renderer::add_state_set_command(ctx, renderer::GXMState::UniformBuffer, nullptr, is_vertex_uniform, block_number, bytes_to_copy_and_pad);
-    return reinterpret_cast<std::uint8_t **>(ctx->command_list.last->data + 2);
+    renderer::add_state_set_command(ctx, renderer::GXMState::UniformBuffer, buffer, is_vertex_uniform, block_number, bytes_to_copy_and_pad);
 }
 
 } // namespace renderer

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -238,7 +238,6 @@ static void bind_vertex_streams(VKContext &context, MemState &mem) {
             context.vertex_stream_ring_buffer.allocate(context.prerender_cmd, state.vertex_streams[i].size, state.vertex_streams[i].data);
 
             context.vertex_buffer_offsets[i] = context.vertex_stream_ring_buffer.data_offset;
-            delete[] state.vertex_streams[i].data;
 
             state.vertex_streams[i].data = nullptr;
             state.vertex_streams[i].size = 0;
@@ -330,10 +329,6 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
     const size_t index_buffer_size = index_size * count;
 
     context.index_stream_ring_buffer.allocate(context.prerender_cmd, index_buffer_size, indices);
-
-    // we can now destroy the indices
-    std::uint8_t *indices_u8 = reinterpret_cast<std::uint8_t *>(indices);
-    delete[] indices_u8;
 
     context.render_cmd.bindIndexBuffer(context.index_stream_ring_buffer.handle(), context.index_stream_ring_buffer.data_offset, index_type);
 


### PR DESCRIPTION
Remove unnecessary copies done by gxm before sending data (vertices, indices and buffers) to the renderer.

Doing so allowed me to uncover a few inaccuracies that I had to fix to prevent regressions:

- The pending queue size includes the frame currently rendering, so the queue size must be reduced by one.
- The behavior of the default uniform buffer allocation and the vertex/fragment ring buffer was inaccurate.

This should improve the performance of the emulator (#android) (as all the data rendered is now copied once instead of twice, the goal being for it only to be copied when it changes) and is the first step towards properly implementing memory mapping.

This pr needs a bit more testing to make sure there are no regressions.