### PR TITLE
cmake: allow building on Ubuntu 22.04

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 23,
+    "minor": 22,
     "patch": 0
   },
   "configurePresets": [


### PR DESCRIPTION
I've tested this on my 22.04 laptop and it worked perfectly - I'd be willing to guess this number can go even lower, but I don't have a 20.04 system to test CMake 3.16 currently.