### PR TITLE
renderer/vulkan: Fix typo for 16-bit 4-component scaled attributes

### DIFF
--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -36,8 +36,8 @@ vk::Format translate_attribute_format(SceGxmAttributeFormat format, unsigned int
     static constexpr vk::Format formats_integer_as_float[][4] = {
         /*SCE_GXM_ATTRIBUTE_FORMAT_U8*/ { vk::Format::eR8Uscaled, vk::Format::eR8G8Uscaled, vk::Format::eR8G8B8Uscaled, vk::Format::eR8G8B8A8Uscaled },
         /*SCE_GXM_ATTRIBUTE_FORMAT_S8*/ { vk::Format::eR8Sscaled, vk::Format::eR8G8Sscaled, vk::Format::eR8G8B8Sscaled, vk::Format::eR8G8B8A8Sscaled },
-        /*SCE_GXM_ATTRIBUTE_FORMAT_U16*/ { vk::Format::eR16Uscaled, vk::Format::eR16G16Uscaled, vk::Format::eR16G16B16Uscaled, vk::Format::eR8G8B8A8Uscaled },
-        /*SCE_GXM_ATTRIBUTE_FORMAT_S16*/ { vk::Format::eR16Sscaled, vk::Format::eR16G16Sscaled, vk::Format::eR16G16B16Sscaled, vk::Format::eR8G8B8A8Sscaled },
+        /*SCE_GXM_ATTRIBUTE_FORMAT_U16*/ { vk::Format::eR16Uscaled, vk::Format::eR16G16Uscaled, vk::Format::eR16G16B16Uscaled, vk::Format::eR16G16B16A16Uscaled },
+        /*SCE_GXM_ATTRIBUTE_FORMAT_S16*/ { vk::Format::eR16Sscaled, vk::Format::eR16G16Sscaled, vk::Format::eR16G16B16Sscaled, vk::Format::eR16G16B16A16Sscaled },
     };
 
     static constexpr vk::Format formats_float[][4] = {


### PR DESCRIPTION
This fixes the characters in A.W Phoenix Fiesta and Batman.