### PR TITLE
gui/home screen: Add badge of compat.

### DIFF
--- a/vita3k/compat/include/compat/state.h
+++ b/vita3k/compat/include/compat/state.h
@@ -39,15 +39,16 @@ struct Compatibility {
 };
 
 struct CompatState {
+    bool compat_db_loaded = false;
     std::map<std::string, Compatibility> app_compat_db;
     std::map<CompatibilityState, ImVec4> compat_color{
         { Unknown, ImVec4(0.54f, 0.54f, 0.54f, 1.f) },
-        { Nothing, ImVec4(0.70f, 0.13f, 0.13f, 1.f) }, // #b60205
+        { Nothing, ImVec4(1.00f, 0.00f, 0.00f, 1.f) }, // #ff0000
         { Bootable, ImVec4(0.39f, 0.12f, 0.62f, 1.f) }, // #621fa5
-        { Intro, ImVec4(0.85f, 0.24f, 0.05f, 1.f) }, // #d93f0b
-        { Menu, ImVec4(0.05f, 0.49f, 0.95f, 1.f) }, // #85def2
-        { Ingame_Less, ImVec4(0.98f, 0.79f, 0.02f, 1.f) }, // #fbca04
-        { Ingame_More, ImVec4(0.98f, 0.79f, 0.02f, 1.f) }, // #fbca04
+        { Intro, ImVec4(0.77f, 0.08f, 0.52f, 1.f) }, // #c71585
+        { Menu, ImVec4(0.11f, 0.46f, 0.85f, 1.f) }, // #1d76db
+        { Ingame_Less, ImVec4(0.88f, 0.54f, 0.12f, 1.f) }, // #e08a1e
+        { Ingame_More, ImVec4(1.00f, 0.84f, 0.00f, 1.f) }, // #ffd700
         { Playable, ImVec4(0.05f, 0.54f, 0.09f, 1.f) }, // #0e8a16
     };
 };

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -279,7 +279,6 @@ struct GuiState {
     std::unique_ptr<ImGui_State> imgui_state;
 
     bool renderer_focused = true;
-    bool compat_loaded = false;
     gui::FileMenuState file_menu;
     gui::DebugMenuState debug_menu;
     gui::ConfigurationMenuState configuration_menu;

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -302,7 +302,7 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
     auto common = emuenv.common_dialog.lang.common;
     auto lang_compat = gui.lang.compatibility;
 
-    const auto has_issue = gui.compat_loaded ? gui.compat.app_compat_db.contains(title_id) : false;
+    const auto has_issue = gui.compat.compat_db_loaded ? gui.compat.app_compat_db.contains(title_id) : false;
     const auto compat_state = has_issue ? gui.compat.app_compat_db[title_id].state : Unknown;
     const auto compat_state_color = gui.compat.compat_color[compat_state];
     const auto compat_state_str = has_issue ? lang_compat.states[compat_state] : lang_compat.states[Unknown];

--- a/vita3k/gui/src/compile_shaders.cpp
+++ b/vita3k/gui/src/compile_shaders.cpp
@@ -89,7 +89,7 @@ void draw_shaders_count_compiled(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(emuenv.viewport_pos.x + (2.f * emuenv.dpi_scale), emuenv.viewport_pos.y + emuenv.viewport_size.y - (42.f * emuenv.dpi_scale)));
     ImGui::SetNextWindowBgAlpha(0.6f);
     ImGui::Begin("##shaders_compiled", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::Text("%llu %s", gui.shaders_compiled_display[Count], gui.lang.compile_shaders["shaders_compiled"].c_str());
+    ImGui::Text("%lu %s", gui.shaders_compiled_display[Count], gui.lang.compile_shaders["shaders_compiled"].c_str());
     ImGui::End();
 }
 

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -643,11 +643,11 @@ void pre_init(GuiState &gui, EmuEnvState &emuenv) {
 
 void init(GuiState &gui, EmuEnvState &emuenv) {
     std::thread load_and_update_compat_db_thread([&gui, &emuenv]() {
-        compat::load_compat_app_db(gui, emuenv);
+        gui.compat.compat_db_loaded = compat::load_compat_app_db(gui, emuenv);
         compat::update_compat_app_db(gui, emuenv);
-        gui.compat_loaded = true;
     });
     load_and_update_compat_db_thread.detach();
+
     get_modules_list(gui, emuenv);
     get_notice_list(emuenv);
     get_users_list(gui, emuenv);


### PR DESCRIPTION
# About:
- gui/home screen: Add badge of compat.
Add feature to display icons and compat badges only in visible area.
- compat: small refactor compat db loaded.

# Result
- grid mode
![image](https://user-images.githubusercontent.com/5261759/218107292-68117652-7e0b-4642-9db5-44e8387cf75b.png)


- List mode
![image](https://user-images.githubusercontent.com/5261759/218107348-57151a3a-c3d1-4cb6-bbdb-40a870c3bda7.png)

