### PR TITLE
glutil: fix mvsc error

### DIFF
--- a/vita3k/glutil/include/glutil/shader.h
+++ b/vita3k/glutil/include/glutil/shader.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <glutil/object.h>
+#include <string>
 
 namespace gl {
 UniqueGLObject load_shaders(const std::string &vertex_file_path, const std::string &fragment_file_path);


### PR DESCRIPTION
I set up Vita3K to build on MSVC 2022 entirely fresh, and it doesn't build without this include.
It doesn't fix it if I add it in the .cpp file, only the header. Either way, I could be doing something wrong if nobody has encountered this issue before.