### PR TITLE
gui/live_area: Add lang strings to the help dialog

### DIFF
--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -380,6 +380,31 @@ Please download and install it.</no_font_exist>
 	<live_area>
 		<start>Start</start>
 		<continue>Continue</continue>
+		<help>
+			<control_setting>Using configuration set for keyboard in control setting</control_setting>
+			<fw_not_detected>Firmware not detected. Installation is highly recommended</fw_not_detected>
+			<fw_font_not_detected>Firmware font not detected. Installing it is recommended for font text in Live Area</fw_font_not_detected>
+			<live_area_help>Live Area Help</live_area_help>
+			<browse_app>Browse in app list</browse_app>
+			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
+			<start_app>Start App</start_app>
+			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<show_hide>Show/Hide Live Area during app run</show_hide>
+			<show_hide_control>Press on PS</show_hide_control>
+			<exit_livearea>Exit Live Area</exit_livearea>
+			<exit_livearea_control>Click on Esc or Press on Circle</exit_livearea_control>
+			<manual_help>Manual Help</manual_help>
+			<browse_page>Browse page</browse_page>
+			<browse_page_control>D-pad, Left Stick in Left/Right or Wheel in Up/Down or Click on</browse_page_control>
+			<hide_show>Hide/Show button</hide_show>
+			<hide_show_control>Right Click</hide_show_control>
+			<zoom_available>Zoom if available</zoom_available>
+			<zoom_available_control>Double Left Click</zoom_available_control>
+			<scroll_zoom>Scroll in zoom</scroll_zoom>
+			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
+			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
+		</help>
 	</live_area>
 
 	<settings name="Settings">

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -380,6 +380,31 @@ Please download and install it.</no_font_exist>
 	<live_area>
 		<start>Start</start>
 		<continue>Continue</continue>
+		<help>
+			<control_setting>Using configuration set for keyboard in control setting</control_setting>
+			<fw_not_detected>Firmware not detected. Installation is highly recommended</fw_not_detected>
+			<fw_font_not_detected>Firmware font not detected. Installing it is recommended for font text in Live Area</fw_font_not_detected>
+			<live_area_help>Live Area Help</live_area_help>
+			<browse_app>Browse in app list</browse_app>
+			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
+			<start_app>Start App</start_app>
+			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<show_hide>Show/Hide Live Area during app run</show_hide>
+			<show_hide_control>Press on PS</show_hide_control>
+			<exit_livearea>Exit Live Area</exit_livearea>
+			<exit_livearea_control>Click on Esc or Press on Circle</exit_livearea_control>
+			<manual_help>Manual Help</manual_help>
+			<browse_page>Browse page</browse_page>
+			<browse_page_control>D-pad, Left Stick in Left/Right or Wheel in Up/Down or Click on</browse_page_control>
+			<hide_show>Hide/Show button</hide_show>
+			<hide_show_control>Right Click</hide_show_control>
+			<zoom_available>Zoom if available</zoom_available>
+			<zoom_available_control>Double Left Click</zoom_available_control>
+			<scroll_zoom>Scroll in zoom</scroll_zoom>
+			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
+			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
+		</help>
 	</live_area>
 
 	<settings name="Settings">

--- a/lang/zh-s.xml
+++ b/lang/zh-s.xml
@@ -380,6 +380,31 @@ Please download and install it.</no_font_exist>
 	<live_area>
 		<start>开始</start>
 		<continue>继续</continue>
