### PR TITLE
shader: Revert disabling DecorationRestrict on macOS

### DIFF
--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -910,10 +910,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         spv_params.buffer_container = b.createVariable(spv::NoPrecision, spv::StorageClassStorageBuffer, buffer_container_type,
             is_vert ? "vertexData" : "fragmentData");
 
-#ifndef __APPLE__
-        // Most Apple GPUs do not support the keyword restrict in MSL
         b.addDecoration(spv_params.buffer_container, spv::DecorationRestrict);
-#endif
         b.addDecoration(spv_params.buffer_container, spv::DecorationNonWritable);
         b.addDecoration(spv_params.buffer_container, spv::DecorationBinding, is_vert ? 0 : 1);
         if (translation_state.is_vulkan)


### PR DESCRIPTION
I've filed a bug to SPIRV-Cross and they have fixed an issue with restrict keyword on Metal (https://github.com/KhronosGroup/SPIRV-Cross/pull/2044).
Latest release of MoltenVK 1.2.1 (Vulkan SDK 1.3.236) contains that fix.(https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.1)

So disabling DecorationRestrict on macOS is not needed anymore.
