### PR TITLE
Theoretical improvements

### DIFF
--- a/vita3k/WindowsDpiAwareness.manifest
+++ b/vita3k/WindowsDpiAwareness.manifest
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <!-- 
 Vita3K emulator project
 Copyright (C) 2021 Vita3K team
@@ -16,8 +17,6 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -->
-
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:application>
     <asmv3:windowsSettings>

--- a/vita3k/audio/src/audio.cpp
+++ b/vita3k/audio/src/audio.cpp
@@ -34,9 +34,6 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
     const int bytes_available = SDL_AudioStreamAvailable(port.shared.stream.get());
     assert(bytes_available >= 0);
 
-    if (bytes_available == 0)
-        return;
-
     // Running out of data?
     // The (len * 3) is according to the value in sceAudioOutOutput
     if (bytes_available < (len * 3)) {
@@ -47,6 +44,9 @@ static void mix_out_port(uint8_t *stream, uint8_t *temp_buffer, int len, AudioOu
             port.shared.thread = -1;
         }
     }
+
+    if (bytes_available == 0)
+        return;
 
     // Mix as much as we need.
     const int bytes_to_get = std::min(len, bytes_available);

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -603,8 +603,12 @@ int remove_file(IOState &io, const char *file, const std::wstring &pref_path, co
 
     LOG_TRACE_IF(log_file_op, "{}: Removing file {} ({})", export_name, file, device::construct_normalized_path(device, translated_path));
 
-    if (!fs::remove(emulated_path)) {
+    boost::system::error_code error_code{};
+    auto res = fs::detail::remove(emulated_path, &error_code);
+
+    if (!(res && !(error_code.value()))) {
         LOG_ERROR("Cannot remove file: {} ({})", file, device::construct_normalized_path(device, translated_path));
+        LOG_ERROR("Error code: {} ({})", error_code.value(), error_code.message());
         return IO_ERROR(SCE_ERROR_ERRNO_ENOENT);
     }
 

--- a/vita3k/modules/SceHttp/SceHttp.cpp
+++ b/vita3k/modules/SceHttp/SceHttp.cpp
@@ -1479,11 +1479,8 @@ EXPORT(SceInt, sceHttpUriParse, SceHttpUriElement *out, const char *srcUrl, Ptr<
     if (!srcUrl)
         return RET_ERROR(SCE_HTTP_ERROR_INVALID_URL);
 
-    if (pool && out) {
-        memset(out, 0, sizeof(*out));
-    } else {
-        if (!require)
-            return SCE_HTTP_ERROR_INVALID_VALUE;
+    if ((!pool || !out) && !require) {
+        return SCE_HTTP_ERROR_INVALID_VALUE;
     }
 
     net_utils::parsedUrl parsed;
@@ -1516,6 +1513,7 @@ EXPORT(SceInt, sceHttpUriParse, SceHttpUriElement *out, const char *srcUrl, Ptr<
         return RET_ERROR(SCE_HTTP_ERROR_OUT_OF_MEMORY);
 
     if (pool && out) {
+        memset(out, 0, sizeof(*out));
         auto pool_ptr = pool.address();
         const auto set_str_value = [&](Ptr<char> &field, const std::string value) {
             field = Ptr<char>(pool_ptr);

--- a/vita3k/modules/SceTouch/SceTouch.cpp
+++ b/vita3k/modules/SceTouch/SceTouch.cpp
@@ -119,14 +119,42 @@ EXPORT(int, sceTouchGetPanelInfo, SceUInt32 port, SceTouchPanelInfo *pPanelInfo)
     }
 }
 
-EXPORT(int, sceTouchGetPixelDensity) {
-    TRACY_FUNC(sceTouchGetPixelDensity);
-    return UNIMPLEMENTED();
+EXPORT(int, sceTouchGetPixelDensity, float *p1, float *p2) {
+    TRACY_FUNC(sceTouchGetPixelDensity, p1, p2);
+    if (!p1 || !p2)
+        return SCE_TOUCH_ERROR_INVALID_ARG;
+    STUBBED("Return constant values (22.0)");
+    /* In disasmed source this function can return one of two set of values depends of hardware info.
+     * I dont know how to get this info, so I just return one of them.
+     */
+    *p1 = 22.0;
+    *p2 = 22.0;
+    /*
+     *p1 = 17.54;
+     *p2 = 17.54;
+     */
+    return 0;
 }
 
-EXPORT(int, sceTouchGetPixelDensity2) {
-    TRACY_FUNC(sceTouchGetPixelDensity2);
-    return UNIMPLEMENTED();
+EXPORT(int, sceTouchGetPixelDensity2, float *p1, float *p2, float *p3, float *p4) {
+    TRACY_FUNC(sceTouchGetPixelDensity2, p1, p2, p3, p4);
+    if (!p1 || !p2 || !p3 || !p4)
+        return SCE_TOUCH_ERROR_INVALID_ARG;
+    STUBBED("Return constant values (22.0)");
+    /* In disasmed source this function can return one of two set of values depends of hardware info.
+     * I dont know how to get this info, so I just return one of them.
+     */
+    *p1 = 22.0;
+    *p2 = 22.0;
+    *p3 = 22.0;
+    *p4 = 22.0;
+    /*
+     *p1 = 17.54;
+     *p2 = 17.54;
+     *p3 = 17.54;
+     *p4 = 17.54; or 24.23;
+     */
+    return 0;
 }
 
 EXPORT(int, sceTouchGetProcessInfo) {


### PR DESCRIPTION
Here I collect all improvements which do not fix any game. It make emulation more accurate, implement unimplemented and so on.
* audio/audio: fix theoretically possible sound freeze
* io/io: workaround of exception on file delete
* kernel/sync_primitives: set timeout if needed and minor event improvement
* vita3k/manifest: fix xml to build with msvc-clang
* modules/SceFiber: functions return errors instead of crash
* modules/SceTouch: Stubbed implementation of sceTouchGetPixelDensity
* modules/SceHttp: improved hard to understand check in sceHttpUriParse


