### PR TITLE
renderer/vulkan: Fix regression when upscaling

### DIFF
--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -54,8 +54,8 @@ void set_context(VKContext &context, const MemState &mem, VKRenderTarget *rt, co
     uint32_t framebuffer_width = rt->width;
     uint32_t framebuffer_height = rt->height;
     if (color_surface_fin != nullptr) {
-        framebuffer_width = std::min<uint32_t>(framebuffer_width, color_surface_fin->width);
-        framebuffer_height = std::min<uint32_t>(framebuffer_height, color_surface_fin->height);
+        framebuffer_width = std::min<uint32_t>(framebuffer_width, color_surface_fin->width * context.state.res_multiplier);
+        framebuffer_height = std::min<uint32_t>(framebuffer_height, color_surface_fin->height * context.state.res_multiplier);
     }
 
     SceGxmDepthStencilSurface *ds_surface_fin = &context.record.depth_stencil_surface;
@@ -147,8 +147,8 @@ void VKContext::start_render_pass() {
     if (!is_recording)
         start_recording();
 
-    const uint32_t framebuffer_width = std::min<uint32_t>(render_target->width, record.color_surface.width);
-    const uint32_t framebuffer_height = std::min<uint32_t>(render_target->height, record.color_surface.height);
+    const uint32_t framebuffer_width = std::min<uint32_t>(render_target->width, record.color_surface.width * state.res_multiplier);
+    const uint32_t framebuffer_height = std::min<uint32_t>(render_target->height, record.color_surface.height * state.res_multiplier);
 
     vk::RenderPassBeginInfo pass_info{
         .renderPass = current_render_pass,

--- a/vita3k/renderer/src/vulkan/surface_cache.cpp
+++ b/vita3k/renderer/src/vulkan/surface_cache.cpp
@@ -491,6 +491,12 @@ vkutil::Image *VKSurfaceCache::retrieve_depth_stencil_texture_handle(const MemSt
     int32_t height, const bool is_reading) {
     bool packed_ds = (surface.control.content & SceGxmDepthStencilControl::format_bits) == SCE_GXM_DEPTH_STENCIL_FORMAT_S8D24;
 
+    if (is_reading) {
+        // when writing we use the render target size which is already upscaled
+        width *= state.res_multiplier;
+        height *= state.res_multiplier;
+    }
+
     size_t found_index = -1;
 
     // The whole depth stencil struct is reserved for future use


### PR DESCRIPTION
Fix a regression caused by #2193 which broke the vulkan renderer when upscaling was used.