### PR TITLE
ci: Bundle openssl so with Vita3K

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -111,6 +111,14 @@ jobs:
         id: build_variable
         run: echo "::set-output name=Build_Variable::$(git rev-list HEAD --count)"
         if: matrix.os == 'ubuntu-latest'
+
+      - name: Bundle OpenSSL shared objects
+        id: bundle_openssl
+        run: |
+            cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
+            cp /usr/lib/x86_64-linux-gnu/libssl.so.3 ./libssl.so.3
+            cp /usr/lib/x86_64-linux-gnu/libcrypto.so.3 ./libcrypto.so.3
+        if: matrix.os == 'ubuntu-latest'
         
       - name: Create DMG (macos-latest)
         run: |


### PR DESCRIPTION
Add the openssl shared objects to the Vita3K package.
This should fix Vita3K not starting on the Steam Deck because openssl is not up to date.
This commit is temporary and should be reverted once openssl is updated on the Steam Deck.

I would also need someone with a Steam Deck to test it and confirm it is working.