### PR TITLE
modules/SceNet: scenetEpoll* functions and sockopts

### DIFF
--- a/vita3k/net/CMakeLists.txt
+++ b/vita3k/net/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(
     net
     STATIC
+    include/net/epoll.h
     include/net/functions.h
     include/net/state.h
     include/net/types.h
     include/net/socket.h
+    src/epoll.cpp
     src/net.cpp
     src/posixsocket.cpp
     src/p2psocket.cpp

--- a/vita3k/net/include/net/epoll.h
+++ b/vita3k/net/include/net/epoll.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <net/socket.h>
+
+struct Epoll;
+
+typedef std::shared_ptr<Epoll> EpollPtr;
+
+struct EpollSocket {
+    unsigned int events;
+    SceNetEpollData data;
+    abs_socket sock;
+};
+
+struct Epoll {
+    std::map<int, EpollSocket> eventEntries;
+
+    int add(int id, abs_socket sock, SceNetEpollEvent *ev);
+    int del(int id, abs_socket sock, SceNetEpollEvent *ev);
+    int mod(int id, abs_socket sock, SceNetEpollEvent *ev);
+    int wait(SceNetEpollEvent *events, int maxevents, int timeout);
+};

--- a/vita3k/net/include/net/socket.h
+++ b/vita3k/net/include/net/socket.h
@@ -35,6 +35,7 @@ typedef int socklen_t;
 #include <cerrno>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -55,6 +56,7 @@ struct Socket {
     virtual int send_packet(const void *msg, unsigned int len, int flags, const SceNetSockaddr *to, unsigned int tolen) = 0;
     virtual int recv_packet(void *buf, unsigned int len, int flags, SceNetSockaddr *from, unsigned int *fromlen) = 0;
     virtual int set_socket_options(int level, int optname, const void *optval, unsigned int optlen) = 0;
+    virtual int get_socket_options(int level, int optname, void *optval, unsigned int *optlen) = 0;
     virtual int connect(const SceNetSockaddr *addr, unsigned int namelen) = 0;
     virtual SocketPtr accept(SceNetSockaddr *addr, unsigned int *addrlen) = 0;
     virtual int listen(int backlog) = 0;
@@ -64,6 +66,16 @@ struct Socket {
 // udp, tcp
 struct PosixSocket : public Socket {
     abs_socket sock;
+
+    int sockopt_so_reuseport = 0;
+    int sockopt_so_onesbcast = 0;
+    int sockopt_so_usecrypto = 0;
+    int sockopt_so_usesignature = 0;
+    int sockopt_so_tppolicy = 0;
+    int sockopt_so_nbio = 0;
+    int sockopt_ip_ttlchk = 0;
+    int sockopt_ip_maxttl = 0;
+    int sockopt_tcp_mss_to_advertise = 0;
 
     explicit PosixSocket(int domain, int type, int protocol)
         : Socket(domain, type, protocol)
@@ -78,6 +90,7 @@ struct PosixSocket : public Socket {
     int send_packet(const void *msg, unsigned int len, int flags, const SceNetSockaddr *to, unsigned int tolen) override;
     int recv_packet(void *buf, unsigned int len, int flags, SceNetSockaddr *from, unsigned int *fromlen) override;
     int set_socket_options(int level, int optname, const void *optval, unsigned int optlen) override;
+    int get_socket_options(int level, int optname, void *optval, unsigned int *optlen) override;
     int connect(const SceNetSockaddr *addr, unsigned int namelen) override;
     SocketPtr accept(SceNetSockaddr *addr, unsigned int *addrlen) override;
     int listen(int backlog) override;
@@ -93,6 +106,7 @@ struct P2PSocket : public Socket {
     int send_packet(const void *msg, unsigned int len, int flags, const SceNetSockaddr *to, unsigned int tolen) override;
     int recv_packet(void *buf, unsigned int len, int flags, SceNetSockaddr *from, unsigned int *fromlen) override;
     int set_socket_options(int level, int optname, const void *optval, unsigned int optlen) override;
+    int get_socket_options(int level, int optname, void *optval, unsigned int *optlen) override;
     int connect(const SceNetSockaddr *addr, unsigned int namelen) override;
     SocketPtr accept(SceNetSockaddr *addr, unsigned int *addrlen) override;
     int listen(int backlog) override;

--- a/vita3k/net/include/net/state.h
+++ b/vita3k/net/include/net/state.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <net/epoll.h>
 #include <net/socket.h>
 #include <net/types.h>
 
@@ -25,11 +26,14 @@
 struct Socket;
 
 typedef std::map<int, SocketPtr> NetSockets;
+typedef std::map<int, EpollPtr> NetEpolls;
 
 struct NetState {
     bool inited = false;
     int next_id = 0;
     NetSockets socks;
+    int next_epoll_id = 0;
+    NetEpolls epolls;
     int state = -1;
 };
 

--- a/vita3k/net/include/net/types.h
+++ b/vita3k/net/include/net/types.h
@@ -294,6 +294,18 @@ enum SceNetErrorCode {
     SCE_NET_ERROR_RESOLVER_EALIGNMENT = 0x804101EA
 };
 
+enum SceNetEpollControlFlag : int32_t {
+    SCE_NET_EPOLL_CTL_ADD = 1,
+    SCE_NET_EPOLL_CTL_MOD,
+    SCE_NET_EPOLL_CTL_DEL
+};
+
+enum SceNetEpollEventType {
+    SCE_NET_EPOLLIN = 1,
+    SCE_NET_EPOLLOUT = 2,
+    SCE_NET_EPOLLERR = 8
+};
+
 struct SceNetEtherAddr {
     unsigned char data[6];
 };
@@ -326,4 +338,15 @@ struct SceNetInitParam {
     Ptr<void> memory;
     int32_t size;
     int32_t flags;
+};
+
+union SceNetEpollData {
+    char data[8];
+};
+
+struct SceNetEpollEvent {
+    unsigned int events;
+    unsigned int reserved;
+    unsigned int system[4];
+    SceNetEpollData data;
 };

--- a/vita3k/net/src/epoll.cpp
+++ b/vita3k/net/src/epoll.cpp
@@ -1,0 +1,96 @@
+#include <net/epoll.h>
+
+int Epoll::add(int id, abs_socket sock, SceNetEpollEvent *ev) {
+    auto it = eventEntries.find(id);
+    if (it != eventEntries.end()) {
+        return SCE_NET_ERROR_EEXIST;
+    }
+
+    eventEntries.emplace(id, EpollSocket{ ev->events, ev->data, sock });
+
+    return 0;
+}
+
+int Epoll::del(int id, abs_socket sock, SceNetEpollEvent *ev) {
+    if (eventEntries.erase(id) == 0) {
+        return SCE_NET_ERROR_ENOENT;
+    }
+
+    return 0;
+}
+
+int Epoll::mod(int id, abs_socket sock, SceNetEpollEvent *ev) {
+    auto it = eventEntries.find(id);
+    if (it == eventEntries.end()) {
+        return SCE_NET_ERROR_ENOENT;
+    }
+
+    it->second.events = ev->events;
+    it->second.data = ev->data;
+    return 0;
+}
+
+static void add_event_fd_set(fd_set *set, int *maxFd, abs_socket sock) {
+    FD_SET(sock, set);
+#ifndef _WIN32
+    if (sock > *maxFd) {
+        *maxFd = sock;
+    }
+#endif
+}
+
+int Epoll::wait(SceNetEpollEvent *events, int maxevents, int timeout_microseconds) {
+    fd_set readFds, writeFds, exceptFds;
+    FD_ZERO(&readFds);
+    FD_ZERO(&writeFds);
+    FD_ZERO(&exceptFds);
+    int maxFd = 0;
+
+    for (auto &pair : eventEntries) {
+        auto &epollSocket = pair.second;
+        if (pair.second.events & SCE_NET_EPOLLIN) {
+            add_event_fd_set(&readFds, &maxFd, pair.second.sock);
+        }
+        if (pair.second.events & SCE_NET_EPOLLOUT) {
+            add_event_fd_set(&writeFds, &maxFd, pair.second.sock);
+        }
+        if (pair.second.events & SCE_NET_EPOLLERR) {
+            add_event_fd_set(&exceptFds, &maxFd, pair.second.sock);
+        }
+    }
+
+    timeval timeout;
+    timeout.tv_sec = timeout_microseconds / 1000000;
+    timeout.tv_usec = timeout_microseconds % 1000000;
+    auto ret = select(maxFd, &readFds, &writeFds, &exceptFds, &timeout);
+    if (ret < 0) {
+        // TODO: translate error code
+        return -1;
+    }
+
+    int eventCount = 0;
+    for (auto &pair : eventEntries) {
+        auto id = pair.first;
+        auto &epollSocket = pair.second;
+
+        unsigned int eventTypes = 0;
+        if (FD_ISSET(pair.second.sock, &readFds)) {
+            eventTypes |= SCE_NET_EPOLLIN;
+        }
+        if (FD_ISSET(pair.second.sock, &writeFds)) {
+            eventTypes |= SCE_NET_EPOLLOUT;
+        }
+        if (FD_ISSET(pair.second.sock, &exceptFds)) {
+            eventTypes |= SCE_NET_EPOLLERR;
+        }
+
+        if (eventTypes != 0 && eventCount < maxevents) {
+            auto i = eventCount++;
+
+            events[i].events = eventTypes;
+            events[i].data = pair.second.data;
+        }
+    }
+
+    return eventCount;
+}

--- a/vita3k/net/src/p2psocket.cpp
+++ b/vita3k/net/src/p2psocket.cpp
@@ -37,6 +37,10 @@ int P2PSocket::set_socket_options(int level, int optname, const void *optval, un
     return 0;
 }
 
+int P2PSocket::get_socket_options(int level, int optname, void *optval, unsigned int *optlen) {
+    return 0;
+}
+
 int P2PSocket::recv_packet(void *buf, unsigned int len, int flags, SceNetSockaddr *from, unsigned int *fromlen) {
     return SCE_NET_ERROR_EAGAIN;
 }


### PR DESCRIPTION
Implement and improve some of the network functions. Improves compatibility with homebrew built using vitasdk that use `select`. This also includes those that use libcurl such as this sample program: https://github.com/vitasdk/samples/tree/master/net_libcurl

- Implement `sceNetEpollControl`
- Implement `sceNetEpollCreate`
- Implement `sceNetEpollDestroy`
- Implement `sceNetEpollWait`
- Implement `sceNetGetsockopt`
- Improve `sceNetSetsockopt` implementation