### PR TITLE
gui/vita3k update: move init after open user.

### DIFF
--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -710,14 +710,6 @@ void init(GuiState &gui, EmuEnvState &emuenv) {
 
     init_home(gui, emuenv);
 
-#ifdef USE_VITA3K_UPDATE
-    std::thread update_vita3k_thread([&gui]() {
-        if (init_vita3k_update(gui))
-            gui.help_menu.vita3k_update = true;
-    });
-    update_vita3k_thread.detach();
-#endif
-
     // Initialize trophy callback
     emuenv.np.trophy_state.trophy_unlock_callback = [&gui](NpTrophyUnlockCallbackData &callback_data) {
         const std::lock_guard<std::mutex> guard(gui.trophy_unlock_display_requests_access_mutex);

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -186,6 +186,14 @@ void open_user(GuiState &gui, EmuEnvState &emuenv) {
         init_theme_start_background(gui, emuenv, gui.users[emuenv.io.user_id].theme_id);
 
     gui.vita_area.start_screen = true;
+
+#ifdef USE_VITA3K_UPDATE
+    std::thread update_vita3k_thread([&gui]() {
+        if (init_vita3k_update(gui))
+            gui.help_menu.vita3k_update = true;
+    });
+    update_vita3k_thread.detach();
+#endif
 }
 
 static auto get_users_index(GuiState &gui, const std::string &user_name) {


### PR DESCRIPTION
# About
- gui/vita3k update: move init after open user.
should fix select user superposed on Vita3K updater when news version is available.