### PR TITLE
shader: Fix UB on ext_vec_predicate_to_ext

### DIFF
--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "util/log.h"
 #include <shader/types_imm.h>
 
 #include <array>
@@ -97,7 +98,7 @@ inline ExtPredicate ext_vec_predicate_to_ext(ExtVecPredicate pred) {
     case ExtVecPredicate::NEGP2:
         // TODO
         assert(false);
-        break;
+        LOG_CRITICAL("ExtVecPredicate::NEGP2 case hit, report this to devs.");
     default:
         return ExtPredicate::NONE;
     }


### PR DESCRIPTION
very IMO, its far better to return NONE instead of just letting it in the hands of undefined behaviour, as reaching function end without returning anything is actually undefined behaviour and ANYTHING can happen, it will still trigger the assert if it happens as theres no break