### PR TITLE
shader: Unboxing the graphics

### DIFF
--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -36,7 +36,7 @@ namespace shader {
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
-static constexpr std::uint32_t CURRENT_VERSION = 5;
+static constexpr uint32_t CURRENT_VERSION = 6;
 
 struct RenderVertUniformBlock {
     std::array<float, 4> viewport_flip;

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -92,9 +92,9 @@ bool USSETranslatorVisitor::vmov(
     spv::Op compare_op = spv::OpAny;
 
     if (is_conditional) {
-        inst.opr.src0.type = is_u8_conditional ? DataType::UINT8 : DataType::F32;
         compare_method = static_cast<CompareMethod>((test_bit_2 << 1) | test_bit_1);
         inst.opr.src0 = decode_src0(inst.opr.src0, src0_n, src0_bank_sel, end_or_src0_bank_ext, is_double_regs, reg_bits, m_second_program);
+        inst.opr.src0.type = is_u8_conditional ? DataType::UINT8 : move_data_type;
         inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank_sel, src2_bank_ext, is_double_regs, reg_bits, m_second_program);
         inst.opr.src2.type = move_data_type;
 


### PR DESCRIPTION
Fix the conditional mov instruction when the data type isn't a F32.
This fixes the "boxes" appearing in many games.

Also bump the shader version number as it fixes many games.

![image](https://user-images.githubusercontent.com/5671744/198822687-3a2fc008-ee22-42f0-8500-ef455bc6b14a.png)
