### PR TITLE
ci: Switch to clang-14 for the ubuntu build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -27,7 +27,7 @@ jobs:
           - os: ubuntu-latest
             cache_path: ~/.ccache
             extra_cmake_args:
-            cmake_preset: linux-ninja-clang12
+            cmake_preset: linux-ninja-clang14
           - os: windows-latest
             cache_path: |
                 C:\vcpkg\installed

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
         os: [ubuntu-latest]
         config: [Release]
-        cmake_preset: [linux-ninja-clang12]
+        cmake_preset: [linux-ninja-clang14]
 
     steps:
       - name: Set up build environment (ubuntu-latest)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,13 +93,13 @@
       }
     },
     {
-      "name": "linux-ninja-clang12",
+      "name": "linux-ninja-clang14",
       "inherits": "linux-ninja",
-      "displayName": "Linux with Ninja and Clang 12",
-      "description": "Linux native build using Ninja Multi-Config generator and Clang 12 compiler",
+      "displayName": "Linux with Ninja and Clang 14",
+      "description": "Linux native build using Ninja Multi-Config generator and Clang 14 compiler",
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-12",
-        "CMAKE_CXX_COMPILER": "clang++-12"
+        "CMAKE_C_COMPILER": "clang-14",
+        "CMAKE_CXX_COMPILER": "clang++-14"
       },
       "environment": {
         "LDFLAGS": "-fuse-ld=lld"
@@ -248,25 +248,25 @@
       "configurePreset": "linux-ninja-clang"
     },
     {
-      "name": "linux-ninja-clang12-debug",
+      "name": "linux-ninja-clang14-debug",
       "displayName": "Debug",
       "description": "Build with debugging information and no compiler optimizations",
       "configuration": "Debug",
-      "configurePreset": "linux-ninja-clang12"
+      "configurePreset": "linux-ninja-clang14"
     },
     {
-      "name": "linux-ninja-clang12-relwithdebinfo",
+      "name": "linux-ninja-clang14-relwithdebinfo",
       "displayName": "Release with debugging information",
       "description": "Build with compiler optimizations enabled and limited debugging information",
       "configuration": "RelWithDebInfo",
-      "configurePreset": "linux-ninja-clang12"
+      "configurePreset": "linux-ninja-clang14"
     },
     {
-      "name": "linux-ninja-clang12-release",
+      "name": "linux-ninja-clang14-release",
       "displayName": "Release",
       "description": "Build with compiler optimizations enabled and no debugging information",
       "configuration": "Release",
-      "configurePreset": "linux-ninja-clang12"
+      "configurePreset": "linux-ninja-clang14"
     },
     {
       "name": "linux-ninja-gnu-debug",


### PR DESCRIPTION
Ubuntu-latest is now based on ubuntu 22.
As such we can now switch to clang 14 for the linux build (we are using clang 12 right now).