### PR TITLE
audio: Make AudioAdapter destructor virtual

### DIFF
--- a/vita3k/audio/include/audio/state.h
+++ b/vita3k/audio/include/audio/state.h
@@ -87,6 +87,7 @@ public:
 
     AudioAdapter(AudioState &audio_state)
         : state(audio_state) {}
+    virtual ~AudioAdapter() {}
 
     virtual bool init() = 0;
     virtual AudioOutPortPtr open_port(int nb_channels, int freq, int nb_sample) { return nullptr; }


### PR DESCRIPTION
Fix a crash that could occur when changing the audio backend before starting a game, the previous backend destructor was not called, leading to some undefined behavior.