### PR TITLE
modules/SceGxm, display, shader: Small fixes

### DIFF
--- a/vita3k/display/include/display/state.h
+++ b/vita3k/display/include/display/state.h
@@ -37,7 +37,6 @@ typedef std::shared_ptr<ThreadState> ThreadStatePtr;
 struct DisplayStateVBlankWaitInfo {
     ThreadStatePtr target_thread;
     uint64_t target_vcount;
-    bool is_cb;
 };
 
 struct DisplayFrameInfo {

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -3089,13 +3089,15 @@ EXPORT(int, sceGxmProgramGetOutputRegisterFormat, const SceGxmProgram *program, 
 
 EXPORT(Ptr<SceGxmProgramParameter>, sceGxmProgramGetParameter, const SceGxmProgram *program, uint32_t index) {
     TRACY_FUNC(sceGxmProgramGetParameter, program, index);
+    if (index >= program->parameter_count)
+        return Ptr<SceGxmProgramParameter>(0);
+
     const SceGxmProgramParameter *const parameters = reinterpret_cast<const SceGxmProgramParameter *>(reinterpret_cast<const uint8_t *>(&program->parameters_offset) + program->parameters_offset);
 
     const SceGxmProgramParameter *const parameter = &parameters[index];
     const uint8_t *const parameter_bytes = reinterpret_cast<const uint8_t *>(parameter);
 
-    const Address parameter_address = static_cast<Address>(parameter_bytes - &emuenv.mem.memory[0]);
-    return Ptr<SceGxmProgramParameter>(parameter_address);
+    return Ptr<SceGxmProgramParameter>(parameter_bytes, emuenv.mem);
 }
 
 EXPORT(uint32_t, sceGxmProgramGetParameterCount, const SceGxmProgram *program) {

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -957,7 +957,7 @@ void USSERecompiler::compile_loop_node(const usse::USSELoopNode &loop) {
     b.setBuildPoint(&loops.head);
 
     // In the head we only want to branch to body. We always do while do anyway
-    b.createLoopMerge(&loops.merge, &loops.head, 0, {});
+    b.createLoopMerge(&loops.merge, &loops.continue_target, 0, {});
     b.createBranch(&loops.body);
 
     // Emit body content


### PR DESCRIPTION
A few simple fixes:
- When calling sceGxmProgramGetParameter, il the parameter index is not valid, exist archive uses this (iterate until null is returned)
- Fix a regression caused when using VBlank callbacks since the svc rewrite, they were executed by the VBlank thread instead of the callback Thread, which made dynarmic crash.
- Fix a validation error when making a loop in spirV

This allows the game exist archive to go from nothing to menu.