### PR TITLE
renderer/texture cache: add fmt U8U8 in unswizzled without decode.

### DIFF
--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -94,6 +94,7 @@ bool can_texture_be_unswizzled_without_decode(SceGxmTextureBaseFormat fmt, bool 
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U5U6U5
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U1U5U5U5
+        || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_F16F16F16F16


### PR DESCRIPTION
# About
- Add texture format U8U8 on can_texture_be_unswizzled_without_decode

# Result
- fix render on limbo
![image](https://user-images.githubusercontent.com/5261759/224566362-86642e6c-178d-4a4d-9161-eb88924a50bc.png)
