### PR TITLE
modules: implement and improve some functions

### DIFF
--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -141,6 +141,7 @@ public:
         "SceMotion",
         "SceNet",
         "SceNetCtl",
+        "SceNetInternal",
         "SceNgs",
         "SceNpCommon",
         "SceNpManager",

--- a/vita3k/kernel/include/kernel/types.h
+++ b/vita3k/kernel/include/kernel/types.h
@@ -47,6 +47,7 @@
 #define SCE_KERNEL_ATTR_NOTIFY_CB_WAKEUP_ONLY 0x00000800U
 
 #define SCE_KERNEL_MUTEX_ATTR_RECURSIVE 0x2U
+#define SCE_KERNEL_MUTEX_ATTR_CEILING 0x4U
 
 #define SCE_KERNEL_MSG_PIPE_MODE_ASAP 0x00000000U
 #define SCE_KERNEL_MSG_PIPE_MODE_FULL 0x00000001U
@@ -727,6 +728,18 @@ struct SceKernelEventFlagInfo {
     SceUInt32 initPattern;
     SceUInt32 currentPattern;
     SceUInt32 numWaitThreads;
+};
+
+struct SceKernelMutexInfo {
+    SceSize size;
+    SceUID mutexId;
+    char name[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+    SceUInt32 attr;
+    SceUInt32 initCount;
+    SceUInt32 currentCount;
+    SceUID currentOwnerId;
+    SceUInt32 numWaitThreads;
+    SceInt32 ceilingPriority;
 };
 
 struct SceKernelSemaInfo {

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1819,8 +1819,10 @@ EXPORT(SceGxmDepthStencilForceStoreMode, sceGxmDepthStencilSurfaceGetForceStoreM
 
 EXPORT(int, sceGxmDepthStencilSurfaceGetFormat, const SceGxmDepthStencilSurface *surface) {
     TRACY_FUNC(sceGxmDepthStencilSurfaceGetFormat, surface);
-    assert(surface);
-    return UNIMPLEMENTED();
+    if (!surface) {
+        return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
+    }
+    return surface->control.content & SceGxmDepthStencilControl::format_bits;
 }
 
 EXPORT(uint32_t, sceGxmDepthStencilSurfaceGetStrideInSamples, const SceGxmDepthStencilSurface *surface) {
@@ -3102,7 +3104,9 @@ EXPORT(int, sceGxmProgramGetOutputRegisterFormat, const SceGxmProgram *program, 
     if (!program->is_fragment())
         return RET_ERROR(SCE_GXM_ERROR_INVALID_VALUE);
 
-    return UNIMPLEMENTED();
+    *type = program->get_fragment_output_type();
+    *componentCount = program->get_fragment_output_component_count();
+    return 0;
 }
 
 EXPORT(Ptr<SceGxmProgramParameter>, sceGxmProgramGetParameter, Ptr<const SceGxmProgram> program, uint32_t index) {

--- a/vita3k/modules/SceKernelModulemgr/SceModulemgr.cpp
+++ b/vita3k/modules/SceKernelModulemgr/SceModulemgr.cpp
@@ -198,7 +198,9 @@ EXPORT(int, sceKernelGetModuleInfo, SceUID modid, SceKernelModuleInfo *info) {
     TRACY_FUNC(sceKernelGetModuleInfo, modid, info);
     KernelState *const state = &emuenv.kernel;
     const SceKernelModuleInfoPtrs::const_iterator module = state->loaded_modules.find(modid);
-    assert(module != state->loaded_modules.end());
+    if (module == state->loaded_modules.end()) {
+        return RET_ERROR(SCE_KERNEL_ERROR_LIBRARYDB_NO_MOD);
+    }
 
     memcpy(info, module->second.get(), module->second.get()->size);
 

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
@@ -47,6 +47,7 @@ EXPORT(SceInt32, _sceKernelGetThreadInfo, SceUID threadId, Ptr<SceKernelThreadIn
 EXPORT(int, _sceKernelLockMutex, SceUID mutexid, int lock_count, unsigned int *timeout);
 EXPORT(SceUID, _sceKernelCreateEventFlag, const char *pName, SceUInt32 attr, SceUInt32 initPattern, const SceKernelEventFlagOptParam *pOptParam);
 EXPORT(int, _sceKernelCreateSema, const char *name, SceUInt attr, int initVal, Ptr<SceKernelCreateSema_opt> opt);
+EXPORT(int, _sceKernelGetMutexInfo, SceUID mutexId, SceKernelMutexInfo *pInfo);
 EXPORT(SceInt32, _sceKernelGetSemaInfo, SceUID semaId, Ptr<SceKernelSemaInfo> pInfo);
 EXPORT(SceInt32, _sceKernelWaitCond, SceUID condId, SceUInt32 *pTimeout);
 EXPORT(SceInt32, _sceKernelWaitCondCB, SceUID condId, SceUInt32 *pTimeout);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -544,8 +544,8 @@ EXPORT(int, sceIoGetstatByFd, const SceUID fd, SceIoStat *stat) {
     return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path, export_name);
 }
 
-EXPORT(int, sceIoIoctl) {
-    TRACY_FUNC(sceIoIoctl);
+EXPORT(int, sceIoIoctl, SceUID fd, int cmd, const void *argp, SceSize arglen, void *bufp, SceSize buflen) {
+    TRACY_FUNC(sceIoIoctl, fd, cmd, argp, arglen, bufp, buflen);
     return UNIMPLEMENTED();
 }
 
@@ -1159,8 +1159,11 @@ EXPORT(int, sceKernelCreateMsgPipeWithLR) {
 
 EXPORT(int, sceKernelCreateMutex, const char *name, SceUInt attr, int init_count, SceKernelMutexOptParam *opt_param) {
     TRACY_FUNC(sceKernelCreateMutex, name, attr, init_count, opt_param);
-    SceUID uid;
+    if ((attr & SCE_KERNEL_MUTEX_ATTR_CEILING)) {
+        STUBBED("priority ceiling feature is not supported");
+    }
 
+    SceUID uid;
     if (auto error = mutex_create(&uid, emuenv.kernel, emuenv.mem, export_name, name, thread_id, attr, init_count, Ptr<SceKernelLwMutexWork>(0), SyncWeight::Heavy)) {
         return error;
     }
@@ -1340,9 +1343,9 @@ EXPORT(int, sceKernelGetMsgPipeInfo) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelGetMutexInfo) {
-    TRACY_FUNC(sceKernelGetMutexInfo);
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelGetMutexInfo, SceUID mutexId, SceKernelMutexInfo *info) {
+    TRACY_FUNC(sceKernelGetMutexInfo, mutexId, info);
+    return CALL_EXPORT(_sceKernelGetMutexInfo, mutexId, info);
 }
 
 EXPORT(int, sceKernelGetOpenPsId) {


### PR DESCRIPTION
modules/SceThreadmgr: implement _sceKernelGetMutexInfo, sceKernelSetTimerTimeWide; refactor _sceKernelGetLwMutexInfoById
_sceKernelGetSemaInfo - fix returning data
_sceKernelGetThreadInfo - also return thread exit status; sceKernelChangeThreadVfpException, sceIoIoctl - describe parameters

modules/SceGxm: implement sceGxmProgramGetOutputRegisterFormat, sceGxmDepthStencilSurfaceGetFormat

modules/SceRtcUser: implement sceRtcCompareTick, sceRtcGetDosTime, sceRtcGetWin32FileTime

modules/SceKernelModulemgr: sceKernelGetModuleInfo change assert to error code

modules/SceLibKernel: sceKernelCreateMutex: add stub if priority ceiling feature is used

config/state: add forgotten module (SceNetInternal) into tracy modules list