### PR TITLE
shader: Fix vtstmsk and or/xor, resize viewport/scissor when the image is downscaled

### DIFF
--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -215,6 +215,7 @@ struct ShadersHash {
 
 struct RenderTarget {
     int holder;
+    uint16_t multisample_mode;
     virtual ~RenderTarget() = default;
 };
 

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -115,6 +115,8 @@ COMMAND(handle_create_render_target) {
         REPORT_MISSING(renderer.current_backend);
         break;
     }
+    (*render_target)->multisample_mode = params->multisampleMode;
+
     complete_command(renderer, helper, result);
 }
 

--- a/vita3k/shader/src/translator/ialu.cpp
+++ b/vita3k/shader/src/translator/ialu.cpp
@@ -121,8 +121,6 @@ bool USSETranslatorVisitor::vbw(
     auto const_val = is_const ? m_b.getConstantScalar(src2) : 1; // default value is intentionally non zero
     if ((operation == spv::Op::OpBitwiseOr || operation == spv::Op::OpBitwiseXor) && is_const && const_val == 0
         || operation == spv::Op::OpBitwiseAnd && is_const && const_val == std::numeric_limits<decltype(const_val)>::max()) {
-        inst.opr.src1.type = bitwise_partial ? DataType::F16 : DataType::F32;
-        inst.opr.dest.type = bitwise_partial ? DataType::F16 : DataType::F32;
         result = load(inst.opr.src1, 0b0001, src1_repeat_offset);
         if (result == spv::NoResult) {
             LOG_ERROR("Source not loaded");


### PR DESCRIPTION
Fix some issues with vtstmsk (the test type does not determine the dest type) and or/xor with a 0 which stored the result as a float instead of an integer.
Also, when a game downscales a surface without using msaa (why would you do that??), the viewport and scissor must have their dimensions divided by 2 as we are directly rendering to the downscaled surface.

This fixes most of the graphical issues of ys memories of Celceta.

![image](https://user-images.githubusercontent.com/5671744/203854973-6ca177b7-758a-4958-96ce-eeb33a318ab6.png)
