### PR TITLE
renderer/vulkan, mem: Small bug fixes

### DIFF
--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -395,7 +395,7 @@ void open_access_parent_protect_segment(MemState &state, Address addr) {
     auto ite = state.protect_tree.lower_bound(addr);
 
     if (ite != state.protect_tree.end() && addr < ite->first + ite->second.size) {
-        ite->second.ref_count;
+        ite->second.ref_count++;
     } else {
         ProtectSegmentInfo protect(0, MemPerm::ReadWrite);
         protect.ref_count = 1;

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -657,8 +657,11 @@ bool VKState::map_memory(MemState &mem, Ptr<void> address, uint32_t size) {
             find_mem_type_with_flag(vk::MemoryPropertyFlagBits::eHostCoherent);
 
         if (mapped_memory_type == -1) {
-            LOG_CRITICAL("No coherent memory available for memory mapping, please report it to the devs!");
-            return false;
+            static bool has_happened = false;
+            LOG_CRITICAL_IF(!has_happened, "No coherent memory available for memory mapping, this may be caused by an old driver!");
+            has_happened = true;
+
+            mapped_memory_type = std::countr_zero(host_mem_props.memoryTypeBits);
         }
 
         vk::StructureChain<vk::MemoryAllocateInfo, vk::ImportMemoryHostPointerInfoEXT, vk::MemoryAllocateFlagsInfo> alloc_info{


### PR DESCRIPTION
Some old GPU support external memory mapping, but the mapped memory has no flag. However it looks like it is working fine, so  display an error but do not fail if this happens.

Also fix a bug in open_access_parent_protect_segment.