### PR TITLE
util: log crashes and flush log file (Windows only)

### DIFF
--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -26,6 +26,15 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #ifdef WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#else
+#include <signal.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+#ifdef WIN32
 #include <winsock2.h>
 #else
 #include <fcntl.h>
@@ -51,6 +60,8 @@ static const fs::path &LOG_FILE_NAME = "vita3k.log";
 static const char *LOG_PATTERN = "%^[%H:%M:%S.%e] |%L| [%!]: %v%$";
 std::vector<spdlog::sink_ptr> sinks;
 
+void register_log_exception_handler();
+
 ExitCode init(const Root &root_paths, bool use_stdout) {
     sinks.clear();
     if (use_stdout)
@@ -64,6 +75,11 @@ ExitCode init(const Root &root_paths, bool use_stdout) {
         assert(0);
     });
 
+    register_log_exception_handler();
+#ifdef WIN32
+    // set console codepage to UTF-8
+    SetConsoleOutputCP(65001);
+#endif
     return Success;
 }
 
@@ -113,6 +129,81 @@ int ret_error_impl(const char *name, const char *error_str, std::uint32_t error_
     return error_val;
 }
 
+// log exceptions and flush log file on exceptions
+#ifdef WIN32
+static LONG WINAPI exception_handler(PEXCEPTION_POINTERS pExp) noexcept {
+    const unsigned ec = pExp->ExceptionRecord->ExceptionCode;
+    bool do_sink = (pExp->ExceptionRecord->ExceptionFlags & EXCEPTION_NONCONTINUABLE);
+    switch (ec) {
+    case EXCEPTION_ACCESS_VIOLATION:
+        LOG_CRITICAL("Exception EXCEPTION_ACCESS_VIOLATION ({}). ", log_hex(ec));
+        switch (pExp->ExceptionRecord->ExceptionInformation[0]) {
+        case 0:
+            LOG_CRITICAL("Read violation at address {}.", log_hex(pExp->ExceptionRecord->ExceptionInformation[1]));
+            break;
+        case 1:
+            LOG_CRITICAL("Write violation at address {}.", log_hex(pExp->ExceptionRecord->ExceptionInformation[1]));
+            break;
+        case 8:
+            LOG_CRITICAL("DEP violation at address {}.", log_hex(pExp->ExceptionRecord->ExceptionInformation[1]));
+            break;
+        default:
+            break;
+        }
+        break;
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+        LOG_CRITICAL("Exception EXCEPTION_ARRAY_BOUNDS_EXCEEDED ({}). ", log_hex(ec));
+        break;
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+        LOG_CRITICAL("Exception EXCEPTION_DATATYPE_MISALIGNMENT ({}). ", log_hex(ec));
+        break;
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+        LOG_CRITICAL("Exception EXCEPTION_FLT_DIVIDE_BY_ZERO ({}). ", log_hex(ec));
+        break;
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+        LOG_CRITICAL("Exception EXCEPTION_ILLEGAL_INSTRUCTION ({}). ", log_hex(ec));
+        break;
+    case EXCEPTION_IN_PAGE_ERROR:
+        LOG_CRITICAL("Exception EXCEPTION_IN_PAGE_ERROR ({}). ", log_hex(ec));
+        break;
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        LOG_CRITICAL("Exception EXCEPTION_INT_DIVIDE_BY_ZERO ({}). ", log_hex(ec));
+        break;
+    case EXCEPTION_PRIV_INSTRUCTION:
+        LOG_CRITICAL("Exception EXCEPTION_PRIV_INSTRUCTION ({}). ", log_hex(ec));
+        break;
+    case EXCEPTION_STACK_OVERFLOW:
+        LOG_CRITICAL("Exception EXCEPTION_STACK_OVERFLOW ({}). ", log_hex(ec));
+        break;
+    case 0xe06d7363: //(C++ EH exception)
+    {
+        const auto exception = reinterpret_cast<const std::exception *>(pExp->ExceptionRecord->ExceptionInformation[1]);
+        LOG_CRITICAL("Exception {} C++ EH exception. {}", log_hex(ec), exception->what());
+        break;
+    }
+    case 0x80040155: // Interface not registered
+        do_sink = false;
+        break;
+    default:
+        if (do_sink) {
+            LOG_CRITICAL("Exception {}", log_hex(ec));
+        }
+    }
+    if (do_sink) {
+        // In this logger any flush is done async and return immediately. force flush can be done only on shutdown
+        spdlog::shutdown();
+    }
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+void register_log_exception_handler() {
+    if (!AddVectoredExceptionHandler(0, exception_handler)) {
+        LOG_CRITICAL("Failed to register an exception handler");
+    }
+}
+
+#else
+void register_log_exception_handler() {}
+#endif
 } // namespace logging
 
 namespace string_utils {


### PR DESCRIPTION
util: log crashes (Windows only), also set console encoding on Windows to utf-8

Windows only, because I don't have Linux to debug this (and it was needed a lot of debug)