### PR TITLE
gui/trophy_collection: Fix the Delete All position

### DIFF
--- a/lang/fi.xml
+++ b/lang/fi.xml
@@ -301,7 +301,7 @@ Vita3K-järjestelmäsi on nyt käyttövalmis!</completed_setup>
 		<no_trophies>Ei trophyjä.
 Voit ansaita trophyjä käyttämällä trophy-ominaisuutta tukevaa sovellusta.</no_trophies>
 		<not_earned>Ei ansaittu</not_earned>
-		<original>Original</original>
+		<original>Alkuperäinen</original>
 		<sort>Lajittele</sort>
 		<trophies>Trophyt</trophies>
 		<grade>Luokka</grade>

--- a/lang/no.xml
+++ b/lang/no.xml
@@ -299,7 +299,7 @@ Vita3K-systemet ditt er klart!</completed_setup>
 		<no_trophies>Det finnes ingen trophies.
 Du kan Oppnå trophies ved å bruke et program som Støtter trophy-funksjonen.</no_trophies>
 		<not_earned>Ikke oppnådd</not_earned>
-		<original>Oppdatert</original>
+		<original>Original</original>
 		<sort>Sorter</sort>
 		<trophies>Trophies</trophies>
 		<grade>Karakter</grade>

--- a/lang/pl.xml
+++ b/lang/pl.xml
@@ -299,7 +299,7 @@ System Vita3K jest gotowy!</completed_setup>
 		<no_trophies>Brak trofeów.
 Trofea można zdobywać, korzystając z aplikacji obsługującej funkcję trofeów.</no_trophies>
 		<not_earned>Nie zdobyto</not_earned>
-		<original>Oryginał</original>
+		<original>Oryginalne</original>
 		<sort>Sortuj</sort>
 		<trophies>Trofea</trophies>
 		<grade>stopień</grade>

--- a/lang/sv.xml
+++ b/lang/sv.xml
@@ -301,7 +301,7 @@ Ditt Vita3K-system är redo!</completed_setup>
 		<no_trophies>Det finns inga trophies.
 Du kan få trophies om du använder en applikation som stder trophy-funktionen.</no_trophies>
 		<not_earned>Ej vunnen</not_earned>
-		<original>Urspruglig</original>
+		<original>Ursprunglig</original>
 		<sort>Sortera</sort>
 		<trophies>Trophies</trophies>
 		<grade>Grad</grade>

--- a/lang/zh-s.xml
+++ b/lang/zh-s.xml
@@ -448,7 +448,7 @@ Please download and install it.</no_font_exist>
 	<trophy_collection>
 		<search>搜索</search>
 		<delete_trophy>删除奖杯</delete_trophy>
-		<trophy_deleted>此用户保存的奖杯信息将被删除。</trophy_deleted>
+		<trophy_deleted>该用户已保存的奖杯信息将被删除。</trophy_deleted>
 		<details>详细信息</details>
 		<earned>获得日期</earned>
 		<name>名称</name>

--- a/lang/zh-t.xml
+++ b/lang/zh-t.xml
@@ -448,7 +448,7 @@
 	<trophy_collection>
 		<search>搜索</search>
 		<delete_trophy>刪除獎盃</delete_trophy>
-		<trophy_deleted>此用戶保存的獎杯資訊將被刪除。</trophy_deleted>
+		<trophy_deleted>刪除該使用者已保存的獎杯資訊。</trophy_deleted>
 		<details>詳細內容</details>
 		<earned>獲得日</earned>
 		<name>名稱</name>

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -790,6 +790,11 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     });
                     np_com_id_sort = "progress";
                 }
+                ImGui::Spacing();
+                ImGui::Separator();
+                ImGui::Spacing();
+                if (ImGui::MenuItem(gui.lang.indicator["delete_all"].c_str()))
+                    fs::remove_all(TROPHY_PATH);
             } else {
                 if (ImGui::MenuItem(lang["original"].c_str(), nullptr, trophy_sort == "original")) {
                     std::sort(trophy_list.begin(), trophy_list.end(), [](const auto &ta, const auto &tb) {
@@ -816,12 +821,6 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     trophy_sort = "name";
                 }
             }
-            ImGui::Spacing();
-            ImGui::Separator();
-            ImGui::Spacing();
-
-            if (ImGui::MenuItem(gui.lang.indicator["delete_all"].c_str()))
-                fs::remove_all(TROPHY_PATH);
             ImGui::EndPopup();
         }
     }


### PR DESCRIPTION
Fixed https://github.com/Vita3K/Vita3K/pull/2194 issue, the "Delete All" should be in the correct position, also fixed typo of the xml.
plz Mr. @Zangetsu38 check it.

- psvita
![2022-11-20-195345](https://user-images.githubusercontent.com/61804715/202915528-dd9abdf0-f1a9-45a2-82f6-aa8ec64e6b70.jpg)

- before
![image](https://user-images.githubusercontent.com/61804715/202915663-19a49294-b32f-4aa5-99b3-e8f8de4de0f2.png)

- after
![image](https://user-images.githubusercontent.com/61804715/202915607-f0c9dc76-4e89-4bbb-8982-9517076606fc.png)
