### PR TITLE
kernel/load_self: implement late binding for export variables

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -691,14 +691,6 @@ static std::vector<std::string> split(const std::string &input, const std::strin
 }
 
 ExitCode run_app(EmuEnvState &emuenv, Ptr<const void> &entry_point) {
-    const CallImport call_import = [&emuenv](CPUState &cpu, uint32_t nid, SceUID main_thread_id) {
-        ::call_import(emuenv, cpu, nid, main_thread_id);
-    };
-
-    const ResolveNIDName resolve_nid_name = [&emuenv](Address addr) {
-        return ::resolve_nid_name(emuenv.kernel, addr);
-    };
-
     const ThreadStatePtr thread = emuenv.kernel.create_thread(emuenv.mem, emuenv.io.title_id.c_str(), entry_point, SCE_KERNEL_DEFAULT_PRIORITY_USER, SCE_KERNEL_THREAD_CPU_AFFINITY_MASK_DEFAULT, static_cast<int>(SCE_KERNEL_STACK_SIZE_USER_MAIN), nullptr);
     if (!thread) {
         app::error_dialog("Failed to init main thread.", emuenv.window.get());

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -61,7 +61,6 @@ typedef std::shared_ptr<SceKernelModuleInfo> SceKernelModuleInfoPtr;
 typedef std::map<SceUID, SceKernelModuleInfoPtr> SceKernelModuleInfoPtrs;
 typedef std::map<SceUID, CallbackPtr> CallbackPtrs;
 typedef std::unordered_map<uint32_t, Address> ExportNids;
-typedef std::map<Address, uint32_t> NidFromExport;
 typedef std::map<Address, uint32_t> NotFoundVars;
 typedef std::unique_ptr<CPUProtocol> CPUProtocolPtr;
 
@@ -113,6 +112,16 @@ struct CorenumAllocator {
     void free_corenum(const int num);
 };
 
+struct late_binding_info {
+    void *entries;
+    uint32_t size;
+    uint32_t module_nid;
+};
+
+typedef std::multimap<uint32_t, late_binding_info> VarLateBindingInfos;
+
+typedef std::map<uint32_t, uint32_t> ModuleUidByNid;
+
 struct KernelState {
     KernelState();
 
@@ -140,7 +149,8 @@ struct KernelState {
     LoadedSysmodules loaded_sysmodules;
     ExportNids export_nids;
     std::shared_mutex export_nids_mutex;
-    NidFromExport nid_from_export;
+    VarLateBindingInfos late_binding_infos;
+    ModuleUidByNid module_uid_by_nid;
 
     bool cpu_opt;
     CPUBackend cpu_backend;
@@ -154,8 +164,6 @@ struct KernelState {
     SceRtcTick base_tick;
     TimerStates timers;
     Ptr<SceProcessParam> process_param;
-
-    NotFoundVars not_found_vars;
 
     Debugger debugger;
 

--- a/vita3k/modules/include/modules/module_parent.h
+++ b/vita3k/modules/include/modules/module_parent.h
@@ -30,7 +30,6 @@ void call_import(EmuEnvState &emuenv, CPUState &cpu, uint32_t nid, SceUID thread
 bool load_module(EmuEnvState &emuenv, SceUID thread_id, SceSysmoduleModuleId module_id);
 Address resolve_export(KernelState &kernel, uint32_t nid);
 uint32_t resolve_nid(KernelState &kernel, Address addr);
-std::string resolve_nid_name(KernelState &kernel, Address addr);
 
 struct VarExport {
     uint32_t nid;

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -92,28 +92,6 @@ Address resolve_export(KernelState &kernel, uint32_t nid) {
     return export_address->second;
 }
 
-uint32_t resolve_nid(KernelState &kernel, Address addr) {
-    auto nid = kernel.nid_from_export.find(addr);
-    if (nid == kernel.nid_from_export.end()) {
-        // resolve the thumbs address
-        addr = addr | 1;
-        nid = kernel.nid_from_export.find(addr);
-        if (nid == kernel.nid_from_export.end()) {
-            return 0;
-        }
-    }
-
-    return nid->second;
-}
-
-std::string resolve_nid_name(KernelState &kernel, Address addr) {
-    auto nid = resolve_nid(kernel, addr);
-    if (nid == 0) {
-        return "";
-    }
-    return import_name(nid);
-}
-
 static void log_import_call(char emulation_level, uint32_t nid, SceUID thread_id, const std::unordered_set<uint32_t> &nid_blacklist, Address lr) {
     if (nid_blacklist.find(nid) == nid_blacklist.end()) {
         const char *const name = import_name(nid);


### PR DESCRIPTION
This PR should fix crashes in games with "[load_var_imports]: 	NID NOT FOUND" warning. It's almost all unity games and some other. I check on "miku miku hockey" game.

The code looks not so good organized, so if you have suggestion of how to make it more simple and understandable, please, comment.