### PR TITLE
modules/module_parent: More correct LLE import path. Fix "Import function for NID 0xE340* not found"

### DIFF
--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -149,6 +149,9 @@ void call_import(EmuEnvState &emuenv, CPUState &cpu, uint32_t nid, SceUID thread
         auto pc = read_pc(cpu);
 
         assert((pc & 1) == 0);
+
+        pc -= 4; // Move back to SVC (SuperVisor Call) instruction
+
         uint32_t *const stub = Ptr<uint32_t>(Address(pc)).get(emuenv.mem);
 
         stub[0] = encode_arm_inst(INSTRUCTION_MOVW, (uint16_t)export_pc, 12);
@@ -165,6 +168,7 @@ void call_import(EmuEnvState &emuenv, CPUState &cpu, uint32_t nid, SceUID thread
         const std::unordered_set<uint32_t> lle_nid_blacklist = {};
         log_import_call('L', nid, thread_id, lle_nid_blacklist, pc);
         write_pc(cpu, export_pc);
+        emuenv.kernel.invalidate_jit_cache(pc, 4 * 3);
     }
 }
 


### PR DESCRIPTION
I was very curious why "Import function for NID 0xE340* not found" appears in log so often and completely disappear when I comment out lle call stub. Now I found why and how to fix it.
Jit cache invalidate is intentional.