### PR TITLE
Revert "vita3k: Enable AVX for the compiler"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,19 +31,6 @@ endif()
 
 enable_testing()
 
-# Define the Architecture variable, right now it should only contain "x86_64" or "arm64"
-include("external/dynarmic/CMakeModules/DetectArchitecture.cmake")
-# Enable AVX on x86_64
-if(ARCHITECTURE STREQUAL "x86_64")
-    if(MSVC)
-        string(APPEND CMAKE_C_FLAGS " /arch:AVX")
-        string(APPEND CMAKE_CXX_FLAGS " /arch:AVX")
-    else()
-        string(APPEND CMAKE_C_FLAGS " -mavx -mf16c")
-        string(APPEND CMAKE_CXX_FLAGS " -mavx -mf16c")
-    endif()
-endif()
-
 ############################
 ########## Boost ###########
 ############################

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -38,6 +38,9 @@ if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	endif()
 endif()
 
+# Define the Architecture variable, right now it should only contain "x86_64" or "arm64"
+include("dynarmic/CMakeModules/DetectArchitecture.cmake")
+
 option(CAPSTONE_BUILD_SHARED "Build shared library" OFF)
 option(CAPSTONE_BUILD_TESTS "Build tests" OFF)
 option(CAPSTONE_BUILD_CSTOOL "Build cstool" OFF)


### PR DESCRIPTION
This reverts commit 7f67d1cdcd6b3ef70af26a1498ac1fe40ad311a9.

I'll instead make two different builds (AVX2 and SSE4).