### PR TITLE
renderer/vulkan: Clear the bound textures at the start of each renderpass

### DIFF
--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -140,6 +140,15 @@ void VKContext::start_render_pass() {
     if (!is_recording)
         start_recording();
 
+    // make sure we are not keeping any texture from the previous pass
+    // (textures can be still bound even though they are not used)
+    last_vert_texture_count = ~0;
+    last_frag_texture_count = ~0;
+    for (int i = 0; i < 16; i++) {
+        vertex_textures[i].sampler = nullptr;
+        fragment_textures[i].sampler = nullptr;
+    }
+
     vk::RenderPassBeginInfo pass_info{
         .renderPass = current_render_pass,
         .framebuffer = current_framebuffer,


### PR DESCRIPTION
Fix an issue where a texture could still stay bound in the next scene if it was unused, but a texture bound to a slot with a higher index was used. The bound texture could then be invalid which caused the vulkan driver to crash (even though the texture itself was not used).

This fixes the crashes in Uncharted.