### PR TITLE
renderer/vulkan/pipeline_cache: fix regression on commit 2779298

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
@@ -20,6 +20,7 @@
 #include <array>
 #include <limits>
 #include <map>
+#include <set>
 #include <unordered_map>
 
 #include <vkutil/objects.h>
@@ -42,7 +43,7 @@ private:
 
     // does the GPU support vertex attributes with 3 components (like R16G16B16_UNORM), some (like AMD GPUs) don't
     // this is needed when creating the input state
-    bool support_rgb_vertex_attribute;
+    std::set<vk::Format> unsupported_rgb_vertex_attribute_formats{};
 
     // how much time should we wait after the last shader compilation
     // to update the disk-saved shader cache (in seconds)


### PR DESCRIPTION
Fix regression an AMD GPU from commit 2779298d70616b2f5d89c7cb9813d2d44df77fbc
Now it checks for each possibly unsupported format separately and use workaround only if needed. It fix regression for PCSE00707 - Ar nosurge... and fix crash on PCSB00102 - Chronovolt
