### PR TITLE
vkutil: Initialize size of buffer to 0

### DIFF
--- a/vita3k/vkutil/include/vkutil/objects.h
+++ b/vita3k/vkutil/include/vkutil/objects.h
@@ -63,7 +63,7 @@ struct Buffer {
     vma::Allocation allocation;
     vk::Buffer buffer;
 
-    vk::DeviceSize size;
+    vk::DeviceSize size = 0;
     // only useful is buffer is host visible
     void *mapped_data = nullptr;
 


### PR DESCRIPTION
This fixes the random crash that can occur when starting a game.