+		<help>
+			<control_setting>在控制设置中使用键盘配置</control_setting>
+			<fw_not_detected>Firmware not detected. Installation is highly recommended</fw_not_detected>
+			<fw_font_not_detected>Firmware font not detected. Installing it is recommended for font text in Live Area</fw_font_not_detected>
+			<live_area_help>Live Area帮助</live_area_help>
+			<browse_app>浏览应用程序列表</browse_app>
+			<browse_app_control>方向键、左摇杆、滚轮上/下或使用滑块</browse_app_control>
+			<start_app>开启应用</start_app>
+			<start_app_control>滚轮上/下或使用滑块</start_app_control>
+			<show_hide>应用程序运行时显示/隐藏</show_hide>
+			<show_hide_control>按PS键</show_hide_control>
+			<exit_livearea>退出Live Area</exit_livearea>
+			<exit_livearea_control>点击Esc或按O键</exit_livearea_control>
+			<manual_help>说明书帮助</manual_help>
+			<browse_page>浏览页面</browse_page>
+			<browse_page_control>方向键、左摇杆左/右或滚轮上/下或点击</browse_page_control>
+			<hide_show>隐藏/显示按钮</hide_show>
+			<hide_show_control>点击右键</hide_show_control>
+			<zoom_available>缩放如果可用</zoom_available>
+			<zoom_available_control>双击左键</zoom_available_control>
+			<scroll_zoom>缩放滚动</scroll_zoom>
+			<scroll_zoom_control>滚轮上/下</scroll_zoom_control>
+			<exit_manual>退出手册帮助</exit_manual>
+			<exit_manual_control>点击Esc或按PS键</exit_manual_control>
+		</help>
 	</live_area>
 
 	<settings name="设定">

--- a/lang/zh-t.xml
+++ b/lang/zh-t.xml
@@ -380,6 +380,31 @@
 	<live_area>
 		<start>啟動</start>
 		<continue>繼續</continue>
+		<help>
+			<control_setting>在控制設置中使用鍵盤配置</control_setting>
+			<fw_not_detected>Firmware not detected. Installation is highly recommended</fw_not_detected>
+			<fw_font_not_detected>Firmware font not detected. Installing it is recommended for font text in Live Area</fw_font_not_detected>
+			<live_area_help>Live Area幫助</live_area_help>
+			<browse_app>瀏覽應用程式列表</browse_app>
+			<browse_app_control>方向鍵、左操作桿、滾輪上/下或使用滑塊</browse_app_control>
+			<start_app>開啓應用</start_app>
+			<start_app_control>滾輪上/下或使用滑塊</start_app_control>
+			<show_hide>應用程式運行時顯示/隱藏</show_hide>
+			<show_hide_control>按PS按鈕</show_hide_control>
+			<exit_livearea>退出Live Area</exit_livearea>
+			<exit_livearea_control>點擊Esc或按圓形按鈕</exit_livearea_control>
+			<manual_help>説明書幫助</manual_help>
+			<browse_page>瀏覽頁面</browse_page>
+			<browse_page_control>方向鍵、左操作桿左/右或滾輪上/下或點擊</browse_page_control>
+			<hide_show>隱藏/顯示按鈕</hide_show>
+			<hide_show_control>點擊右鍵</hide_show_control>
+			<zoom_available>縮放如果可用</zoom_available>
+			<zoom_available_control>雙擊左鍵</zoom_available_control>
+			<scroll_zoom>縮放滾動</scroll_zoom>
+			<scroll_zoom_control>滾輪上/下</scroll_zoom_control>
+			<exit_manual>退出手冊幫助</exit_manual>
+			<exit_manual_control>點擊Esc或按PS按鈕</exit_manual_control>
+		</help>
 	</live_area>
 
 	<settings name="設定">

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -937,7 +937,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
     const auto default_font_scale = (25.f * emuenv.dpi_scale) * (ImGui::GetFontSize() / (19.2f * emuenv.dpi_scale));
     const auto font_size_scale = default_font_scale / ImGui::GetFontSize();
 
-    const std::string BUTTON_STR = app_path == emuenv.io.app_path ? gui.lang.live_area[CONTINUE] : gui.lang.live_area[START];
+    const std::string BUTTON_STR = app_path == emuenv.io.app_path ? gui.lang.live_area.main["coutinue"] : gui.lang.live_area.main["start"];
     const auto GATE_SIZE = ImVec2(280.0f * SCALE.x, 158.0f * SCALE.y);
     const auto GATE_POS = ImVec2(display_size.x - (items_pos[type[app_path]]["gate"]["pos"].x * SCALE.x), display_size.y - (items_pos[type[app_path]]["gate"]["pos"].y * SCALE.y));
     const auto START_SIZE = ImVec2((ImGui::CalcTextSize(BUTTON_STR.c_str()).x * font_size_scale), (ImGui::CalcTextSize(BUTTON_STR.c_str()).y * font_size_scale));
