### PR TITLE
Add libssl-dev for building on Ubuntu/Debian

### DIFF
--- a/building.md
+++ b/building.md
@@ -113,7 +113,7 @@ Note: The CMake preset `linux-ninja-clang` makes use of the LLD linker, which wi
 - Install dependencies.
 
   ```sh
-  sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev clang lld xdg-desktop-portal openssl
+  sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev clang lld xdg-desktop-portal openssl libssl-dev
   ```
 
 - Clone this repo.


### PR DESCRIPTION
Fixes CMake error when running `cmake --preset linux-ninja-clang` on Lubuntu 22.04.1:
```
CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the                                                  
  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY                                                          
  OPENSSL_INCLUDE_DIR)                                                                                                       
Call Stack (most recent call first):                                                                                         
  /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)                             
  /usr/share/cmake-3.22/Modules/FindOpenSSL.cmake:574 (find_package_handle_standard_args)                                    
  external/CMakeLists.txt:336 (find_package)                                                                                 
                                                                                                                             
                                                                                                                             
-- Configuring incomplete, errors occurred!
```