### PR TITLE
vita3k: Enable AVX for the compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,19 @@ endif()
 
 enable_testing()
 
+# Define the Architecture variable, right now it should only contain "x86_64" or "arm64"
+include("external/dynarmic/CMakeModules/DetectArchitecture.cmake")
+# Enable AVX on x86_64
+if(ARCHITECTURE STREQUAL "x86_64")
+    if(MSVC)
+        string(APPEND CMAKE_C_FLAGS " /arch:AVX")
+        string(APPEND CMAKE_CXX_FLAGS " /arch:AVX")
+    else()
+        string(APPEND CMAKE_C_FLAGS " -mavx -mf16c")
+        string(APPEND CMAKE_CXX_FLAGS " -mavx -mf16c")
+    endif()
+endif()
+
 ############################
 ########## Boost ###########
 ############################

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -38,9 +38,6 @@ if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	endif()
 endif()
 
-# Define the Architecture variable, right now it should only contain "x86_64" or "arm64"
-include("dynarmic/CMakeModules/DetectArchitecture.cmake")
-
 option(CAPSTONE_BUILD_SHARED "Build shared library" OFF)
 option(CAPSTONE_BUILD_TESTS "Build tests" OFF)
 option(CAPSTONE_BUILD_CSTOOL "Build cstool" OFF)


### PR DESCRIPTION
As indicated by the FAQ (https://vita3k.org/faq.html), Vita3K requires an AVX compatible processor, but right now the compiler does not know this.
Enabling AVX for the compiler should provide a good speed boost for some functions (in particular texture decompressing functions).