### PR TITLE
lang: Complement more languages text

### DIFF
--- a/lang/da.xml
+++ b/lang/da.xml
@@ -72,7 +72,6 @@ Fejlkode: {}</an_error_occurred>
 		<delete>Slet</delete>
 		<file_corrupted>Filen er defekt.</file_corrupted>
 		<microphone_disabled>Aktivér mikrofonen.</microphone_disabled>
-		<nospace>Der er ikke nok ledig plads på hukommelseskortet.</nospace>
 		<no>Nej</no>
 		<ok>OK</ok>
 		<please_wait>Vent venligst...</please_wait>
@@ -219,10 +218,58 @@ Fejlkode: {}</an_error_occurred>
 Connect a controller that is compatible with SDL2.</not_connected>
 	</controllers>
 
+	<dialog>
+		<trophy>
+			<preparing_start_app>Forbereder start af programmet...</preparing_start_app>
+		</trophy>
+		<save_data>
+			<delete>
+				<cancel_deleting>Ønsker du at afbryde sletningen?</cancel_deleting>
+				<deletion_complete>Sletning udført.</deletion_complete>
+				<delete_saved_data>Ønsker du at slette disse gemte data?</delete_saved_data>
+			</delete>
+			<info>
+				<details>Detaljer</details>
+				<updated>Opdateret</updated>
+			</info>
+			<load name="Indlæs">
+				<cancel_loading>Ønsker du at afbryde indlæsningen?</cancel_loading>
+				<no_saved_data>Der er ingen gemte data.</no_saved_data>
+				<load_complete>Indlæsning udført.</load_complete>
+				<loading>Indlæser...</loading>
+				<load_saved_data>Ønsker du at indlæse disse gemte data?</load_saved_data>
+			</load>
+			<save name="Gem">
+				<cancel_saving>Ønsker du at afbryde lagringen?</cancel_saving>
+				<could_not_save>Kunne ikke gemme filen.
+Der er ikke nok ledig plads på hukommelseskortet.</could_not_save>
+				<not_free_space>Der er ikke nok ledig plads på hukommelseskortet.</not_free_space>
+				<new_saved_data>Nye gemte data</new_saved_data>
+				<saving_complete>Lagring udført.</saving_complete>
+				<save_the_data>Ønsker du at gemme dataene?</save_the_data>
+				<saving>Gemmer...</saving>
+				<warning_saving>Gemmer...
+Undlad at slukke for systemet eller lukke programmet.</warning_saving>
+				<overwrite_saved_data>Ønsker du at overskrive disse gemte data?</overwrite_saved_data>
+			</save>
+		</save_data>
+	</dialog>
+
 	<game_data>
 		<app_close>Følgende program bliver lukket.</app_close>
 		<data_delete>Data, som skal slettes:</data_delete>
 	</game_data>
+
+	<indicator>
+		<app_added_home>Programmet er blevet føjet til hjemmeskærm.</app_added_home>
+		<delete_all>Slet alt</delete_all>
+		<notif_deleted>Meddelelserne vil blive slettet.</notif_deleted>
+		<install_failed>Kunne ikke installere.</install_failed>
+		<install_complete>Installation udført.</install_complete>
+		<installing>Installerer...</installing>
+		<no_notif>Der er ingen meddelelsen.</no_notif>
+		<trophy_earned>Du har opnået et trophy!</trophy_earned>
+	</indicator>
 
 	<initial_setup>
 		<back>Tilbage</back>
@@ -250,7 +297,7 @@ Dit Vita3K-system er klart!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -264,7 +311,7 @@ Dit Vita3K-system er klart!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -355,6 +402,7 @@ Du kan opnå trophies ved at bruge et program, der understøtter trophy-funkitio
 		<create_user>Opret bruger</create_user>
 		<user_created>Den følgende bruger er blevet oprettet:</user_created>
 		<edit_user>Edit User</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>Navent er allerede i brug.</user_name_used>
 		<delete_user>Slet bruger</delete_user>
 		<user_delete>Vælg den bruger, som du vil slette.</user_delete>
@@ -370,4 +418,21 @@ Er du sikker på, at du ønsker at fortsætte.</user_delete_warn>
 		<confirm>Bekræft</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K-opdatering">
