### PR TITLE
shader: Fix 4th component of rgb input on AMD GPUs

### DIFF
--- a/vita3k/features/include/features/state.h
+++ b/vita3k/features/include/features/state.h
@@ -25,6 +25,7 @@ struct FeatureState {
     bool support_get_texture_sub_image = false;
     bool preserve_f16_nan_as_u16 = false; ///< Emit store of 4xU16 to draw buffer 1. This buffer is expected to be U16U16U16U16, which can be casted to F16F16F16F16. This is to preserve some drivers's behaviour of casting NaN to default value when store in framebuffer, not keeping its original value.
     bool support_unknown_format = false;
+    bool support_rgb_attributes = true; ///< Do the GPU supports RGB (3 components) vertex attribute? If not (AMD GPU), some modifications must be applied to the renderer and the shader recompiler
     bool use_mask_bit = false; ///< Is the mask bit (1 per sample) emulated ? It is only used in homebrews afaik
 
     bool is_programmable_blending_supported() const {

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -144,6 +144,7 @@ void PipelineCache::init() {
                 unsupported_rgb_vertex_attribute_formats.emplace(fmt);
             }
         }
+        state.features.support_rgb_attributes = unsupported_rgb_vertex_attribute_formats.empty();
     }
 }
 

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -36,7 +36,7 @@ namespace shader {
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
-static constexpr uint32_t CURRENT_VERSION = 6;
+static constexpr uint32_t CURRENT_VERSION = 7;
 
 struct RenderVertUniformBlock {
     std::array<float, 4> viewport_flip;


### PR DESCRIPTION
Some game were passing as input vector of 3 components and expecting as an input in the shader a vector of 4 components. When this happens, the 4-th component is set to 1. However, because amd GPUs do not support 3-component input vectors, we are instead passing them as 4-component vector, causing the 4th value to be what is in the memory at that location (often 0 or the r-value of the next input). 

Look for these cases when compiling the shader and manually set the 4th component to 1.
This should fix all the vertex explosion happening only on AMD GPUs (like in Uncharted):

![image](https://user-images.githubusercontent.com/5671744/209534070-b76d1f4e-6ea8-4a1f-a156-1e9464ec5f58.png)
