### PR TITLE
renderer/vulkan: Add support for VK_KHR_image_format_list

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/surface_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/surface_cache.h
@@ -103,6 +103,10 @@ private:
     void destroy_surface(DepthStencilSurfaceCacheInfo &info);
 
 public:
+    // when creating a mutable image, can we pass as an argument
+    // the possible format used for an image view to improve performance ?
+    bool support_image_format_specifier = false;
+
     explicit VKSurfaceCache(VKState &state);
 
     // when writing, the swizzled given to this function is inversed

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -296,6 +296,8 @@ bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state
             { VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME, &temp_bool },
             // can be used by vma to improve perfomance
             { VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME, &support_dedicated_allocations },
+            // can be used to specify which format will be used by mutable images
+            { VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME, &surface_cache.support_image_format_specifier },
         };
 
         for (const vk::ExtensionProperties &ext : physical_device.enumerateDeviceExtensionProperties()) {

--- a/vita3k/vkutil/include/vkutil/objects.h
+++ b/vita3k/vkutil/include/vkutil/objects.h
@@ -49,7 +49,7 @@ struct Image {
     Image(const Image &) = delete;
     Image &operator=(Image const &) = delete;
 
-    void init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping = default_comp_mapping, const vk::ImageCreateFlags image_create_flags = vk::ImageCreateFlags());
+    void init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping = default_comp_mapping, const vk::ImageCreateFlags image_create_flags = vk::ImageCreateFlags(), const void *pNext = nullptr);
     // called by ~Image
     void destroy();
 

--- a/vita3k/vkutil/src/objects.cpp
+++ b/vita3k/vkutil/src/objects.cpp
@@ -70,8 +70,9 @@ Image::~Image() {
     destroy();
 }
 
-void Image::init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping, const vk::ImageCreateFlags image_create_flags) {
+void Image::init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping, const vk::ImageCreateFlags image_create_flags, const void *pNext) {
     vk::ImageCreateInfo image_info{
+        .pNext = pNext,
         .flags = image_create_flags,
         .imageType = vk::ImageType::e2D,
         .format = format,


### PR DESCRIPTION
Add (optional) support for the VK_KHR_image_format_list extension.
This allows, when creating an image with the mutable flag (used only for srgb) to say we will only use the linear and srgb corresponding format on it. This can improve performance.