### PR TITLE
shader: Define exp(NaN) as 1.0

### DIFF
--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1642,8 +1642,13 @@ bool USSETranslatorVisitor::vdual(
             break;
         }
         case Opcode::FEXP: {
+            // hack: set exp(nan) = 1.0 (see VEXP)
             const spv::Id source = load(ops[0], write_mask_source);
             result = m_b.createBuiltinCall(m_b.getTypeId(source), std_builtins, GLSLstd450Exp, { source });
+            const int num_comp = m_b.getNumComponents(source);
+            const spv::Id ones = utils::make_uniform_vector_from_type(m_b, m_b.getTypeId(result), 1.0f);
+            const spv::Id is_nan = m_b.createUnaryOp(spv::OpIsNan, utils::make_vector_or_scalar_type(m_b, m_b.makeBoolType(), num_comp), result);
+            result = m_b.createTriOp(spv::OpSelect, m_b.getTypeId(result), is_nan, ones, result);
             break;
         }
         case Opcode::FLOG: {


### PR DESCRIPTION
Define exp(NaN) as 1.0 for the FEXP operand (this was already the case for VEXP).
Same as Freedom Wars, Soul sacrifice computes exp(0*log(0)) and expects it to be 1 but it is nan.

This fixes the blue textures in Soul Sacrifice.