### PR TITLE
ngs: Return correct number of samples

### DIFF
--- a/vita3k/ngs/src/modules/atrac9.cpp
+++ b/vita3k/ngs/src/modules/atrac9.cpp
@@ -322,8 +322,8 @@ bool Module::decode_more_data(KernelState &kern, const MemState &mem, const SceU
 
     temp_buffer.clear();
 
-    state->samples_generated_since_key_on += decoded_size;
-    state->samples_generated_total += decoded_size;
+    state->samples_generated_since_key_on += decoded_size * params->channels;
+    state->samples_generated_total += decoded_size * params->channels;
     state->bytes_consumed_since_key_on += superframe_size;
     state->total_bytes_consumed += superframe_size;
 

--- a/vita3k/ngs/src/modules/player.cpp
+++ b/vita3k/ngs/src/modules/player.cpp
@@ -297,8 +297,8 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
 
     state->decoded_samples_pending -= samples_to_be_passed;
     state->decoded_samples_passed += samples_to_be_passed;
-    state->samples_generated_since_key_on += samples_to_be_passed;
-    state->samples_generated_total += samples_to_be_passed;
+    state->samples_generated_since_key_on += samples_to_be_passed * params->channels;
+    state->samples_generated_total += samples_to_be_passed * params->channels;
 
     if (finished) {
         state->samples_generated_since_key_on = 0;


### PR DESCRIPTION
Ngs samples are not following the usual sample definition (when using stereo audio, two samples are counted each time).

This fixes the speed issues in Persona 3 and 5 Dancing.