### PR TITLE
audio: Add Cubeb backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -93,3 +93,6 @@
 [submodule "external/nativefiledialog-extended"]
 	path = external/nativefiledialog-extended
 	url = https://github.com/btzy/nativefiledialog-extended.git
+[submodule "external/cubeb"]
+	path = external/cubeb
+	url = https://github.com/mozilla/cubeb.git

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -117,6 +117,30 @@ add_library(sdl2 INTERFACE)
 target_include_directories(sdl2 INTERFACE "${SDL2_INCLUDE_DIR}")
 target_link_libraries(sdl2 INTERFACE "${SDL2_LIBRARY}")
 
+# Cubeb setup, from https://github.com/RPCS3/rpcs3/blob/master/3rdparty/cubeb/CMakeLists.txt
+set(BUILD_SHARED_LIBS FALSE CACHE BOOL "Don't build shared libs")
+set(BUILD_TESTS FALSE CACHE BOOL "Don't build tests")
+set(BUILD_RUST_LIBS FALSE CACHE BOOL "Don't build rust libs")
+set(BUILD_TOOLS FALSE CACHE BOOL "Don't build tools")
+set(BUNDLE_SPEEX TRUE CACHE BOOL "Bundle the speex library")
+set(LAZY_LOAD_LIBS TRUE CACHE BOOL "Lazily load shared libraries")
+set(USE_SANITIZERS FALSE CACHE BOOL "Dont't use sanitizers")
+
+add_subdirectory(cubeb EXCLUDE_FROM_ALL)
+set_property(TARGET cubeb PROPERTY FOLDER externals)
+set_property(TARGET speex PROPERTY FOLDER externals)
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|ARM|aarch64|AArch64|Aarch64)")
+	target_compile_definitions(speex PUBLIC
+		#_USE_NEON
+	)
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86|X86|amd64|AMD64|em64t|EM64T)")
+	target_compile_definitions(speex PUBLIC
+		_USE_SSE
+		_USE_SSE2
+	)
+endif ()
+
 if(WIN32)
 	add_library(winsock INTERFACE)
 	find_library(WSOCK32 wsock32)

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -144,7 +144,7 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         break;
     }
 
