### PR TITLE
renderer/vulkan: Improve texture uploading

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1184,6 +1184,9 @@ struct SceGxmTexture {
     }
 
     uint32_t true_mip_count() const {
+        if (texture_type() == SCE_GXM_TEXTURE_LINEAR_STRIDED)
+            return 1;
+
         uint32_t count = (mip_count + 1) & 15;
         return (count == 0) ? 1 : count; // 0 count is no mip chain, but there's still top level...
     }

--- a/vita3k/renderer/include/renderer/texture_cache_state.h
+++ b/vita3k/renderer/include/renderer/texture_cache_state.h
@@ -52,6 +52,7 @@ typedef std::array<TextureCacheInfo, TextureCacheSize> TextureCacheInfoes;
 typedef std::function<void(std::size_t, const void *)> TextureCacheStateSelectCallback;
 typedef std::function<void(TextureCacheState &, const void *)> TextureCacheStateConfigureTextureCallback;
 typedef std::function<void(SceGxmTextureBaseFormat base_format, uint32_t width, uint32_t height, uint32_t mip_index, const void *pixels, int face, bool is_compressed, size_t pixels_per_stride)> TextureCacheStateUploadTextureCallback;
+typedef std::function<void()> TextureCacheStateUploadDoneCallback;
 
 struct TextureCacheState {
     Backend *backend;
@@ -63,5 +64,6 @@ struct TextureCacheState {
     TextureCacheStateSelectCallback select_callback;
     TextureCacheStateConfigureTextureCallback configure_texture_callback;
     TextureCacheStateUploadTextureCallback upload_texture_callback;
+    TextureCacheStateUploadDoneCallback upload_done_callback;
 };
 } // namespace renderer

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -62,10 +62,11 @@ namespace texture {
 
 bool init(VKTextureCacheState &cache, const bool hashless_texture_cache);
 
-void configure_bound_texture(const renderer::TextureCacheState &state, const SceGxmTexture &gxm_texture);
+void configure_bound_texture(VKTextureCacheState &cache, const SceGxmTexture &gxm_texture);
 vk::Sampler create_sampler(VKState &state, const SceGxmTexture &gxm_texture, const uint16_t mip_count = 1);
 void upload_bound_texture(VKTextureCacheState &cache, SceGxmTextureBaseFormat base_format, uint32_t width, uint32_t height,
     uint32_t mip_index, const void *pixels, int face, bool is_compressed, size_t pixels_per_stride);
+void upload_done(VKTextureCacheState &cache);
 
 } // namespace texture
 

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -68,6 +68,8 @@ bool init(GLTextureCacheState &cache, const bool hashless_texture_cache) {
 
     cache.upload_texture_callback = upload_bound_texture;
 
+    cache.upload_done_callback = []() {};
+
     cache.use_protect = hashless_texture_cache;
 
     return cache.textures.init(reinterpret_cast<renderer::Generator *>(glGenTextures), reinterpret_cast<renderer::Deleter *>(glDeleteTextures));

--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -811,6 +811,7 @@ void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_t
                 return true;
             });
         }
+        cache.upload_done_callback();
     }
 
     info->timestamp = cache.timestamp++;

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -75,7 +75,8 @@ void new_frame(VKContext &context) {
         frame.rendered_fences.clear();
     }
 
-    device.resetCommandPool(frame.command_pool);
+    device.resetCommandPool(frame.prerender_pool);
+    device.resetCommandPool(frame.render_pool);
     device.resetDescriptorPool(frame.descriptor_pool);
 
     // deferred destruction of the objects

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -19,6 +19,8 @@
 
 #include <renderer/vulkan/gxm_to_vulkan.h>
 
+#include <vulkan/vulkan_format_traits.hpp>
+
 #include <gxm/functions.h>
 #include <renderer/functions.h>
 #include <util/align.h>
@@ -101,7 +103,7 @@ void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTe
             return;
         }
         renderer::texture::cache_and_bind_texture(context.state.texture_cache, texture, mem);