@@ -1028,6 +1028,8 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
             update_app(gui, emuenv, app_path);
     }
 
+    auto lang = gui.lang.live_area.help;
+
     if (!gui.live_area.content_manager && !gui.live_area.manual) {
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f * SCALE.x);
         ImGui::SetCursorPos(ImVec2(display_size.x - (60.0f * SCALE.x) - BUTTON_SIZE.x, 44.0f * SCALE.y));
@@ -1052,40 +1054,44 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::OpenPopup("Live Area Help");
         ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
         if (ImGui::BeginPopupModal("Live Area Help", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
-            ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize("Help").x / 2.f));
-            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "Help");
+            auto help_str = gui.lang.main_menubar.help["title"].c_str();
+            ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize(help_str).x / 2.f));
+            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", help_str);
             ImGui::Spacing();
-            ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize("Using configuration set for keyboard in control setting").x / 2.f));
-            ImGui::TextColored(GUI_COLOR_TEXT, "Using configuration set for keyboard in control setting");
+            auto control_setting_str = lang["control_setting"].c_str();
+            ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize(control_setting_str).x / 2.f));
+            ImGui::TextColored(GUI_COLOR_TEXT, "%s", control_setting_str);
             if (gui.modules.empty()) {
                 ImGui::Spacing();
-                ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize("Firmware not detected. Installation is highly recommended").x / 2.f));
-                ImGui::TextColored(GUI_COLOR_TEXT, "Firmware not detected. Installation is highly recommended");
+                auto fw_str = lang["fw_not_detected"].c_str();
+                ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize(fw_str).x / 2.f));
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", fw_str);
             }
             if (!gui.fw_font) {
                 ImGui::Spacing();
-                ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize("Firmware Font Package not detected. Installing it is recommended for font text in Live Area").x / 2.f));
-                ImGui::TextColored(GUI_COLOR_TEXT, "Firmware Font Package not detected. Installing it is recommended for font text in Live Area");
+                auto fw_font_str = lang["fw_font_not_detected"].c_str();
+                ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize(fw_font_str).x / 2.f));
+                ImGui::TextColored(GUI_COLOR_TEXT, "%s", fw_font_str);
             }
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();
-            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "Live Area Help");
+            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["live_area_help"].c_str());
             ImGui::Spacing();
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Browse in app list", "D-pad, Left Stick, Wheel in Up/Down or using Slider");
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Start App", "Click on Start or Press on Cross");
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Show/Hide Live Area during app run", "Press on PS");
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Exit Live Area", "Click on Esc or Press on Circle");
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", lang["browse_app"].c_str(), lang["browse_app_control"].c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", lang["start_app"].c_str(), lang["start_app_control"].c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", lang["show_hide"].c_str(), lang["show_hide_control"].c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", lang["exit_livearea"].c_str(), lang["exit_livearea_control"].c_str());
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();
-            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "Manual Help");
+            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["manual_help"].c_str());
             ImGui::Spacing();
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Browse page", "D-pad, Left Stick in Left/Right or Wheel in Up/Down or Click on </>");
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Hide/Show button", "Right Click");
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Zoom if available", "Double left click");
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Scroll in zoom", "Wheel Up/Down");
-            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", "Exit Manual", "Click on X or Press on PS");
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s </>", lang["browse_page"].c_str(), lang["browse_page_control"].c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", lang["hide_show"].c_str(), lang["hide_show_control"].c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", lang["zoom_available"].c_str(), lang["zoom_available_control"].c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", lang["scroll_zoom"].c_str(), lang["scroll_zoom_control"].c_str());
+            ImGui::TextColored(GUI_COLOR_TEXT, "%-16s    %-16s", lang["exit_manual"].c_str(), lang["exit_manual_control"].c_str());
             ImGui::Spacing();
             ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (BUTTON_SIZE.x / 2.f));
             if (ImGui::Button("OK", BUTTON_SIZE))

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -23,11 +23,6 @@
 #include <string>
 #include <vector>
 
