### PR TITLE
renderer/vulkan: Implement Memory Mapping

### DIFF
--- a/vita3k/features/include/features/state.h
+++ b/vita3k/features/include/features/state.h
@@ -27,6 +27,7 @@ struct FeatureState {
     bool support_unknown_format = false;
     bool support_rgb_attributes = true; ///< Do the GPU supports RGB (3 components) vertex attribute? If not (AMD GPU), some modifications must be applied to the renderer and the shader recompiler
     bool use_mask_bit = false; ///< Is the mask bit (1 per sample) emulated ? It is only used in homebrews afaik
+    bool support_memory_mapping = false; ///< Is the host GPU memory directly mapped with gxm memory?
 
     bool is_programmable_blending_supported() const {
         return support_shader_interlock || support_texture_barrier || direct_fragcolor;

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2075,24 +2075,30 @@ static int gxmDrawElementGeneral(EmuEnvState &emuenv, const char *export_name, c
     // Update vertex data. We should stores a copy of the data to pass it to GPU later, since another scene
     // may start to overwrite stuff when this scene is being processed in our queue (in case of OpenGL).
     size_t max_index = 0;
-    if (indexType == SCE_GXM_INDEX_FORMAT_U16) {
-        const uint16_t *const data = static_cast<const uint16_t *>(indexData);
-        max_index = *std::max_element(&data[0], &data[indexCount]);
-    } else {
-        const uint32_t *const data = static_cast<const uint32_t *>(indexData);
-        max_index = *std::max_element(&data[0], &data[indexCount]);
+    if (!emuenv.renderer->features.support_memory_mapping) {
+        // we don't need to get the vertex buffer size with memory mapping
+        if (indexType == SCE_GXM_INDEX_FORMAT_U16) {
+            const uint16_t *const data = static_cast<const uint16_t *>(indexData);
+            max_index = *std::max_element(&data[0], &data[indexCount]);
+        } else {
+            const uint32_t *const data = static_cast<const uint32_t *>(indexData);
+            max_index = *std::max_element(&data[0], &data[indexCount]);
+        }
     }
 
     size_t max_data_length[SCE_GXM_MAX_VERTEX_STREAMS] = {};
     std::uint32_t stream_used = 0;
     for (const SceGxmVertexAttribute &attribute : gxm_vertex_program.attributes) {
-        const SceGxmAttributeFormat attribute_format = static_cast<SceGxmAttributeFormat>(attribute.format);
-        const size_t attribute_size = gxm::attribute_format_size(attribute_format) * attribute.componentCount;
-        const SceGxmVertexStream &stream = gxm_vertex_program.streams[attribute.streamIndex];
-        const SceGxmIndexSource index_source = static_cast<SceGxmIndexSource>(stream.indexSource);
-        const size_t data_passed_length = gxm::is_stream_instancing(index_source) ? ((instanceCount - 1) * stream.stride) : (max_index * stream.stride);
-        const size_t data_length = attribute.offset + data_passed_length + attribute_size;
-        max_data_length[attribute.streamIndex] = std::max<size_t>(max_data_length[attribute.streamIndex], data_length);
+        if (!emuenv.renderer->features.support_memory_mapping) {
+            const SceGxmAttributeFormat attribute_format = static_cast<SceGxmAttributeFormat>(attribute.format);
+            const size_t attribute_size = gxm::attribute_format_size(attribute_format) * attribute.componentCount;
+            const SceGxmVertexStream &stream = gxm_vertex_program.streams[attribute.streamIndex];
+            const SceGxmIndexSource index_source = static_cast<SceGxmIndexSource>(stream.indexSource);
+            const size_t data_passed_length = gxm::is_stream_instancing(index_source) ? ((instanceCount - 1) * stream.stride) : (max_index * stream.stride);
+            const size_t data_length = attribute.offset + data_passed_length + attribute_size;
+            max_data_length[attribute.streamIndex] = std::max<size_t>(max_data_length[attribute.streamIndex], data_length);
+        }
+
         stream_used |= (1 << attribute.streamIndex);
     }
 
@@ -2175,13 +2181,16 @@ EXPORT(int, sceGxmDrawPrecomputed, SceGxmContext *context, SceGxmPrecomputedDraw
 
     // Update vertex data. We should stores a copy of the data to pass it to GPU later, since another scene
     // may start to overwrite stuff when this scene is being processed in our queue (in case of OpenGL).
-    size_t max_index = 0;
-    if (draw->index_format == SCE_GXM_INDEX_FORMAT_U16) {
-        const uint16_t *const data = draw->index_data.cast<const uint16_t>().get(emuenv.mem);
-        max_index = *std::max_element(&data[0], &data[draw->vertex_count]);
-    } else {
-        const uint32_t *const data = draw->index_data.cast<const uint32_t>().get(emuenv.mem);
-        max_index = *std::max_element(&data[0], &data[draw->vertex_count]);
+    uint32_t max_index = 0;
+    if (!emuenv.renderer->features.support_memory_mapping) {
+        // we don't need to get the vertex buffer size with memory mapping
+        if (draw->index_format == SCE_GXM_INDEX_FORMAT_U16) {
+            const uint16_t *const data = draw->index_data.cast<const uint16_t>().get(emuenv.mem);
+            max_index = *std::max_element(&data[0], &data[draw->vertex_count]);
+        } else {
+            const uint32_t *const data = draw->index_data.cast<const uint32_t>().get(emuenv.mem);
+            max_index = *std::max_element(&data[0], &data[draw->vertex_count]);
+        }
     }
 
     // set all textures that are used and mark them as dirty
@@ -2204,13 +2213,16 @@ EXPORT(int, sceGxmDrawPrecomputed, SceGxmContext *context, SceGxmPrecomputedDraw
     size_t max_data_length[SCE_GXM_MAX_VERTEX_STREAMS] = {};
     std::uint32_t stream_used = 0;
     for (const SceGxmVertexAttribute &attribute : vertex_program->attributes) {
-        const SceGxmAttributeFormat attribute_format = static_cast<SceGxmAttributeFormat>(attribute.format);
-        const size_t attribute_size = gxm::attribute_format_size(attribute_format) * attribute.componentCount;
-        const SceGxmVertexStream &stream = vertex_program->streams[attribute.streamIndex];
-        const SceGxmIndexSource index_source = static_cast<SceGxmIndexSource>(stream.indexSource);
-        const size_t data_passed_length = gxm::is_stream_instancing(index_source) ? ((draw->instance_count - 1) * stream.stride) : (max_index * stream.stride);
-        const size_t data_length = attribute.offset + data_passed_length + attribute_size;
-        max_data_length[attribute.streamIndex] = std::max<size_t>(max_data_length[attribute.streamIndex], data_length);
+        if (!emuenv.renderer->features.support_memory_mapping) {
+            const SceGxmAttributeFormat attribute_format = static_cast<SceGxmAttributeFormat>(attribute.format);
+            const size_t attribute_size = gxm::attribute_format_size(attribute_format) * attribute.componentCount;
+            const SceGxmVertexStream &stream = vertex_program->streams[attribute.streamIndex];
+            const SceGxmIndexSource index_source = static_cast<SceGxmIndexSource>(stream.indexSource);
+            const size_t data_passed_length = gxm::is_stream_instancing(index_source) ? ((draw->instance_count - 1) * stream.stride) : (max_index * stream.stride);
+            const size_t data_length = attribute.offset + data_passed_length + attribute_size;
+            max_data_length[attribute.streamIndex] = std::max<size_t>(max_data_length[attribute.streamIndex], data_length);
+        }
+
         stream_used |= (1 << attribute.streamIndex);
     }
 
@@ -2281,18 +2293,10 @@ EXPORT(int, sceGxmEndScene, SceGxmContext *context, SceGxmNotification *vertexNo
         return RET_ERROR(SCE_GXM_ERROR_WITHIN_SCENE);
     }
 
+    SceGxmNotification empty_notification = { Ptr<uint32_t>(0), 0 };
+
     // Add command to end the scene
-    renderer::sync_surface_data(*emuenv.renderer, context->renderer.get());
-
-    if (vertexNotification) {
-        renderer::add_command(context->renderer.get(), renderer::CommandOpcode::SignalNotification,
-            nullptr, *vertexNotification, true);
-    }
-
-    if (fragmentNotification) {
-        renderer::add_command(context->renderer.get(), renderer::CommandOpcode::SignalNotification,
-            nullptr, *fragmentNotification, false);
-    }
+    renderer::sync_surface_data(*emuenv.renderer, context->renderer.get(), vertexNotification ? *vertexNotification : empty_notification, fragmentNotification ? *fragmentNotification : empty_notification);
 
     if (context->state.fragment_sync_object) {
         SceGxmSyncObject *sync = context->state.fragment_sync_object.get(mem);
@@ -2594,8 +2598,21 @@ EXPORT(int, sceGxmMapMemory, Ptr<void> base, uint32_t size, uint32_t attribs) {
     GxmState &gxm = emuenv.gxm;
 
     auto ite = gxm.memory_mapped_regions.lower_bound(base.address());
-    if ((ite == gxm.memory_mapped_regions.end()) || (ite->first != base.address())) {
+    if (ite == gxm.memory_mapped_regions.end() || ite->first != base.address()) {
+        if (ite != gxm.memory_mapped_regions.end() && base.address() + size >= ite->first) {
+            LOG_ERROR("Overlapping mapped memory detected");
+
+            if (emuenv.renderer->features.support_memory_mapping) {
+                // overlapping memory mapping is not supported
+                return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
+            }
+        }
         gxm.memory_mapped_regions.emplace(base.address(), MemoryMapInfo{ base.address(), size, attribs });
+
+        // little big planet maps regions of size 0
+        if (emuenv.renderer->features.support_memory_mapping && size > 0)
+            renderer::send_single_command(*emuenv.renderer, nullptr, renderer::CommandOpcode::MemoryMap, true, base, size);
+
         return 0;
     }
 
@@ -5215,6 +5232,9 @@ EXPORT(int, sceGxmUnmapMemory, Ptr<void> base) {
     if (ite == emuenv.gxm.memory_mapped_regions.end()) {
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
     }
+
+    if (emuenv.renderer->features.support_memory_mapping && ite->second.size > 0)
+        renderer::send_single_command(*emuenv.renderer, nullptr, renderer::CommandOpcode::MemoryUnmap, true, base);
 
     emuenv.gxm.memory_mapped_regions.erase(ite);
     return 0;

--- a/vita3k/renderer/include/renderer/commands.h
+++ b/vita3k/renderer/include/renderer/commands.h
@@ -41,6 +41,9 @@ enum class CommandOpcode : std::uint8_t {
     CreateContext,
     CreateRenderTarget,
 
+    MemoryMap,
+    MemoryUnmap,
+
     /**
      * Do draw.
      */

--- a/vita3k/renderer/include/renderer/driver_functions.h
+++ b/vita3k/renderer/include/renderer/driver_functions.h
@@ -55,6 +55,8 @@ COMMAND(handle_create_context);
 COMMAND(handle_destroy_context);
 COMMAND(handle_create_render_target);
 COMMAND(handle_destroy_render_target);
+COMMAND(handle_memory_map);
+COMMAND(handle_memory_unmap);
 
 // Scene
 COMMAND(handle_set_context);

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -84,7 +84,7 @@ void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndex
 void transfer_copy(State &state, uint32_t colorKeyValue, uint32_t colorKeyMask, SceGxmTransferColorKeyMode colorKeyMode, const SceGxmTransferImage *images, SceGxmTransferType srcType, SceGxmTransferType destType);
 void transfer_downscale(State &state, const SceGxmTransferImage *src, const SceGxmTransferImage *dest);
 void transfer_fill(State &state, uint32_t fillColor, const SceGxmTransferImage *dest);
-void sync_surface_data(State &state, Context *ctx);
+void sync_surface_data(State &state, Context *ctx, const SceGxmNotification vertex_notification, const SceGxmNotification fragment_notification);
 
 bool create_context(State &state, std::unique_ptr<Context> &context);
 void destroy_context(State &state, std::unique_ptr<Context> &context);

--- a/vita3k/renderer/include/renderer/gl/types.h
+++ b/vita3k/renderer/include/renderer/gl/types.h
@@ -80,6 +80,12 @@ struct GLContext : public renderer::Context {
     std::pair<std::uint8_t *, std::size_t> vertex_uniform_buffer_storage_ptr{ nullptr, 0 };
     std::pair<std::uint8_t *, std::size_t> fragment_uniform_buffer_storage_ptr{ nullptr, 0 };
 
+    shader::RenderVertUniformBlock previous_vert_info;
+    shader::RenderFragUniformBlock previous_frag_info;
+
+    shader::RenderVertUniformBlock current_vert_render_info;
+    shader::RenderFragUniformBlock current_frag_render_info;
+
     std::vector<size_t> self_sampling_indices;
 
     explicit GLContext();

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -69,6 +69,10 @@ struct State {
     virtual void set_fxaa(bool enable_fxaa) = 0;
     virtual int get_max_anisotropic_filtering() = 0;
     virtual void set_anisotropic_filtering(int anisotropic_filtering) = 0;
+    virtual bool map_memory(void *address, uint32_t size) {
+        return true;
+    }
+    virtual void unmap_memory(void *address) {}
     virtual std::vector<std::string> get_gpu_list() {
         return { "Automatic" };
     }

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -31,6 +31,7 @@
 #include <bitset>
 #include <map>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <vector>
 
@@ -173,12 +174,6 @@ struct Context {
 
     Sha256Hash last_draw_fragment_program_hash;
     Sha256Hash last_draw_vertex_program_hash;
-
-    shader::RenderVertUniformBlock previous_vert_info;
-    shader::RenderFragUniformBlock previous_frag_info;
-
-    shader::RenderVertUniformBlock current_vert_render_info;
-    shader::RenderFragUniformBlock current_frag_render_info;
 
     std::map<int, std::vector<uint8_t>> ubo_data;
 

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -20,25 +20,22 @@
 #include "state.h"
 
 struct Config;
+struct MemState;
 
 namespace renderer::vulkan {
 
 bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const char *base_path);
 
-bool create(VKState &state, std::unique_ptr<Context> &context);
+bool create(VKState &state, std::unique_ptr<Context> &context, MemState &mem);
 bool create(VKState &state, std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &params, const FeatureState &features);
 void destroy(VKState &state, std::unique_ptr<RenderTarget> &rt);
 bool create(std::unique_ptr<VertexProgram> &vp, VKState &state, const SceGxmProgram &program);
 bool create(std::unique_ptr<FragmentProgram> &fp, VKState &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend);
-void create(SceGxmSyncObject *sync);
-void destroy(SceGxmSyncObject *sync);
 
 void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format,
     void *indices, size_t count, uint32_t instance_count, MemState &mem, const Config &config);
 
 void new_frame(VKContext &context);
-void update_sync_target(SceGxmSyncObject *sync, VKRenderTarget *target);
-void update_sync_signal(SceGxmSyncObject *sync);
 
 void set_context(VKContext &context, const MemState &mem, VKRenderTarget *rt, const FeatureState &features);
 void set_uniform_buffer(VKContext &context, const ShaderProgram *program, const bool vertex_shader, const int block_num, const int size, const uint8_t *data);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -62,6 +62,12 @@ struct VKState : public renderer::State {
     // Transfer pool has transient bit set.
     vk::CommandPool transfer_command_pool;
 
+    // only used when memory mapping is enabled
+    std::map<uint64_t, MappedMemory, std::greater<uint64_t>> mapped_memories;
+
+    vkutil::Image default_image;
+    vkutil::Buffer default_buffer;
+
     VKState(int gpu_idx);
 
     bool init(const char *base_path, const bool hashless_texture_cache) override;
@@ -73,6 +79,12 @@ struct VKState : public renderer::State {
     void set_fxaa(bool enable_fxaa) override;
     int get_max_anisotropic_filtering() override;
     void set_anisotropic_filtering(int anisotropic_filtering) override;
+    bool map_memory(void *address, uint32_t size) override;
+    void unmap_memory(void *address) override;
+    // return the matching buffer and offset for the memory location
+    std::tuple<vk::Buffer, uint32_t> get_matching_mapping(const void *address);
+    // return the GPU buffer device address matching this one
+    uint64_t get_matching_device_address(const void *address);
     std::vector<std::string> get_gpu_list() override;
 
     void precompile_shader(const ShadersHash &hash) override;

--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -75,6 +75,8 @@ void process_batch(renderer::State &state, const FeatureState &features, MemStat
         { CommandOpcode::SyncSurfaceData, cmd_handle_sync_surface_data },
         { CommandOpcode::CreateContext, cmd_handle_create_context },
         { CommandOpcode::CreateRenderTarget, cmd_handle_create_render_target },
+        { CommandOpcode::MemoryMap, cmd_handle_memory_map },
+        { CommandOpcode::MemoryUnmap, cmd_handle_memory_unmap },
         { CommandOpcode::Draw, cmd_handle_draw },
         { CommandOpcode::TransferCopy, cmd_handle_transfer_copy },
         { CommandOpcode::TransferDownscale, cmd_handle_transfer_downscale },

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -109,8 +109,8 @@ void transfer_fill(State &state, uint32_t fillColor, const SceGxmTransferImage *
     renderer::send_single_command(state, nullptr, renderer::CommandOpcode::TransferFill, false, fillColor, dest);
 }
 
-void sync_surface_data(State &state, Context *ctx) {
-    renderer::add_command(ctx, renderer::CommandOpcode::SyncSurfaceData, nullptr);
+void sync_surface_data(State &state, Context *ctx, const SceGxmNotification vertex_notification, const SceGxmNotification fragment_notification) {
+    renderer::add_command(ctx, renderer::CommandOpcode::SyncSurfaceData, nullptr, vertex_notification, fragment_notification);
 }
 
 bool create_context(State &state, std::unique_ptr<Context> &context) {

--- a/vita3k/renderer/src/sync.cpp
+++ b/vita3k/renderer/src/sync.cpp
@@ -53,13 +53,6 @@ COMMAND(handle_wait_sync_object) {
     const uint32_t timestamp = helper.pop<uint32_t>();
 
     renderer::wishlist(sync, timestamp);
-
-    if (renderer.current_backend == Backend::Vulkan) {
-        vulkan::VKContext *context = reinterpret_cast<vulkan::VKContext *>(renderer.context);
-        if (context->is_recording)
-            context->stop_recording();
-        vulkan::update_sync_target(sync, reinterpret_cast<vulkan::VKRenderTarget *>(target));
-    }
 }
 
 COMMAND(handle_notification) {

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -44,37 +44,39 @@ void PipelineCache::init() {
     // the layout for uniforms buffer can be made here as it will always be the same
     {
         std::array<vk::DescriptorSetLayoutBinding, 4> layout_bindings;
-        // GXM vertex uniform
+        // Our vertex uniform (GXMRenderVertUniformBlock)
         layout_bindings[0] = vk::DescriptorSetLayoutBinding{
             .binding = 0,
-            .descriptorType = vk::DescriptorType::eStorageBufferDynamic,
-            .descriptorCount = 1,
-            .stageFlags = vk::ShaderStageFlagBits::eVertex,
-        };
-        // GXM Fragment uniform
-        layout_bindings[1] = vk::DescriptorSetLayoutBinding{
-            .binding = 1,
-            .descriptorType = vk::DescriptorType::eStorageBufferDynamic,
-            .descriptorCount = 1,
-            .stageFlags = vk::ShaderStageFlagBits::eFragment,
-        };
-        // Our vertex uniform (GXMRenderVertUniformBlock)
-        layout_bindings[2] = vk::DescriptorSetLayoutBinding{
-            .binding = 2,
             .descriptorType = vk::DescriptorType::eUniformBufferDynamic,
             .descriptorCount = 1,
             .stageFlags = vk::ShaderStageFlagBits::eVertex,
         };
         // Our fragment uniform (GXMRenderFragUniformBlock)
-        layout_bindings[3] = vk::DescriptorSetLayoutBinding{
-            .binding = 3,
+        layout_bindings[1] = vk::DescriptorSetLayoutBinding{
+            .binding = 1,
             .descriptorType = vk::DescriptorType::eUniformBufferDynamic,
             .descriptorCount = 1,
             .stageFlags = vk::ShaderStageFlagBits::eFragment,
         };
+        // GXM vertex uniform (if no memory mapping)
+        layout_bindings[2] = vk::DescriptorSetLayoutBinding{
+            .binding = 2,
+            .descriptorType = vk::DescriptorType::eStorageBufferDynamic,
+            .descriptorCount = 1,
+            .stageFlags = vk::ShaderStageFlagBits::eVertex,
+        };
+        // GXM Fragment uniform (if no memory mapping)
+        layout_bindings[3] = vk::DescriptorSetLayoutBinding{
+            .binding = 3,
+            .descriptorType = vk::DescriptorType::eStorageBufferDynamic,
+            .descriptorCount = 1,
+            .stageFlags = vk::ShaderStageFlagBits::eFragment,
+        };
 
-        vk::DescriptorSetLayoutCreateInfo descriptor_info{};
-        descriptor_info.setBindings(layout_bindings);
+        vk::DescriptorSetLayoutCreateInfo descriptor_info{
+            .bindingCount = state.features.support_memory_mapping ? 2U : 4U,
+            .pBindings = layout_bindings.data()
+        };
         uniforms_layout = state.device.createDescriptorSetLayout(descriptor_info);
     }
 

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -36,7 +36,7 @@ namespace shader {
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
-static constexpr uint32_t CURRENT_VERSION = 7;
+static constexpr uint32_t CURRENT_VERSION = 8;
 
 struct RenderVertUniformBlock {
     std::array<float, 4> viewport_flip;
@@ -47,6 +47,10 @@ struct RenderVertUniformBlock {
     float z_scale;
 };
 
+struct RenderVertUniformBlockWithMapping : public RenderVertUniformBlock {
+    uint64_t buffer_addresses[SCE_GXM_REAL_MAX_UNIFORM_BUFFER] = {};
+};
+
 // used internally to identify the field by the shader recompiler
 // it is put next to the RenderVertUniformBlock so we don't forget to update both fields every time
 enum VertUniformFieldId : uint32_t {
@@ -55,7 +59,8 @@ enum VertUniformFieldId : uint32_t {
     VERT_UNIFORM_screen_width,
     VERT_UNIFORM_screen_height,
     VERT_UNIFORM_z_offset,
-    VERT_UNIFORM_z_scale
+    VERT_UNIFORM_z_scale,
+    VERT_UNIFORM_buffer_addresses
 };
 
 struct RenderFragUniformBlock {
@@ -66,12 +71,17 @@ struct RenderFragUniformBlock {
     int32_t res_multiplier = 0;
 };
 
+struct RenderFragUniformBlockWithMapping : public RenderFragUniformBlock {
+    uint64_t buffer_addresses[SCE_GXM_REAL_MAX_UNIFORM_BUFFER] = {};
+};
+
 enum FragUniformFieldId : uint32_t {
     FRAG_UNIFORM_back_disabled,
     FRAG_UNIFORM_front_disabled,
     FRAG_UNIFORM_writing_mask,
     FRAG_UNIFORM_use_raw_image,
-    FRAG_UNIFORM_res_multiplier
+    FRAG_UNIFORM_res_multiplier,
+    FRAG_UNIFORM_buffer_addresses
 };
 
 enum struct Target {

--- a/vita3k/shader/include/shader/usse_translator_types.h
+++ b/vita3k/shader/include/shader/usse_translator_types.h
@@ -78,9 +78,13 @@ struct SpirvShaderParameters {
     SamplerMap samplers;
 
     // Uniform buffer map contains layout info of a UBO inside the big SSBO.
+    // only used if memory mapping is not enabled
     std::map<std::uint32_t, SpirvUniformBufferInfo> buffers;
 
+    // when not using buffer device address, contains the storage buffer type
     spv::Id buffer_container;
+
+    spv::Id render_info_id;
 };
 
 using Coord = std::pair<spv::Id, int>;

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -34,6 +34,11 @@ struct SpirvUtilFunctions {
     spv::Function *fetch_memory{ nullptr };
     spv::Function *pack_fx8{ nullptr };
     spv::Function *unpack_fx8{ nullptr };
+
+    // buffer_addres_vec[i] contains the buffer pointer with an array of vec_i and stride 16 bytes
+    // this is technically not a function but is the best place to put it
+    // buffer_address_vec[0] is for a packed float[] array
+    spv::Id buffer_address_vec[5] = {};
 };
 
 spv::Id finalize(spv::Builder &b, spv::Id first, spv::Id second, const Swizzle4 swizz, const int offset, const Imm4 dest_mask);
@@ -47,6 +52,7 @@ spv::Id unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureStat
 spv::Id pack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id vec, const DataType source_type);
 
 spv::Id fetch_memory(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, spv::Id addr);
+void buffer_address_load(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand &dest, spv::Id addr, uint32_t component_size, uint32_t nb_components, bool is_fragment, int buffer_idx = -1);
 
 spv::Id make_vector_or_scalar_type(spv::Builder &b, spv::Id component, int size);
 
@@ -54,6 +60,8 @@ spv::Id unwrap_type(spv::Builder &b, spv::Id type);
 
 spv::Id convert_to_float(spv::Builder &b, spv::Id opr, DataType type, bool normal);
 spv::Id convert_to_int(spv::Builder &b, spv::Id opr, DataType type, bool normal);
+
+spv::Id add_uvec2_uint(spv::Builder &b, spv::Id vec, spv::Id to_add);
 
 size_t dest_mask_to_comp_count(shader::usse::Imm4 dest_mask);
 

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -15,9 +15,11 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include <shader/spirv_recompiler.h>
 #include <shader/usse_constant_table.h>
 #include <shader/usse_program_analyzer.h>
 #include <shader/usse_utilities.h>
+
 #include <util/log.h>
 
 #include <SPIRV/GLSL.std.450.h>
@@ -532,6 +534,124 @@ spv::Id shader::usse::utils::fetch_memory(spv::Builder &b, const SpirvShaderPara
     }
 
     return b.createFunctionCall(utils.fetch_memory, { addr });
+}
+
+static spv::Id make_or_get_buffer_ptr(spv::Builder &b, shader::usse::utils::SpirvUtilFunctions &utils, int nb_components, int stride = 16) {
+    const int buffer_utils_idx = (stride == 4) ? 0 : nb_components;
+
+    if (utils.buffer_address_vec[buffer_utils_idx])
+        return utils.buffer_address_vec[buffer_utils_idx];
+
+    const spv::Id f32 = b.makeFloatType(32);
+    const spv::Id vec = shader::usse::utils::make_vector_or_scalar_type(b, f32, nb_components);
+    const spv::Id runtime_array = b.makeRuntimeArray(vec);
+    // always a stride of 16, even if the array size is less
+    b.addDecoration(runtime_array, spv::DecorationArrayStride, stride);
+    const spv::Id buffer_data = b.makeStructType({ runtime_array }, fmt::format("buffer_ptr{}_s{}", nb_components, stride).c_str());
+    b.addDecoration(buffer_data, spv::DecorationBlock);
+    b.addMemberName(buffer_data, 0, "data");
+    // non-writable for the time being
+    b.addMemberDecoration(buffer_data, 0, spv::DecorationNonWritable);
+    b.addMemberDecoration(buffer_data, 0, spv::DecorationOffset, 0);
+
+    utils.buffer_address_vec[buffer_utils_idx] = b.makePointer(spv::StorageClassPhysicalStorageBuffer, buffer_data);
+    return utils.buffer_address_vec[buffer_utils_idx];
+}
+
+void shader::usse::utils::buffer_address_load(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand &dest, spv::Id addr, uint32_t component_size, uint32_t nb_components, bool is_fragment, int buffer_idx) {
+    const spv::Id i32 = b.makeIntType(32);
+    const spv::Id zero = b.makeIntConstant(0);
+
+    spv::Id buffer_idx_val;
+    if (buffer_idx == -1) {
+        // buffer index is in the upper 4 bits of addr
+        buffer_idx_val = b.createBinOp(spv::OpShiftRightLogical, i32, addr, b.makeIntConstant(28));
+        // remove the buffer index bits from the address
+        addr = b.createBinOp(spv::OpBitwiseAnd, i32, addr, b.makeIntConstant((1 << 28) - 1));
+    } else {
+        buffer_idx_val = b.makeIntConstant(buffer_idx);
+    }
+
+    const int render_buffer_idx = is_fragment ? shader::FRAG_UNIFORM_buffer_addresses : shader::VERT_UNIFORM_buffer_addresses;
+    spv::Id buffer_address = utils::create_access_chain(b, spv::StorageClassUniform, params.render_info_id, { b.makeIntConstant(render_buffer_idx), buffer_idx_val });
+    buffer_address = b.createLoad(buffer_address, spv::NoPrecision);
+    // add the offset from the base address
+    buffer_address = add_uvec2_uint(b, buffer_address, addr);
+
+    if (component_size == sizeof(uint32_t)) {
+        int components_left = nb_components;
+        int buffer_idx_vec4 = 0;
+        if (nb_components >= 4) {
+            // first copy them 4 by 4 (using the fact that we can do 4-byte aligned reads)
+            const spv::Id buffer_container = make_or_get_buffer_ptr(b, utils, 4);
+            const spv::Id buffer_address_vec4 = b.createUnaryOp(spv::OpBitcast, buffer_container, buffer_address);
+            while (nb_components >= 4) {
+                spv::Id loaded = utils::create_access_chain(b, spv::StorageClassPhysicalStorageBuffer, buffer_address_vec4, { zero, b.makeIntConstant(buffer_idx_vec4) });
+                loaded = b.createLoad(loaded, spv::NoPrecision, spv::MemoryAccessAlignedMask, spv::ScopeMax, 4);
+
+                store(b, params, utils, features, dest, loaded, 0b1111, 0);
+
+                dest.num += 4;
+                nb_components -= 4;
+                buffer_idx_vec4++;
+            }
+        }
+
+        assert(nb_components < 4);
+        if (nb_components > 0) {
+            // do one last load for the at most 3 last components
+            const spv::Id buffer_container = make_or_get_buffer_ptr(b, utils, nb_components);
+            const spv::Id buffer_address_vec = b.createUnaryOp(spv::OpBitcast, buffer_container, buffer_address);
+
+            spv::Id loaded = utils::create_access_chain(b, spv::StorageClassPhysicalStorageBuffer, buffer_address_vec, { zero, b.makeIntConstant(buffer_idx_vec4) });
+            loaded = b.createLoad(loaded, spv::NoPrecision, spv::MemoryAccessAlignedMask, spv::ScopeMax, 4);
+
+            store(b, params, utils, features, dest, loaded, (1 << nb_components) - 1, 0);
+        }
+    } else {
+        spv::Id f32 = b.makeFloatType(32);
+        spv::Id u32 = b.makeUintType(32);
+
+        // less optimized
+        // TODO: if the gpu supports it, load it as a u16vec4 / u8vec4
+        const spv::Id buffer_container = make_or_get_buffer_ptr(b, utils, 1, 4);
+        // pack the component by groups of 4 (except possible the last ones) when storing them
+        std::vector<spv::Id> loaded_components;
+
+        for (int component_idx = 0; component_idx < nb_components; component_idx++) {
+            spv::Id component_addr = add_uvec2_uint(b, buffer_address, b.makeUintConstant(component_idx * component_size));
+            // we must make it 4-byte aligned
+            spv::Id addr_low_bits = b.createCompositeExtract(component_addr, i32, { 0 });
+            spv::Id alignment = b.createBinOp(spv::OpBitwiseAnd, i32, addr_low_bits, b.makeIntConstant(0b11));
+            addr_low_bits = b.createBinOp(spv::OpBitwiseAnd, i32, addr_low_bits, b.makeIntConstant(~0b11));
+            component_addr = b.createCompositeInsert(addr_low_bits, component_addr, b.getTypeId(component_addr), { 0 });
+
+            // now we can finally load it
+            component_addr = b.createUnaryOp(spv::OpBitcast, buffer_container, component_addr);
+            spv::Id loaded = utils::create_access_chain(b, spv::StorageClassPhysicalStorageBuffer, component_addr, { zero, zero });
+            loaded = b.createLoad(loaded, spv::NoPrecision, spv::MemoryAccessAlignedMask, spv::ScopeMax, 4);
+
+            // now keep only the interesting 8/16 bits
+            loaded = b.createUnaryOp(spv::OpBitcast, i32, loaded);
+            spv::Id shift = b.createBinOp(spv::OpShiftLeftLogical, i32, alignment, b.makeIntConstant(3)); // 1 byte = 8 bits
+            loaded = b.createOp(spv::OpBitFieldSExtract, i32, { loaded, shift, b.makeIntConstant(component_size * 8) });
+
+            loaded_components.push_back(loaded);
+
+            if (loaded_components.size() == 4 || component_idx == nb_components - 1) {
+                spv::Id component_vec;
+                if (loaded_components.size() == 1) {
+                    component_vec = loaded_components[0];
+                } else {
+                    component_vec = b.createCompositeConstruct(b.makeVectorType(i32, loaded_components.size()), loaded_components);
+                }
+                store(b, params, utils, features, dest, component_vec, (1 << loaded_components.size()) - 1, 0);
+
+                dest.num += component_size;
+                loaded_components.clear();
+            }
+        }
+    }
 }
 
 spv::Id shader::usse::utils::unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id scalar, const DataType type) {
@@ -1408,4 +1528,30 @@ spv::Id shader::usse::utils::convert_to_int(spv::Builder &b, spv::Id opr, DataTy
     }
 
     return opr;
+}
+
+spv::Id shader::usse::utils::add_uvec2_uint(spv::Builder &b, spv::Id vec, spv::Id to_add) {
+    if (b.isConstant(to_add) && b.getConstantScalar(to_add) == 0)
+        return vec;
+
+    const spv::Id u32 = b.makeUintType(32);
+    const spv::Id uvec2 = b.makeVectorType(u32, 2);
+    const spv::Id add_result_type = b.makeStructResultType(u32, u32);
+
+    if (!b.isUintType(b.getTypeId(to_add)))
+        // convert i32 to u32
+        to_add = b.createUnaryOp(spv::OpBitcast, u32, to_add);
+
+    // add to_add to the lower part of vec then add the carry to the upper part of vec
+    // something like this
+    // uint carry;
+    // vec.x = uaddCarry(vec.x, to_add, carry);
+    // vec.y += carry;
+    spv::Id lower = b.createCompositeExtract(vec, u32, { 0 });
+    spv::Id lower_add = b.createBinOp(spv::OpIAddCarry, add_result_type, lower, to_add);
+    spv::Id carry = b.createCompositeExtract(lower_add, u32, { 1 });
+    spv::Id upper = b.createCompositeExtract(vec, u32, { 1 });
+    upper = b.createBinOp(spv::OpIAdd, u32, upper, carry);
+    lower = b.createCompositeExtract(lower_add, u32, { 0 });
+    return b.createCompositeConstruct(uvec2, { lower, upper });
 }

--- a/vita3k/threads/include/threads/queue.h
+++ b/vita3k/threads/include/threads/queue.h
@@ -28,7 +28,8 @@
 template <typename T>
 class Queue {
 public:
-    unsigned int maxPendingCount_;
+    // default value: unlimited
+    unsigned int maxPendingCount_ = -1;
 
     std::unique_ptr<T> top(const int ms = 0) {
         T item{ T() };
@@ -108,8 +109,7 @@ public:
 
     void wait_empty() {
         std::unique_lock<std::mutex> mlock(mutex_);
-        if (!aborted && !queue_.empty())
-            cond_.wait(mlock, [&]() { return aborted || queue_.empty(); });
+        cond_.wait(mlock, [&]() { return aborted || queue_.empty(); });
     }
 
     Queue() = default;

--- a/vita3k/vkutil/include/vkutil/objects.h
+++ b/vita3k/vkutil/include/vkutil/objects.h
@@ -96,12 +96,11 @@ protected:
     uint32_t cursor = ~0;
     uint32_t capacity;
 
-    virtual void create() = 0;
-
 public:
     uint32_t data_offset = 0;
 
     explicit RingBuffer(vma::Allocator allocator, vk::BufferUsageFlags usage, const size_t capacity);
+    virtual void create() = 0;
 
     // Allocate new data from ring buffer
     void allocate(const uint32_t data_size);
@@ -124,14 +123,11 @@ public:
 // updates are done with updateBuffer, so each data chunk should be small
 // this is used for our uniform buffers
 class LocalRingBuffer : public RingBuffer {
-protected:
-    void create() override;
-
 public:
     explicit LocalRingBuffer(vma::Allocator allocator, vk::BufferUsageFlags usage, const size_t capacity)
         : RingBuffer(allocator, usage, capacity) {
-        create();
     }
+    void create() override;
 
     void copy(vk::CommandBuffer cmd_buffer, const uint32_t size, const void *data, const uint32_t offset = 0) override;
 };
@@ -142,13 +138,12 @@ public:
 class HostRingBuffer : public RingBuffer {
 protected:
     bool is_coherent;
-    void create() override;
 
 public:
     explicit HostRingBuffer(vma::Allocator allocator, vk::BufferUsageFlags usage, const size_t capacity)
         : RingBuffer(allocator, usage, capacity) {
-        create();
     }
+    void create() override;
 
     void copy(vk::CommandBuffer cmd_buffer, const uint32_t size, const void *data, const uint32_t offset = 0) override;
 };


### PR DESCRIPTION
Implement Memory mapping in Vulkan, this is a first implementation and requires the following extensions:
- VK_KHR_external_memory_host to make the buffers gxm wants to map host gpu accessible
- VK_KHR_buffer_device_address to access buffers using their address instead of a ssbo
- VK_KHR_uniform_buffer_standard_layout so that the uniform buffer passed to shaders are not twice as big as they should be, because in the default std140 layout, the stride of an array of uvec2 is 16 bytes...

This requires a lot of modification, in particular how we handle gxm notifications because now the host gpu must be done when the notification is signaled.

What will be done in other PR:
- Add another memory mapping implementation using a page table for devices not supporting VK_KHR_external_memory_host 
- Implement the shader store operation because gpu buffers are no longer read only (should fix T-Posing in 3D unity games)
- Lots of speed improvements can be made