### PR TITLE
modules/SceGxm: Improve texture handling

### DIFF
--- a/vita3k/gxm/include/gxm/functions.h
+++ b/vita3k/gxm/include/gxm/functions.h
@@ -20,6 +20,7 @@
 #include <gxm/types.h>
 
 #include <array>
+#include <bitset>
 #include <string>
 
 namespace gxm {
@@ -90,6 +91,7 @@ const char *get_container_name(const std::uint16_t idx);
 
 int get_uniform_buffer_base(const SceGxmProgram &program, const SceGxmProgramParameter &parameter);
 
-uint16_t get_texture_count(const SceGxmProgram &program_gxp);
+typedef std::bitset<SCE_GXM_MAX_TEXTURE_UNITS> TextureInfo;
+TextureInfo get_textures_used(const SceGxmProgram &program_gxp);
 
 } // namespace gxp

--- a/vita3k/gxm/src/gxp.cpp
+++ b/vita3k/gxm/src/gxp.cpp
@@ -382,14 +382,16 @@ const char *get_container_name(const std::uint16_t idx) {
     return "INVALID ";
 }
 
-uint16_t get_texture_count(const SceGxmProgram &program_gxp) {
+TextureInfo get_textures_used(const SceGxmProgram &program_gxp) {
+    TextureInfo textures_used;
+
     const auto parameters = gxp::program_parameters(program_gxp);
 
     int max_texture_index = -1;
     for (uint32_t i = 0; i < program_gxp.parameter_count; ++i) {
         const auto parameter = parameters[i];
         if (parameter.category == SCE_GXM_PARAMETER_CATEGORY_SAMPLER) {
-            max_texture_index = std::max(max_texture_index, parameter.resource_index);
+            textures_used[parameter.resource_index] = true;
         }
     }
 
@@ -402,7 +404,7 @@ uint16_t get_texture_count(const SceGxmProgram &program_gxp) {
         const uint32_t tex_coord_index = (descriptor->attribute_info & 0x40F);
         if (tex_coord_index == 0xF)
             continue;
-        max_texture_index = std::max<int>(max_texture_index, descriptor->resource_index);
+        textures_used[descriptor->resource_index] = true;
     }
 
     // also look for an anonymous sampler
@@ -413,10 +415,10 @@ uint16_t get_texture_count(const SceGxmProgram &program_gxp) {
 
         for (uint32_t i = 0; i < program_gxp.dependent_sampler_count; i++) {
             const uint16_t rsc_index = dependent_samplers[i].resource_index_layout_offset / 4;
-            max_texture_index = std::max<int>(max_texture_index, rsc_index);
+            textures_used[rsc_index] = true;
         }
     }
 
-    return static_cast<uint16_t>(max_texture_index + 1);
+    return textures_used;
 }
 } // namespace gxp

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -27,6 +27,7 @@
 #include <shader/usse_program_analyzer.h>
 
 #include <array>
+#include <bitset>
 #include <map>
 #include <string>
 #include <tuple>
@@ -187,6 +188,8 @@ struct Context {
     virtual ~Context() = default;
 };
 
+typedef std::bitset<SCE_GXM_MAX_TEXTURE_UNITS> TextureInfo;
+
 struct ShaderProgram {
     Sha256Hash hash;
     UniformBufferSizes uniform_buffer_sizes; // Size of the buffer in 4-bytes unit
@@ -194,6 +197,7 @@ struct ShaderProgram {
 
     std::size_t max_total_uniform_buffer_storage;
     uint16_t texture_count; // max texture index used by the shader + 1
+    TextureInfo textures_used; // textures_used[i] is true if and only if the i-th texture is used by the shader
 };
 
 struct FragmentProgram : ShaderProgram {

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -161,7 +161,8 @@ bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProg
 
     shader::usse::get_uniform_buffer_sizes(program, fp->uniform_buffer_sizes);
     layout_ssbo_offset_from_uniform_buffer_sizes(fp->uniform_buffer_sizes, fp->uniform_buffer_data_offsets, fp->max_total_uniform_buffer_storage);
-    fp->texture_count = gxp::get_texture_count(program);
+    fp->textures_used = gxp::get_textures_used(program);
+    fp->texture_count = std::bit_width(fp->textures_used.to_ulong());
 
     return true;
 }
@@ -188,7 +189,8 @@ bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgra
     shader::usse::get_uniform_buffer_sizes(program, vp->uniform_buffer_sizes);
     shader::usse::get_attribute_informations(program, vp->attribute_infos);
     layout_ssbo_offset_from_uniform_buffer_sizes(vp->uniform_buffer_sizes, vp->uniform_buffer_data_offsets, vp->max_total_uniform_buffer_storage);
-    vp->texture_count = gxp::get_texture_count(program);
+    vp->textures_used = gxp::get_textures_used(program);
+    vp->texture_count = std::bit_width(vp->textures_used.to_ulong());
 
     if (vp->attribute_infos.empty()) {
         vp->stripped_symbols_checked = false;


### PR DESCRIPTION
Improve the way we handle textures to sync them only right before the draw call. The code should handle better (less texture sync) the transitions between precomputed and normal draws.

Moreover, each texture sync now is inside a scene, so we can remove the inefficient single time submits in the vulkan renderer.