-        image = context.state.texture_cache.current_texture;
+        image = &context.state.texture_cache.current_texture->texture;
     }
 
     vk::DescriptorImageInfo &image_info = is_vertex
@@ -121,25 +123,120 @@ void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTe
     }
 }
 
+void VKTextureCacheState::prepare_staging_buffer(bool is_configure) {
+    assert(!is_texture_transfer_ready);
+    VKContext *context = reinterpret_cast<VKContext *>(state.context);
+
+    TextureStagingBuffer *staging_buffer = &staging_buffers[staging_idx];
+    // some textures must be 16-bytes aligned, and staging_buffer->buffer.size is 16-bytes aligned
+    staging_buffer->used_so_far = align(staging_buffer->used_so_far, 16);
+    // we can keep using the same buffer as before if we are in the same scene and there is enough memory left
+    bool use_previous_buffer = (context->scene_timestamp == staging_buffer->scene_timestamp) && (staging_buffer->buffer.size - staging_buffer->used_so_far) >= current_texture->memory_needed;
+
+    if (!use_previous_buffer) {
+        staging_idx = (staging_idx + 1) % NB_TEXTURE_STAGING_BUFFERS;
+        staging_buffer = &staging_buffers[staging_idx];
+    }
+
+    // if we are not using the previous buffer, we wait if the buffer was used at least once,
+    // less than MAX_FRAMES_RENDERING frames ago and we have not yet waited for its fence
+    const bool need_wait = !use_previous_buffer
+        && staging_buffer->frame_timestamp != ~0
+        && staging_buffer->frame_timestamp > context->frame_timestamp - MAX_FRAMES_RENDERING
+        && staging_buffer->scene_timestamp > last_waited_scene;
+    const vk::Fence current_fence = context->render_target->fences[context->render_target->fence_idx];
+
+    if (need_wait) {
+        if (staging_buffer->scene_timestamp == context->scene_timestamp) {
+            assert(current_fence == staging_buffer.waiting_fence);
+            // special case, all the staging buffer are occupied by the current scene
+            // submit the command buffer and wait for it
+            context->prerender_cmd.end();
+            vk::SubmitInfo submit_info{};
+            submit_info.setCommandBuffers(context->prerender_cmd);
+            state.general_queue.submit(submit_info, current_fence);
+            state.device.waitForFences(current_fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
+            state.device.resetFences(current_fence);
+
+            // also call begin again on the prerender command
+            vk::CommandBufferBeginInfo begin_info{
+                .flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit
+            };
+            context->prerender_cmd.begin(begin_info);
+
+            // then set all buffers as unused
+            for (auto &buffer : staging_buffers) {
+                buffer.frame_timestamp = ~0;
+                buffer.scene_timestamp = ~0;
+            }
+        } else {
+            // wait for the fence, but don't reset it
+            state.device.waitForFences(staging_buffer->waiting_fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
+            last_waited_scene = staging_buffer->scene_timestamp;
+        }
+    }
+
+    // then we can use the buffer
+    cmd_buffer = context->prerender_cmd;
+    if (!use_previous_buffer) {
+        staging_buffer->scene_timestamp = context->scene_timestamp;
+        staging_buffer->frame_timestamp = context->frame_timestamp;
+        staging_buffer->waiting_fence = current_fence;
+        staging_buffer->used_so_far = 0;
+
+        if (staging_buffer->buffer.size < current_texture->memory_needed) {
+            // we need to create a bigger buffer
+            // destroy the previous one if there is, no need to defer destroy it as we now it is no longer being used
+            staging_buffer->buffer.destroy();
+
+            staging_buffer->buffer.size = current_texture->memory_needed;
+            staging_buffer->buffer.init_buffer(vk::BufferUsageFlagBits::eTransferSrc, vkutil::vma_mapped_alloc);
+        }
+    }
+
+    // now the transition
+    vk::ImageSubresourceRange range{
+        .aspectMask = vk::ImageAspectFlagBits::eColor,
+        .baseMipLevel = 0,
+        .levelCount = current_texture->mip_count,
+        .baseArrayLayer = 0,
+        .layerCount = current_texture->is_cube ? 6U : 1U
+    };
+
+    // if this is done during configure, layout is undefined, otherwise it is shader read only
+    if (is_configure)
+        vkutil::transition_image_layout(cmd_buffer, current_texture->texture.image, vkutil::ImageLayout::Undefined, vkutil::ImageLayout::TransferDst, range);
+    else
+        vkutil::transition_image_layout_discard(cmd_buffer, current_texture->texture.image, vkutil::ImageLayout::SampledImage, vkutil::ImageLayout::TransferDst, range);
+
+    is_texture_transfer_ready = true;
+}
+
 namespace texture {
 
 bool init(VKTextureCacheState &cache, const bool hashless_texture_cache) {
     cache.select_callback = [&cache](const std::size_t index, const void *texture) {
         cache.current_texture = &cache.textures[index];
+        cache.is_texture_transfer_ready = false;
     };
 
-    cache.configure_texture_callback = [](const renderer::TextureCacheState &text_cache, const void *texture) {
-        configure_bound_texture(text_cache, *reinterpret_cast<const SceGxmTexture *>(texture));
+    cache.configure_texture_callback = [&cache](const renderer::TextureCacheState &text_cache, const void *texture) {
+        configure_bound_texture(cache, *reinterpret_cast<const SceGxmTexture *>(texture));
     };
 
     cache.upload_texture_callback = [&cache](SceGxmTextureBaseFormat base_format, uint32_t width, uint32_t height, uint32_t mip_index, const void *pixels, int face, bool is_compressed, size_t pixels_per_stride) {
         upload_bound_texture(cache, base_format, width, height, mip_index, pixels, face, is_compressed, pixels_per_stride);
     };
 
+    cache.upload_done_callback = [&cache]() {
+        upload_done(cache);
+    };
+
     cache.use_protect = hashless_texture_cache;
 
-    vk::FenceCreateInfo fence_info{};
-    cache.wait_fence = cache.state.device.createFence(fence_info);
+    // don't forget to specify the allocator for all the staging buffers
+    for (int i = 0; i < NB_TEXTURE_STAGING_BUFFERS; i++)
+        cache.staging_buffers[i].buffer.allocator = cache.state.allocator;
 
     return true;
 }
@@ -167,7 +264,24 @@ static vk::Format linear_to_srgb(const vk::Format format) {
     }
 }
 
-void configure_bound_texture(const renderer::TextureCacheState &state, const SceGxmTexture &gxm_texture) {
+// get an upper bound on the amount of memory needed to upload this texture
+// the bound is only for one face and the base mip
+static uint32_t get_image_memory_upper_bound(const SceGxmTexture &gxm_texture, const vk::Format vk_format, const SceGxmTextureBaseFormat base_format) {
+    // we only want an upper bound, it doesn't matter if because of some conversions we later get the width instead of the stride
+    // aligning to 8 takes care of the default stride values
+    uint32_t stride = align(gxm::get_width(&gxm_texture), 8);
+    uint32_t height = align(gxm::get_height(&gxm_texture), 8);
+
+    if (gxm_texture.texture_type() == SCE_GXM_TEXTURE_LINEAR_STRIDED) {
+        const uint32_t bpp = (renderer::texture::bits_per_pixel(base_format) + 7) / 8;
+        // the max is to handle the case of P4 textures
+        stride = std::max<uint32_t>(stride, gxm::get_stride_in_bytes(&gxm_texture) / bpp);
+    }
+
+    return ((stride * height) / vk::texelsPerBlock(vk_format)) * vk::blockSize(vk_format);
+}
+
+void configure_bound_texture(VKTextureCacheState &cache, const SceGxmTexture &gxm_texture) {
     const SceGxmTextureFormat format = gxm::get_format(&gxm_texture);
     const SceGxmTextureBaseFormat base_format = gxm::get_base_format(format);
 
@@ -183,18 +297,24 @@ void configure_bound_texture(const renderer::TextureCacheState &state, const Sce
         height = align(height, 4);
     }
 
-    uint16_t mip_count = renderer::texture::get_upload_mip(gxm_texture.true_mip_count(), width, height, base_format);
-    if (gxm_texture.texture_type() == SCE_GXM_TEXTURE_LINEAR_STRIDED) {
-        mip_count = 1;
-    }
+    const uint16_t mip_count = renderer::texture::get_upload_mip(gxm_texture.true_mip_count(), width, height, base_format);
 
     vk::Format vk_format = translate_format(base_format);
     if (gxm_texture.gamma_mode) {
         vk_format = linear_to_srgb(vk_format);
     }
 
-    const VKTextureCacheState &cache = static_cast<const VKTextureCacheState &>(state);
-    vkutil::Image &image = *cache.current_texture;
+    cache.current_texture->mip_count = mip_count;
+    cache.current_texture->is_cube = is_cube;
+    uint32_t memory_needed = get_image_memory_upper_bound(gxm_texture, vk_format, base_format);
+    if (mip_count > 1)
+        // using mips, the overall memory needed will be 4/3 of the base memory
+        // round up to 3/2
+        memory_needed += memory_needed / 2;
+    if (is_cube)
+        memory_needed *= 6;
+    cache.current_texture->memory_needed = align(memory_needed, 16);
+    vkutil::Image &image = cache.current_texture->texture;
 
     // manually initialize the image
     image.allocator = cache.state.allocator;
@@ -241,6 +361,8 @@ void configure_bound_texture(const renderer::TextureCacheState &state, const Sce
     image.view = cache.state.device.createImageView(view_info);
 
     image.sampler = create_sampler(cache.state, gxm_texture, mip_count);
+
+    cache.prepare_staging_buffer(true);
 }
 
 vk::Sampler create_sampler(VKState &state, const SceGxmTexture &gxm_texture, const uint16_t mip_count) {
@@ -298,7 +420,11 @@ static void *add_alpha_channel(const void *pixels, const uint32_t width, const u
 
 void upload_bound_texture(VKTextureCacheState &cache, SceGxmTextureBaseFormat base_format, uint32_t width, uint32_t height,
     uint32_t mip_index, const void *pixels, int face, bool is_compressed, size_t pixels_per_stride) {
-    vkutil::Image &image = *cache.current_texture;
+    if (!cache.is_texture_transfer_ready)
+        cache.prepare_staging_buffer();
+
+    vkutil::Image &image = cache.current_texture->texture;
+    TextureStagingBuffer &staging_buffer = cache.staging_buffers[cache.staging_idx];
 
     if (face > 0)
         face--;
@@ -322,32 +448,13 @@ void upload_bound_texture(VKTextureCacheState &cache, SceGxmTextureBaseFormat ba
         upload_size = pixels_per_stride * height * bytes_per_pixel;
     }
 
-    if (cache.alloc_info.size < upload_size) {
-        // we need to create a bigger buffer
-        if (cache.staging_buffer) {
-            // delete the previous one if there is
-            cache.state.allocator.destroyBuffer(cache.staging_buffer, cache.alloc);
-        }
-
-        vk::BufferCreateInfo buffer_info{
-            .size = upload_size,
-            .usage = vk::BufferUsageFlagBits::eTransferSrc,
-            .sharingMode = vk::SharingMode::eExclusive
-        };
-        std::tie(cache.staging_buffer, cache.alloc) = cache.state.allocator.createBuffer(buffer_info, vkutil::vma_mapped_alloc, cache.alloc_info);
+    if (staging_buffer.used_so_far + upload_size > staging_buffer.buffer.size) {
+        LOG_ERROR("Staging buffer size left ({}) is too small for texture size {}!", staging_buffer.buffer.size - staging_buffer.used_so_far, upload_size);
+        return;
     }
 
-    memcpy(cache.alloc_info.pMappedData, text_data, upload_size);
-    vk::CommandBuffer cmd_buffer = vkutil::create_single_time_command(cache.state.device, cache.state.transfer_command_pool);
+    memcpy(reinterpret_cast<uint8_t *>(staging_buffer.buffer.mapped_data) + staging_buffer.used_so_far, text_data, upload_size);
 
-    vk::ImageSubresourceRange range{
-        .aspectMask = vk::ImageAspectFlagBits::eColor,
-        .baseMipLevel = mip_index,
-        .levelCount = 1,
-        .baseArrayLayer = static_cast<uint32_t>(face),
-        .layerCount = 1
-    };
-    vkutil::transition_image_layout(cmd_buffer, image.image, vkutil::ImageLayout::Undefined, vkutil::ImageLayout::TransferDst, range);
     vk::ImageSubresourceLayers layer{
         .aspectMask = vk::ImageAspectFlagBits::eColor,
         .mipLevel = mip_index,
@@ -355,30 +462,30 @@ void upload_bound_texture(VKTextureCacheState &cache, SceGxmTextureBaseFormat ba
         .layerCount = 1
     };
     vk::BufferImageCopy region{
-        .bufferOffset = 0,
+        .bufferOffset = staging_buffer.used_so_far,
         .bufferRowLength = static_cast<uint32_t>(pixels_per_stride),
         .bufferImageHeight = height,
         .imageSubresource = layer,
         .imageOffset = { 0, 0, 0 },
         .imageExtent = { width, height, 1 }
     };
-    cmd_buffer.copyBufferToImage(cache.staging_buffer, image.image, vk::ImageLayout::eTransferDstOptimal, region);
-    vkutil::transition_image_layout(cmd_buffer, image.image, vkutil::ImageLayout::TransferDst, vkutil::ImageLayout::SampledImage, range);
-    cmd_buffer.end();
+    cache.cmd_buffer.copyBufferToImage(staging_buffer.buffer.buffer, image.image, vk::ImageLayout::eTransferDstOptimal, region);
+    staging_buffer.used_so_far += upload_size;
+}
 
-    vk::Device device = cache.state.device;
-
-    vk::SubmitInfo submit_info{};
-    submit_info.setCommandBuffers(cmd_buffer);
-    cache.state.transfer_queue.submit(submit_info, cache.wait_fence);
-    auto result = device.waitForFences(cache.wait_fence, VK_TRUE, std::numeric_limits<uint64_t>::max());
-    if (result != vk::Result::eSuccess) {
-        LOG_ERROR("Could not wait for fences.");
-        assert(false);
-        return;
-    }
-    device.resetFences(cache.wait_fence);
-    device.freeCommandBuffers(cache.state.transfer_command_pool, cmd_buffer);
+void upload_done(VKTextureCacheState &cache) {
+    // transition the texture back to read only
+    vk::ImageSubresourceRange range{
+        .aspectMask = vk::ImageAspectFlagBits::eColor,
+        .baseMipLevel = 0,
+        .levelCount = cache.current_texture->mip_count,
+        .baseArrayLayer = 0,
+        .layerCount = cache.current_texture->is_cube ? 6U : 1U
+    };
+    vkutil::transition_image_layout(cache.cmd_buffer, cache.current_texture->texture.image, vkutil::ImageLayout::TransferDst, vkutil::ImageLayout::SampledImage, range);
+    // this should not be necessary
+    cache.cmd_buffer = nullptr;
+    cache.is_texture_transfer_ready = false;
 }
 } // namespace texture
 


### PR DESCRIPTION
Improve the vulkan texture uploading code so that no fence wait occurs (most of the time).
There are now 16 staging buffers used to transfer texture data, a wait will occur only if these 16 buffers are busy sending data and we will wait only for the oldest buffer. Moreover, the number of image transition has been reduced as only 2 transitions are done per texture upload (instead of 2 per mip per face).

This should reduce stutter when the game uses lots of new images at the same time.

This PR needs a bit more testing before merging.