### PR TITLE
renderer/vulkan: Improve the accuracy of the depth buffer cache

### DIFF
--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -110,8 +110,6 @@ struct GxmRecordState {
     Sha256Hash fragment_program_hash;
 
     SceGxmColorBaseFormat color_base_format;
-    uint16_t width;
-    uint16_t height;
 
     SceGxmCullMode cull_mode = SCE_GXM_CULL_NONE;
     SceGxmTwoSidedMode two_sided = SCE_GXM_TWO_SIDED_DISABLED;

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1223,6 +1223,14 @@ static spv::Function *make_frag_finalize_function(spv::Builder &b, const SpirvSh
     if (color_val_operand.type == DataType::INT32 || color_val_operand.type == DataType::UINT32)
         color_val_operand.type = DataType::F32;
 
+    // if the output component count is greater than the surface component count,
+    // it means we must pack multiple components (with lower precision) into one of the surface component
+    // this is used in assassin creed 3
+    if (gxm::get_base_format(translate_state.hints->color_format) == SCE_GXM_COLOR_BASE_FORMAT_F32F32 && vertex_varyings_ptr->output_comp_count > 2) {
+        if (color_val_operand.type == DataType::F16)
+            color_val_operand.type = DataType::F32;
+    }
+
     int reg_off = 0;
     if (!program.is_native_color() && vertex_varyings_ptr->output_param_type == 1) {
         reg_off = vertex_varyings_ptr->fragment_output_start;


### PR DESCRIPTION
Improve the accuracy of the depth buffer cache when sampling from only a part of the depth buffer.

The other commit also handles the case when a shader declares 4 16bit outputs on a surface with only 2 components, it should be seen as 2 32bit outputs.

This partially fixes the graphics of Assassin Creed 3.