### PR TITLE
gui/app context menu/compat: Add pre-filled body in create issue and small fix

### DIFF
--- a/vita3k/config/include/config/version.h
+++ b/vita3k/config/include/config/version.h
@@ -19,5 +19,7 @@
 
 extern const char org_name[];
 extern const char app_name[];
+extern const char app_version[];
 extern const int app_number;
+extern const char app_hash[];
 extern const char window_title[];

--- a/vita3k/config/src/version.cpp.in
+++ b/vita3k/config/src/version.cpp.in
@@ -19,5 +19,7 @@
 
 const char org_name[] = "${VITA3K_ORG_NAME}";
 const char app_name[] = "${VITA3K_APP_NAME}";
+const char app_version[] = "${VITA3K_APP_VERSION}";
 const int app_number = ${GIT_COUNT};
+const char app_hash[] = "${GIT_HASH}";
 const char window_title[] = "${VITA3K_APP_NAME} ${VITA3K_APP_VERSION} ${GIT_COUNT}-${VITA3K_GIT_REV}";

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -45,6 +45,7 @@ std::vector<std::string>::iterator get_app_open_list_index(GuiState &gui, const 
 std::map<DateTime, std::string> get_date_time(GuiState &gui, EmuEnvState &emuenv, const tm &date_time);
 std::string get_unit_size(const size_t &size);
 void get_app_param(GuiState &gui, EmuEnvState &emuenv, const std::string app_path);
+std::string get_cpu_backend(GuiState &gui, EmuEnvState &emuenv, const std::string app_path);
 void get_modules_list(GuiState &gui, EmuEnvState &emuenv);
 void get_notice_list(EmuEnvState &emuenv);
 std::string get_theme_title_from_buffer(const vfs::FileBuffer buffer);
@@ -98,7 +99,7 @@ void save_notice_list(EmuEnvState &emuenv);
 
 void draw_begin(GuiState &gui, EmuEnvState &emuenv);
 void draw_end(GuiState &emuenv, SDL_Window *window);
-void draw_live_area(GuiState &gui, EmuEnvState &emuenv);
+void draw_vita_area(GuiState &gui, EmuEnvState &emuenv);
 void draw_ui(GuiState &gui, EmuEnvState &emuenv);
 
 void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -123,7 +123,7 @@ struct AppsSelector {
     SelectorState state = SELECT_APP;
 };
 
-struct LiveAreaState {
+struct VitaAreaState {
     bool app_close = false;
     bool app_information = false;
     bool content_manager = false;
@@ -290,7 +290,7 @@ struct GuiState {
     gui::ConfigurationMenuState configuration_menu;
     gui::ControlMenuState controls_menu;
     gui::HelpMenuState help_menu;
-    gui::LiveAreaState live_area;
+    gui::VitaAreaState vita_area;
     gui::AppsSelector app_selector;
 
     CompatState compat;

--- a/vita3k/gui/src/content_manager.cpp
+++ b/vita3k/gui/src/content_manager.cpp
@@ -251,7 +251,7 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
 
-    ImGui::Begin("##content_manager", &gui.live_area.content_manager, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##content_manager", &gui.vita_area.content_manager, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
         ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10026"], ImVec2(0.f, 0.f), display_size);
     else
@@ -327,7 +327,7 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SetWindowFontScale(1.2f);
         if (ImGui::Selectable(lang.main["theme"].c_str(), false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0.f, SIZE_SELECT))) {
             emuenv.app_path = "NPXS10026";
-            gui.live_area.content_manager = false;
+            gui.vita_area.content_manager = false;
             pre_run_app(gui, emuenv, "NPXS10015");
         }
         ImGui::NextColumn();
@@ -564,10 +564,10 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
                     menu.clear();
             } else {
                 if (!gui.apps_list_opened.empty() && gui.apps_list_opened[gui.current_app_selected] == "NPXS10026")
-                    gui.live_area.live_area_screen = true;
+                    gui.vita_area.live_area_screen = true;
                 else
-                    gui.live_area.home_screen = true;
-                gui.live_area.content_manager = false;
+                    gui.vita_area.home_screen = true;
+                gui.vita_area.content_manager = false;
             }
         }
     } else {

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -496,12 +496,12 @@ void init_home(GuiState &gui, EmuEnvState &emuenv) {
     if (!gui.users.empty() && (gui.users.find(emuenv.cfg.user_id) != gui.users.end()) && (is_cmd || emuenv.cfg.auto_user_login)) {
         init_user(gui, emuenv, emuenv.cfg.user_id);
         if (!is_cmd && emuenv.cfg.auto_user_login) {
-            gui.live_area.information_bar = true;
+            gui.vita_area.information_bar = true;
             open_user(gui, emuenv);
         }
     } else {
-        gui.live_area.information_bar = true;
-        gui.live_area.user_management = true;
+        gui.vita_area.information_bar = true;
+        gui.vita_area.user_management = true;
     }
 }
 
@@ -725,21 +725,24 @@ void draw_end(GuiState &gui, SDL_Window *window) {
     ImGui_ImplSdl_RenderDrawData(gui.imgui_state.get());
 }
 
-void draw_live_area(GuiState &gui, EmuEnvState &emuenv) {
+void draw_vita_area(GuiState &gui, EmuEnvState &emuenv) {
+    if (gui.vita_area.start_screen)
+        draw_start_screen(gui, emuenv);
+
     ImGui::PushFont(gui.vita_font);
 
-    if (gui.live_area.app_close)
+    if (gui.vita_area.app_close)
         draw_app_close(gui, emuenv);
 
-    if (gui.live_area.home_screen)
+    if (gui.vita_area.home_screen)
         draw_home_screen(gui, emuenv);
 
-    if ((emuenv.cfg.show_info_bar || !emuenv.display.imgui_render || !gui.live_area.home_screen) && gui.live_area.information_bar)
+    if ((emuenv.cfg.show_info_bar || !emuenv.display.imgui_render || !gui.vita_area.home_screen) && gui.vita_area.information_bar)
         draw_information_bar(gui, emuenv);
 
-    if (gui.live_area.live_area_screen)
+    if (gui.vita_area.live_area_screen)
         draw_live_area_screen(gui, emuenv);
-    if (gui.live_area.manual)
+    if (gui.vita_area.manual)
         draw_manual(gui, emuenv);
 
     if (gui.file_menu.archive_install_dialog)
@@ -751,7 +754,7 @@ void draw_live_area(GuiState &gui, EmuEnvState &emuenv) {
     if (gui.file_menu.pkg_install_dialog)
         draw_pkg_install_dialog(gui, emuenv);
 
-    if (gui.live_area.user_management)
+    if (gui.vita_area.user_management)
         draw_user_management(gui, emuenv);
 
     if (!gui.shaders_compiled_display.empty())
@@ -760,27 +763,27 @@ void draw_live_area(GuiState &gui, EmuEnvState &emuenv) {
     if (!gui.trophy_unlock_display_requests.empty())
         draw_trophies_unlocked(gui, emuenv);
 
-    if (emuenv.ime.state && !gui.live_area.home_screen && !gui.live_area.live_area_screen && get_sys_apps_state(gui))
+    if (emuenv.ime.state && !gui.vita_area.home_screen && !gui.vita_area.live_area_screen && get_sys_apps_state(gui))
         draw_ime(emuenv.ime, emuenv);
 
     // System App
-    if (gui.live_area.content_manager)
+    if (gui.vita_area.content_manager)
         draw_content_manager(gui, emuenv);
 
-    if (gui.live_area.settings)
+    if (gui.vita_area.settings)
         draw_settings(gui, emuenv);
 
-    if (gui.live_area.trophy_collection)
+    if (gui.vita_area.trophy_collection)
         draw_trophy_collection(gui, emuenv);
+
+    if (gui.help_menu.vita3k_update)
+        draw_vita3k_update(gui, emuenv);
 
     // Info Message
     if (!gui.info_message.msg.empty())
         draw_info_message(gui, emuenv);
 
     ImGui::PopFont();
-
-    if (gui.live_area.start_screen)
-        draw_start_screen(gui, emuenv);
 }
 
 void draw_ui(GuiState &gui, EmuEnvState &emuenv) {
@@ -824,9 +827,6 @@ void draw_ui(GuiState &gui, EmuEnvState &emuenv) {
 
     if (gui.configuration_menu.custom_settings_dialog || gui.configuration_menu.settings_dialog)
         draw_settings_dialog(gui, emuenv);
-
-    if (gui.help_menu.vita3k_update)
-        draw_vita3k_update(gui, emuenv);
 
     ImGui::PopFont();
 }

--- a/vita3k/gui/src/home_screen.cpp
+++ b/vita3k/gui/src/home_screen.cpp
@@ -115,9 +115,9 @@ void open_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string app_pa
     update_apps_list_opened(gui, emuenv, app_path);
     last_time["home"] = 0;
     init_live_area(gui, emuenv, app_path);
-    gui.live_area.home_screen = false;
-    gui.live_area.information_bar = true;
-    gui.live_area.live_area_screen = true;
+    gui.vita_area.home_screen = false;
+    gui.vita_area.information_bar = true;
+    gui.vita_area.live_area_screen = true;
 }
 
 void pre_load_app(GuiState &gui, EmuEnvState &emuenv, bool live_area, const std::string &app_path) {
@@ -136,30 +136,30 @@ void pre_run_app(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
     if (app_path.find("NPXS") == std::string::npos) {
         if (emuenv.io.app_path != app_path) {
             if (!emuenv.io.app_path.empty())
-                gui.live_area.app_close = true;
+                gui.vita_area.app_close = true;
             else {
-                gui.live_area.home_screen = false;
-                gui.live_area.live_area_screen = false;
+                gui.vita_area.home_screen = false;
+                gui.vita_area.live_area_screen = false;
                 emuenv.io.app_path = app_path;
             }
         } else {
-            gui.live_area.live_area_screen = false;
-            gui.live_area.information_bar = false;
+            gui.vita_area.live_area_screen = false;
+            gui.vita_area.information_bar = false;
         }
     } else {
-        gui.live_area.home_screen = false;
-        gui.live_area.live_area_screen = false;
+        gui.vita_area.home_screen = false;
+        gui.vita_area.live_area_screen = false;
         init_app_background(gui, emuenv, app_path);
         update_last_time_app_used(gui, emuenv, app_path);
 
         if (app_path == "NPXS10008") {
             init_trophy_collection(gui, emuenv);
-            gui.live_area.trophy_collection = true;
+            gui.vita_area.trophy_collection = true;
         } else if (app_path == "NPXS10015")
-            gui.live_area.settings = true;
+            gui.vita_area.settings = true;
         else {
             init_content_manager(gui, emuenv);
-            gui.live_area.content_manager = true;
+            gui.vita_area.content_manager = true;
         }
     }
 }
@@ -176,7 +176,7 @@ void draw_app_close(GuiState &gui, EmuEnvState &emuenv) {
 
     ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
-    ImGui::Begin("##app_close", &gui.live_area.app_close, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##app_close", &gui.vita_area.app_close, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f * SCALE.x);
     ImGui::BeginChild("##app_close_child", WINDOW_SIZE, true, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
@@ -196,7 +196,7 @@ void draw_app_close(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::TextColored(GUI_COLOR_TEXT, "%s", emuenv.current_app_title.c_str());
     ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2) - (BUTTON_SIZE.x + (20.f * SCALE.x)), WINDOW_SIZE.y - BUTTON_SIZE.y - (24.0f * SCALE.y)));
     if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_circle))
-        gui.live_area.app_close = false;
+        gui.vita_area.app_close = false;
     ImGui::SameLine(0, 20.f * SCALE.x);
     if (ImGui::Button("OK", BUTTON_SIZE) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_cross)) {
         const auto app_path = gui.apps_list_opened[gui.current_app_selected];
@@ -362,7 +362,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
     const auto SCALE = ImVec2(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
     const auto INFORMATION_BAR_HEIGHT = 32.f * SCALE.y;
-    const auto MENUBAR_BG_HEIGHT = (!emuenv.cfg.show_info_bar && emuenv.display.imgui_render) || !gui.live_area.information_bar ? 22.f * SCALE.x : INFORMATION_BAR_HEIGHT;
+    const auto MENUBAR_BG_HEIGHT = (!emuenv.cfg.show_info_bar && emuenv.display.imgui_render) || !gui.vita_area.information_bar ? 22.f * SCALE.x : INFORMATION_BAR_HEIGHT;
 
     const auto is_background = (gui.users[emuenv.io.user_id].use_theme_bg && !gui.theme_backgrounds.empty()) || !gui.user_backgrounds.empty();
 
@@ -370,13 +370,13 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
     ImGui::SetNextWindowBgAlpha(is_background ? emuenv.cfg.background_alpha : 0.f);
-    ImGui::Begin("##home_screen", &gui.live_area.home_screen, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##home_screen", &gui.vita_area.home_screen, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
     if (!emuenv.display.imgui_render || ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows))
-        gui.live_area.information_bar = true;
+        gui.vita_area.information_bar = true;
 
     const auto config_dialog = gui.configuration_menu.custom_settings_dialog || gui.configuration_menu.settings_dialog || gui.controls_menu.controls_dialog;
     const auto install_dialog = gui.file_menu.archive_install_dialog || gui.file_menu.firmware_install_dialog || gui.file_menu.pkg_install_dialog;
-    if (!config_dialog && !install_dialog && !gui.live_area.app_close && !gui.live_area.app_information && !gui.help_menu.about_dialog && !gui.help_menu.welcome_dialog) {
+    if (!config_dialog && !install_dialog && !gui.vita_area.app_close && !gui.vita_area.app_information && !gui.help_menu.about_dialog && !gui.help_menu.welcome_dialog) {
         if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) || ImGui::IsAnyItemActive() || ImGui::IsAnyItemHovered())
             last_time["start"] = 0;
         else {
@@ -386,14 +386,14 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
             while (last_time["start"] + emuenv.cfg.delay_start < current_time()) {
                 last_time["start"] += emuenv.cfg.delay_start;
                 last_time["home"] = 0;
-                gui.live_area.home_screen = false;
-                gui.live_area.information_bar = true;
-                gui.live_area.start_screen = true;
+                gui.vita_area.home_screen = false;
+                gui.vita_area.information_bar = true;
+                gui.vita_area.start_screen = true;
             }
         }
     }
 
-    if (!gui.live_area.start_screen && !gui.live_area.live_area_screen && (!gui.theme_backgrounds.empty() || !gui.user_backgrounds.empty())) {
+    if (!gui.vita_area.start_screen && !gui.vita_area.live_area_screen && (!gui.theme_backgrounds.empty() || !gui.user_backgrounds.empty())) {
         if (last_time["home"] == 0)
             last_time["home"] = current_time();
 
@@ -719,8 +719,8 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
             || !ImGui::GetIO().WantTextInput && (ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_r1) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_leftstick_right) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_right))) {
             last_time["start"] = 0;
             ++gui.current_app_selected;
-            gui.live_area.home_screen = false;
-            gui.live_area.live_area_screen = true;
+            gui.vita_area.home_screen = false;
+            gui.vita_area.live_area_screen = true;
         }
     }
     if (current_scroll_pos < max_scroll_pos) {

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -510,18 +510,18 @@ void draw_information_bar(GuiState &gui, EmuEnvState &emuenv) {
     const ImU32 DEFAULT_BAR_COLOR = 0xFF000000; // Black
     const ImU32 DEFAULT_INDICATOR_COLOR = 0xFFFFFFFF; // White
     const auto is_12_hour_format = emuenv.cfg.sys_time_format == SCE_SYSTEM_PARAM_TIME_FORMAT_12HOUR;
-    const auto is_notif_pos = !gui.live_area.start_screen && (gui.live_area.live_area_screen || gui.live_area.home_screen) ? 78.f * SCALE.x : 0.f;
-    const auto is_theme_color = gui.live_area.home_screen || gui.live_area.live_area_screen || gui.live_area.start_screen;
+    const auto is_notif_pos = !gui.vita_area.start_screen && (gui.vita_area.live_area_screen || gui.vita_area.home_screen) ? 78.f * SCALE.x : 0.f;
+    const auto is_theme_color = gui.vita_area.home_screen || gui.vita_area.live_area_screen || gui.vita_area.start_screen;
     const auto indicator_color = gui.information_bar_color.indicator;
     const auto bar_color = gui.information_bar_color.bar;
 
     ImGui::SetNextWindowPos(ImVec2(0.f, 0.f), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
-    ImGui::Begin("##information_bar", &gui.live_area.information_bar, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##information_bar", &gui.vita_area.information_bar, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
 
     ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(0.f, 0.f), ImVec2(display_size.x, INFORMATION_BAR_HEIGHT), is_theme_color ? bar_color : DEFAULT_BAR_COLOR, 0.f, ImDrawFlags_RoundCornersAll);
 
-    if (gui.live_area.home_screen || gui.live_area.live_area_screen) {
+    if (gui.vita_area.home_screen || gui.vita_area.live_area_screen) {
         const auto HOME_ICON_POS_CENTER = (display_size.x / 2.f) - (32.f * ((float(gui.apps_list_opened.size())) / 2.f)) * SCALE.x;
         const auto APP_IS_OPEN = gui.current_app_selected >= 0;
 
@@ -589,8 +589,8 @@ void draw_information_bar(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (54.f * SCALE.x) - is_notif_pos, 12.f * SCALE.y), ImVec2(display_size.x - (50.f * SCALE.x) - is_notif_pos, 20 * SCALE.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
     ImGui::GetForegroundDrawList()->AddRectFilled(ImVec2(display_size.x - (50.f * SCALE.x) - is_notif_pos, 5.f * SCALE.y), ImVec2(display_size.x - (12.f * SCALE.x) - is_notif_pos, 27 * SCALE.y), IM_COL32(81.f, 169.f, 32.f, 255.f), 2.f * SCALE.x, ImDrawFlags_RoundCornersAll);
 
-    if (emuenv.display.imgui_render && !gui.live_area.start_screen && !gui.live_area.live_area_screen && !gui.help_menu.vita3k_update && get_sys_apps_state(gui) && (ImGui::IsWindowHovered(ImGuiHoveredFlags_None) || ImGui::IsItemClicked(0)))
-        gui.live_area.information_bar = false;
+    if (emuenv.display.imgui_render && !gui.vita_area.start_screen && !gui.vita_area.live_area_screen && !gui.help_menu.vita3k_update && get_sys_apps_state(gui) && (ImGui::IsWindowHovered(ImGuiHoveredFlags_None) || ImGui::IsItemClicked(0)))
+        gui.vita_area.information_bar = false;
 
     if (is_notif_pos)
         draw_notice_info(gui, emuenv);

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -38,7 +38,7 @@
 namespace gui {
 
 bool get_sys_apps_state(GuiState &gui) {
-    return !gui.live_area.content_manager && !gui.live_area.settings && !gui.live_area.trophy_collection && !gui.live_area.manual && !gui.live_area.user_management;
+    return !gui.vita_area.content_manager && !gui.vita_area.settings && !gui.vita_area.trophy_collection && !gui.vita_area.manual && !gui.vita_area.user_management;
 }
 
 struct FRAME {
@@ -142,10 +142,10 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string app_pa
     const VitaIoDevice app_device = is_sys_app ? VitaIoDevice::vs0 : VitaIoDevice::ux0;
     const auto APP_INDEX = get_app_index(gui, app_path);
 
-    if (is_ps_app && (sku_flag.find(app_path) == sku_flag.end()))
+    if (is_ps_app && !sku_flag.contains(app_path))
         sku_flag[app_path] = get_license_sku_flag(emuenv, APP_INDEX->content_id);
 
-    if (gui.live_area_contents.find(app_path) == gui.live_area_contents.end()) {
+    if (!gui.live_area_contents.contains(app_path)) {
         auto default_contents = false;
         const auto fw_path{ fs::path(emuenv.pref_path) / "vs0" };
         const auto default_fw_contents{ fw_path / "data/internal/livearea/default/sce_sys/livearea/contents/template.xml" };
@@ -525,9 +525,9 @@ void open_search(const std::string title) {
 }
 
 void update_app(GuiState &gui, EmuEnvState &emuenv, const std::string app_path) {
-    if (gui.live_area_contents.find(app_path) != gui.live_area_contents.end())
+    if (gui.live_area_contents.contains(app_path))
         gui.live_area_contents.erase(app_path);
-    if (gui.live_items.find(app_path) != gui.live_items.end())
+    if (gui.live_items.contains(app_path))
         gui.live_items.erase(app_path);
 
     init_user_app(gui, emuenv, app_path);
@@ -553,7 +553,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
 
     ImGui::SetNextWindowBgAlpha(is_background ? 0.5f : 0.f);
-    ImGui::Begin("##live_area", &gui.live_area.live_area_screen, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##live_area", &gui.vita_area.live_area_screen, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
     if (is_background)
         ImGui::GetBackgroundDrawList()->AddImage((gui.users[emuenv.io.user_id].use_theme_bg && !gui.theme_backgrounds.empty()) ? gui.theme_backgrounds[gui.current_theme_bg] : gui.user_backgrounds[gui.users[emuenv.io.user_id].backgrounds[gui.current_user_bg]],
@@ -565,7 +565,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
     const auto pos_bg = ImVec2(display_size.x - background_pos.x, display_size.y - background_pos.y);
     const auto background_size = ImVec2(840.0f * SCALE.x, 500.0f * SCALE.y);
 
-    if (gui.live_area_contents[app_path].find("livearea-background") != gui.live_area_contents[app_path].end())
+    if (gui.live_area_contents[app_path].contains("livearea-background"))
         ImGui::GetWindowDrawList()->AddImage(gui.live_area_contents[app_path]["livearea-background"], pos_bg, ImVec2(pos_bg.x + background_size.x, pos_bg.y + background_size.y));
     else
         ImGui::GetWindowDrawList()->AddRectFilled(pos_bg, ImVec2(pos_bg.x + background_size.x, pos_bg.y + background_size.y), IM_COL32(148.f, 164.f, 173.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
@@ -578,12 +578,12 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
             while (last_time[app_path][frame.id] + frame.autoflip < current_time()) {
                 last_time[app_path][frame.id] += frame.autoflip;
 
-                if (gui.live_items[app_path][frame.id].find("background") != gui.live_items[app_path][frame.id].end()) {
+                if (gui.live_items[app_path][frame.id].contains("background")) {
                     if (current_item[app_path][frame.id] != int(gui.live_items[app_path][frame.id]["background"].size()) - 1)
                         ++current_item[app_path][frame.id];
                     else
                         current_item[app_path][frame.id] = 0;
-                } else if (gui.live_items[app_path][frame.id].find("image") != gui.live_items[app_path][frame.id].end()) {
+                } else if (gui.live_items[app_path][frame.id].contains("image")) {
                     if (current_item[app_path][frame.id] != int(gui.live_items[app_path][frame.id]["image"].size()) - 1)
                         ++current_item[app_path][frame.id];
                     else
@@ -698,11 +698,11 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
             img_pos.y += pos_frame.y - img_pos.y;
 
         // Display items
-        if (gui.live_items[app_path][frame.id].find("background") != gui.live_items[app_path][frame.id].end()) {
+        if (gui.live_items[app_path][frame.id].contains("background")) {
             ImGui::SetCursorPos(bg_pos);
             ImGui::Image(gui.live_items[app_path][frame.id]["background"][current_item[app_path][frame.id]], bg_scal_size);
         }
-        if (gui.live_items[app_path][frame.id].find("image") != gui.live_items[app_path][frame.id].end()) {
+        if (gui.live_items[app_path][frame.id].contains("image")) {
             ImGui::SetCursorPos(img_pos);
             ImGui::Image(gui.live_items[app_path][frame.id]["image"][current_item[app_path][frame.id]], img_scal_size);
         }
@@ -737,14 +737,14 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
 
                 // Origin
                 if (liveitem[app_path][frame.id]["text"]["origin"].second.empty() || (liveitem[app_path][frame.id]["text"]["origin"].second == "background")) {
-                    if (gui.live_items[app_path][frame.id].find("background") != gui.live_items[app_path][frame.id].end())
+                    if (gui.live_items[app_path][frame.id].contains("background"))
                         str_size = bg_scal_size, text_pos = bg_pos;
-                    else if (!liveitem[app_path][frame.id]["text"]["origin"].second.empty() && (gui.live_items[app_path][frame.id].find("image") != gui.live_items[app_path][frame.id].end()))
+                    else if (!liveitem[app_path][frame.id]["text"]["origin"].second.empty() && gui.live_items[app_path][frame.id].contains("image"))
                         str_size = img_scal_size, text_pos = img_pos;
                 } else if (liveitem[app_path][frame.id]["text"]["origin"].second == "image") {
-                    if (gui.live_items[app_path][frame.id].find("image") != gui.live_items[app_path][frame.id].end())
+                    if (gui.live_items[app_path][frame.id].contains("image"))
                         str_size = img_scal_size, text_pos = img_pos;
-                    else if (gui.live_items[app_path][frame.id].find("background") != gui.live_items[app_path][frame.id].end())
+                    else if (gui.live_items[app_path][frame.id].contains("background"))
                         str_size = bg_scal_size, text_pos = bg_pos;
                 }
 
@@ -798,7 +798,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
                         else if (liveitem[app_path][frame.id]["text"]["line-align"].second == "outside-right") {
                             text_pos.x += str_size.x;
                             if (liveitem[app_path][frame.id]["text"]["origin"].second == "image") {
-                                if (gui.live_items[app_path][frame.id].find("background") != gui.live_items[app_path][frame.id].end())
+                                if (gui.live_items[app_path][frame.id].contains("background"))
                                     str_size.x = bg_scal_size.x - img_scal_size.x - (img_pos.x - bg_pos.x);
                                 else
                                     str_size = scal_size_frame, text_pos = pos_frame;
@@ -816,7 +816,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
                         else if (liveitem[app_path][frame.id]["text"]["text-align"].second == "outside-right") {
                             text_pos.x += str_size.x;
                             if (liveitem[app_path][frame.id]["text"]["origin"].second == "image") {
-                                if (gui.live_items[app_path][frame.id].find("background") != gui.live_items[app_path][frame.id].end())
+                                if (gui.live_items[app_path][frame.id].contains("background"))
                                     str_size.x = bg_scal_size.x - img_scal_size.x - (img_pos.x - bg_pos.x);
                                 else
                                     str_size = scal_size_frame, text_pos = pos_frame;
@@ -833,7 +833,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
                     else if (liveitem[app_path][frame.id]["text"]["align"].second == "outside-right") {
                         text_pos.x += str_size.x;
                         if (liveitem[app_path][frame.id]["text"]["origin"].second == "image") {
-                            if (gui.live_items[app_path][frame.id].find("background") != gui.live_items[app_path][frame.id].end())
+                            if (gui.live_items[app_path][frame.id].contains("background"))
                                 str_size.x = bg_scal_size.x - img_scal_size.x - (img_pos.x - bg_pos.x);
                             else
                                 str_size = scal_size_frame, text_pos = pos_frame;
@@ -950,7 +950,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
 
     const auto BUTTON_SIZE = ImVec2(72.f * SCALE.x, 30.f * SCALE.y);
 
-    if (gui.live_area_contents[app_path].find("gate") != gui.live_area_contents[app_path].end()) {
+    if (gui.live_area_contents[app_path].contains("gate")) {
         ImGui::SetCursorPos(GATE_POS);
         ImGui::Image(gui.live_area_contents[app_path]["gate"], GATE_SIZE);
     } else {
@@ -1030,7 +1030,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
 
     auto lang = gui.lang.live_area.help;
 
-    if (!gui.live_area.content_manager && !gui.live_area.manual) {
+    if (!gui.vita_area.content_manager && !gui.vita_area.manual) {
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f * SCALE.x);
         ImGui::SetCursorPos(ImVec2(display_size.x - (60.0f * SCALE.x) - BUTTON_SIZE.x, 44.0f * SCALE.y));
         if (ImGui::Button("Esc", BUTTON_SIZE) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_circle)) {
@@ -1043,8 +1043,8 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
             } else {
                 gui.apps_list_opened.erase(get_app_open_list_index(gui, app_path));
                 if (gui.current_app_selected == 0) {
-                    gui.live_area.live_area_screen = false;
-                    gui.live_area.home_screen = true;
+                    gui.vita_area.live_area_screen = false;
+                    gui.vita_area.home_screen = true;
                 }
                 --gui.current_app_selected;
             }
@@ -1112,8 +1112,8 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetCursorPos(ImVec2(ARROW_LEFT_CENTER.x - (SELECTABLE_SIZE.x / 2.f), ARROW_LEFT_CENTER.y - (SELECTABLE_SIZE.y / 2.f)));
     if ((ImGui::Selectable("##left", false, ImGuiSelectableFlags_None, SELECTABLE_SIZE)) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_l1) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_leftstick_left) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_left) || (wheel_counter == 1)) {
         if (gui.current_app_selected == 0) {
-            gui.live_area.live_area_screen = false;
-            gui.live_area.home_screen = true;
+            gui.vita_area.live_area_screen = false;
+            gui.vita_area.home_screen = true;
         }
         --gui.current_app_selected;
     }

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -82,9 +82,9 @@ static void draw_config_menu(GuiState &gui, EmuEnvState &emuenv) {
     if (ImGui::BeginMenu(lang["title"].c_str())) {
         if (ImGui::MenuItem(lang["settings"].c_str(), nullptr, &settings_dialog))
             init_config(gui, emuenv, emuenv.io.app_path);
-        if (ImGui::MenuItem(lang["user_management"].c_str(), nullptr, &gui.live_area.user_management, (!gui.live_area.user_management && emuenv.io.title_id.empty()))) {
-            gui.live_area.home_screen = false;
-            gui.live_area.information_bar = true;
+        if (ImGui::MenuItem(lang["user_management"].c_str(), nullptr, &gui.vita_area.user_management, (!gui.vita_area.user_management && emuenv.io.title_id.empty()))) {
+            gui.vita_area.home_screen = false;
+            gui.vita_area.information_bar = true;
         }
         ImGui::EndMenu();
     }

--- a/vita3k/gui/src/manual.cpp
+++ b/vita3k/gui/src/manual.cpp
@@ -34,9 +34,9 @@ static std::pair<bool, bool> zoom;
 
 void open_manual(GuiState &gui, EmuEnvState &emuenv, const std::string app_path) {
     if (init_manual(gui, emuenv, app_path)) {
-        gui.live_area.information_bar = false;
-        gui.live_area.live_area_screen = false;
-        gui.live_area.manual = true;
+        gui.vita_area.information_bar = false;
+        gui.vita_area.live_area_screen = false;
+        gui.vita_area.manual = true;
     } else
         LOG_ERROR("Error opening Manual");
 }
@@ -98,7 +98,7 @@ void draw_manual(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(-5.f, -1.f), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x + 10.f, display_size.y + 2.f), ImGuiCond_Always);
     ImGui::SetNextWindowBgAlpha(0.999f);
-    ImGui::Begin("##manual", &gui.live_area.manual, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##manual", &gui.vita_area.manual, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     if (zoom.first && ImGui::IsMouseDoubleClicked(0)) {
         zoom.second ? size_page["current"] = size_page["mini"] : size_page["current"] = size_page["max"];
@@ -118,10 +118,10 @@ void draw_manual(GuiState &gui, EmuEnvState &emuenv) {
 
     ImGui::SetCursorPos(ImVec2(size_child.x - ((!zoom.second ? 70.0f : 85.f) * SCALE.x), 10.0f * SCALE.y));
     if (!hidden_button && ImGui::Button("Esc", BUTTON_SIZE) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_psbutton)) {
-        gui.live_area.manual = false;
-        gui.live_area.information_bar = true;
-        if (!gui.live_area.home_screen)
-            gui.live_area.live_area_screen = true;
+        gui.vita_area.manual = false;
+        gui.vita_area.information_bar = true;
+        if (!gui.vita_area.home_screen)
+            gui.vita_area.live_area_screen = true;
     }
 
     const auto wheel_counter = ImGui::GetIO().MouseWheel;

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -213,7 +213,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(0, INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
-    ImGui::Begin("##settings", &gui.live_area.settings, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##settings", &gui.vita_area.settings, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
         ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10015"], ImVec2(0.f, 0.f), display_size);
     else
@@ -958,14 +958,14 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                 settings_menu = SELECT;
         } else {
             if (emuenv.app_path == "NPXS10026") {
-                gui.live_area.content_manager = true;
+                gui.vita_area.content_manager = true;
             } else {
                 if (!gui.apps_list_opened.empty() && gui.apps_list_opened[gui.current_app_selected] == "NPXS10015")
-                    gui.live_area.live_area_screen = true;
+                    gui.vita_area.live_area_screen = true;
                 else
-                    gui.live_area.home_screen = true;
+                    gui.vita_area.home_screen = true;
             }
-            gui.live_area.settings = false;
+            gui.vita_area.settings = false;
         }
     }
 

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -86,7 +86,7 @@ void get_modules_list(GuiState &gui, EmuEnvState &emuenv) {
 
 static void reset_emulator(GuiState &gui, EmuEnvState &emuenv) {
     gui.configuration_menu.settings_dialog = false;
-    gui.live_area.home_screen = false;
+    gui.vita_area.home_screen = false;
 
     // Clean and save new config value
     emuenv.cfg.auto_user_login = false;
@@ -312,6 +312,13 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         emuenv.cfg.psn_status = config.psn_status;
     }
     config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+}
+
+std::string get_cpu_backend(GuiState &gui, EmuEnvState &emuenv, const std::string app_path) {
+    if (!get_custom_config(gui, emuenv, app_path))
+        return emuenv.cfg.cpu_backend;
+
+    return config.cpu_backend;
 }
 
 static void set_vsync_state(const bool &state) {

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -130,7 +130,7 @@ void init_theme_start_background(GuiState &gui, EmuEnvState &emuenv, const std::
         start_param.clock_pos.x = 50.f;
         break;
     default:
-        LOG_WARN("Date layout for this theme is unknown : {}", start_param.date_layout);
+        LOG_WARN("Date layout for this theme is unknown : {}", static_cast<uint32_t>(start_param.date_layout));
         break;
     }
 
@@ -373,7 +373,7 @@ void draw_start_screen(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(0.f, INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
-    ImGui::Begin("##start_screen", &gui.live_area.start_screen, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##start_screen", &gui.vita_area.start_screen, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
 
     if (gui.start_background)
         ImGui::GetBackgroundDrawList()->AddImage(gui.start_background, ImVec2(0.f, INFORMATION_BAR_HEIGHT), display_size);
@@ -432,9 +432,9 @@ void draw_start_screen(GuiState &gui, EmuEnvState &emuenv) {
     }
     ImGui::PopFont();
 
-    if (ImGui::IsMouseClicked(0) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_circle)) {
-        gui.live_area.start_screen = false;
-        gui.live_area.home_screen = true;
+    if ((ImGui::IsWindowHovered(ImGuiFocusedFlags_RootWindow) && ImGui::IsMouseClicked(0)) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_circle)) {
+        gui.vita_area.start_screen = false;
+        gui.vita_area.home_screen = true;
     }
 
     ImGui::End();

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -411,7 +411,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(0, INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
-    ImGui::Begin("##trophy_collection", &gui.live_area.trophy_collection, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##trophy_collection", &gui.vita_area.trophy_collection, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     if (is_background)
         ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background["NPXS10008"], ImVec2(0.f, 0.f), display_size);
     else
@@ -755,10 +755,10 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
             }
         } else {
             if (!gui.apps_list_opened.empty() && (gui.current_app_selected >= 0))
-                gui.live_area.live_area_screen = true;
+                gui.vita_area.live_area_screen = true;
             else
-                gui.live_area.home_screen = true;
-            gui.live_area.trophy_collection = false;
+                gui.vita_area.home_screen = true;
+            gui.vita_area.trophy_collection = false;
         }
     }
     if (trophy_id_selected.empty() && !detail_np_com_id && (np_com_id_selected.empty() || !group_id_selected.empty())) {

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -178,14 +178,14 @@ void init_user(GuiState &gui, EmuEnvState &emuenv, const std::string &user_id) {
 }
 
 void open_user(GuiState &gui, EmuEnvState &emuenv) {
-    gui.live_area.user_management = false;
+    gui.vita_area.user_management = false;
 
     if (gui.users[emuenv.io.user_id].start_type == "image")
         init_user_start_background(gui, gui.users[emuenv.io.user_id].start_path);
     else
         init_theme_start_background(gui, emuenv, gui.users[emuenv.io.user_id].theme_id);
 
-    gui.live_area.start_screen = true;
+    gui.vita_area.start_screen = true;
 }
 
 static auto get_users_index(GuiState &gui, const std::string &user_name) {
@@ -217,10 +217,10 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowSize(WINDOW_SIZE, ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
     ImGui::SetNextWindowBgAlpha(0.f);
-    ImGui::Begin("##user_management", &gui.live_area.user_management, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##user_management", &gui.vita_area.user_management, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
 
     if (!emuenv.display.imgui_render || ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows))
-        gui.live_area.information_bar = true;
+        gui.vita_area.information_bar = true;
 
     ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, INFORMATION_BAR_HEIGHT), display_size, IM_COL32(10.f, 50.f, 140.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
 
@@ -498,8 +498,8 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
                 else
                     menu.clear();
             } else if (USER_ALREADY_INIT) {
-                gui.live_area.user_management = false;
-                gui.live_area.home_screen = true;
+                gui.vita_area.user_management = false;
+                gui.vita_area.home_screen = true;
             }
         }
     }

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -41,7 +41,7 @@ enum Vita3kUpdate {
 };
 
 static Vita3kUpdate state;
-static LiveAreaState live_area_state;
+static VitaAreaState vita_area_state;
 
 static int git_version;
 static std::vector<std::pair<std::string, std::string>> git_commit_desc_list;
@@ -58,7 +58,7 @@ bool init_vita3k_update(GuiState &gui) {
     state = NO_UPDATE;
     git_commit_desc_list.clear();
     git_version = 0;
-    live_area_state = {};
+    vita_area_state = {};
 
     // Get Build number of latest release
     const auto latest_link = "https://api.github.com/repos/Vita3K/Vita3K/releases/latest";
@@ -170,11 +170,11 @@ bool init_vita3k_update(GuiState &gui) {
     }
 
     if (has_update || gui.help_menu.vita3k_update) {
-        live_area_state = gui.live_area;
-        gui.live_area.home_screen = false;
-        gui.live_area.live_area_screen = false;
-        gui.live_area.start_screen = false;
-        gui.live_area.information_bar = true;
+        vita_area_state = gui.vita_area;
+        gui.vita_area.home_screen = false;
+        gui.vita_area.live_area_screen = false;
+        gui.vita_area.start_screen = false;
+        gui.vita_area.information_bar = true;
     }
 
     return has_update;
@@ -235,7 +235,6 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
     auto common = emuenv.common_dialog.lang.common;
     auto lang = gui.lang.vita3k_update;
 
-    ImGui::PushFont(gui.vita_font);
     ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
     ImGui::Begin("##vita3k_update", &gui.help_menu.vita3k_update, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
@@ -334,7 +333,7 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
         if (state < DESCRIPTION) {
             if (fs::exists("windows-latest.zip"))
                 fs::remove("windows-latest.zip");
-            gui.live_area = live_area_state;
+            gui.vita_area = vita_area_state;
             gui.help_menu.vita3k_update = false;
         } else
             state = (Vita3kUpdate)(state - 1);
@@ -353,7 +352,6 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::EndDisabled();
     }
     ImGui::PopStyleVar();
-    ImGui::PopFont();
     ImGui::End();
 }
 

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -598,7 +598,7 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
                     gui.is_capturing_keys = false;
                 }
             }
-            if (!emuenv.io.title_id.empty() && !gui.live_area.user_management && !gui.configuration_menu.custom_settings_dialog && !gui.configuration_menu.settings_dialog && !gui.controls_menu.controls_dialog) {
+            if (!emuenv.io.title_id.empty() && !gui.vita_area.user_management && !gui.configuration_menu.custom_settings_dialog && !gui.configuration_menu.settings_dialog && !gui.controls_menu.controls_dialog) {
                 // toggle gui state
                 if (event.key.keysym.sym == SDLK_g && !ImGui::GetIO().WantTextInput)
                     emuenv.display.imgui_render = !emuenv.display.imgui_render;
@@ -607,8 +607,8 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
                     if (gui::get_app_open_list_index(gui, emuenv.io.app_path) == gui.apps_list_opened.end())
                         gui::open_live_area(gui, emuenv, emuenv.io.app_path);
                     else {
-                        gui.live_area.information_bar = !gui.live_area.information_bar;
-                        gui.live_area.live_area_screen = !gui.live_area.live_area_screen;
+                        gui.vita_area.information_bar = !gui.vita_area.information_bar;
+                        gui.vita_area.live_area_screen = !gui.vita_area.live_area_screen;
                     }
                 }
             }

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -283,7 +283,7 @@ int main(int argc, char *argv[]) {
 #if USE_DISCORD
                 discordrpc::update_init_status(emuenv.cfg.discord_rich_presence, &discord_rich_presence_old);
 #endif
-                gui::draw_live_area(gui, emuenv);
+                gui::draw_vita_area(gui, emuenv);
                 gui::draw_ui(gui, emuenv);
 
                 gui::draw_end(gui, emuenv.window.get());
@@ -355,7 +355,7 @@ int main(int argc, char *argv[]) {
     if (const auto err = load_app(entry_point, emuenv, string_utils::utf_to_wide(emuenv.io.app_path)) != Success)
         return err;
 
-    gui.live_area.information_bar = false;
+    gui.vita_area.information_bar = false;
 
     // Pre-Compile Shaders
     emuenv.renderer->base_path = emuenv.base_path.c_str();
@@ -422,9 +422,9 @@ int main(int argc, char *argv[]) {
 
         gui::draw_begin(gui, emuenv);
         gui::draw_common_dialog(gui, emuenv);
-        gui::draw_live_area(gui, emuenv);
+        gui::draw_vita_area(gui, emuenv);
 
-        if (emuenv.cfg.performance_overlay && !gui.live_area.home_screen && !gui.live_area.live_area_screen && gui::get_sys_apps_state(gui))
+        if (emuenv.cfg.performance_overlay && !gui.vita_area.home_screen && !gui.vita_area.live_area_screen && !gui.vita_area.start_screen && gui::get_sys_apps_state(gui))
             gui::draw_perf_overlay(gui, emuenv);
 
         if (emuenv.display.imgui_render) {


### PR DESCRIPTION
# About
- gui/app context menu/compat: Add pre-filled body in create issue.
- gui: rename struct LiveAreaState live_area to VitaAreaState vita_area.
- gui: fix click on button of info message when start screen is open.
- gui/themes: fix one warning compile.

# Result:
- create template of open new issue in compat
![image](https://user-images.githubusercontent.com/5261759/219823453-d5455bc4-b9bb-4f71-87c7-f309875bdfcd.png)
