### PR TITLE
renderer/vulkan: Various fixes

### DIFF
--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -131,6 +131,7 @@ struct GxmRecordState {
     SceGxmFragmentProgramMode back_side_fragment_program_mode = SCE_GXM_FRAGMENT_PROGRAM_ENABLED;
 
     bool is_maskupdate = false;
+    bool is_gamma_corrected = false;
 
     // Do not put any state not used for the Vulkan pipeline creation before vertex_streams
     std::array<GXMStreamInfo, SCE_GXM_MAX_VERTEX_STREAMS> vertex_streams;

--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -90,6 +90,7 @@ void set_context(VKContext &context, const MemState &mem, VKRenderTarget *rt, co
     SceGxmColorSurface *color_surface_fin = &context.record.color_surface;
     // set these values for the pipeline cache
     context.record.color_base_format = gxm::get_base_format(color_surface_fin->colorFormat);
+    context.record.is_gamma_corrected = static_cast<bool>(color_surface_fin->gamma);
     vk::Format vk_format = color::translate_format(context.record.color_base_format);
 
     if (color_surface_fin->gamma && (vk_format == vk::Format::eR8G8B8A8Unorm)) {

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -277,6 +277,8 @@ static constexpr vk::ComponentMapping swizzle_rgba = { Swizzle::eR, Swizzle::eG,
 static constexpr vk::ComponentMapping swizzle_bgra = { Swizzle::eB, Swizzle::eG, Swizzle::eR, Swizzle::eA };
 static constexpr vk::ComponentMapping swizzle_abgr = { Swizzle::eA, Swizzle::eB, Swizzle::eG, Swizzle::eR };
 static constexpr vk::ComponentMapping swizzle_gbar = { Swizzle::eG, Swizzle::eB, Swizzle::eA, Swizzle::eR };
+static constexpr vk::ComponentMapping swizzle_1bgr = { Swizzle::eOne, Swizzle::eB, Swizzle::eG, Swizzle::eR };
+static constexpr vk::ComponentMapping swizzle_1rgb = { Swizzle::eOne, Swizzle::eR, Swizzle::eG, Swizzle::eB };
 
 namespace color {
 
@@ -569,6 +571,12 @@ static const vk::ComponentMapping translate_swizzle4(SceGxmTextureSwizzle4Mode m
         return swizzle_gbar;
     case SCE_GXM_TEXTURE_SWIZZLE4_1BGR:
         return swizzle_rgb1;
+    case SCE_GXM_TEXTURE_SWIZZLE4_1RGB:
+        return swizzle_bgr1;
+    case SCE_GXM_TEXTURE_SWIZZLE4_RGB1:
+        return swizzle_1bgr;
+    case SCE_GXM_TEXTURE_SWIZZLE4_BGR1:
+        return swizzle_1rgb;
     default:
         LOG_ERROR("Unknown swizzle mode {}", log_hex(mode));
         return {};

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -679,6 +679,7 @@ vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC1:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
         return translate_swizzle4(static_cast<SceGxmTextureSwizzle4Mode>(swizzle));
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
@@ -786,6 +787,9 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format) {
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
         return vk::Format::eBc3UnormBlock;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
+        return vk::Format::eBc4UnormBlock;
 
     default:
         LOG_ERROR("Unknown format {}", log_hex(base_format));


### PR DESCRIPTION
- Gamma correction was not taken into account when computing the pipeline hash, causing incompatible render passes issues with Vulkan.
- Add support for BC4 textures, which are used by Killzone (but gamma correction is not supported on them...)
- Add missing swizzles for Vulkan 4-component textures

This fixes graphical issues occuring in Killzone, but a GPU with support for rgba4 color attachments is necessary for it to render properly.