### PR TITLE
renderer/vulkan: Add PageTable implementation for memory mapping

### DIFF
--- a/vita3k/cpu/src/dynarmic_cpu.cpp
+++ b/vita3k/cpu/src/dynarmic_cpu.cpp
@@ -308,12 +308,16 @@ std::unique_ptr<Dynarmic::A32::Jit> DynarmicCPU::make_jit() {
     Dynarmic::A32::UserConfig config;
     config.arch_version = Dynarmic::A32::ArchVersion::v7;
     config.callbacks = cb.get();
-    config.fastmem_pointer = (log_mem || !cpu_opt) ? nullptr : parent->mem->memory.get();
+    if (parent->mem->use_page_table) {
+        config.page_table = (log_mem || !cpu_opt) ? nullptr : reinterpret_cast<decltype(config.page_table)>(parent->mem->page_table.get());
+        config.absolute_offset_page_table = true;
+    } else {
+        config.fastmem_pointer = (log_mem || !cpu_opt) ? nullptr : parent->mem->memory.get();
+    }
     config.hook_hint_instructions = true;
     config.enable_cycle_counting = false;
     config.global_monitor = monitor;
     config.coprocessors[15] = cp15;
-    config.page_table = nullptr;
     config.processor_id = core_id;
     config.optimizations = cpu_opt ? Dynarmic::all_safe_optimizations : Dynarmic::no_optimizations;
 

--- a/vita3k/gui/src/allocations_dialog.cpp
+++ b/vita3k/gui/src/allocations_dialog.cpp
@@ -42,7 +42,7 @@ void draw_allocations_dialog(GuiState &gui, EmuEnvState &emuenv) {
     for (const auto &pair : emuenv.mem.page_name_map) {
         const auto generation_num = pair.first;
         const auto generation_name = pair.second;
-        const auto page = emuenv.mem.page_table[generation_num];
+        const auto page = emuenv.mem.alloc_table[generation_num];
 
         if (std::find(std::begin(blacklist), std::end(blacklist), generation_name) != std::end(blacklist))
             continue;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -374,7 +374,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
     }
 
     // can be changed while ingame
-    emuenv.renderer->disable_surface_sync = emuenv.cfg.current_config.disable_surface_sync;
+    emuenv.renderer->set_surface_sync_state(emuenv.cfg.current_config.disable_surface_sync);
     emuenv.renderer->set_fxaa(emuenv.cfg.current_config.enable_fxaa);
     if (emuenv.renderer->current_backend == renderer::Backend::OpenGL)
         set_vsync_state(emuenv.cfg.current_config.v_sync);

--- a/vita3k/mem/include/mem/functions.h
+++ b/vita3k/mem/include/mem/functions.h
@@ -31,7 +31,7 @@ enum {
     MEM_PERM_READWRITE = MEM_PERM_READONLY | MEM_PERM_WRITE
 };
 
-bool init(MemState &state);
+bool init(MemState &state, const bool use_page_table);
 Address alloc(MemState &state, size_t size, const char *name);
 Address alloc(MemState &state, size_t size, const char *name, unsigned int alignment);
 void protect_inner(MemState &state, Address addr, size_t size, const std::uint32_t perm);
@@ -39,6 +39,8 @@ void unprotect_inner(MemState &state, Address addr, size_t size);
 bool add_protect(MemState &state, Address addr, const size_t size, const std::uint32_t perm, ProtectCallback callback);
 void open_access_parent_protect_segment(MemState &mem, Address addr);
 void close_access_parent_protect_segment(MemState &mem, Address addr);
+void add_external_mapping(MemState &mem, Address addr, uint32_t size, uint8_t* addr_ptr);
+void remove_external_mapping(MemState &mem, uint8_t* addr_ptr);
 bool is_protecting(MemState &state, Address addr, std::uint32_t *perm = nullptr);
 bool is_valid_addr(const MemState &state, Address addr);
 bool is_valid_addr_range(const MemState &state, Address start, Address end);

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -20,6 +20,7 @@
 
 #include <util/align.h>
 #include <util/log.h>
+#include <util/float_to_half.h>
 
 #include <algorithm>
 #include <cassert>
@@ -46,9 +47,8 @@ static void register_access_violation_handler(AccessViolationHandler handler);
 
 static Address alloc_inner(MemState &state, uint32_t start_page, int page_count, const char *name, const bool force);
 static void delete_memory(uint8_t *memory);
-static void delete_pagetable(MemPage *page_table);
 
-bool init(MemState &state) {
+bool init(MemState &state, const bool use_page_table) {
 #ifdef WIN32
     SYSTEM_INFO system_info = {};
     GetSystemInfo(&system_info);
@@ -88,8 +88,8 @@ bool init(MemState &state) {
 #endif
 
     const size_t table_length = TOTAL_MEM_SIZE / state.page_size;
-    state.page_table = PageTable(new MemPage[table_length], delete_pagetable);
-    memset(state.page_table.get(), 0, sizeof(MemPage) * table_length);
+    state.alloc_table = AllocPageTable(new AllocMemPage[table_length]);
+    memset(state.alloc_table.get(), 0, sizeof(AllocMemPage) * table_length);
 
     state.allocator.set_maximum(table_length);
 
@@ -108,6 +108,13 @@ bool init(MemState &state) {
     mprotect(state.memory.get(), state.page_size, PROT_NONE);
 #endif
 
+    state.use_page_table = use_page_table;
+    if (use_page_table) {
+        state.page_table = PageTable(new PagePtr[TOTAL_MEM_SIZE / KiB(4)]);
+        // we use an absolute offset (it is faster), so each entry is the same
+        std::fill_n(state.page_table.get(), TOTAL_MEM_SIZE / KiB(4), state.memory.get());
+    }
+
     return true;
 }
 
@@ -120,10 +127,6 @@ static void delete_memory(uint8_t *memory) {
         munmap(memory, TOTAL_MEM_SIZE);
 #endif
     }
-}
-
-static void delete_pagetable(MemPage *page_table) {
-    delete[] page_table;
 }
 
 bool is_valid_addr(const MemState &state, Address addr) {
@@ -163,7 +166,7 @@ static Address alloc_inner(MemState &state, uint32_t start_page, int page_count,
 #endif
     std::memset(memory, 0, size);
 
-    MemPage &page = state.page_table[page_num];
+    AllocMemPage &page = state.alloc_table[page_num];
     assert(!page.allocated);
     page.allocated = 1;
     page.size = page_count;
@@ -187,8 +190,8 @@ Address alloc(MemState &state, size_t size, const char *name, unsigned int align
     const size_t align_page_num = align_addr / state.page_size;
 
     if (page_num != align_page_num) {
-        MemPage &page = state.page_table[page_num];
-        MemPage &align_page = state.page_table[align_page_num];
+        AllocMemPage &page = state.alloc_table[page_num];
+        AllocMemPage &align_page = state.alloc_table[align_page_num];
         const size_t remnant_front = align_page_num - page_num;
         state.allocator.free(page_num, remnant_front);
         page.allocated = 0;
@@ -219,23 +222,27 @@ void unprotect_inner(MemState &state, Address addr, size_t size) {
     if (LOG_PROTECT) {
         fmt::print("Unprotect: {} {}\n", log_hex(addr), size);
     }
+    uint8_t *addr_ptr = state.use_page_table ? state.page_table[addr / KiB(4)] : state.memory.get();
+
 #ifdef WIN32
     DWORD old_protect = 0;
-    const BOOL ret = VirtualProtect(&state.memory[addr], size - 1, PAGE_READWRITE, &old_protect);
+    const BOOL ret = VirtualProtect(&addr_ptr[addr], size - 1, PAGE_READWRITE, &old_protect);
     LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", log_hex(GetLastError()));
 #else
-    mprotect(&state.memory[addr], size, PROT_READ | PROT_WRITE);
+    mprotect(&addr_ptr[addr], size, PROT_READ | PROT_WRITE);
 #endif
 }
 
 void protect_inner(MemState &state, Address addr, size_t size, const std::uint32_t perm) {
+    uint8_t *addr_ptr = state.use_page_table ? state.page_table[addr / KiB(4)] : state.memory.get();
+
 #ifdef WIN32
     DWORD old_protect = 0;
-    const BOOL ret = VirtualProtect(&state.memory[addr], size - 1, (perm == MEM_PERM_NONE) ? PAGE_NOACCESS : ((perm == MEM_PERM_READONLY) ? PAGE_READONLY : PAGE_READWRITE), &old_protect);
+    const BOOL ret = VirtualProtect(&addr_ptr[addr], size - 1, (perm == MEM_PERM_NONE) ? PAGE_NOACCESS : ((perm == MEM_PERM_READONLY) ? PAGE_READONLY : PAGE_READWRITE), &old_protect);
     LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", log_hex(GetLastError()));
 
 #else
-    mprotect(&state.memory[addr], size, (perm == MEM_PERM_NONE) ? PROT_NONE : ((perm == MEM_PERM_READONLY) ? PROT_READ : (PROT_READ | PROT_WRITE)));
+    mprotect(&addr_ptr[addr], size, (perm == MEM_PERM_NONE) ? PROT_NONE : ((perm == MEM_PERM_READONLY) ? PROT_READ : (PROT_READ | PROT_WRITE)));
 #endif
 }
 
@@ -249,10 +256,27 @@ static ProtectSegmentTrees::iterator find_protect_segment(ProtectSegmentTrees &t
 bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcept {
     const uintptr_t memory_addr = reinterpret_cast<uintptr_t>(state.memory.get());
     const uintptr_t fault_addr = reinterpret_cast<uintptr_t>(addr);
+
+    Address vaddr = 0;
+    const std::unique_lock<std::mutex> lock(state.protect_mutex);
     if (fault_addr < memory_addr || fault_addr >= memory_addr + TOTAL_MEM_SIZE) {
-        return false;
+
+        if(state.use_page_table){
+            // this may come from an external mapping
+            uint64_t addr_val = std::bit_cast<uint64_t>(addr);
+            auto it = state.external_mapping.lower_bound(addr_val);
+            if(it != state.external_mapping.end() && addr_val < it->first + it->second.size){
+                vaddr = addr_val - it->first + it->second.address;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    } else {
+        vaddr = fault_addr - memory_addr;
     }
-    const Address vaddr = fault_addr - memory_addr;
+
     if (!is_valid_addr(state, vaddr)) {
         return false;
     }
@@ -260,7 +284,6 @@ bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcep
         fmt::print("Access: {}\n", log_hex(vaddr));
     }
 
-    const std::unique_lock<std::mutex> lock(state.protect_mutex);
     const auto it = find_protect_segment(state.protect_tree, vaddr);
     if (it == state.protect_tree.end()) {
         // HACK: keep going
@@ -394,6 +417,62 @@ void close_access_parent_protect_segment(MemState &state, Address addr) {
     }
 }
 
+void add_external_mapping(MemState &mem, Address addr, uint32_t size, uint8_t* addr_ptr) {
+    assert((size & 4095) == 0);
+
+    uint64_t addr_value = std::bit_cast<uint64_t>(addr_ptr);
+    uint8_t *page_table_entry = addr_ptr - addr;
+    uint8_t *original_address = &mem.memory[addr];
+    for (int block = 0; block < size / KiB(4); block++) {
+        // this is not thread write safe, but hopefully not other thread is busy copying while this happens
+        memcpy(addr_ptr + block * KiB(4), original_address + block * KiB(4), KiB(4));
+        mem.page_table[addr / KiB(4) + block] = page_table_entry;
+    }
+
+    // set the first page table entry to the original value to be able to call protect_inner
+    mem.page_table[addr / KiB(4)] = mem.memory.get();
+    protect_inner(mem, addr, size, MEM_PERM_NONE);
+    mem.page_table[addr / KiB(4)] = page_table_entry;
+
+    const std::unique_lock<std::mutex> lock(mem.protect_mutex);
+    mem.external_mapping[addr_value] = {addr, size};
+}
+
+void remove_external_mapping(MemState &mem, uint8_t *addr_ptr) {
+    uint64_t addr_value = std::bit_cast<uint64_t>(addr_ptr);
+    MemExternalMapping mapping;
+    {     
+        const std::unique_lock<std::mutex> lock(mem.protect_mutex);
+        auto it = mem.external_mapping.find(addr_value);
+        assert(it != mem.external_mapping.end());
+
+        mapping = it->second;
+        mem.external_mapping.erase(it);
+    }
+
+    // remove all protections on this range
+    unprotect_inner(mem, mapping.address, mapping.size);
+    {
+        const std::unique_lock<std::mutex> lock(mem.protect_mutex);
+        auto prot_it = mem.protect_tree.lower_bound(ProtectSegmentInfo(mapping.address));
+        while(prot_it != mem.protect_tree.end() && prot_it->addr < mapping.address + mapping.size){
+            mem.protect_tree.erase(prot_it++);
+        }
+    }
+
+    // unprotect the original memory range
+    mem.page_table[mapping.address / KiB(4)] = mem.memory.get();
+    unprotect_inner(mem, mapping.address, mapping.size);
+    // copy back and reset the page table
+    for (int block = 0; block < mapping.size / KiB(4); block++) {
+        // this is not thread write safe, but hopefully not other thread is busy copying while this happens
+        memcpy(&mem.memory[mapping.address] + block * KiB(4), addr_ptr + block * KiB(4), KiB(4));
+        mem.page_table[mapping.address / KiB(4) + block] = mem.memory.get();
+    }
+
+    LOG_DEBUG("Remove mappping");
+}
+
 Address alloc(MemState &state, size_t size, const char *name) {
     const std::lock_guard<std::mutex> lock(state.generation_mutex);
     const size_t page_count = align(size, state.page_size) / state.page_size;
@@ -433,7 +512,7 @@ void free(MemState &state, Address address) {
     const size_t page_num = address / state.page_size;
     assert(page_num >= 0);
 
-    MemPage &page = state.page_table[page_num];
+    AllocMemPage &page = state.alloc_table[page_num];
     if (!page.allocated) {
         LOG_CRITICAL("Freeing unallocated page");
     }
@@ -444,6 +523,7 @@ void free(MemState &state, Address address) {
         state.page_name_map.erase(page_num);
     }
 
+    assert(!state.use_page_table || state.page_table[address / KiB(4)] == state.memory.get());
     uint8_t *const memory = &state.memory[page_num * state.page_size];
 
 #ifdef WIN32
@@ -530,6 +610,7 @@ static void signal_handler(int sig, siginfo_t *info, void *uct) noexcept {
         }
     }
 
+    LOG_CRITICAL("Unhandled access to {}", log_hex(*reinterpret_cast<uint64_t *>(&info->si_addr)));
     raise(SIGTRAP);
     return;
 }

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -80,7 +80,7 @@ void set_uniform_buffer(State &state, Context *ctx, const bool is_vertex_uniform
 
 void set_context(State &state, Context *ctx, RenderTarget *target, SceGxmColorSurface *color_surface, SceGxmDepthStencilSurface *depth_stencil_surface);
 void set_vertex_stream(State &state, Context *ctx, const std::size_t index, const std::size_t data_len, const Ptr<const void> stream);
-void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndexFormat index_type, const void *index_data, const std::uint32_t index_count, const std::uint32_t instance_count);
+void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndexFormat index_type, Ptr<const void> index_data, const std::uint32_t index_count, const std::uint32_t instance_count);
 void transfer_copy(State &state, uint32_t colorKeyValue, uint32_t colorKeyMask, SceGxmTransferColorKeyMode colorKeyMode, const SceGxmTransferImage *images, SceGxmTransferType srcType, SceGxmTransferType destType);
 void transfer_downscale(State &state, const SceGxmTransferImage *src, const SceGxmTransferImage *dest);
 void transfer_fill(State &state, uint32_t fillColor, const SceGxmTransferImage *dest);

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -61,6 +61,8 @@ struct State {
 
     bool should_display;
 
+    bool need_page_table = false;
+
     virtual bool init(const char *base_path, const bool hashless_texture_cache) = 0;
     virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem)
@@ -69,10 +71,13 @@ struct State {
     virtual void set_fxaa(bool enable_fxaa) = 0;
     virtual int get_max_anisotropic_filtering() = 0;
     virtual void set_anisotropic_filtering(int anisotropic_filtering) = 0;
-    virtual bool map_memory(void *address, uint32_t size) {
+    virtual void set_surface_sync_state(bool disable) {
+        disable_surface_sync = disable;
+    }
+    virtual bool map_memory(MemState &mem, Ptr<void> address, uint32_t size) {
         return true;
     }
-    virtual void unmap_memory(void *address) {}
+    virtual void unmap_memory(MemState &mem, Ptr<void> address) {}
     virtual std::vector<std::string> get_gpu_list() {
         return { "Automatic" };
     }

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -86,7 +86,7 @@ enum class GXMState : std::uint16_t {
 struct RenderTarget;
 
 struct GXMStreamInfo {
-    const uint8_t *data = nullptr;
+    Ptr<const uint8_t> data = Ptr<const uint8_t>(0);
     size_t size = 0;
 };
 

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -33,12 +33,12 @@ bool create(std::unique_ptr<VertexProgram> &vp, VKState &state, const SceGxmProg
 bool create(std::unique_ptr<FragmentProgram> &fp, VKState &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend);
 
 void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format,
-    void *indices, size_t count, uint32_t instance_count, MemState &mem, const Config &config);
+    Ptr<void> indices, size_t count, uint32_t instance_count, MemState &mem, const Config &config);
 
 void new_frame(VKContext &context);
 
 void set_context(VKContext &context, const MemState &mem, VKRenderTarget *rt, const FeatureState &features);
-void set_uniform_buffer(VKContext &context, const ShaderProgram *program, const bool vertex_shader, const int block_num, const int size, const uint8_t *data);
+void set_uniform_buffer(VKContext &context, const MemState &mem, const ShaderProgram *program, const bool vertex_shader, const int block_num, const int size, Ptr<uint8_t> data);
 
 void sync_clipping(VKContext &context);
 void sync_stencil_func(VKContext &context, const bool is_back);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -63,7 +63,7 @@ struct VKState : public renderer::State {
     vk::CommandPool transfer_command_pool;
 
     // only used when memory mapping is enabled
-    std::map<uint64_t, MappedMemory, std::greater<uint64_t>> mapped_memories;
+    std::map<Address, MappedMemory, std::greater<Address>> mapped_memories;
 
     vkutil::Image default_image;
     vkutil::Buffer default_buffer;
@@ -79,12 +79,13 @@ struct VKState : public renderer::State {
     void set_fxaa(bool enable_fxaa) override;
     int get_max_anisotropic_filtering() override;
     void set_anisotropic_filtering(int anisotropic_filtering) override;
-    bool map_memory(void *address, uint32_t size) override;
-    void unmap_memory(void *address) override;
+    void set_surface_sync_state(bool disable) override;
+    bool map_memory(MemState &mem, Ptr<void> address, uint32_t size) override;
+    void unmap_memory(MemState &mem, Ptr<void> address) override;
     // return the matching buffer and offset for the memory location
-    std::tuple<vk::Buffer, uint32_t> get_matching_mapping(const void *address);
+    std::tuple<vk::Buffer, uint32_t> get_matching_mapping(const Ptr<void> address);
     // return the GPU buffer device address matching this one
-    uint64_t get_matching_device_address(const void *address);
+    uint64_t get_matching_device_address(const Address address);
     std::vector<std::string> get_gpu_list() override;
 
     void precompile_shader(const ShadersHash &hash) override;

--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -82,11 +82,16 @@ struct FrameObject {
     vkutil::DestroyQueue destroy_queue;
 };
 
-struct MappedMemory {
-    void *address;
-    uint32_t size;
+struct MappedMemoryBuffer {
     vk::DeviceMemory memory;
     vk::Buffer buffer;
+};
+
+struct MappedMemory {
+    Address address;
+    std::variant<vk::DeviceMemory, vkutil::Buffer> buffer_impl;
+    vk::Buffer buffer;
+    uint32_t size;
     uint64_t buffer_address;
 };
 

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -149,7 +149,7 @@ COMMAND(handle_memory_map) {
     const uint32_t size = helper.pop<uint32_t>();
 
     if (renderer.current_backend == Backend::Vulkan) {
-        dynamic_cast<vulkan::VKState &>(renderer).map_memory(addr.get(mem), size);
+        dynamic_cast<vulkan::VKState &>(renderer).map_memory(mem, addr, size);
     }
 
     complete_command(renderer, helper, 0);
@@ -161,7 +161,7 @@ COMMAND(handle_memory_unmap) {
     const Ptr<void> addr = helper.pop<Ptr<void>>();
 
     if (renderer.current_backend == Backend::Vulkan) {
-        dynamic_cast<vulkan::VKState &>(renderer).unmap_memory(addr.get(mem));
+        dynamic_cast<vulkan::VKState &>(renderer).unmap_memory(mem, addr);
     }
 
     complete_command(renderer, helper, 0);

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -476,7 +476,7 @@ void sync_vertex_streams_and_attributes(GLContext &context, GxmRecordState &stat
             if (!result.first) {
                 LOG_ERROR("Failed to allocate vertex stream data from GPU!");
             } else {
-                std::memcpy(result.first, state.vertex_streams[i].data, state.vertex_streams[i].size);
+                std::memcpy(result.first, state.vertex_streams[i].data.get(mem), state.vertex_streams[i].size);
                 offset_in_buffer[i] = result.second;
             }
 

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -93,7 +93,7 @@ void set_vertex_stream(State &state, Context *ctx, const std::size_t index, cons
     renderer::add_state_set_command(ctx, renderer::GXMState::VertexStream, stream, index, data_len);
 }
 
-void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndexFormat index_type, const void *index_data, const std::uint32_t index_count, const std::uint32_t instance_count) {
+void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndexFormat index_type, Ptr<const void> index_data, const std::uint32_t index_count, const std::uint32_t instance_count) {
     renderer::add_command(ctx, renderer::CommandOpcode::Draw, nullptr, prim_type, index_type, index_data, index_count, instance_count);
 }
 

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -192,18 +192,18 @@ COMMAND(handle_draw) {
     TRACY_FUNC_COMMANDS(handle_draw);
     SceGxmPrimitiveType type = helper.pop<SceGxmPrimitiveType>();
     SceGxmIndexFormat format = helper.pop<SceGxmIndexFormat>();
-    void *indicies = helper.pop<void *>();
+    Ptr<const void> indicies = helper.pop<Ptr<const void>>();
     const std::uint32_t count = helper.pop<const std::uint32_t>();
     const std::uint32_t instance_count = helper.pop<const std::uint32_t>();
 
     switch (renderer.current_backend) {
     case Backend::OpenGL:
         gl::draw(dynamic_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context),
-            features, type, format, indicies, count, instance_count, mem, base_path, title_id, self_name, config);
+            features, type, format, indicies.cast<void>().get(mem), count, instance_count, mem, base_path, title_id, self_name, config);
         break;
 
     case Backend::Vulkan:
-        vulkan::draw(*reinterpret_cast<vulkan::VKContext *>(render_context), type, format, indicies,
+        vulkan::draw(*reinterpret_cast<vulkan::VKContext *>(render_context), type, format, indicies.cast<void>(),
             count, instance_count, mem, config);
         break;
 

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -109,7 +109,7 @@ COMMAND_SET_STATE(program) {
 
 COMMAND_SET_STATE(uniform_buffer) {
     TRACY_FUNC_COMMANDS_SET_STATE(uniform_buffer);
-    const uint8_t *data = helper.pop<const Ptr<void>>().cast<uint8_t>().get(mem);
+    const Ptr<uint8_t> data = helper.pop<const Ptr<uint8_t>>();
     const bool is_vertex = helper.pop<bool>();
     const int block_num = helper.pop<int>();
     const std::uint32_t size = helper.pop<std::uint32_t>();
@@ -119,11 +119,11 @@ COMMAND_SET_STATE(uniform_buffer) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL:
-        gl::set_uniform_buffer(*reinterpret_cast<gl::GLContext *>(render_context), program, is_vertex, block_num, size, data);
+        gl::set_uniform_buffer(*reinterpret_cast<gl::GLContext *>(render_context), program, is_vertex, block_num, size, data.get(mem));
         break;
 
     case Backend::Vulkan:
-        vulkan::set_uniform_buffer(*reinterpret_cast<vulkan::VKContext *>(render_context), program, is_vertex, block_num, size, data);
+        vulkan::set_uniform_buffer(*reinterpret_cast<vulkan::VKContext *>(render_context), mem, program, is_vertex, block_num, size, data);
         break;
 
     default:
@@ -135,7 +135,7 @@ COMMAND_SET_STATE(uniform_buffer) {
     if (offset != static_cast<uint32_t>(-1) && config.log_active_shaders) {
         const int base_binding_ubo_relative = is_vertex ? 0 : (SCE_GXM_REAL_MAX_UNIFORM_BUFFER + 1);
 
-        std::vector<uint8_t> my_data((uint8_t *)data, (uint8_t *)data + size);
+        std::vector<uint8_t> my_data(data.get(mem), data.get(mem) + size);
         render_context->ubo_data[base_binding_ubo_relative + block_num] = my_data;
     }
 }
@@ -484,7 +484,7 @@ COMMAND_SET_STATE(cull_mode) {
 
 COMMAND_SET_STATE(vertex_stream) {
     TRACY_FUNC_COMMANDS_SET_STATE(vertex_stream);
-    const uint8_t *stream_data = helper.pop<Ptr<const void>>().cast<const uint8_t>().get(mem);
+    const Ptr<const uint8_t> stream_data = helper.pop<Ptr<const uint8_t>>();
     const std::size_t stream_index = helper.pop<std::size_t>();
     const std::size_t stream_data_length = helper.pop<std::size_t>();
 


### PR DESCRIPTION
Add another implementation for memory mapping which does not rely on the VK_External_Memory_Host extension.

This is only useful on PC for debugging purposes (Renderdoc does not support it). However it will be useful for the Android version as the external memory host is not supported on most android devices.