### PR TITLE
vita3k Add dpi support on linux. 

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -148,14 +148,15 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         state.display.fullscreen = true;
         window_type |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
-#ifdef WIN32
+#ifndef __APPLE__
     float ddpi, hdpi, vdpi;
     SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi);
     state.dpi_scale = ddpi / 96;
+    window_type |= SDL_WINDOW_ALLOW_HIGHDPI;
 #endif
     state.res_width_dpi_scale = DEFAULT_RES_WIDTH * state.dpi_scale;
     state.res_height_dpi_scale = DEFAULT_RES_HEIGHT * state.dpi_scale;
-    state.window = WindowPtr(SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, state.res_width_dpi_scale, state.res_height_dpi_scale, window_type | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI), SDL_DestroyWindow);
+    state.window = WindowPtr(SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, state.res_width_dpi_scale, state.res_height_dpi_scale, window_type | SDL_WINDOW_RESIZABLE ), SDL_DestroyWindow);
 
     if (!state.window) {
         LOG_ERROR("SDL failed to create window!");

--- a/vita3k/compat/src/compat.cpp
+++ b/vita3k/compat/src/compat.cpp
@@ -96,16 +96,10 @@ bool load_compat_app_db(GuiState &gui, EmuEnvState &emuenv) {
             LOG_WARN("App with title ID {} has an issue but no status label. Please check GitHub issue {} and request a status label to be added.", title_id, issue_id);
 
         // Check if app already exists in compatibility database
-        if (gui.compat.app_compat_db.contains(title_id)) {
-            const auto exist_app = gui.compat.app_compat_db[title_id];
-            const auto duplicate_issue = issue_id > exist_app.issue_id ? issue_id : exist_app.issue_id;
-            LOG_WARN("App with title ID {} already exists in compatibility database. Please check and close GitHub issue {}.", title_id, duplicate_issue);
+        if (gui.compat.app_compat_db.contains(title_id))
+            LOG_WARN("App with title ID {} already exists in compatibility database. Please check and close GitHub issue {}.", title_id, gui.compat.app_compat_db[title_id].issue_id);
 
-            // If the issue ID is different, update the issue for using original old issue
-            if (duplicate_issue != issue_id)
-                gui.compat.app_compat_db[title_id] = { issue_id, state, updated_at };
-        } else
-            gui.compat.app_compat_db[title_id] = { issue_id, state, updated_at };
+        gui.compat.app_compat_db[title_id] = { issue_id, state, updated_at };
     }
 
     // Update compatibility status of all user apps

--- a/vita3k/emuenv/include/emuenv/state.h
+++ b/vita3k/emuenv/include/emuenv/state.h
@@ -150,9 +150,9 @@ public:
     Ime &ime;
     SfoFile &sfo_handle;
     NIDSet missing_nids;
-    float dpi_scale = 1.0f;
-    float res_width_dpi_scale{};
-    float res_height_dpi_scale{};
+    float dpi_scale = 1.f;
+    uint32_t res_width_dpi_scale = 0;
+    uint32_t res_height_dpi_scale = 0;
     GDBState &gdb;
     HTTPState &http;
 


### PR DESCRIPTION
# About
- vita3k Add dpi support on linux.
- Disable SDL_WINDOW_ALLOW_HIGHDPI for mac.
should fix big size issue and set all element in good size.
- compat: little clean code no needed.

# result in mac on app background loading
- before in old build
![image](https://cdn.discordapp.com/attachments/1080307347458625576/1081586790902800465/Capture_decran_2023-03-04_a_15.39.31.png)

- in pr
![image](https://cdn.discordapp.com/attachments/1080307347458625576/1081586061647552524/Capture_decran_2023-03-04_a_15.36.41.png)