-enum LiveArea {
-    START,
-    CONTINUE,
-};
-
 enum TypeLang {
     GUI,
     LIVE_AREA,
@@ -306,6 +301,38 @@ struct LangState {
         { "title_id", "Title ID:" },
         { "delete_bin_rif", "Delete the work.bin/rif file?" }
     };
+    struct LiveArea {
+        std::map<std::string, std::string> main = {
+            { "start", "Start" },
+            { "continue", "Continue" }
+        };
+        std::map<std::string, std::string> help = {
+            { "control_setting", "Using configuration set for keyboard in control setting" },
+            { "fw_not_detected", "Firmware not detected. Installation is highly recommended" },
+            { "fw_font_not_detected", "Firmware font not detected. Installing it is recommended for font text in Live Area" },
+            { "live_area_help", "Live Area Help" },
+            { "browse_app", "Browse in app list" },
+            { "browse_app_control", "D-pad, Left Stick, Wheel in Up/Down or using Slider" },
+            { "start_app", "Start App" },
+            { "start_app_control", "Wheel in Up/Down or using Slider" },
+            { "show_hide", "Show/Hide Live Area during app run" },
+            { "show_hide_control", "Press on PS" },
+            { "exit_livearea", "Exit Live Area" },
+            { "exit_livearea_control", "Click on Esc or Press on Circle" },
+            { "manual_help", "Manual Help" },
+            { "browse_page", "Browse page" },
+            { "browse_page_control", "D-pad, Left Stick in Left/Right or Wheel in Up/Down or Click on" },
+            { "hide_show", "Hide/Show button" },
+            { "hide_show_control", "Right Click" },
+            { "zoom_available", "Zoom if available" },
+            { "zoom_available_control", "Double Left Click" },
+            { "scroll_zoom", "Scroll in zoom" },
+            { "scroll_zoom_control", "Wheel Up/Down" },
+            { "exit_manual", "Exit Manual Help" },
+            { "exit_manual_control", "Click on Esc or Press on PS" }
+        };
+    };
+    LiveArea live_area;
     struct Settings {
         std::map<std::string, std::string> main = { { "title", "Settings" } };
         struct ThemeBackground {
@@ -479,9 +506,5 @@ struct LangState {
         };
     };
     Common common;
-    std::map<LiveArea, std::string> live_area = {
-        { START, "Start" },
-        { CONTINUE, "Continue" }
-    };
     std::map<TypeLang, std::string> user_lang;
 };

--- a/vita3k/lang/src/lang.cpp
+++ b/vita3k/lang/src/lang.cpp
@@ -210,8 +210,11 @@ void init_lang(LangState &lang, EmuEnvState &emuenv) {
                 // Live Area
                 const auto live_area = lang_child.child("live_area");
                 if (!live_area.empty()) {
-                    lang.live_area[START] = live_area.child("start").text().as_string();
-                    lang.live_area[CONTINUE] = live_area.child("continue").text().as_string();
+                    // Main
+                    set_lang_string(lang.live_area.main, live_area);
+
+                    // Help
+                    set_lang_string(lang.live_area.help, live_area.child("help"));
                 }
 
                 // Settings


### PR DESCRIPTION
add some lang strings to the livearea/help dialog, add lang can help some users to know about these controls. plz Mr. @Zangetsu38 check this PR. 

- not install fw
![image](https://user-images.githubusercontent.com/61804715/206856222-19beec95-571d-46a3-8f91-a275ddb9f91f.png)

- installed fw
![image](https://user-images.githubusercontent.com/61804715/206855425-74bc2c83-dc39-4f5b-a77c-4c8fa81b5cd6.png)
