### PR TITLE
gui/home screen: Add app compatibility sorting feature.

### DIFF
--- a/vita3k/compat/include/compat/state.h
+++ b/vita3k/compat/include/compat/state.h
@@ -22,14 +22,14 @@
 #include <string>
 
 enum CompatibilityState {
-    Unknown,
-    Nothing = 1260231569, // 0x4b1d9b91
-    Bootable = 1344750319, // 0x502742ef
-    Intro = 1260231381, // 0x4B9F5E5D
-    Menu = 1344751053, // 0x4F1B9135
-    Ingame_Less = 1344752299, // 0x4F7B6B3B
-    Ingame_More = 1260231985, // 0x4B2A9819
-    Playable = 920344019, // 0x36db55d3
+    Unknown = -1,
+    Nothing,
+    Bootable,
+    Intro,
+    Menu,
+    Ingame_Less,
+    Ingame_More,
+    Playable,
 };
 
 struct Compatibility {

--- a/vita3k/compat/src/compat.cpp
+++ b/vita3k/compat/src/compat.cpp
@@ -28,6 +28,16 @@ namespace compat {
 static std::string db_updated_at;
 static const uint32_t db_version = 1;
 
+enum class LabelIdState {
+    Nothing = 1260231569, // 0x4b1d9b91
+    Bootable = 1344750319, // 0x502742ef
+    Intro = 1260231381, // 0x4B9F5E5D
+    Menu = 1344751053, // 0x4F1B9135
+    Ingame_Less = 1344752299, // 0x4F7B6B3B
+    Ingame_More = 1260231985, // 0x4B2A9819
+    Playable = 920344019, // 0x36db55d3
+};
+
 bool load_compat_app_db(GuiState &gui, EmuEnvState &emuenv) {
     const auto app_compat_db_path = fs::path(emuenv.base_path) / "cache/app_compat_db.xml";
     if (!fs::exists(app_compat_db_path)) {
@@ -65,15 +75,15 @@ bool load_compat_app_db(GuiState &gui, EmuEnvState &emuenv) {
         const auto labels = app.child("labels");
         if (!labels.empty()) {
             for (const auto &label : labels) {
-                const auto label_id = static_cast<CompatibilityState>(label.text().as_uint());
+                const auto label_id = static_cast<LabelIdState>(label.text().as_uint());
                 switch (label_id) {
-                case Nothing: state = Nothing; break;
-                case Bootable: state = Bootable; break;
-                case Intro: state = Intro; break;
-                case Menu: state = Menu; break;
-                case Ingame_Less: state = Ingame_Less; break;
-                case Ingame_More: state = Ingame_More; break;
-                case Playable: state = Playable; break;
+                case LabelIdState::Nothing: state = Nothing; break;
+                case LabelIdState::Bootable: state = Bootable; break;
+                case LabelIdState::Intro: state = Intro; break;
+                case LabelIdState::Menu: state = Menu; break;
+                case LabelIdState::Ingame_Less: state = Ingame_Less; break;
+                case LabelIdState::Ingame_More: state = Ingame_More; break;
+                case LabelIdState::Playable: state = Playable; break;
                 default: break;
                 }
             }
@@ -182,7 +192,7 @@ bool update_compat_app_db(GuiState &gui, EmuEnvState &emuenv) {
     gui.info_message.level = spdlog::level::info;
 
     if (compat_db_exist) {
-        const int32_t dif = gui.compat.app_compat_db.size() - old_compat_count;
+        const auto dif = static_cast<int32_t>(gui.compat.app_compat_db.size() - old_compat_count);
         if (dif > 0)
             gui.info_message.msg = fmt::format("The compatibility database was successfully updated from {} to {}.\n\n{} new application(s) are listed!", old_db_updated_at, db_updated_at, dif);
         else

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -49,10 +49,6 @@ struct EmuEnvState;
 
 namespace gui {
 
-enum SelectorState {
-    SELECT_APP
-};
-
 enum SortState {
     NOT_SORTED,
     ASCENDANT,
@@ -62,6 +58,7 @@ enum SortState {
 enum SortType {
     APP_VER,
     CATEGORY,
+    COMPAT,
     LAST_TIME,
     TITLE,
     TITLE_ID
@@ -79,6 +76,7 @@ struct App {
     std::string title_id;
     std::string path;
     time_t last_time;
+    CompatibilityState compat;
 };
 
 struct AppInfo {
@@ -120,7 +118,6 @@ struct AppsSelector {
     std::map<std::string, ImGui_Texture> user_apps_icon;
     bool is_app_list_sorted{ false };
     std::map<SortType, SortState> app_list_sorted;
-    SelectorState state = SELECT_APP;
 };
 
 struct VitaAreaState {

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -338,8 +338,20 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                     open_path(compat_url);
                 }
                 if (has_issue) {
-                    if (ImGui::MenuItem(lang["open_issue"].c_str()))
+                    const auto copy_vita3k_summary = [&]() {
+                        const auto vita3k_summary = fmt::format(
+                            "# Vita3K summary\n- Version: {}\n- Build number: {}\n- Commit hash: https://github.com/vita3k/vita3k/commit/{}\n- CPU backend: {}\n- GPU backend: {}",
+                            app_version, app_number, app_hash, get_cpu_backend(gui, emuenv, app_path), emuenv.cfg.backend_renderer);
+                        ImGui::LogToClipboard();
+                        ImGui::LogText("%s", vita3k_summary.c_str());
+                        ImGui::LogFinish();
+                    };
+                    if (ImGui::MenuItem("Copy Vita3K Summary"))
+                        copy_vita3k_summary();
+                    if (ImGui::MenuItem(lang["open_issue"].c_str())) {
+                        copy_vita3k_summary();
                         open_path(fmt::format("{}/{}", ISSUES_URL, gui.compat.app_compat_db[title_id].issue_id));
+                    }
                 } else {
                     if (ImGui::MenuItem(lang["create_issue"].c_str())) {
                         // Create body of issue

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -59,7 +59,7 @@ void draw_info_message(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::BeginChild("##info", ImVec2(display_size.x / 1.4f, display_size.y / 2.6f), true, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoDecoration);
         const auto title = fmt::format("{}", spdlog::level::to_string_view(gui.info_message.level));
         ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize(title.c_str()).x) / 2);
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title.c_str(), ImGuiWindowFlags_AlwaysAutoResize);
+        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title.c_str());
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
@@ -489,6 +489,12 @@ void init_home(GuiState &gui, EmuEnvState &emuenv) {
     if (gui.app_selector.user_apps.empty() && (emuenv.cfg.load_app_list || !emuenv.cfg.run_app_path)) {
         if (!get_user_apps(gui, emuenv))
             init_user_apps(gui, emuenv);
+    }
+
+    // Init compatibilty in user apps list
+    if (gui.compat.compat_db_loaded) {
+        for (auto &app : gui.app_selector.user_apps)
+            app.compat = gui.compat.app_compat_db.contains(app.title_id) ? gui.compat.app_compat_db[app.title_id].state : Unknown;
     }
 
     init_app_background(gui, emuenv, "NPXS10015");


### PR DESCRIPTION
# About
- gui/home screen: Add app compatibility sorting feature. 
remove app selector state, no have any utility.
-  gui/src/app_context_menu: Add cah copy vita3k summary for can easy update issue.

# Result
![image](https://user-images.githubusercontent.com/5261759/219869999-c2a6e6ec-2ec5-470f-86b0-a7508a1a4b03.png)
![image](https://user-images.githubusercontent.com/5261759/219870014-0e453d5b-44f1-4571-b45a-34a0bde04b15.png)
