### PR TITLE
gui/settings dialog: Add clean all custom config

### DIFF
--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -771,6 +771,16 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("Reset Vita3K emulator path to the default.\nYou will need to move your old folder to the new location manually.");
         }
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize("Custom Config Settings").x / 2.f));
+        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "Custom Config Settings");
+        ImGui::Spacing();
+        if (ImGui::Button("Clear Custom Config")) {
+            if (fs::remove_all({ fs::path(emuenv.base_path) / "config" })) {
+                LOG_INFO("Clear all custom config settings successfully.");
+            }
+        }
         ImGui::EndTabItem();
     } else
         ImGui::PopStyleColor();

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -793,8 +793,11 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::Spacing();
                 ImGui::Separator();
                 ImGui::Spacing();
-                if (ImGui::MenuItem(gui.lang.indicator["delete_all"].c_str()))
-                    fs::remove_all(TROPHY_PATH);
+                if (ImGui::MenuItem(gui.lang.indicator["delete_all"].c_str())) {
+                    if (fs::remove_all(TROPHY_PATH)) {
+                        LOG_INFO("Delete all trophies successfully.");
+                    }
+                }
             } else {
                 if (ImGui::MenuItem(lang["original"].c_str(), nullptr, trophy_sort == "original")) {
                     std::sort(trophy_list.begin(), trophy_list.end(), [](const auto &ta, const auto &tb) {


### PR DESCRIPTION
# About
- gui/settings dialog: Add clean all custom config
to make it easier to clear all custom config settings.
- gui/trophy collection: Add delete all trophies log info

Please Mr. @Zangetsu38 check this PR.

# Result
![image](https://user-images.githubusercontent.com/61804715/227619758-ce96df48-7a9c-4a8d-8af7-859ba60fb8de.png)
![image](https://user-images.githubusercontent.com/61804715/227619842-ab143450-15f9-4b73-b526-49cb1b737936.png)
