### PR TITLE
modules/SceVideodecUser: set frame horizontalSize and verticalSize

### DIFF
--- a/vita3k/modules/SceVideodec/SceVideodecUser.cpp
+++ b/vita3k/modules/SceVideodec/SceVideodecUser.cpp
@@ -190,6 +190,7 @@ EXPORT(int, sceAvcdecDecode, SceAvcdecCtrl *decoder, const SceAvcdecAu *au, SceA
     const auto send = decoder_info->send(reinterpret_cast<uint8_t *>(au->es.pBuf.get(emuenv.mem)), au->es.size);
     if (send && decoder_info->receive(output)) {
         decoder_info->get_res(pPicture->frame.frameWidth, pPicture->frame.frameHeight);
+        decoder_info->get_res(pPicture->frame.horizontalSize, pPicture->frame.verticalSize);
         decoder_info->get_pts(pPicture->info.pts.upper, pPicture->info.pts.lower);
         picture->numOfOutput++;
     }
@@ -296,6 +297,7 @@ EXPORT(int, sceAvcdecDecodeStop, SceAvcdecCtrl *decoder, SceAvcdecArrayPicture *
         memset(output, 0, H264DecoderState::buffer_size(size));
         // we get the values from the last frame, maybe we should slightly increase the pts value?
         decoder_info->get_res(pPicture->frame.frameWidth, pPicture->frame.frameHeight);
+        decoder_info->get_res(pPicture->frame.horizontalSize, pPicture->frame.verticalSize);
         decoder_info->get_pts(pPicture->info.pts.upper, pPicture->info.pts.lower);
 
         picture->numOfOutput = 1;


### PR DESCRIPTION
Setting horizontalSize and verticalSize values is needed for MGF and Project Diva games to not get stuck when handling AVC videos.

Another thing probably worth mentioning is that, these game may also depend on a stopped video for its game object textures, if the video is stopped, the related object will have green color. Potential fix would be for sceAvcdecDecodeStop to return 0 frames or return the last decoded frame. This however, is not the scope of the current PR.