### PR TITLE
Typo and wording fixes Season 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-Vita3K is an experimental PlayStation Vita emulator for Windows, Linux and macOS.
+Vita3K is an experimental PlayStation Vita emulator for Windows, Linux, macOS and [Android](https://github.com/Vita3K/Vita3K-Android).
 
 * [Website](https://vita3k.org/) (information for users)
 * [Wiki](https://github.com/Vita3K/Vita3K/wiki) (information for developers)
@@ -13,9 +13,11 @@ Vita3K is an experimental PlayStation Vita emulator for Windows, Linux and macOS
 * IRC `#vita3k` on **freenode** ([Web-based IRC client](https://webchat.freenode.net/?channels=%23vita3k))
 * [Patreon](https://www.patreon.com/Vita3K) (support the project)
 
+You can view the Android version [here](https://github.com/Vita3K/Vita3K-Android).
+
 ## Compatibility
 
-The emulator currently runs some homebrew programs. It is also able to load some decrypted commercial games.
+The emulator currently runs most homebrew programs. It is also able to load some decrypted commercial games.
 
 - [Homebrew compatibility page](https://vita3k.org/compatibility-homebrew.html)
 - [Commercial compatibility page](https://vita3k.org/compatibility.html)
@@ -77,4 +79,4 @@ If you support us on Patreon and would like your name added, please get in touch
 ## Note
 The purpose of this emulator is not to enable illegal activity. You can dump games by using [NoNpDrm](https://github.com/TheOfficialFloW/NoNpDrm)/[FAGDec](https://github.com/CelesteBlue-dev/PSVita-RE-tools/tree/master/FAGDec/build). You can get homebrew programs from [VitaDB](https://vitadb.rinnegatamante.it/).
 
-PlayStation, PlayStation Vita and PS Vita are trademarks of Sony Interactive Entertainment Inc. This emulator is not related to or endorsed by Sony, or derived from confidential materials belonging to Sony.
+PlayStation and PlayStation Vita are trademarks of Sony Interactive Entertainment Inc. This emulator is not related to or endorsed by Sony, or derived from confidential materials belonging to Sony.

--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -348,7 +348,7 @@ Do not power off the system or close the application.</warning_saving>
 
 	<initial_setup>
 		<back>Back</back>
-		<completed_setup>You have now completed the initial setup.
+		<completed_setup>You have now completed initial setup.
 Your Vita3K system is ready!</completed_setup>
 		<select_language>Select a language.</select_language>
 		<completed>Completed.</completed>

--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -26,7 +26,7 @@
 
 	<about name="About">
 		<vita3k>Vita3K: a PS Vita/PS TV Emulator. The world's first functional PS Vita/PS TV emulator.</vita3k>
-		<about_vita3k>Vita3K is an experimental open-source PlayStation Vita/PlayStation TV emulator written in C++ for Windows, Linux and macOS operating systems.</about_vita3k>
+		<about_vita3k>Vita3K is an experimental open-source PlayStation Vita/PlayStation TV emulator written in C++ for Windows, Linux, macOS and Android operating systems.</about_vita3k>
 		<note>Note: The emulator is still in a very early stage of development.</note>
 		<github_website>If you're interested in contributing, check out our GitHub:</github_website>
 		<vita3k_website>Visit our website for more info:</vita3k_website>
@@ -324,7 +324,7 @@ Do not power off the system or close the application.</warning_saving>
 		<usa>USA</usa>
 		<europe>Europe</europe>
 		<japan>Japan</japan>
-		<asia>ASIA</asia>
+		<asia>Asia</asia>
 		<by_type>By Type</by_type>
 		<commercial>Commercial</commercial>
 		<homebrew>Homebrew</homebrew>
@@ -348,7 +348,7 @@ Do not power off the system or close the application.</warning_saving>
 
 	<initial_setup>
 		<back>Back</back>
-		<completed_setup>You have now completed initial setup.
+		<completed_setup>You have now completed the initial setup.
 Your Vita3K system is ready!</completed_setup>
 		<select_language>Select a language.</select_language>
 		<completed>Completed.</completed>
@@ -362,7 +362,7 @@ Your Vita3K system is ready!</completed_setup>
 		<no_font_exist>No firmware font package present.
 Please download and install it.</no_font_exist>
 		<download_firmware_font_package>Download Firmware Font Package</download_firmware_font_package>
-		<firmware_font_package_note>Firmware font package is mandatory for some applications and also for Asian regional font support. (Generally Recommended)</firmware_font_package_note>
+		<firmware_font_package_note>Firmware font package is needed for some applications and also for Asian regional font support. (Generally Recommended)</firmware_font_package_note>
 		<delete_fw>Delete the firmware installation file?</delete_fw>
 		<select_key_type>Select key type</select_key_type>
 		<select_work>Select work.bin</select_work>
@@ -372,7 +372,7 @@ Please download and install it.</no_font_exist>
 		<copy_paste_zrif>Ctrl(Cmd) + C to copy, Ctrl(Cmd) + V to paste.</copy_paste_zrif>
 		<delete_pkg>Delete the pkg file?</delete_pkg>
 		<delete_work>Delete the work.bin file?</delete_work>
-		<check_log>Please check log for more details.</check_log>
+		<check_log>Please check the log for more details.</check_log>
 		<select_install_type>Select install type</select_install_type>
 		<select_file>Select File</select_file>
 		<select_directory>Select Directory</select_directory>

--- a/lang/es.xml
+++ b/lang/es.xml
@@ -31,20 +31,20 @@
 		<github_website>If you're interested in contributing, check out our GitHub:</github_website>
 		<vita3k_website>Visit our website for more info:</vita3k_website>
 		<vita3k_staff>Vita3K Staff</vita3k_staff>
-		<developers>Developers</developers>
-		<contributors>Contributors</contributors>
+		<developers>Desarrolladores</developers>
+		<contributors>Ayudantes</contributors>
 	</about>
 
 	<app_context>
-		<boot>Boot</boot>
+		<boot>Comenzar</boot>
 		<check_app_compatibility>Check App Compatibility</check_app_compatibility>
 		<copy_app_info>Copy App Info</copy_app_info>
-		<name_and_id>Name and Title ID</name_and_id>
+		<name_and_id>Nombre y título ID</name_and_id>
 		<app_summary>App Summary</app_summary>
 		<custom_config>Custom Config</custom_config>
-		<create>Create</create>
-		<edit>Edit</edit>
-		<remove>Remove</remove>
+		<create>Hacer</create>
+		<edit>Editar</edit>
+		<remove>Quitar</remove>
 		<open_folder>Open Folder</open_folder>
 		<addcont>DLCs</addcont>
 		<license>License</license>
@@ -213,8 +213,8 @@ depending on its size and your hardware.</app_delete_note>
 		<clear_all>Borrar todo</clear_all>
 	</content_manager>
 
-	<controllers name="Controllers">
-		<connected>Controllers connected</connected>
+	<controllers name="Controles">
+		<connected>Controles conectado</connected>
 		<name>Nombre</name>
 		<num>Num</num>
 		<not_connected>No compatible controllers connected.


### PR DESCRIPTION
Changes:
- Included mentions of Vita3K being on Android in the readme (this includes links to said repo)
- Added some words in the Spanish translation file (there's too much English!)
- Made changes to the en-gb language file
- Fixed inaccurate PS Vita trademark on readme (PS Vita is NOT a registered trademark, but PLAYSTATION VITA is. Source: https://trademarks.ipo.gov.uk/ipo-tmcase/page/Results/1/UK00910017861

Idk why, I can't merge all commits into one ¯\_(ツ)_/¯