### PR TITLE
renderer/vulkan: Flush ring buffers if memory is not coherent

### DIFF
--- a/vita3k/vkutil/include/vkutil/objects.h
+++ b/vita3k/vkutil/include/vkutil/objects.h
@@ -141,6 +141,7 @@ public:
 // transferring to the GPU memory
 class HostRingBuffer : public RingBuffer {
 protected:
+    bool is_coherent;
     void create() override;
 
 public:


### PR DESCRIPTION
AMD GPUs running on Metal have a host-visible memory type that is not coherent. A flush is therefore needed for the buffers to be seen by the GPU.

This allows games to render with Vita3K on AMD GPUs with MacOS

Thank you very much for Lupia for the help in finding out this issue.