### PR TITLE
modules/SceCommonDialog: Update SCE_MSG_DIALOG_SYSMSG_TYPE_TRC_MIC_DISABLED

### DIFF
--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -358,8 +358,10 @@ EXPORT(int, sceMsgDialogInit, const Ptr<SceMsgDialogParam> param) {
             emuenv.common_dialog.msg.btn_val[0] = SCE_MSG_DIALOG_BUTTON_ID_OK;
             break;
         case SCE_MSG_DIALOG_SYSMSG_TYPE_TRC_MIC_DISABLED:
-            emuenv.common_dialog.msg.message = "You must enable the microphone.";
-            emuenv.common_dialog.msg.btn_num = 0;
+            emuenv.common_dialog.msg.message = common["microphone_disabled"];
+            emuenv.common_dialog.msg.btn_num = 1;
+            emuenv.common_dialog.msg.btn[0] = common["ok"];
+            emuenv.common_dialog.msg.btn_val[0] = SCE_MSG_DIALOG_BUTTON_ID_OK;
             break;
         case SCE_MSG_DIALOG_SYSMSG_TYPE_TRC_WIFI_REQUIRED_OPERATION:
             emuenv.common_dialog.msg.message = "You must use Wi-Fi to do this.";


### PR DESCRIPTION
# About
- modules/SceCommonDialog: Update SCE_MSG_DIALOG_SYSMSG_TYPE_TRC_MIC_DISABLED
  Can solve some games to close microphone dialog, e.g. Senran Kagura: Shinovi Versus, etc,.

# PS Vita
![2023-03-10-062319](https://user-images.githubusercontent.com/61804715/224174080-fe5a465b-e275-4e57-b793-f12cc6fd332b.jpg)

# Result
![image](https://user-images.githubusercontent.com/61804715/224173575-f84b5a3f-fc06-47a1-8903-ef03a1782621.png)
