### PR TITLE
compat: Fix failure when updating compat DB on macOS

### DIFF
--- a/vita3k/compat/src/compat.cpp
+++ b/vita3k/compat/src/compat.cpp
@@ -23,11 +23,6 @@
 
 #include <pugixml.hpp>
 
-#ifdef __APPLE__
-#include <pwd.h>
-#include <unistd.h>
-#endif
-
 namespace compat {
 
 static std::string db_updated_at;
@@ -122,13 +117,7 @@ static std::string get_string_output(const std::string cmd) {
 }
 
 bool update_compat_app_db(GuiState &gui, EmuEnvState &emuenv) {
-#ifndef __APPLE__
     const auto compat_db_path = fs::path(emuenv.base_path) / "cache/app_compat_db.xml";
-#else
-    struct passwd *pwent = getpwuid(getuid());
-    const auto compat_db_path = fs::path(fmt::format("{}/cache/app_compat_db.yml", pwent->pw_dir));
-#endif
-
     const auto latest_link = "https://api.github.com/repos/Vita3K/compatibility/releases/latest";
 
 #ifdef WIN32


### PR DESCRIPTION
Updating and loading compat DB on macOS failed due to two reasons.

First, it try to download `app_compat_db.xml` to `~/cache/app_compat_db.xml`. But if `~/cache` directory doesn't exist, it will fail to download.

Second, if `~/cache` directory exist `app_compat_db.xml` is downloaded successfully. However Vita3k try to load `app_compat_db.xml` from `Vita3K.app/Contents/Resources/cache/app_compat_db.xml` which is not the place where `app_compat_db.xml ` has been downloaded.

BTW, it doesn't need to download `app_compat_db.xml` in `~/cache/app_compat_db.xml`. So doing same with Linux will make it work.