+ 		<new_version_available>En ny version af Vita3K er tilgængelig.</new_version_available>
+		<back>Tilbage</back>
+		<downloading>Downloader...
+Efter download er udført, vil Vita3K automatisk genstarte og derefter installere den nye Vita3K.</downloading>
+		<not_complete_update>Kunne ikke udføre opdateringen.</not_complete_update>
+		<next>Næste</next>
+		<update_vita3k>Ønsker du at opdatere Vita3K?</update_vita3k>
+		<later_version_already_installed>Den senere version af Vita3K er allerede installeret.</later_version_already_installed>
+		<latest_version_already_installed>Den seneste version af Vita3K er allerede installeret.</latest_version_already_installed>
+		<new_features>Nye funktioner i version {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Opdater</update>
+		<version>Version {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/de.xml
+++ b/lang/de.xml
@@ -83,7 +83,6 @@ Fehlercode: {}</an_error_occurred>
 		<delete>Löschen</delete>
 		<file_corrupted>Die Datei ist beschädigt.</file_corrupted>
 		<microphone_disabled>Aktiviere das Mikrofon.</microphone_disabled>
-		<nospace>Nicht genügend freier Speicherplatz auf der Speicherkarte.</nospace>
 		<no>Nein</no>
 		<ok>OK</ok>
 		<please_wait>Warte bitte ...</please_wait>
@@ -232,37 +231,37 @@ Connect a controller that is compatible with SDL2.</not_connected>
 
 	<dialog>
 		<trophy>
-			<preparing_start_app>Bereite den Start der Anwendung vor...</preparing_start_app>
+			<preparing_start_app>Starten der Anwendung wird vorbereitet ...</preparing_start_app>
 		</trophy>
 		<save_data>
 			<delete>
-				<cancel_deleting>Willst du das Löschen abbrechen?</cancel_deleting>
-				<deletion_complete>Daten gelöscht.</deletion_complete>
-				<delete_saved_data>Diese Nutzerdaten löschen?</delete_saved_data>
+				<cancel_deleting>Möchtest du den Löschvorgang abbrechen?</cancel_deleting>
+				<deletion_complete>Löschen abgeschlossen.</deletion_complete>
+				<delete_saved_data>Möchtest du diese gespeicherten Daten löschen?</delete_saved_data>
 			</delete>
 			<info>
-				<details>Details</details>
+				<details>Einzelheiten</details>
 				<updated>Aktualisiert</updated>
 			</info>
 			<load name="Laden">
-				<cancel_loading>Willst du das Laden abbrechen?</cancel_loading>
-				<no_saved_data>Keine Nutzerdaten vorhanden.</no_saved_data>
-				<load_complete>Daten geladen.</load_complete>
-				<loading>Lade...</loading>
-				<load_saved_data>Diese Nutzerdaten laden?</load_saved_data>
+				<cancel_loading>Möchtest du den Ladevorgang abbrechen?</cancel_loading>
+				<no_saved_data>Es gibt keine gespeicherten Daten.</no_saved_data>
+				<load_complete>Laden abgeschlossen.</load_complete>
+				<loading>Lädt ...</loading>
+				<load_saved_data>Möchtest du diese gespeicherten Daten laden?</load_saved_data>
 			</load>
 			<save name="Speichern">
-				<cancel_saving>Willst du das Speichern abbrechen?</cancel_saving>
-				<could_not_save>Konnte die Datei nicht speichern.
-Es fehlt freier Platz auf der Speicherkarte.</could_not_save>
-				<not_free_space>Es fehlt freier Platz auf der Speicherkarte.</not_free_space>
-				<new_saved_data>Neue Nutzerdaten</new_saved_data>
-				<saving_complete>Daten gespeichert.</saving_complete>
-				<save_the_data>Diese Nutzerdaten speichern?</save_the_data>
-				<saving>Speichere...</saving>
-				<warning_saving>Speichere...
-Schalte die Konsole nicht aus und beende nicht die Anwendung.</warning_saving>
-				<overwrite_saved_data>Vorhandene Nutzerdaten überschreiben?</overwrite_saved_data>
+				<cancel_saving>Möchtest du den Speichervorgang abbrechen?</cancel_saving>
+				<could_not_save>Speichern der Datei gescheitert.
+Nicht genügend freier Speicherplatz auf der Speicherkarte.</could_not_save>
+				<not_free_space>Nicht genügend freier Speicherplatz auf der Speicherkarte.</not_free_space>
+				<new_saved_data>Neue gespeicherte Daten</new_saved_data>
+				<saving_complete>Speichern abgeschlossen.</saving_complete>
+				<save_the_data>Möchtest du die Daten speichern?</save_the_data>
+				<saving>Speichert ...</saving>
+				<warning_saving>Speichert ...
+Schalte das System nicht aus und schließe die Anwendung nicht.</warning_saving>
+				<overwrite_saved_data>Möchtest du diese gespeicherten Daten überschreiben?</overwrite_saved_data>
 			</save>
 		</save_data>
 	</dialog>
@@ -309,7 +308,7 @@ Dein Vita3K-System ist bereit!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -323,7 +322,7 @@ Dein Vita3K-System ist bereit!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -414,6 +413,7 @@ Du kannst Trophäen in Anwendungen verdienen, die die Trophäen-Funktionen unter
 		<create_user>Benutzer erstellen</create_user>
 		<user_created>Der folgende Benutzer wurde erstellt.</user_created>
 		<edit_user>Benutzer bearbeiten</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>Dieser Name wird bereits verwendet.</user_name_used>
 		<delete_user>Benutzer löschen</delete_user>
 		<user_delete>Wähle den Benutzer aus, den löschen möchtest.</user_delete>
@@ -429,4 +429,21 @@ Wirklich fortfahren?</user_delete_warn>
 		<confirm>Bestätigen</confirm>
 		<automatic_user_login>Benutzer automatisch einloggen</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K Aktualisiert">
+ 		<new_version_available>Es ist eine neue Version der Vita3K verfügbar.</new_version_available>
+		<back>Zurück</back>
+		<downloading>Download läuft ...
+Nach dem Herunterladen wird Vita3K automatisch neu gestartet und die neue Vita3K installiert.</downloading>
+		<not_complete_update>Aktualisierung konnte nicht abgeschlossen werden.</not_complete_update>
+		<next>Weiter</next>
+		<update_vita3k>Möchtest du Vita3K aktualisieren?</update_vita3k>
+		<later_version_already_installed>Es ist bereits eine höhere Version der Vita3K installiert.</later_version_already_installed>
+		<latest_version_already_installed>Es ist bereits die aktuellste Version der Vita3K installiert.</latest_version_already_installed>
+		<new_features>Neue Funktionen in Version {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Aktualisieren</update>
+		<version>Version {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -83,7 +83,6 @@ Error code: {}</an_error_occurred>
 		<delete>Delete</delete>
 		<file_corrupted>The file is corrupt.</file_corrupted>
 		<microphone_disabled>Enable the microphone.</microphone_disabled>
-		<nospace>There is not enough free space on the memory card.</nospace>
 		<no>No</no>
 		<ok>OK</ok>
 		<please_wait>Please wait...</please_wait>
@@ -541,6 +540,7 @@ You can earn trophies by using an application that supports the trophy feature.<
 		<create_user>Create User</create_user>
 		<user_created>The following user has been created.</user_created>
 		<edit_user>Edit User</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>This name is already in use.</user_name_used>
 		<delete_user>Delete User</delete_user>
 		<user_delete>Select the user you want to delete.</user_delete>
@@ -568,6 +568,8 @@ After the download is complete, Vita3K will restart automatically and then insta
 		<later_version_already_installed>The later version of Vita3K is already installed.</later_version_already_installed>
 		<latest_version_already_installed>The latest version of Vita3K is already installed.</latest_version_already_installed>
 		<new_features>New Features in Version {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
 		<update>Update</update>
 		<version>Version {}</version>
 	</vita3k_update>

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -83,7 +83,6 @@ Error code: {}</an_error_occurred>
 		<delete>Delete</delete>
 		<file_corrupted>The file is corrupt.</file_corrupted>
 		<microphone_disabled>Enable the microphone.</microphone_disabled>
-		<nospace>There is not enough free space on the memory card.</nospace>
 		<no>No</no>
 		<ok>OK</ok>
 		<please_wait>Please wait...</please_wait>
@@ -541,6 +540,7 @@ You can earn trophies by using an application that supports the trophy feature.<
 		<create_user>Create User</create_user>
 		<user_created>The following user has been created.</user_created>
 		<edit_user>Edit User</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>This name is already in use.</user_name_used>
 		<delete_user>Delete User</delete_user>
 		<user_delete>Select the user you want to delete.</user_delete>
@@ -568,6 +568,8 @@ After the download is complete, Vita3K will restart automatically and then insta
 		<later_version_already_installed>The later version of Vita3K is already installed.</later_version_already_installed>
 		<latest_version_already_installed>The latest version of Vita3K is already installed.</latest_version_already_installed>
 		<new_features>New Features in Version {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
 		<update>Update</update>
 		<version>Version {}</version>
 	</vita3k_update>

--- a/lang/es.xml
+++ b/lang/es.xml
@@ -83,7 +83,6 @@ Código del error: {}</an_error_occurred>
 		<delete>Eliminar</delete>
 		<file_corrupted>El archivo está dañado.</file_corrupted>
 		<microphone_disabled>Activa el micrófono.</microphone_disabled>
-		<nospace>No hay suficiente espacio libre en la tarjeta de memoria.</nospace>
 		<no>No</no>
 		<ok>OK</ok>
 		<please_wait>Espera un momento...</please_wait>
@@ -309,7 +308,7 @@ No apagues el sistema ni cierres la aplicación.</warning_saving>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -323,7 +322,7 @@ No apagues el sistema ni cierres la aplicación.</warning_saving>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -415,6 +414,7 @@ Podrás conseguir trofeos si usas una aplicación compatible con la función de 
 		<user_created>Se ha creado el siguiente usuario:</user_created>
 		<user_name_used>El nombre ya está en uso.</user_name_used>
 		<edit_user>Modificar usuario</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<delete_user>Eliminar usuario</delete_user>
 		<user_delete>Seleciona el usuario que quieres eliminar.</user_delete>
 		<user_delete_msg>Se eliminará el siguiente usuario:</user_delete_msg>
@@ -431,7 +431,7 @@ Podrás conseguir trofeos si usas una aplicación compatible con la función de 
 	</user_management>
 
 	<vita3k_update name="Actualizar Vita3K">
-		<new_version_available>Hay una nueva actualización de Vita3K disponible.</new_version_available>
+		<new_version_available>Está disponible una nueva versión de Vita3K.</new_version_available>
 		<back>Atrás</back>
 		<downloading>Descargando...
 Cuando la descarga se haya completado, Vita3K se reiniciará automáticamente e instalará la actualización.</downloading>
@@ -441,6 +441,8 @@ Cuando la descarga se haya completado, Vita3K se reiniciará automáticamente e 
 		<later_version_already_installed>Ya está instalada una versión posterior de Vita3K.</later_version_already_installed>
 		<latest_version_already_installed>Ya está instalada la versión más reciente de Vita3K.</latest_version_already_installed>
 		<new_features>Nuevas funciones de la versión {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
 		<update>Actualizar</update>
 		<version>Versión {}</version>
 	</vita3k_update>

--- a/lang/fi.xml
+++ b/lang/fi.xml
@@ -72,7 +72,6 @@ Virhekoodi: {}</an_error_occurred>
 		<delete>Poista</delete>
 		<file_corrupted>Tiedosto on vioittunt.</file_corrupted>
 		<microphone_disabled>Ota mikrofoni käyttöön.</microphone_disabled>
-		<nospace>Muistikortilla ei ole tarpeeksi vapaata tilaa.</nospace>
 		<no>Ei</no>
 		<ok>OK</ok>
 		<please_wait>Odota hetki...</please_wait>
@@ -219,10 +218,58 @@ Virhekoodi: {}</an_error_occurred>
 Connect a controller that is compatible with SDL2.</not_connected>
 	</controllers>
 
+	<dialog>
+		<trophy>
+			<preparing_start_app>Valmistellaan sovelluksen käynnistämistä...</preparing_start_app>
+		</trophy>
+		<save_data>
+			<delete>
+				<cancel_deleting>Haluatko peruuttaa poistamisen?</cancel_deleting>
+				<deletion_complete>Poistaminen suoritettu.</deletion_complete>
+				<delete_saved_data>Haluatko poistaa nämä tallennetut tiedot?</delete_saved_data>
+			</delete>
+			<info>
+				<details>Lisätiedot</details>
+				<updated>Päivitetty</updated>
+			</info>
+			<load name="Lataa">
+				<cancel_loading>Haluatko peruuttaa latauksen?</cancel_loading>
+				<no_saved_data>Tallennettua tietoa ei ole saatavilla.</no_saved_data>
+				<load_complete>Lataus suoritettu.</load_complete>
+				<loading>Ladataan...</loading>
+				<load_saved_data>Haluatko ladata tallennetun tiedon?</load_saved_data>
+			</load>
+			<save name="Tallenna">
+				<cancel_saving>Haluatko peruuttaa tallennuksen?</cancel_saving>
+				<could_not_save>Tiedostoa ei voitu tallentaa.
+Muistikortilla ei ole tarpeeksi vapaata tilaa.</could_not_save>
+				<not_free_space>Muistikortilla ei ole tarpeeksi vapaata tilaa.</not_free_space>
+				<new_saved_data>Uusi tallennettu tieto</new_saved_data>
+				<saving_complete>Tallennus suoritettu.</saving_complete>
+				<save_the_data>Haluatko tallentaa tiedot?</save_the_data>
+				<saving>Tallennetaan...</saving>
+				<warning_saving>Tallennetaan...
+Älä katkaise virtaa järjestelmästä tai sulje sovellusta.</warning_saving>
+				<overwrite_saved_data>Haluatko kirjoittaa tallennetun tiedon päälle?</overwrite_saved_data>
+			</save>
+		</save_data>
+	</dialog>
+
 	<game_data>
 		<app_close>Seuraava sovellus suljetaan.</app_close>
 		<data_delete>Poistettavat tiedot:</data_delete>
 	</game_data>
+
+	<indicator>
+		<app_added_home>Sovellus on lisätty aloitusnäyttöön.</app_added_home>
+		<delete_all>Poista kaikki</delete_all>
+		<notif_deleted>Ilmoitukset poistetaan.</notif_deleted>
+		<install_failed>Ei voitu asentaa.</install_failed>
+		<install_complete>Asennus suoritettu.</install_complete>
+		<installing>Asennetaan...</installing>
+		<no_notif>Ei ilmoituksia.</no_notif>
+		<trophy_earned>Olet ansainnut trophyn!</trophy_earned>
+	</indicator>
 
 	<initial_setup>
 		<back>Takaisin</back>
@@ -250,7 +297,7 @@ Vita3K-järjestelmäsi on nyt käyttövalmis!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -264,7 +311,7 @@ Vita3K-järjestelmäsi on nyt käyttövalmis!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -355,6 +402,7 @@ Voit ansaita trophyjä käyttämällä trophy-ominaisuutta tukevaa sovellusta.</
 		<create_user>Luo käyttäjä</create_user>
 		<user_created>Seuraava käyttäjä on luotu:</user_created>
 		<edit_user>Edit User</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>This name is already in use.</user_name_used>
 		<delete_user>Poista käyttäjä</delete_user>
 		<user_delete>Valitse käyttäjä, jonka haulat poistaa.</user_delete>
@@ -370,4 +418,21 @@ Oletko varma, että haluat jatkaa?</user_delete_warn>
 		<confirm>Vahvista</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K-päivitys">
+ 		<new_version_available>Vita3K on saatavissa uusi versio.</new_version_available>
+		<back>Takaisin</back>
+		<downloading>Ladataan...
+Kun lataus on valmis, Vita3K käynnistyy automaattisesti uudelleen ja asentaa sitten uuden Vita3K.</downloading>
+		<not_complete_update>Päivityksen suoritus ei onnistunut.</not_complete_update>
+		<next>Seuraava</next>
+		<update_vita3k>Haluatko päivittää Vita3K?</update_vita3k>
+		<later_version_already_installed>Vita3K viimeisin versio on jo asennettu.</later_version_already_installed>
+		<latest_version_already_installed>Vita3K viimeisin versio on jo asennettu.</latest_version_already_installed>
+		<new_features>Uutta versiossa {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Päivitä</update>
+		<version>Versio {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/fr.xml
+++ b/lang/fr.xml
@@ -83,7 +83,6 @@ Code d'erreur: {}</an_error_occurred>
 		<delete>Supprimer</delete>
 		<file_corrupted>Le fichier est corrompu.</file_corrupted>
 		<microphone_disabled>Activez le microphone.</microphone_disabled>
-		<nospace>Espace libre insuffisant sur la carte mémoire.</nospace>
 		<no>Non</no>
 		<ok>OK</ok>
 		<please_wait>Merci de patienter...</please_wait>
@@ -320,8 +319,8 @@ Votre système Vita3K est prêt !</completed_setup>
 			<live_area_help>Live Area Help</live_area_help>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
-			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app>Démarrer App</start_app>
+			<start_app_control>Cliquer sur Démarrer ou Appuyer sur Croix</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -335,7 +334,7 @@ Votre système Vita3K est prêt !</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -426,6 +425,7 @@ Pour obtenir des trophées, utilisez une application compatible avec cette fonct
 		<create_user>Créer un utilisateur</create_user>
 		<user_created>L'utilisateur suivant a été créés :</user_created>
 		<edit_user>Modifier un utilisateur</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>! Ce nom est déjà utilisé.</user_name_used>
 		<delete_user>Supprimer un utilisateur</delete_user>
 		<user_delete>Sélectionnez l'utilisateur que vous souhaitez supprimer.</user_delete>
@@ -453,6 +453,8 @@ Une fois le téléchargement terminé, Vita3K redémarrera automatiquement et in
 		<later_version_already_installed>Une version plus récente de Vita3K est déjà installée.</later_version_already_installed>
 		<latest_version_already_installed>La dernière version de Vita3K est déjà installée.</latest_version_already_installed>
 		<new_features>Nouveautés de la version {}</new_features>
+		<authors>Auterus</authors>
+		<comments>Commentaires</comments>
 		<update>Mettre à jour</update>
 		<version>Version {}</version>
 	</vita3k_update>

--- a/lang/it.xml
+++ b/lang/it.xml
@@ -83,7 +83,6 @@ Codice di errore: {}</an_error_occurred>
 		<delete>Elimina</delete>
 		<file_corrupted>Il file è danneggiato.</file_corrupted>
 		<microphone_disabled>Attiva il microfono.</microphone_disabled>
-		<nospace>Spazio libero insufficiente sulla scheda di memoria.</nospace>
 		<no>No</no>
 		<ok>OK</ok>
 		<please_wait>Attendi...</please_wait>
@@ -322,7 +321,7 @@ Il tuo sistema Vita3K è pronto per l'uso!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -336,7 +335,7 @@ Il tuo sistema Vita3K è pronto per l'uso!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -427,6 +426,7 @@ Puoi guadagnare trofei usando un'applicazione che supporta questa funzione.</no_
 		<create_user>Crea utente</create_user>
 		<user_created>L'utente seguente è stato creato:</user_created>
 		<edit_user>Modifica utente</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>Il nome utente è già in uso.</user_name_used>
 		<delete_user>Elimina utente</delete_user>
 		<user_delete>Seleziona l'utente che vuoi eliminare.</user_delete>
@@ -442,4 +442,21 @@ Vuoi davvero continuare?</user_delete_warn>
 		<confirm>Conferma</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Aggiornamento del Vita3K">
+ 		<new_version_available>È disponibile una nuova versione del Vita3K.</new_version_available>
+		<back>Indietro</back>
+		<downloading>Download in corso...
+Al termine del download, Vita3K si riavvierà automaticamente e quindi installerà il nuovo Vita3K.</downloading>
+		<not_complete_update>Impossibile completare l'aggiornamento.</not_complete_update>
+		<next>Seguente</next>
+		<update_vita3k>Vuoi aggiornare Vita3K?</update_vita3k>
+		<later_version_already_installed>È già installata una versione più recente del Vita3K.</later_version_already_installed>
+		<latest_version_already_installed>La versione più recente del Vita3K è già installata.</latest_version_already_installed>
+		<new_features>Nuove funzioni disponibili nella versione {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Aggiorna</update>
+		<version>Versione {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/ja.xml
+++ b/lang/ja.xml
@@ -83,7 +83,6 @@
 		<delete>削除</delete>
 		<file_corrupted>ファイルが壊れています。</file_corrupted>
 		<microphone_disabled>マイクを有効にしてください。</microphone_disabled>
-		<nospace>メモリーカードの空き容量が不足しています。</nospace>
 		<no>いいえ</no>
 		<ok>OK</ok>
 		<please_wait>しばらくお待ちください...</please_wait>
@@ -364,7 +363,7 @@ Vita3Kをお楽しみください。</completed_setup>
 		<select_language>言語を選んでください。</select_language>
 		<install_firmware>ファームウェアをインストール。</install_firmware>
 		<install_highly_recommended>どちらのファームウェアもインストールすることを推奨します。</install_highly_recommended>
-		<installed>インストールされました:</installed>
+		<installed>インストールされました：</installed>
 		<download_firmware>ファームウェアをダウンロード</download_firmware>
 		<download_font_package>フォントパッケージをダウンロード</download_font_package>
 		<install_firmware_file>ファームウェアファイルをインストール</install_firmware_file>
@@ -542,6 +541,7 @@ Vita3Kをお楽しみください。</completed_setup>
 		<create_user>ユーザーを作成する</create_user>
 		<user_created>以下のユーザーを作成しました。</user_created>
 		<edit_user>ユーザーを編集する</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>その名前はすでに使われています。</user_name_used>
 		<delete_user>ユーザーを削除する</delete_user>
 		<user_delete>削除するユーザーを選んでください。</user_delete>
@@ -559,16 +559,18 @@ Vita3Kをお楽しみください。</completed_setup>
 	</user_management>
 	
 	<vita3k_update name="Vita3Kのアップデート">
- 		<new_version_available>新しいバージョンのVita3Kが利用できます。</new_version_available>
+ 		<new_version_available>新しいバージョンのVita3Kがあります。</new_version_available>
 		<back>戻る</back>
 		<downloading>ダウンロード中...
-ダウンロードが終了すると、自動的にVita3Kが再起動し、更新が完了します。</downloading>
+ダウンロード後にVita3Kは自動的に再起動して、新しいVita3Kをインストールします。</downloading>
 		<not_complete_update>アップデートできませんでした。</not_complete_update>
 		<next>次へ</next>
 		<update_vita3k>Vita3Kをアップデートしますか?</update_vita3k>
-		<later_version_already_installed>新しいVita3Kがすでにインストールされています。</later_version_already_installed>
-		<latest_version_already_installed>Vita3Kはすでに最新の状態です。</latest_version_already_installed>
-		<new_features>{}　で新たに変更された点</new_features>
+		<later_version_already_installed>新しいバージョンのVita3Kがインストールされています。</later_version_already_installed>
+		<latest_version_already_installed>最新のバージョンのVita3Kがインストールされています。</latest_version_already_installed>
+		<new_features>バージョン{}の新しい機能</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
 		<update>アップデート</update>
 		<version>バージョン {}</version>
 	</vita3k_update>

--- a/lang/ko.xml
+++ b/lang/ko.xml
@@ -83,7 +83,6 @@ depending on its size and your hardware.</app_delete_note>
 		<delete>삭제</delete>
 		<file_corrupted>파일이 손상되어 있습니다.</file_corrupted>
 		<microphone_disabled>마이크를 활성화해 주십시오.</microphone_disabled>
-		<nospace>메모리 카드의 빈 용량이 부족합니다.</nospace>
 		<no>아니요</no>
 		<ok>OK</ok>
 		<please_wait>잠시 기다려 주십시오...</please_wait>
@@ -322,7 +321,7 @@ Your Vita3K system is ready!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -336,7 +335,7 @@ Your Vita3K system is ready!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -427,6 +426,7 @@ Your Vita3K system is ready!</completed_setup>
 		<create_user>사용자 생성</create_user>
 		<user_created>해당 사용자가 생성되었습니다.</user_created>
 		<edit_user>사용자 편집</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>이미 사용하고 있는 이름입니다.</user_name_used>
 		<delete_user>사용자 삭제</delete_user>
 		<user_delete>지우려고 하는 사용자를 선택하세요.</user_delete>
@@ -442,4 +442,21 @@ Your Vita3K system is ready!</completed_setup>
 		<confirm>확인</confirm>
 		<automatic_user_login>자동 로그인</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K 업데이트">
+ 		<new_version_available>새 버전의 Vita3K 있습니다.</new_version_available>
+		<back>돌아가기</back>
+		<downloading>다운로드 중입니다...
+다운로드 후에 Vita3K 자동으로 재기동하여 새로운 Vita3K를 설치합니다.</downloading>
+		<not_complete_update>업데이트하지 못했습니다.</not_complete_update>
+		<next>다음</next>
+		<update_vita3k>Vita3K를 업데이트하시겠습니까?</update_vita3k>
+		<later_version_already_installed>새 버전의 Vita3K가 설치되어 있습니다.</later_version_already_installed>
+		<latest_version_already_installed>최신 버전의 Vita3K가 설치되어 있습니다.</latest_version_already_installed>
+		<new_features>버전 {}의 새로운 기능</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>업데이트</update>
+		<version>버전 {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/nl.xml
+++ b/lang/nl.xml
@@ -83,7 +83,6 @@ Foutcode: {}</an_error_occurred>
 		<delete>Verwijderen</delete>
 		<file_corrupted>Het bestand is beschadigd.</file_corrupted>
 		<microphone_disabled>Schakel de microfoon in.</microphone_disabled>
-		<nospace>Er is onvoldoende vrije ruimte op de geheugenkaart.</nospace>
 		<no>Nee</no>
 		<ok>OK</ok>
 		<please_wait>Een ogenblik geduld...</please_wait>
@@ -296,7 +295,7 @@ Schakel het systeem niet uit en sluit de applicatie niet.</warning_saving>
 		<trophy_earned>Je hebt een trofee gewonnen!</trophy_earned>
 	</indicator>
 
-    <initial_setup>
+	<initial_setup>
 		<back>Terug</back>
 		<completed_setup>Je hebt de initiële setup nu voltooid.
 Je Vita3K-systeem is gereed!</completed_setup>
@@ -322,7 +321,7 @@ Je Vita3K-systeem is gereed!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -336,7 +335,7 @@ Je Vita3K-systeem is gereed!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -427,6 +426,7 @@ Je kunt trofeeën verdienen door een applicatie te gebruiken die de trofeefuncti
 		<create_user>Gebruiker maken</create_user>
 		<user_created>De volgende gebruiker is gemaakt:</user_created>
 		<edit_user>Gebruiker bewerken</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>This name is already in use.</user_name_used>
 		<delete_user>Gebruiker verwijderen</delete_user>
 		<user_delete>Selecteer de gebruiker die u wil verwijderen.</user_delete>
@@ -442,4 +442,21 @@ Weet je zeker dat je doorgaan?</user_delete_warn>
 		<confirm>Bevestigen</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K-update">
+ 		<new_version_available>Een nieuwe versie van Vita3K is beschikbaar.</new_version_available>
+		<back>Terug</back>
+		<downloading>Bezig met downloaden...
+Nadat het downloaden is voltooid, Vita3K automatisch opnieuw gestart en wordt de nieuwe Vita3K geïnstalleerd.</downloading>
+		<not_complete_update>Kan de update niet voltooien.</not_complete_update>
+		<next>Volgende</next>
+		<update_vita3k>Wil je Vita3K updaten?</update_vita3k>
+		<later_version_already_installed>Een recentere versie van Vita3K is al geïnstalleerd.</later_version_already_installed>
+		<latest_version_already_installed>De meest recente versie van Vita3K is al geïnstalleerd.</latest_version_already_installed>
+		<new_features>Nieuwe functies in versie {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Update</update>
+		<version>Versie {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/no.xml
+++ b/lang/no.xml
@@ -72,7 +72,6 @@ Feilkode: {}</an_error_occurred>
 		<delete>Slett</delete>
 		<file_corrupted>Filen er korrupt.</file_corrupted>
 		<microphone_disabled>Aktiver mikrofonen.</microphone_disabled>
-		<nospace>Det er ikke nok ledig plass på minnekortet.</nospace>
 		<no>Nei</no>
 		<ok>OK</ok>
 		<please_wait>Vennligst vent...</please_wait>
@@ -219,10 +218,58 @@ Feilkode: {}</an_error_occurred>
 Connect a controller that is compatible with SDL2.</not_connected>
 	</controllers>
 
+	<dialog>
+		<trophy>
+			<preparing_start_app>Forbereder oppstart av programmet...</preparing_start_app>
+		</trophy>
+		<save_data>
+			<delete>
+				<cancel_deleting>Vil du avbryte slettingen?</cancel_deleting>
+				<deletion_complete>Sletting fullført.</deletion_complete>
+				<delete_saved_data>Vil du slette disse lagrede dataene?</delete_saved_data>
+			</delete>
+			<info>
+				<details>Detaljer</details>
+				<updated>Oppdatert</updated>
+			</info>
+			<load name="Last">
+				<cancel_loading>Vil du avbryte lastingen?</cancel_loading>
+				<no_saved_data>Det finnes ingen lagret data.</no_saved_data>
+				<load_complete>Lasting fullført.</load_complete>
+				<loading>Laster...</loading>
+				<load_saved_data>Vil du laste disse lagrede dataene?</load_saved_data>
+			</load>
+			<save name="Lagre">
+				<cancel_saving>Vil du avbryte lagringen?</cancel_saving>
+				<could_not_save>Kunne ikke lagre filen.
+Det er ikke nok ledig plass på minnekortet.</could_not_save>
+				<not_free_space>Det er ikke nok ledig plass på minnekortet.</not_free_space>
+				<new_saved_data>Nylagret data</new_saved_data>
+				<saving_complete>Lagring fullført.</saving_complete>
+				<save_the_data>Vil du lagre dataene?</save_the_data>
+				<saving>Lagrer...</saving>
+				<warning_saving>Lagrer...
+Slå ikke av systemet og lukk ikke programmet.</warning_saving>
+				<overwrite_saved_data>Vil du overskrive disse lagrede dataene?</overwrite_saved_data>
+			</save>
+		</save_data>
+	</dialog>
+
 	<game_data>
 		<app_close>Følgende program vil lukkes.</app_close>
 		<data_delete>Data som skal slettes：</data_delete>
 	</game_data>
+
+	<indicator>
+		<app_added_home>Programmet har blitt lagt til hjem-skjermen.</app_added_home>
+		<delete_all>Slett alt</delete_all>
+		<notif_deleted>Varslingene vil bli slettet.</notif_deleted>
+		<install_failed>Kunne ikke installere.</install_failed>
+		<install_complete>Installering fullført.</install_complete>
+		<installing>Installerer...</installing>
+		<no_notif>Det er ingen varslinger.</no_notif>
+		<trophy_earned>Du har oppnådd et trophy!</trophy_earned>
+	</indicator>
 
 	<initial_setup>
 		<back>Tilbake</back>
@@ -250,7 +297,7 @@ Vita3K-systemet ditt er klart!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -264,7 +311,7 @@ Vita3K-systemet ditt er klart!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -353,6 +400,7 @@ Du kan Oppnå trophies ved å bruke et program som Støtter trophy-funksjonen.</
 		<create_user>Opprett bruker</create_user>
 		<user_created>Følgende bruker er opprettet:</user_created>
 		<edit_user>Edit User</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>Navnet er allerede i bruk.</user_name_used>
 		<delete_user>Slett bruker</delete_user>
 		<user_delete>Velg brukeren du vil slette.</user_delete>
@@ -368,4 +416,21 @@ Er du sikker på at du vil fortsette?</user_delete_warn>
 		<confirm>Bekreft</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K-oppdatering">
+ 		<new_version_available>En ny versjon av Vita3K er tilgjengelig.</new_version_available>
+		<back>Tilbake</back>
+		<downloading>Laster ned...
+Etter at Etter at nedlastingen er fullført, vil Vita3K starte på nytt automatisk og deretter installere den nye Vita3K.</downloading>
+		<not_complete_update>Kunne ikke fullføre oppdateringen.</not_complete_update>
+		<next>Neste</next>
+		<update_vita3k>Vil du oppdatere Vita3K?</update_vita3k>
+		<later_version_already_installed>Den siste versjonen av Vita3K er allerede installert.</later_version_already_installed>
+		<latest_version_already_installed>Den siste versjonen av Vita3K er allerede installert.</latest_version_already_installed>
+		<new_features>Nye funksjoner i versjon {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Oppdater</update>
+		<version>Versjon {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/pl.xml
+++ b/lang/pl.xml
@@ -72,7 +72,6 @@ Kod błędu: {}</an_error_occurred>
 		<delete>Usuń</delete>
 		<file_corrupted>Plik jest uszkodzony.</file_corrupted>
 		<microphone_disabled>Włącz mikrofon.</microphone_disabled>
-		<nospace>Na karcie pamięci nie ma wystarczającej ilości wolnego miejsca.</nospace>
 		<no>Nie</no>
 		<ok>OK</ok>
 		<please_wait>Czekaj...</please_wait>
@@ -231,11 +230,59 @@ Kod błędu: {}</an_error_occurred>
 		<not_connected>No compatible controllers connected.
 Connect a controller that is compatible with SDL2.</not_connected>
 	</controllers>
+
+	<dialog>
+		<trophy>
+			<preparing_start_app>Przygotowanie do uruchomienia aplikacji...</preparing_start_app>
+		</trophy>
+		<save_data>
+			<delete>
+				<cancel_deleting>Czy chcesz anulować usunięcie?</cancel_deleting>
+				<deletion_complete>Usuwanie ukończone.</deletion_complete>
+				<delete_saved_data>Czy chcesz usunąć te zapisane dane?</delete_saved_data>
+			</delete>
+			<info>
+				<details>Szczegóły</details>
+				<updated>Zaktualizowano</updated>
+			</info>
+			<load name="Załaduj">
+				<cancel_loading>Czy chcesz anulować ładowanie?</cancel_loading>
+				<no_saved_data>Brak zapisanych danych.</no_saved_data>
+				<load_complete>Ładowanie ukończone.</load_complete>
+				<loading>Ładowanie...</loading>
+				<load_saved_data>Czy chcesz załadować zapisane dane?</load_saved_data>
+			</load>
+			<save name="Zapisz">
+				<cancel_saving>Czy chcesz anulować zapis?</cancel_saving>
+				<could_not_save>Nie można zapisać pliku.
+Na karcie pamięci nie ma wystarczającej ilości wolnego miejsca.</could_not_save>
+				<not_free_space>Na karcie pamięci nie ma wystarczającej ilości wolnego miejsca.</not_free_space>
+				<new_saved_data>Nowe zapisane dane</new_saved_data>
+				<saving_complete>Zapis ukończony.</saving_complete>
+				<save_the_data>Czy chcesz zapisać te dane?</save_the_data>
+				<saving>Zapisywanie...</saving>
+				<warning_saving>Zapisywanie...
+Nie wyłączaj systemu ani nie zamykaj aplikacji.</warning_saving>
+				<overwrite_saved_data>Czy chcesz zastąpić zapisane dane?</overwrite_saved_data>
+			</save>
+		</save_data>
+	</dialog>
 	
 	<game_data>
 		<app_close>Następująca aplikacja zostanie zamknięta.</app_close>
 		<data_delete>Dane do usunięcia:</data_delete>
 	</game_data>
+
+	<indicator>
+		<app_added_home>Aplikacja została dodana do ekranu głównego.</app_added_home>
+		<delete_all>Usuń wszystko</delete_all>
+		<notif_deleted>Powiadomienia zostaną usunięte.</notif_deleted>
+		<install_failed>Nie można zainstalować pliku.</install_failed>
+		<install_complete>Instalacja ukończona.</install_complete>
+		<installing>Instalowanie...</installing>
+		<no_notif>Brak powiadomień.</no_notif>
+		<trophy_earned>Udało Ci się zdobyć trofeum!</trophy_earned>
+	</indicator>
 
 	<initial_setup>
 		<back>Wstecz</back>
@@ -263,7 +310,7 @@ System Vita3K jest gotowy!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -277,7 +324,7 @@ System Vita3K jest gotowy!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -366,6 +413,7 @@ Trofea można zdobywać, korzystając z aplikacji obsługującej funkcję trofe�
 		<create_user>Utwórz użytkownika</create_user>
 		<user_created>Został utworzony następujący użytkownik:</user_created>
 		<edit_user>Edit User</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>Ta nazwa jest już używana.</user_name_used>
 		<delete_user>Usuń użytkownika</delete_user>
 		<user_delete>Wybierz użytkownika, którego chcesz usunąć.</user_delete>
@@ -381,4 +429,21 @@ Czy na pewno chcesz kontynuować?</user_delete_warn>
 		<confirm>Potwierdź</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Aktualizacja Vita3K">
+ 		<new_version_available>Dostępna jest nowa wersja Vita3K.</new_version_available>
+		<back>Wstecz</back>
+		<downloading>Pobieranie...
+Po ukończeniu pobierania Vita3K zostanie automatycznie ponownie uruchomiony, a następnie zostanie zainstalowane nowe Vita3K.</downloading>
+		<not_complete_update>Nie można ukończyć aktualizacji.</not_complete_update>
+		<next>Dalej</next>
+		<update_vita3k>Czy chcesz zaktualizować Vita3K?</update_vita3k>
+		<later_version_already_installed>Zainstalowana jest już nowsza wersja Vita3K.</later_version_already_installed>
+		<latest_version_already_installed>Najnowsza wersja Vita3K jest już zainstalowana.</latest_version_already_installed>
+		<new_features>Nowe funkcje w wersji {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Aktualizuj</update>
+		<version>Wersja {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/pt-br.xml
+++ b/lang/pt-br.xml
@@ -83,7 +83,6 @@ Código de erro: {}</an_error_occurred>
 		<delete>Excluir</delete>
 		<file_corrupted>O arquivo está corrompido.</file_corrupted>
 		<microphone_disabled>Ative o microfone.</microphone_disabled>
-		<nospace>Não há espaço livre suficiente no cartão de memória.</nospace>
 		<no>Não</no>
 		<ok>OK</ok>
 		<please_wait>Aguarde...</please_wait>
@@ -227,7 +226,7 @@ Código de erro: {}</an_error_occurred>
 			<no_item>Não há nenhum itens de conteúdo.</no_item>
 		</application>
 		<saved_data name="Dados salvos">
-			<delete>Os itens de dados salvos selecionados serão excludíos.</delete>
+			<delete>Os itens de dados salvos selecionados serão excluídos.</delete>
 			<no_saved_data>Não há dados salvos.</no_saved_data>
 		</saved_data>
 		<theme>Tema</theme>
@@ -249,33 +248,33 @@ Connect a controller that is compatible with SDL2.</not_connected>
 		</trophy>
 		<save_data>
 			<delete>
-				<cancel_deleting>Você quer cancelar a exclusão?</cancel_deleting>
-				<deletion_complete>Exclusão completa.</deletion_complete>
-				<delete_saved_data>Você quer apagar estes dados salvos?</delete_saved_data>
+				<cancel_deleting>Deseja cancelar a exclusão?</cancel_deleting>
+				<deletion_complete>Exclusão concluída.</deletion_complete>
+				<delete_saved_data>Deseja excluir esses dados salvos?</delete_saved_data>
 			</delete>
 			<info>
 				<details>Detalhes</details>
 				<updated>Atualizado</updated>
 			</info>
 			<load name="Carregar">
-				<cancel_loading>Você quer cancelar o carregamento?</cancel_loading>
+				<cancel_loading>Deseja cancelar o carregamento?</cancel_loading>
 				<no_saved_data>Não há dados salvos.</no_saved_data>
-				<load_complete>Carregamento completo.</load_complete>
-				<loading>Carregamento...</loading>
-				<load_saved_data>Você quer carregar estes dados salvos?</load_saved_data>
+				<load_complete>Carregamento concluído.</load_complete>
+				<loading>Carregando...</loading>
+				<load_saved_data>Deseja carregar esses dados salvos?</load_saved_data>
 			</load>
 			<save name="Salvar">
-				<cancel_saving>Você quer cancelar o salvamento?</cancel_saving>
-				<could_not_save>Não pôde salvar o arquivo.
-Não há espaço livre o bastante no memory card.</could_not_save>
-				<not_free_space>Não há espaço livre o bastante no memory card.</not_free_space>
-				<new_saved_data>Novos Dados Salvos</new_saved_data>
-				<saving_complete>Salvamento completo.</saving_complete>
-				<save_the_data>Você quer salvar os dados?</save_the_data>
+				<cancel_saving>Deseja cancelar o salvamento?</cancel_saving>
+				<could_not_save>Não foi possível salvar o arquivo.
+Não há espaço livre suficiente no cartão de memória.</could_not_save>
+				<not_free_space>Não há espaço livre suficiente no cartão de memória.</not_free_space>
+				<new_saved_data>Novos dados salvos</new_saved_data>
+				<saving_complete>Gravação concluída.</saving_complete>
+				<save_the_data>Deseja salvar os dados?</save_the_data>
 				<saving>Salvando...</saving>
 				<warning_saving>Salvando...
-Não desligue o sistema ou feche o aplicativo.</warning_saving>
-				<overwrite_saved_data>Você quer sobrescrever estes dados salvos?</overwrite_saved_data>
+Não desligue o sistema nem feche o aplicativo.</warning_saving>
+				<overwrite_saved_data>Deseja substituir esses dados salvos?</overwrite_saved_data>
 			</save>
 		</save_data>
 	</dialog>
@@ -322,7 +321,7 @@ O seu sistema Vita3K está pronto!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -336,7 +335,7 @@ O seu sistema Vita3K está pronto!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -427,6 +426,7 @@ Você pode conquistar troféus usando um aplicativo compatível com o recurso de
 		<create_user>Criar usuário</create_user>
 		<user_created>O usuários a seguir foi criado:</user_created>
 		<edit_user>Editar usuário</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>O nome já está sendo usado.</user_name_used>
 		<delete_user>Excluir usuário</delete_user>
 		<user_delete>Selecione o usuário que você deseja excluir.</user_delete>
@@ -442,4 +442,21 @@ Tem certeza de que deseja continuar?</user_delete_warn>
 		<confirm>Confirmar</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Atualização Vita3K">
+ 		<new_version_available>Uma nova versão Vita3K está disponível.</new_version_available>
+		<back>Voltar</back>
+		<downloading>Fazendo download...
+Quando o download terminar, Vita3K será reiniciado automaticamente e o novo Vita3K será instalado.</downloading>
+		<not_complete_update>Não foi possível concluir a atualização.</not_complete_update>
+		<next>Próximo</next>
+		<update_vita3k>Deseja atualizar o Vita3K?</update_vita3k>
+		<later_version_already_installed>A versão posterior Vita3K já está instalada.</later_version_already_installed>
+		<latest_version_already_installed>A versão mais recente Vita3K já está instalada.</latest_version_already_installed>
+		<new_features>Novos recursos da versão {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Atualizar</update>
+		<version>Versão {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/pt.xml
+++ b/lang/pt.xml
@@ -72,7 +72,6 @@ Código de erro: {}</an_error_occurred>
 		<delete>Eliminar</delete>
 		<file_corrupted>O ficheiro está corrompido.</file_corrupted>
 		<microphone_disabled>Ative o microfone.</microphone_disabled>
-		<nospace>Não existe espaço livre suficiente no cartão de memória.</nospace>
 		<no>Não</no>
 		<ok>OK</ok>
 		<please_wait>Por favor aguarde...</please_wait>
@@ -219,10 +218,58 @@ Código de erro: {}</an_error_occurred>
 Connect a controller that is compatible with SDL2.</not_connected>
 	</controllers>
 
+	<dialog>
+		<trophy>
+			<preparing_start_app>A preparar para iniciar a aplicação...</preparing_start_app>
+		</trophy>
+		<save_data>
+			<delete>
+				<cancel_deleting>Pretende cancelar a eliminação?</cancel_deleting>
+				<deletion_complete>Eliminação concluída.</deletion_complete>
+				<delete_saved_data>Pretende eliminar estes dados guardados?</delete_saved_data>
+			</delete>
+			<info>
+				<details>Detalhes</details>
+				<updated>Atualizado</updated>
+			</info>
+			<load name="Carregar">
+				<cancel_loading>Pretende cancelar o carregamento?</cancel_loading>
+				<no_saved_data>Não existem dados guardados.</no_saved_data>
+				<load_complete>Carregamento concluído.</load_complete>
+				<loading>A carregar...</loading>
+				<load_saved_data>Pretende carregar estes dados guardados?</load_saved_data>
+			</load>
+			<save name="Guardar">
+				<cancel_saving>Pretende cancelar a operação de guardar?</cancel_saving>
+				<could_not_save>Não foi possível guardar o ficheiro.
+Não existe espaço livre suficiente no cartão de memória.</could_not_save>
+				<not_free_space>Não existe espaço livre suficiente no cartão de memória.</not_free_space>
+				<new_saved_data>Novos dados guardados</new_saved_data>
+				<saving_complete>Guardado.</saving_complete>
+				<save_the_data>Pretende guardar os dados?</save_the_data>
+				<saving>A guardar...</saving>
+				<warning_saving>A guardar...
+Não desligue o sistema nem feche a aplicação.</warning_saving>
+				<overwrite_saved_data>Pretende gravar por cima destes dados guardados?</overwrite_saved_data>
+			</save>
+		</save_data>
+	</dialog>
+
 	<game_data>
 		<app_close>A seguinte aplicação será fechada.</app_close>
 		<data_delete>Dados a serem eliminados:</data_delete>
 	</game_data>
+
+	<indicator>
+		<app_added_home>A aplicação foi adicionada ao ecrã de início.</app_added_home>
+		<delete_all>Elimine todos</delete_all>
+		<notif_deleted>As notificações serão eliminadas.</notif_deleted>
+		<install_failed>Não foi possível instalar.</install_failed>
+		<install_complete>Instalação concluída.</install_complete>
+		<installing>A instalar...</installing>
+		<no_notif>Não existem notificações.</no_notif>
+		<trophy_earned>Ganhaste um troféu!</trophy_earned>
+	</indicator>
 
 	<initial_setup>
 		<back>Retroceder</back>
@@ -250,7 +297,7 @@ O seu sistema Vita3K está pronto!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -264,7 +311,7 @@ O seu sistema Vita3K está pronto!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -355,6 +402,7 @@ Pode ganhar troféus utilizando uma aplicações que suporte a funcionalidade de
 		<create_user>Criar utilizador</create_user>
 		<user_created>O seguinte utilizador foi criado:</user_created>
 		<edit_user>Editar utilizador</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>O nome já está a ser utilizador.</user_name_used>
 		<delete_user>Eliminar utilizador</delete_user>
 		<user_delete>Selecione o utilizador que pretende eliminar.</user_delete>
@@ -370,4 +418,21 @@ Tem a certeza de que pretende continuar?</user_delete_warn>
 		<confirm>Confirmar</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Atualização Vita3K">
+ 		<new_version_available>Está disponível uma nova versão da Vita3K.</new_version_available>
+		<back>Retroceder</back>
+		<downloading>A transferir...
+Uma vez concluída a transferência, Vita3K será reiniciado automaticamente e, em seguida, instalará o novo Vita3K.</downloading>
+		<not_complete_update>Não foi possível concluir a atualização.</not_complete_update>
+		<next>Seguinte</next>
+		<update_vita3k>Pretende atualizar o Vita3K?</update_vita3k>
+		<later_version_already_installed>Já está instalada a versão mais recente Vita3K.</later_version_already_installed>
+		<latest_version_already_installed>A última versão Vita3K já está instalada.</latest_version_already_installed>
+		<new_features>Novas funcionalidades na versão {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Atualizar</update>
+		<version>Versão {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/ru.xml
+++ b/lang/ru.xml
@@ -83,7 +83,6 @@ depending on its size and your hardware.</app_delete_note>
 		<delete>Удалить</delete>
 		<file_corrupted>Файл поврежден.</file_corrupted>
 		<microphone_disabled>Включите микрофон.</microphone_disabled>
-		<nospace>На карте памяти недостаточно свободного места.</nospace>
 		<no>Нет</no>
 		<ok>OK</ok>
 		<please_wait>Подождите...</please_wait>
@@ -322,7 +321,7 @@ depending on its size and your hardware.</app_delete_note>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -336,7 +335,7 @@ depending on its size and your hardware.</app_delete_note>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -428,6 +427,7 @@ depending on its size and your hardware.</app_delete_note>
 		<create_user>Создать пользователя</create_user>
 		<user_created>Создан следующий пользователь:</user_created>
 		<edit_user>Изменить пользователя</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>Это имя уже используется.</user_name_used>
 		<delete_user>Удалить пользователя</delete_user>
 		<user_delete>Выберите пользователя, которого хотите удалить.</user_delete>
@@ -443,4 +443,21 @@ depending on its size and your hardware.</app_delete_note>
 		<confirm>Подтвердить</confirm>
 		<automatic_user_login>Автоматический вход пользователя</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Обновление Vita3K">
+ 		<new_version_available>Доступна новая версия Vita3K.</new_version_available>
+		<back>Назад</back>
+		<downloading>Идет загрузка...
+После завершения загрузки Vita3K автоматически перезапустится и установит новую версию.</downloading>
+		<not_complete_update>Не удалось завершить обновление.</not_complete_update>
+		<next>Далее</next>
+		<update_vita3k>Обновить Vita3K?</update_vita3k>
+		<later_version_already_installed>Более поздняя версия Vita3K уже установлена.</later_version_already_installed>
+		<latest_version_already_installed>Установлена последняя версия Vita3K.</latest_version_already_installed>
+		<new_features>Новые функции в версии {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Обновление</update>
+		<version>Версия {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/sv.xml
+++ b/lang/sv.xml
@@ -72,7 +72,6 @@ Felkod: {}</an_error_occurred>
 		<delete>Radera</delete>
 		<file_corrupted>Filen är skadad.</file_corrupted>
 		<microphone_disabled>Aktivera mikrofonen.</microphone_disabled>
-		<nospace>Det finns inte tillräckligt med ledigt utrymme på minneskortet.</nospace>
 		<no>Nej</no>
 		<ok>OK</ok>
 		<please_wait>Vänta...</please_wait>
@@ -219,10 +218,58 @@ Felkod: {}</an_error_occurred>
 Connect a controller that is compatible with SDL2.</not_connected>
 	</controllers>
 
+	<dialog>
+		<trophy>
+			<preparing_start_app>Förbereder start av applikationen...</preparing_start_app>
+		</trophy>
+		<save_data>
+			<delete>
+				<cancel_deleting>Vill du avbryta raderingen?</cancel_deleting>
+				<deletion_complete>Radering slutförd.</deletion_complete>
+				<delete_saved_data>Vill du radera dessa sparade data?</delete_saved_data>
+			</delete>
+			<info>
+				<details>Detaljer</details>
+				<updated>Uppdaterat</updated>
+			</info>
+			<load name="Ladda">
+				<cancel_loading>Vill du avbryta laddningen?</cancel_loading>
+				<no_saved_data>Det finns inga sparade data.</no_saved_data>
+				<load_complete>Laddning slutförd.</load_complete>
+				<loading>Laddar...</loading>
+				<load_saved_data>Vill du ladda in dessa sparade data?</load_saved_data>
+			</load>
+			<save name="Spara">
+				<cancel_saving>Vill du avbryta sparningen?</cancel_saving>
+				<could_not_save>Kunde inte spara filen.
+Det finns inte tillräckligt med ledigt utrymme på minneskortet.</could_not_save>
+				<not_free_space>Det finns inte tillräckligt med ledigt utrymme på minneskortet.</not_free_space>
+				<new_saved_data>Nya sparade data</new_saved_data>
+				<saving_complete>Sparning slutförd.</saving_complete>
+				<save_the_data>Vill du spara datan?</save_the_data>
+				<saving>Sparar...</saving>
+				<warning_saving>Sparar...
+Stäng inte av systemet och stäng inte applikationen.</warning_saving>
+				<overwrite_saved_data>Vill du skriva över dessa sparade data?</overwrite_saved_data>
+			</save>
+		</save_data>
+	</dialog>
+
 	<game_data>
 		<app_close>Följande applikation stängs.</app_close>
 		<data_delete>Data att radera:</data_delete>
 	</game_data>
+
+	<indicator>
+		<app_added_home>Applikationen har lagts till på hemskärmen.</app_added_home>
+		<delete_all>Radera alla</delete_all>
+		<notif_deleted>Notiserna raderas.</notif_deleted>
+		<install_failed>Kunde inte installera.</install_failed>
+		<install_complete>Installation slutförd.</install_complete>
+		<installing>Installerar...</installing>
+		<no_notif>Det finns inga notiser.</no_notif>
+		<trophy_earned>Du har vunnit en trophy!</trophy_earned>
+	</indicator>
 
 	<initial_setup>
 		<back>Tillbaka</back>
@@ -250,7 +297,7 @@ Ditt Vita3K-system är redo!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -264,7 +311,7 @@ Ditt Vita3K-system är redo!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -355,6 +402,7 @@ Du kan få trophies om du använder en applikation som stder trophy-funktionen.<
 		<create_user>Skapa användare</create_user>
 		<user_created>Följande användare har skapats:</user_created>
 		<edit_user>Edit User</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>Namnet finns redan.</user_name_used>
 		<delete_user>Ta bort användare</delete_user>
 		<user_delete>Välj den användare du vill ta bort.</user_delete>
@@ -370,4 +418,21 @@ Du kan få trophies om du använder en applikation som stder trophy-funktionen.<
 		<confirm>Bekräfta</confirm>
 		<automatic_user_login>Automatic User Login</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K-uppdatering">
+ 		<new_version_available>En ny version av Vita3K är tillgänglig.</new_version_available>
+		<back>Tillbaka</back>
+		<downloading>Laddar ned...
+När nedladdningen är slutförd kommer Vita3K automatiskt att startas om och den nya Vita3K installeras.</downloading>
+		<not_complete_update>Kunde inte slutföra uppdateringen.</not_complete_update>
+		<next>Nästa</next>
+		<update_vita3k>Vill du uppdatera Vita3K?</update_vita3k>
+		<later_version_already_installed>Den senare versionen av Vita3K har redan installerats.</later_version_already_installed>
+		<latest_version_already_installed>Den senaste versionen av Vita3K har redan installerats.</latest_version_already_installed>
+		<new_features>Nya funktioner i version {}</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Uppdatera</update>
+		<version>Version {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/tr.xml
+++ b/lang/tr.xml
@@ -83,7 +83,6 @@ Hata Kodu: {}</an_error_occurred>
 		<delete>Sil</delete>
 		<file_corrupted>Dosya bozuk.</file_corrupted>
 		<microphone_disabled>Enable the microphone.</microphone_disabled>
-		<nospace>Hafıza kartında yeterli boş alan yok.</nospace>
 		<no>Hayır</no>
 		<ok>Tamam</ok>
 		<please_wait>Lütfen bekleyin...</please_wait>
@@ -309,7 +308,7 @@ Vita3K sisteminiz artık hazır!</completed_setup>
 			<browse_app>Browse in app list</browse_app>
 			<browse_app_control>D-pad, Left Stick, Wheel in Up/Down or using Slider</browse_app_control>
 			<start_app>Start App</start_app>
-			<start_app_control>Wheel in Up/Down or using Slider</start_app_control>
+			<start_app_control>Click on Start or Press on Cross</start_app_control>
 			<show_hide>Show/Hide Live Area during app run</show_hide>
 			<show_hide_control>Press on PS</show_hide_control>
 			<exit_livearea>Exit Live Area</exit_livearea>
@@ -323,7 +322,7 @@ Vita3K sisteminiz artık hazır!</completed_setup>
 			<zoom_available_control>Double Left Click</zoom_available_control>
 			<scroll_zoom>Scroll in zoom</scroll_zoom>
 			<scroll_zoom_control>Wheel Up/Down</scroll_zoom_control>
-			<exit_manual>Exit Manual Help</exit_manual>
+			<exit_manual>Exit Manual</exit_manual>
 			<exit_manual_control>Click on Esc or Press on PS</exit_manual_control>
 		</help>
 	</live_area>
@@ -414,6 +413,7 @@ Kupa özelliğini destekleyen bir uygulamayı kullanarak kupa kazanabilirsiniz.<
 		<create_user>Kullanıcı Oluştur</create_user>
 		<user_created>Şu kullanıcı oluşturuldu:</user_created>
 		<edit_user>Kullanıcı Düzenle</edit_user>
+		<open_user_folder>Open User Folder</open_user_folder>
 		<user_name_used>Bu isim zaten kullanılıyor.</user_name_used>
 		<delete_user>Kullanıcıyı Sil</delete_user>
 		<user_delete>Silmek istediğiniz kullanıcıyı seçin.</user_delete>
@@ -429,4 +429,21 @@ Devam etmek istediğinizden emin misiniz?</user_delete_warn>
 		<confirm>Onayla</confirm>
 		<automatic_user_login>Otomatik Kullanıcı Girişi</automatic_user_login>
 	</user_management>
+
+	<vita3k_update name="Vita3K Güncelleme">
+ 		<new_version_available>Vita3K yeni bir sürümü mevcut.</new_version_available>
+		<back>Geri</back>
+		<downloading>İndiriliyor...
+İndirme tamamlandığında, Vita3K otomatik olarak yeniden başlatılır ve yeni sabit yazılım kurulur.</downloading>
+		<not_complete_update>Could not complete the update.</not_complete_update>
+		<next>İleri</next>
+		<update_vita3k>Vita3K güncellemek istiyor musunuz?</update_vita3k>
+		<later_version_already_installed>Vita3K sonraki sürümü önceden kuruldu.</later_version_already_installed>
+		<latest_version_already_installed>Vita3K en son sürümü önceden kuruldu.</latest_version_already_installed>
+		<new_features>%1 Sürümündeki Yeni Özellikler</new_features>
+		<authors>Authors</authors>
+		<comments>Comments</comments>
+		<update>Güncelle</update>
+		<version>Sürüm {}</version>
+	</vita3k_update>
 </lang>

--- a/lang/zh-s.xml
+++ b/lang/zh-s.xml
@@ -83,7 +83,6 @@
 		<delete>删除</delete>
 		<file_corrupted>文件已损坏。</file_corrupted>
 		<microphone_disabled>请启用麦克风。</microphone_disabled>
-		<nospace>存储卡没有足够的空余容量。</nospace>
 		<no>否</no>
 		<ok>OK</ok>
 		<please_wait>请稍等…</please_wait>
@@ -541,6 +540,7 @@ Please download and install it.</no_font_exist>
 		<create_user>创建用户</create_user>
 		<user_created>已创建以下用户。</user_created>
 		<edit_user>编辑用户</edit_user>
+		<open_user_folder>打开用户文件夹</open_user_folder>
 		<user_name_used>此名称已被使用。</user_name_used>
 		<delete_user>删除用户</delete_user>
 		<user_delete>请选择要删除的用户。</user_delete>
@@ -562,12 +562,14 @@ Please download and install it.</no_font_exist>
 		<back>返回</back>
 		<downloading>下载中…
 下载完毕后，Vita3K将会自动重新启动，并安装新的版本。</downloading>
-		<not_complete_update>无法完成更新。</not_complete_update>
+		<not_complete_update>无法完成升级。</not_complete_update>
 		<next>继续</next>
 		<update_vita3k>要升级Vita3K吗？</update_vita3k>
-		<later_version_already_installed>已安装更新版本的Vita3K。</later_version_already_installed>
+		<later_version_already_installed>已安装新版本的Vita3K。</later_version_already_installed>
 		<latest_version_already_installed>已安装最新版本的Vita3K。</latest_version_already_installed>
 		<new_features>{}版本的追加功能</new_features>
+		<authors>作者</authors>
+		<comments>注释</comments>
 		<update>更新</update>
 		<version>{}版本</version>
 	</vita3k_update>

--- a/lang/zh-t.xml
+++ b/lang/zh-t.xml
@@ -83,7 +83,6 @@
 		<delete>刪除</delete>
 		<file_corrupted>檔案已毀損。</file_corrupted>
 		<microphone_disabled>請啟用麥克風。</microphone_disabled>
-		<nospace>記憶卡的可用容量不足。</nospace>
 		<no>否</no>
 		<ok>OK</ok>
 		<please_wait>請稍候……</please_wait>
@@ -541,6 +540,7 @@ Please download and install it.</no_font_exist>
 		<create_user>建立使用者</create_user>
 		<user_created>已建立以下使用者。</user_created>
 		<edit_user>編輯使用者</edit_user>
+		<open_user_folder>開啟使用者資料夾</open_user_folder>
 		<user_name_used>此名稱已被使用。</user_name_used>
 		<delete_user>刪除使用者</delete_user>
 		<user_delete>請選擇要刪除的使用者。</user_delete>
@@ -562,12 +562,14 @@ Please download and install it.</no_font_exist>
 		<back>返回</back>
 		<downloading>下載中…
 下載完成后，Vita3K會自動重新啟動，並安裝新的版本。</downloading>
-		<not_complete_update>無法完成更新。</not_complete_update>
+		<not_complete_update>無法更新。</not_complete_update>
 		<next>繼續</next>
 		<update_vita3k>確定要更新Vita3K吗？</update_vita3k>
-		<later_version_already_installed>已安裝更新版本的Vita3K。</later_version_already_installed>
+		<later_version_already_installed>已安裝新版的Vita3K。</later_version_already_installed>
 		<latest_version_already_installed>已安裝最新版本的Vita3K。</latest_version_already_installed>
 		<new_features>{} 版本的追加機能</new_features>
+		<authors>作者</authors>
+		<comments>注釋</comments>
 		<update>更新</update>
 		<version>{} 版本</version>
 	</vita3k_update>

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -532,11 +532,11 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::Checkbox("Enable anti-aliasing (FXAA)", &config.enable_fxaa);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("Anti-aliasing is a technique for smoothing out jagged edges.\n FXAA comes at almost no performance cost but makes games look slightly blurry.");
+            ImGui::SetTooltip("Anti-aliasing is a technique for smoothing out jagged edges.\nFXAA comes at almost no performance cost but makes games look slightly blurry.");
 
         // Linear Filter
         ImGui::Spacing();
-        ImGui::Checkbox("Enable Linear Filter (Reboot to Appy)", &emuenv.cfg.enable_linear_filter);
+        ImGui::Checkbox("Enable Linear Filter (Reboot to apply)", &emuenv.cfg.enable_linear_filter);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("The image will be softer, which could help with aliasing.\nDisabling Linear filtering will result in a more sharper aliased image.");
 
@@ -899,7 +899,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (psn / 2.f));
         ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "PlayStation Network");
         ImGui::Spacing();
-        ImGui::Combo("PSN Status", &config.psn_status, "Unknown\0Signed Out\0Signed In\0Online");
+        ImGui::Combo("PSN Status", &config.psn_status, "Unknown\0Signed Out\0Signed In\0Online\0");
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Select the state of the PS Network.");
 
@@ -926,10 +926,10 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::SliderInt("HTTP Read End Attempts", &emuenv.cfg.http_read_end_attempts, 0, 100);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("How many attempts to do when there isn't more data to read, lower can improve performance but can make games unstable if you have bad enough internet.");
+            ImGui::SetTooltip("How many attempts to do when there isn't more data to read,\nlower can improve performance but can make games unstable if you have bad enough internet.");
         ImGui::SliderInt("HTTP Read End Sleep", &emuenv.cfg.http_read_end_sleep_ms, 50, 3000);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("Attempt sleep time when there isn't more data to read, lower can improve performance but can make games unstable if you have bad enough internet.");
+            ImGui::SetTooltip("Attempt sleep time when there isn't more data to read,\nlower can improve performance but can make games unstable if you have bad enough internet.");
         ImGui::EndTabItem();
     } else
         ImGui::PopStyleColor();

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -316,7 +316,7 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::SetWindowFontScale(0.9f);
             ImGui::PopStyleColor();
             if (ImGui::BeginPopupContextItem("##user_context_menu")) {
-                if (ImGui::MenuItem("Open User Folder"))
+                if (ImGui::MenuItem(lang["open_user_folder"].c_str()))
                     open_path((user_path / user.first).string());
                 ImGui::EndPopup();
             }

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -253,9 +253,9 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Columns(2, "commit_columns", true);
         ImGui::SetColumnWidth(0, 200 * SCALE.x);
         const auto space_margin = ImGui::GetStyle().ItemSpacing.x * 2.f;
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "Author");
+        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["authors"].c_str());
         ImGui::NextColumn();
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "Comments");
+        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["comments"].c_str());
         ImGui::Separator();
         ImGui::NextColumn();
         for (const auto &desc : git_commit_desc_list) {

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -36,7 +36,6 @@ struct DialogLangState {
         { "delete", "Delete" },
         { "file_corrupted", "The file is corrupt." },
         { "microphone_disabled", "Enable the microphone." },
-        { "nospace", "There is not enough free space on the memory card." },
         { "no", "No" },
         { "ok", "OK" },
         { "please_wait", "Please wait..." },
@@ -466,6 +465,7 @@ struct LangState {
         { "create_user", "Create User" },
         { "user_created", "The following user has been created." },
         { "edit_user", "Edit User" },
+        { "open_user_folder", "Open User Folder" },
         { "user_name_used", "This name is already in use." },
         { "delete_user", "Delete User" },
         { "user_delete", "Select the user you want to delete." },
@@ -491,6 +491,8 @@ struct LangState {
         { "later_version_already_installed", "The later version of Vita3K is already installed." },
         { "latest_version_already_installed", "The latest version of Vita3K is already installed." },
         { "new_features", "New Features in Version {}" },
+        { "authors", "Authors" },
+        { "comments", "Comments" },
         { "update", "Update" },
         { "version", "Version {}" }
     };

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -267,6 +267,7 @@ EXPORT(int, sceMsgDialogInit, const Ptr<SceMsgDialogParam> param) {
     emuenv.common_dialog.msg.status = SCE_MSG_DIALOG_BUTTON_ID_INVALID;
 
     auto common = emuenv.common_dialog.lang.common;
+    auto save = emuenv.common_dialog.lang.save_data.save;
     const auto CANCEL = common["cancel"];
 
     switch (p->mode) {
@@ -322,7 +323,7 @@ EXPORT(int, sceMsgDialogInit, const Ptr<SceMsgDialogParam> param) {
             emuenv.common_dialog.msg.btn_num = 0;
             break;
         case SCE_MSG_DIALOG_SYSMSG_TYPE_NOSPACE:
-            emuenv.common_dialog.msg.message = "There is not enough free space on the memory card.";
+            emuenv.common_dialog.msg.message = save["not_free_space"];
             emuenv.common_dialog.msg.btn_num = 0;
             break;
         case SCE_MSG_DIALOG_SYSMSG_TYPE_MAGNETIC_CALIBRATION:
@@ -352,7 +353,7 @@ EXPORT(int, sceMsgDialogInit, const Ptr<SceMsgDialogParam> param) {
             emuenv.common_dialog.msg.btn_num = 0;
             break;
         case SCE_MSG_DIALOG_SYSMSG_TYPE_NOSPACE_CONTINUABLE:
-            emuenv.common_dialog.msg.message = common["nospace"];
+            emuenv.common_dialog.msg.message = save["not_free_space"];
             emuenv.common_dialog.msg.btn_num = 1;
             emuenv.common_dialog.msg.btn[0] = common["ok"];
             emuenv.common_dialog.msg.btn_val[0] = SCE_MSG_DIALOG_BUTTON_ID_OK;


### PR DESCRIPTION
# About
- lang: Complement more languages text
  based on psvita lang, and fixed a few typo.
- gui/lang: Add a few lang strings.
- gui/settings dialog: Adjust the text display.

used [CXML-Decompiler](https://bitbucket.org/SilicaAndPina/cxml-decompiler) by SilicaAndPina dumped the original lang xml from psvita fw rco files, complement to `dialog`, `indicator` and `vita3k_update`. not exactly 100% correct for `vita3k_update`, i currently only understand en/zh-s/zh-t. need devs, contributors and users check this lang pr.