-    if (cfg.fullscreen) {
+    if (state.cfg.fullscreen) {
         state.display.fullscreen = true;
         window_type |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
@@ -167,11 +167,11 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         return false;
     }
 
-    if (!state.audio.init(resume_thread, cfg.audio_backend)) {
+    if (!state.audio.init(resume_thread, state.cfg.audio_backend)) {
         LOG_WARN("Failed to init audio! Audio will not work.");
     }
 
-    if (!init(state.io, state.base_path, state.pref_path, cfg.console)) {
+    if (!init(state.io, state.base_path, state.pref_path, state.cfg.console)) {
         LOG_ERROR("Failed to initialize file system for the emulator!");
         return false;
     }
@@ -182,12 +182,12 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
     }
 
 #if USE_DISCORD
-    if (discordrpc::init() && cfg.discord_rich_presence) {
+    if (discordrpc::init() && state.cfg.discord_rich_presence) {
         discordrpc::update_presence();
     }
 #endif
 
-    if (!cfg.console) {
+    if (!state.cfg.console) {
         if (renderer::init(state.window.get(), state.renderer, state.backend_renderer, state.cfg, state.base_path.data())) {
             update_viewport(state);
             return true;

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -17,7 +17,7 @@
 
 #include <app/functions.h>
 
-#include <audio/functions.h>
+#include <audio/state.h>
 #include <config/functions.h>
 #include <config/state.h>
 #include <config/version.h>
@@ -167,7 +167,7 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         return false;
     }
 
-    if (!init(state.audio, resume_thread)) {
+    if (!state.audio.init(resume_thread, cfg.audio_backend)) {
         LOG_WARN("Failed to init audio! Audio will not work.");
     }
 

--- a/vita3k/audio/CMakeLists.txt
+++ b/vita3k/audio/CMakeLists.txt
@@ -1,11 +1,10 @@
 add_library(
     audio
     STATIC
-    include/audio/functions.h
-    include/audio/state.h
     src/audio.cpp
-)
+    src/impl/sdl_audio.cpp
+    src/impl/cubeb_audio.cpp)
 
 target_include_directories(audio PUBLIC include)
 target_link_libraries(audio PUBLIC sdl2)
-target_link_libraries(audio PRIVATE tracy util)
+target_link_libraries(audio PRIVATE tracy util cubeb kernel)

--- a/vita3k/audio/include/audio/impl/cubeb_audio.h
+++ b/vita3k/audio/include/audio/impl/cubeb_audio.h
@@ -1,0 +1,58 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include "../state.h"
+
+#include <condition_variable>
+
+#include <cubeb/cubeb.h>
+
+struct AudioBuffer {
+    std::vector<uint8_t> buffer;
+    int buffer_position;
+};
+
+struct CubebAudioOutPort : AudioOutPort {
+    cubeb_stream *out_stream = nullptr;
+    cubeb_stream_params spec;
+    // sync variables used to wait for the buffer to be ready
+    std::mutex mutex;
+    std::condition_variable cond_var;
+    // buffer filled with audio data to pass to cubeb
+    std::vector<AudioBuffer> audio_buffers;
+    // position of the next audio buffer to put audio
+    int next_audio_buffer = 0;
+    int nb_buffers_ready = 0;
+
+    // use the destructor to destroy the cubeb stream
+    ~CubebAudioOutPort();
+};
+
+class CubebAudioAdapter : public AudioAdapter {
+    cubeb *cubeb_ctx = nullptr;
+
+public:
+    CubebAudioAdapter(AudioState &audio_state);
+    ~CubebAudioAdapter();
+
+    bool init() override;
+    AudioOutPortPtr open_port(int nb_channels, int freq, int nb_sample) override;
+    void audio_output(ThreadState &thread, AudioOutPort &out_port, const void *buffer) override;
+    void set_volume(AudioOutPort &out_port, float volume) override;
+};

--- a/vita3k/audio/include/audio/impl/sdl_audio.h
+++ b/vita3k/audio/include/audio/impl/sdl_audio.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,12 +17,15 @@
 
 #pragma once
 
-#include <util/types.h>
+#include "../state.h"
 
-#include <functional>
+class SDLAudioAdapter : public AudioAdapter {
+    SDL_AudioDeviceID device_id = 0;
+    SDL_AudioSpec spec{};
 
-struct AudioState;
+public:
+    SDLAudioAdapter(AudioState &audio_state);
+    ~SDLAudioAdapter();
 
-typedef std::function<void(SceUID)> ResumeAudioThread;
-
-bool init(AudioState &state, ResumeAudioThread resume_thread);
+    bool init() override;
+};

--- a/vita3k/audio/include/audio/state.h
+++ b/vita3k/audio/include/audio/state.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2021 Vita3K team
+// Copyright (C) 2022 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -33,25 +33,24 @@
 typedef std::shared_ptr<SDL_AudioStream> AudioStreamPtr;
 typedef std::function<void(SceUID)> ResumeAudioThread;
 
-struct ReadOnlyAudioOutPortState {
-    int len_bytes = 0;
-};
-
-struct SharedAudioOutPortState {
-    std::mutex mutex;
-    AudioStreamPtr stream;
-    SceUID thread = -1;
-};
-
 struct AudioOutPort {
-    ReadOnlyAudioOutPortState ro;
-    SharedAudioOutPortState shared;
     // Channel range from 0 - 32768
     int left_channel_volume = SCE_AUDIO_VOLUME_0DB;
     int right_channel_volume = SCE_AUDIO_VOLUME_0DB;
-    // Volume range from 1 - 128
-    float volume = SDL_MIX_MAXVOLUME;
+    // Volume range from 0 to 1
+    float volume = 1.0f;
+    // length of the buffer for each call
+    int len_bytes = 0;
+
+    std::mutex mutex;
+    // stream to get the data
+    AudioStreamPtr stream;
+    // thread currently waiting for the audio to be processed
+    SceUID thread = -1;
 };
+
+typedef std::shared_ptr<AudioOutPort> AudioOutPortPtr;
+typedef std::map<int, AudioOutPortPtr> AudioOutPortPtrs;
 
 struct AudioInPort {
     SDL_AudioDeviceID id;
@@ -59,29 +58,58 @@ struct AudioInPort {
     int len_bytes = 0;
 };
 
-typedef std::shared_ptr<AudioOutPort> AudioOutPortPtr;
-typedef std::map<int, AudioOutPortPtr> AudioOutPortPtrs;
-typedef std::shared_ptr<void> AudioDevicePtr;
-
-struct ReadOnlyAudioState {
-    SDL_AudioSpec spec;
-    ResumeAudioThread resume_thread;
+struct AudioSpec {
+    int freq;
+    // number of samples to be processed per callback per channel
+    int nb_samples = 0;
+    // value for silence
+    uint8_t silence;
 };
 
-struct AudioCallbackState {
+struct ThreadState;
+struct AudioState;
+
+// abstract class that need to be overloaded with an audio implementation
+class AudioAdapter {
+private:
+    // buffer used to mix audio
     std::vector<uint8_t> temp_buffer;
+
+protected:
+    AudioState &state;
+    // are we using a single stream and mixing everything inside or multiple streams?
+    bool single_stream = true;
+
+public:
+    // called by subclasses once they get called by their implementation callback
+    // stream points to the location where we need to write state.ro.len_bytes bytes
+    void audio_callback(uint8_t *stream, int len_bytes);
+
+    AudioAdapter(AudioState &audio_state)
+        : state(audio_state) {}
+
+    virtual bool init() = 0;
+    virtual AudioOutPortPtr open_port(int nb_channels, int freq, int nb_sample) { return nullptr; }
+    virtual void audio_output(ThreadState &thread, AudioOutPort &out_port, const void *buffer) {}
+    virtual void set_volume(AudioOutPort &out_port, float volume) {}
+
+    friend struct AudioState;
 };
 
-struct SharedAudioState {
+struct AudioState {
+    AudioSpec spec;
+    // the adapter must be before out_ports for the destructors to work correctly
+    std::unique_ptr<AudioAdapter> adapter;
     std::mutex mutex;
     int next_port_id = 1;
     AudioOutPortPtrs out_ports;
     AudioInPort in_port;
-};
+    ResumeAudioThread resume_thread;
+    std::string audio_backend;
 
-struct AudioState {
-    ReadOnlyAudioState ro;
-    AudioCallbackState callback;
-    SharedAudioState shared;
-    AudioDevicePtr device;
+    bool init(const ResumeAudioThread &resume_thread, const std::string &adapter_name);
+    void set_backend(const std::string &adapter_name);
+    AudioOutPortPtr open_port(int nb_channels, int freq, int nb_sample);
+    void audio_output(ThreadState &thread, AudioOutPort &out_port, const void *buffer);
+    void set_volume(AudioOutPort &out_port, float volume);
 };

--- a/vita3k/audio/src/impl/cubeb_audio.cpp
+++ b/vita3k/audio/src/impl/cubeb_audio.cpp
@@ -1,0 +1,157 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "audio/impl/cubeb_audio.h"
+
+#include "public/tracy/Tracy.hpp"
+
+#include "kernel/thread/thread_state.h"
+
+#include "util/log.h"
+
+static long impl_cubeb_audio_callback(cubeb_stream *stream, void *user_data, const void *input, void *output, long nframes) {
+    assert(user_data != nullptr);
+    assert(stream != nullptr);
+    CubebAudioOutPort *port = reinterpret_cast<CubebAudioOutPort *>(user_data);
+    uint8_t *output_buffer = reinterpret_cast<uint8_t *>(output);
+
+    int bytes_given = 0;
+    const int bytes_to_give = nframes * port->spec.channels * sizeof(uint16_t);
+    while (bytes_given < bytes_to_give) {
+        if (port->nb_buffers_ready == 0) {
+            // no data available, should we wait for it or return nothing?
+            // return nothing for now
+            break;
+        }
+
+        AudioBuffer &audio_buffer = port->audio_buffers[port->next_audio_buffer];
+        // compute the number of bytes we can copy from this buffer to the output
+        const int bytes_to_copy = std::min(bytes_to_give - bytes_given, port->len_bytes - audio_buffer.buffer_position);
+        memcpy(&output_buffer[bytes_given], &audio_buffer.buffer[audio_buffer.buffer_position], bytes_to_copy);
+        audio_buffer.buffer_position += bytes_to_copy;
+
+        if (audio_buffer.buffer_position == port->len_bytes) {
+            // if we are done with this buffer, tell it
+            std::unique_lock<std::mutex> lock(port->mutex);
+            port->next_audio_buffer = (port->next_audio_buffer + 1) % port->audio_buffers.size();
+            port->nb_buffers_ready--;
+            lock.unlock();
+            port->cond_var.notify_one();
+        }
+
+        bytes_given += bytes_to_copy;
+    }
+
+    return nframes;
+}
+
+static void impl_cubeb_state_callback(cubeb_stream *stm, void *user, cubeb_state state) {
+    // we must give this function as a parameter to cubeb, but we don't care about it
+}
+
+CubebAudioOutPort::~CubebAudioOutPort() {
+    if (out_stream) {
+        cubeb_stream_stop(out_stream);
+        cubeb_stream_destroy(out_stream);
+    }
+}
+
+CubebAudioAdapter::CubebAudioAdapter(AudioState &audio_state)
+    : AudioAdapter(audio_state) {
+    this->single_stream = false;
+}
+
+CubebAudioAdapter::~CubebAudioAdapter() {
+    if (cubeb_ctx)
+        cubeb_destroy(cubeb_ctx);
+}
+
+bool CubebAudioAdapter::init() {
+    if (cubeb_init(&cubeb_ctx, "Vita3K audio", nullptr) != CUBEB_OK) {
+        LOG_ERROR("Could not initialize cubeb context");
+        return false;
+    }
+
+    return true;
+}
+
+AudioOutPortPtr CubebAudioAdapter::open_port(int nb_channels, int freq, int nb_sample) {
+    std::shared_ptr<CubebAudioOutPort> port = std::make_shared<CubebAudioOutPort>();
+    port->spec = {
+        // all the ps vita samples are signed 16 bits low edian
+        .format = CUBEB_SAMPLE_S16LE,
+        .rate = static_cast<uint32_t>(freq),
+        .channels = static_cast<uint32_t>(nb_channels),
+        .layout = CUBEB_LAYOUT_UNDEFINED,
+        // we could use the params of sceAudioOutOpenPort to select some prefs, although I don't think it will change anything
+        .prefs = CUBEB_STREAM_PREF_NONE
+    };
+
+    uint32_t latency;
+    cubeb_get_min_latency(cubeb_ctx, &port->spec, &latency);
+
+    if (cubeb_stream_init(cubeb_ctx, &port->out_stream, "Vita3K audio out", nullptr, nullptr, nullptr,
+            &port->spec, latency, impl_cubeb_audio_callback, impl_cubeb_state_callback, port.get())
+        != CUBEB_OK) {
+        LOG_ERROR("Could not initialize cubeb stream");
+        return nullptr;
+    }
+
+    port->len_bytes = nb_sample * nb_channels * sizeof(uint16_t);
+
+    // allocate enough buffers to be able to satisfy a callback (+1 to make sure one buffer can be ready)
+    const int nb_buffers = (latency + nb_sample - 1) / nb_sample + 1;
+    port->audio_buffers.resize(nb_buffers);
+    for (AudioBuffer &audio_buffer : port->audio_buffers) {
+        // initialize all of the buffers
+        audio_buffer.buffer.resize(port->len_bytes);
+        audio_buffer.buffer_position = 0;
+    }
+
+    cubeb_stream_start(port->out_stream);
+    return port;
+}
+
+void CubebAudioAdapter::audio_output(ThreadState &thread, AudioOutPort &out_port, const void *buffer) {
+    CubebAudioOutPort &port = static_cast<CubebAudioOutPort &>(out_port);
+
+    std::unique_lock<std::mutex> lock(port.mutex);
+    if (port.nb_buffers_ready == port.audio_buffers.size()) {
+        // is it really useful to update the thread status?
+        thread.update_status(ThreadStatus::wait);
+        port.cond_var.wait(lock);
+        thread.update_status(ThreadStatus::run);
+    }
+
+    assert(port.nb_buffers_ready < port.audio_buffers.size());
+    if (buffer) {
+        // the buffer can be empty to drain the port
+        int next_buffer_pos = (port.next_audio_buffer + port.nb_buffers_ready) % port.audio_buffers.size();
+        // we could unlock the lock here and re-lock it right after, but will this be faster?
+        memcpy(port.audio_buffers[next_buffer_pos].buffer.data(), buffer, port.len_bytes);
+        port.audio_buffers[next_buffer_pos].buffer_position = 0;
+        port.nb_buffers_ready++;
+    }
+
+    lock.unlock();
+    port.cond_var.notify_one();
+}
+
+void CubebAudioAdapter::set_volume(AudioOutPort &out_port, float volume) {
+    CubebAudioOutPort &port = static_cast<CubebAudioOutPort &>(out_port);
+    cubeb_stream_set_volume(port.out_stream, volume);
+}

--- a/vita3k/audio/src/impl/sdl_audio.cpp
+++ b/vita3k/audio/src/impl/sdl_audio.cpp
@@ -1,0 +1,70 @@
+// Vita3K emulator project
+// Copyright (C) 2022 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "audio/impl/sdl_audio.h"
+
+#include <SDL.h>
+
+#include "util/log.h"
+
+static void SDLCALL sdl_audio_callback(void *userdata, Uint8 *stream, int len) {
+    assert(userdata != nullptr);
+    assert(stream != nullptr);
+    SDLAudioAdapter *adapter = reinterpret_cast<SDLAudioAdapter *>(userdata);
+    assert(len == state.callback.temp_buffer.size());
+
+    adapter->audio_callback(stream, len);
+}
+
+SDLAudioAdapter::SDLAudioAdapter(AudioState &audio_state)
+    : AudioAdapter(audio_state) {}
+
+SDLAudioAdapter::~SDLAudioAdapter() {
+    if (device_id > 0) {
+        SDL_PauseAudioDevice(device_id, 1);
+        SDL_CloseAudioDevice(device_id);
+    }
+}
+
+bool SDLAudioAdapter::init() {
+    SDL_AudioSpec desired = {};
+    desired.freq = 48000;
+    desired.format = AUDIO_S16LSB;
+    desired.channels = 2;
+    desired.samples = 512;
+    desired.callback = sdl_audio_callback;
+    desired.userdata = this;
+
+    // we only allow the samples amount to be changed
+    // if resampling or format change has to be done, it is better
+    // to do it after all channels have been merged
+    device_id = SDL_OpenAudioDevice(nullptr, false, &desired, &spec, SDL_AUDIO_ALLOW_SAMPLES_CHANGE);
+    if (device_id <= 0) {
+        LOG_ERROR("SDL audio error: {}", SDL_GetError());
+        return false;
+    }
+
+    state.spec = {
+        .freq = spec.freq,
+        .nb_samples = spec.samples,
+        .silence = spec.silence
+    };
+
+    SDL_PauseAudioDevice(device_id, 0);
+
+    return true;
+}

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -70,6 +70,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "texture-cache", true, texture_cache)                                                    \
     code(bool, "hashless-texture-cache", false, hashless_texture_cache)                                 \
     code(bool, "boot-apps-full-screen", false, boot_apps_full_screen)                                   \
+    code(std::string, "audio-backend", "SDL", audio_backend)                                            \
     code(bool, "ngs-enable", true, ngs_enable)                                                          \
     code(int, "sys-button", static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS), sys_button)          \
     code(int, "sys-lang", static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US), sys_lang)                 \

--- a/vita3k/gui/CMakeLists.txt
+++ b/vita3k/gui/CMakeLists.txt
@@ -51,5 +51,5 @@ add_library(
 
 target_include_directories(gui PUBLIC include ${CMAKE_SOURCE_DIR}/vita3k)
 target_link_libraries(gui PUBLIC app config dialog emuenv ime imgui glutil lang np)
-target_link_libraries(gui PRIVATE ctrl kernel miniz psvpfsparser pugixml::pugixml stb renderer packages sdl2 vkutil host::dialog)
+target_link_libraries(gui PRIVATE audio ctrl kernel miniz psvpfsparser pugixml::pugixml stb renderer packages sdl2 vkutil host::dialog)
 target_link_libraries(gui PUBLIC tracy)

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
         SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_SWITCH, "1");
         SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
 
-        if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_VIDEO) < 0) {
+        if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0) {
             app::error_dialog("SDL initialisation failed.");
             return SDLInitFailed;
         }

--- a/vita3k/modules/SceAudioIn/SceAudioIn.cpp
+++ b/vita3k/modules/SceAudioIn/SceAudioIn.cpp
@@ -103,19 +103,19 @@ EXPORT(int, sceAudioInGetStatus, int select) {
     if (select != SCE_AUDIO_IN_GETSTATUS_MUTE) {
         return RET_ERROR(SCE_AUDIO_IN_ERROR_INVALID_PARAMETER);
     }
-    return emuenv.audio.shared.in_port.running ? 0 : 1;
+    return emuenv.audio.in_port.running ? 0 : 1;
 }
 
 EXPORT(int, sceAudioInInput, int port, void *destPtr) {
     TRACY_FUNC(sceAudioInInput, port, destPtr);
-    if (!emuenv.audio.shared.in_port.running) {
+    if (!emuenv.audio.in_port.running) {
         return RET_ERROR(SCE_AUDIO_IN_ERROR_NOT_OPENED);
     }
     if (port != PORT_ID) {
         return RET_ERROR(SCE_AUDIO_IN_ERROR_INVALID_PORT_PARAM);
     }
 
-    while (SDL_DequeueAudio(emuenv.audio.shared.in_port.id, destPtr, emuenv.audio.shared.in_port.len_bytes) > 0) {
+    while (SDL_DequeueAudio(emuenv.audio.in_port.id, destPtr, emuenv.audio.in_port.len_bytes) > 0) {
     }
     return 0;
 }
@@ -127,7 +127,7 @@ EXPORT(int, sceAudioInInputWithInputDeviceState) {
 
 EXPORT(int, sceAudioInOpenPort, SceAudioInPortType portType, int grain, int freq, SceAudioInParam param) {
     TRACY_FUNC(sceAudioInOpenPort, portType, grain, freq, param);
-    if (emuenv.audio.shared.in_port.running) {
+    if (emuenv.audio.in_port.running) {
         return RET_ERROR(SCE_AUDIO_IN_ERROR_PORT_FULL);
     }
     if (param != SCE_AUDIO_IN_PARAM_FORMAT_S16_MONO) {
@@ -162,15 +162,15 @@ EXPORT(int, sceAudioInOpenPort, SceAudioInPortType portType, int grain, int freq
     desired.callback = nullptr;
     desired.userdata = nullptr;
 
-    emuenv.audio.shared.in_port.id = SDL_OpenAudioDevice(nullptr, 1, &desired, &received, 0);
-    if (emuenv.audio.shared.in_port.id == 0) {
+    emuenv.audio.in_port.id = SDL_OpenAudioDevice(nullptr, true, &desired, &received, 0);
+    if (emuenv.audio.in_port.id == 0) {
         return RET_ERROR(SCE_AUDIO_IN_ERROR_FATAL);
     }
 
-    SDL_PauseAudioDevice(emuenv.audio.shared.in_port.id, 0);
+    SDL_PauseAudioDevice(emuenv.audio.in_port.id, 0);
 
-    emuenv.audio.shared.in_port.len_bytes = grain * 2;
-    emuenv.audio.shared.in_port.running = true;
+    emuenv.audio.in_port.len_bytes = grain * 2;
+    emuenv.audio.in_port.running = true;
     return PORT_ID;
 }
 
@@ -184,12 +184,12 @@ EXPORT(int, sceAudioInReleasePort, int port) {
     if (port != PORT_ID) {
         return RET_ERROR(SCE_AUDIO_IN_ERROR_INVALID_PORT_PARAM);
     }
-    if (!emuenv.audio.shared.in_port.running) {
+    if (!emuenv.audio.in_port.running) {
         return RET_ERROR(SCE_AUDIO_IN_ERROR_NOT_OPENED);
     }
-    emuenv.audio.shared.in_port.running = false;
-    SDL_PauseAudioDevice(emuenv.audio.shared.in_port.id, 1);
-    SDL_CloseAudioDevice(emuenv.audio.shared.in_port.id);
+    emuenv.audio.in_port.running = false;
+    SDL_PauseAudioDevice(emuenv.audio.in_port.id, 1);
+    SDL_CloseAudioDevice(emuenv.audio.in_port.id);
     return 0;
 }
 


### PR DESCRIPTION
Add a cubeb audio backend to Vita3K.
I tried to do it a bit differently and create a new stream for each Audio out port. 
Because the latency of the PS Vita API and the host may not match, it is still necessary to add some buffering in-between, I tried to minimize.
It is possible to choose in the GUI between the SDL audio backend and the cubeb backend, SDL is chosen by default for now.

The input (microphone) still only uses SDL, it could be implemented using cubeb later.