### PR TITLE
renderer: Only enable programmable blending when direct frag color is used

### DIFF
--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -104,7 +104,7 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
     const SceGxmColorBaseFormat base_format = gxm::get_base_format(context.record.color_surface.colorFormat);
     const GLenum surface_format = color::translate_internal_format(base_format);
 
-    if (fragment_program_gxp.is_native_color() && features.is_programmable_blending_need_to_bind_color_attachment()) {
+    if (fragment_program_gxp.is_frag_color_used() && features.is_programmable_blending_need_to_bind_color_attachment()) {
         if (use_raw_image) {
             glBindImageTexture(shader::COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE, context.current_color_attachment, 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA16UI);
             glBindImageTexture(shader::COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE, 0, 0, GL_FALSE, 0, GL_READ_WRITE, surface_format);

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -311,7 +311,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
 
     const SceGxmFragmentProgram &gxm_fragment_program = *context.record.fragment_program.get(mem);
     const SceGxmProgram &fragment_program_gxp = *gxm_fragment_program.program.get(mem);
-    if (fragment_program_gxp.is_native_color()) {
+    if (fragment_program_gxp.is_frag_color_used()) {
         // the fragment shader is using programmable blending
         vk::ImageMemoryBarrier barrier{
             .srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite,


### PR DESCRIPTION
Right now programmable blending (pipeline self-dependency for vulkan, surface texture binding for opengl) is used if the fragment shader is using native color. This works fine but is not optimized as we should only do that if the shader is reading the previous fragment color only.