### PR TITLE
renderer/vulkan: Add support for s8s8s8 textures

### DIFF
--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -96,6 +96,7 @@ bool can_texture_be_unswizzled_without_decode(SceGxmTextureBaseFormat fmt, bool 
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U1U5U5U5
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8
+        || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8
         || fmt == SCE_GXM_TEXTURE_BASE_FORMAT_F16F16F16F16
         || (is_vulkan && fmt == SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9);

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -661,6 +661,7 @@ vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format) {
 
     // 3 components
     case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8:
     case SCE_GXM_TEXTURE_BASE_FORMAT_F11F11F10:
     case SCE_GXM_TEXTURE_BASE_FORMAT_SE5M9M9M9:
         return translate_swizzle3(static_cast<SceGxmTextureSwizzle3Mode>(swizzle));
@@ -774,6 +775,10 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P3:
     case SCE_GXM_TEXTURE_BASE_FORMAT_YUV422:
         return vk::Format::eR8G8B8A8Unorm;
+
+    // Because of the lack of support of s8s8s8, an alpha channel is added to this texture
+    case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8:
+        return vk::Format::eR8G8B8A8Snorm;
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
         return vk::Format::eR4G4B4A4UnormPack16;

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -434,9 +434,9 @@ void upload_bound_texture(VKTextureCacheState &cache, SceGxmTextureBaseFormat ba
 
     const void *text_data = pixels;
     std::vector<uint8_t> temp_data;
-    if (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8) {
+    if (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8 || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8) {
         text_data = add_alpha_channel(pixels, pixels_per_stride, height, temp_data);
-        base_format = SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8;
+        base_format = (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8) ? SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8 : SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8S8;
     }
 
     vk::DeviceSize upload_size;


### PR DESCRIPTION
Killzone uses S8S8S8 textures. Because their support using Vulkan is not widespread, they are decompressed into S8S8S8S8 textures.