### PR TITLE
gui/app context menu: Add delete DLC/license dialog

### DIFF
--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -49,7 +49,7 @@
 		<edit>Edit</edit>
 		<remove>Remove</remove>
 		<open_folder>Open Folder</open_folder>
-		<addcont>DLCs</addcont>
+		<addcont>DLC</addcont>
 		<license>License</license>
 		<shaders_cache>Shaders Cache</shaders_cache>
 		<shaders_log>Shaders Log</shaders_log>
@@ -59,6 +59,8 @@
 		<app_delete>This application and all related data, including saved data, will be deleted.</app_delete>
 		<app_delete_note>Deleting a application may take a while
 depending on its size and your hardware.</app_delete_note>
+		<addcont_delete>Do you want to delete this add-on data?</addcont_delete>
+		<license_delete>Do you want to delete this license?</license_delete>
 		<save_delete>Do you want to delete this saved data?</save_delete>
 		<eligible>Eligible</eligible>
 		<ineligible>Ineligible</ineligible>
@@ -220,7 +222,7 @@ Error code: {}</an_error_occurred>
 
 	<compile_shaders>
 		<compiling_shaders>Compiling Shaders</compiling_shaders>
-		<shaders_compiled>shaders compiled</shaders_compiled>
+		<shaders_compiled>{} shaders compiled</shaders_compiled>
 	</compile_shaders>
 
 	<content_manager name="Content Manager">
@@ -278,7 +280,9 @@ Connect a controller that is compatible with SDL2.</not_connected>
 		<gui>GUI</gui>
 		<full_screen>Full Screen</full_screen>
 		<toggle_touch>Toggle Touch</toggle_touch>
+		<toggle_touch_note>Toggles between back touch and screen touch.</toggle_touch_note>
 		<toggle_gui_visibility>Toggle GUI Visibility</toggle_gui_visibility>
+		<toggle_gui_visibility_note>Toggles between showing and hiding the GUI at the top of the screen while the app is running.</toggle_gui_visibility_note>
 		<error>Error</error>
 		<error_duplicate_key>The key is used for other bindings or it is reserved.</error_duplicate_key>
 	</controls>
@@ -372,6 +376,7 @@ Your Vita3K system is ready!</completed_setup>
 
 	<install_dialog>
 		<firmware_install>
+			<firmware_installation>Firmware Installation</firmware_installation>
 			<firmware_installing>Installation in progress, please wait...</firmware_installing>
 			<successed_install_firmware>Firmware successfully installed.</successed_install_firmware>
 			<firmware_version>Firmware version:</firmware_version>
@@ -522,6 +527,7 @@ Please check work.bin/rif file or zRIF key.</failed_install_license>
 		<search>Search</search>
 		<delete_trophy>Delete Trophy</delete_trophy>
 		<trophy_deleted>This trophy information saved on this user will be deleted.</trophy_deleted>
+		<locked>Locked</locked>
 		<details>Details</details>
 		<earned>Earned</earned>
 		<name>Name</name>

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -49,7 +49,7 @@
 		<edit>Edit</edit>
 		<remove>Remove</remove>
 		<open_folder>Open Folder</open_folder>
-		<addcont>DLCs</addcont>
+		<addcont>DLC</addcont>
 		<license>License</license>
 		<shaders_cache>Shaders Cache</shaders_cache>
 		<shaders_log>Shaders Log</shaders_log>
@@ -59,6 +59,8 @@
 		<app_delete>This application and all related data, including saved data, will be deleted.</app_delete>
 		<app_delete_note>Deleting a application may take a while
 depending on its size and your hardware.</app_delete_note>
+		<addcont_delete>Do you want to delete this add-on data?</addcont_delete>
+		<license_delete>Do you want to delete this license?</license_delete>
 		<save_delete>Do you want to delete this saved data?</save_delete>
 		<eligible>Eligible</eligible>
 		<ineligible>Ineligible</ineligible>
@@ -220,7 +222,7 @@ Error code: {}</an_error_occurred>
 
 	<compile_shaders>
 		<compiling_shaders>Compiling Shaders</compiling_shaders>
-		<shaders_compiled>shaders compiled</shaders_compiled>
+		<shaders_compiled>{} shaders compiled</shaders_compiled>
 	</compile_shaders>
 
 	<content_manager name="Content Manager">
@@ -278,7 +280,9 @@ Connect a controller that is compatible with SDL2.</not_connected>
 		<gui>GUI</gui>
 		<full_screen>Full Screen</full_screen>
 		<toggle_touch>Toggle Touch</toggle_touch>
+		<toggle_touch_note>Toggles between back touch and screen touch.</toggle_touch_note>
 		<toggle_gui_visibility>Toggle GUI Visibility</toggle_gui_visibility>
+		<toggle_gui_visibility_note>Toggles between showing and hiding the GUI at the top of the screen while the app is running.</toggle_gui_visibility_note>
 		<error>Error</error>
 		<error_duplicate_key>The key is used for other bindings or it is reserved.</error_duplicate_key>
 	</controls>
@@ -372,6 +376,7 @@ Your Vita3K system is ready!</completed_setup>
 
 	<install_dialog>
 		<firmware_install>
+			<firmware_installation>Firmware Installation</firmware_installation>
 			<firmware_installing>Installation in progress, please wait...</firmware_installing>
 			<successed_install_firmware>Firmware successfully installed.</successed_install_firmware>
 			<firmware_version>Firmware version:</firmware_version>
@@ -522,6 +527,7 @@ Please check work.bin/rif file or zRIF key.</failed_install_license>
 		<search>Search</search>
 		<delete_trophy>Delete Trophy</delete_trophy>
 		<trophy_deleted>This trophy information saved on this user will be deleted.</trophy_deleted>
+		<locked>Locked</locked>
 		<details>Details</details>
 		<earned>Earned</earned>
 		<name>Name</name>

--- a/lang/zh-s.xml
+++ b/lang/zh-s.xml
@@ -59,6 +59,8 @@
 		<app_delete>删除此应用程序及所有相关数据，包括保存数据。</app_delete>
 		<app_delete_note>删除应用程序可能需要一段时间。
 取决于它的大小和您的硬件。</app_delete_note>
+		<addcont_delete>要删除此追加内容吗？</addcont_delete>
+		<license_delete>要删除此授权吗？</license_delete>
 		<save_delete>要删除此保存数据吗？</save_delete>
 		<eligible>有权</eligible>
 		<ineligible>无权</ineligible>
@@ -220,7 +222,7 @@
 
 	<compile_shaders>
 		<compiling_shaders>正在编译着色器</compiling_shaders>
-		<shaders_compiled>个着色器已编译</shaders_compiled>
+		<shaders_compiled>已编译{}个着色器</shaders_compiled>
 	</compile_shaders>
 
 	<content_manager name="内容管理">
@@ -278,7 +280,9 @@
 		<gui>图形用户界面</gui>
 		<full_screen>全屏</full_screen>
 		<toggle_touch>切换触碰</toggle_touch>
+		<toggle_touch_note>在背触和前触之间切换。</toggle_touch_note>
 		<toggle_gui_visibility>切换图形用户界面可见性</toggle_gui_visibility>
+		<toggle_gui_visibility_note>在应用程序运行时，在屏幕顶部显示和隐藏图形用户界面之间切换。</toggle_gui_visibility_note>
 		<error>错误</error>
 		<error_duplicate_key>该键已被使用并绑定其他键或被预留。</error_duplicate_key>
 	</controls>
@@ -337,6 +341,7 @@
 		<by_type>按类型</by_type>
 		<commercial>商业</commercial>
 		<homebrew>自制</homebrew>
+		<by_compatibility_state>按兼容性状态</by_compatibility_state>
 		<ver>版本</ver>
 		<cat>类别</cat>
 		<comp>兼容性</comp>
@@ -372,6 +377,7 @@ Your Vita3K system is ready!</completed_setup>
 
 	<install_dialog>
 		<firmware_install>
+			<firmware_installation>固件安装</firmware_installation>
 			<firmware_installing>Installation in progress, please wait...</firmware_installing>
 			<successed_install_firmware>固件已成功安装。</successed_install_firmware>
 			<firmware_version>固件版本：</firmware_version>
@@ -521,7 +527,8 @@ Please download and install it.</no_font_exist>
 	<trophy_collection>
 		<search>搜索</search>
 		<delete_trophy>删除奖杯</delete_trophy>
-		<trophy_deleted>该用户已保存的奖杯信息将被删除。</trophy_deleted>
+		<trophy_deleted>此用户已保存的奖杯信息将被删除。</trophy_deleted>
+		<locked>未解锁</locked>
 		<details>详细信息</details>
 		<earned>获得日期</earned>
 		<name>名称</name>
@@ -546,7 +553,7 @@ Please download and install it.</no_font_exist>
 		<delete_user>删除用户</delete_user>
 		<user_delete>请选择要删除的用户。</user_delete>
 		<user_delete_msg>将删除以下用户。</user_delete_msg>
-		<user_delete_message>若删除用户，该用户的保存数据、奖杯也会一并被删除。</user_delete_message>
+		<user_delete_message>若删除用户，此用户的保存数据、奖杯也会一并被删除。</user_delete_message>
 		<user_delete_warn>用户将被删除。
 确定要继续吗？</user_delete_warn>
 		<user_deleted>用户已删除。</user_deleted>

--- a/lang/zh-t.xml
+++ b/lang/zh-t.xml
@@ -36,7 +36,7 @@
 	</about>
 
 	<app_context>
-		<check_app_state>檢查應用程式狀態</check_app_state>
+		<check_app_state>檢查應用程式狀況</check_app_state>
 		<copy_vita3k_summary>複製Vita3K摘要</copy_vita3k_summary>
 		<open_state_report>開啟狀態匯報</open_state_report>
 		<create_state_report>建立狀態匯報</create_state_report>
@@ -59,6 +59,8 @@
 		<app_delete>刪除此應用程式及所有相關資料（包括保存資料）。</app_delete>
 		<app_delete_note>刪除應用程式可能需要一段時間
 取決於它的大小和您的硬件。</app_delete_note>
+		<addcont_delete>確定要刪除此追加內容嗎？</addcont_delete>
+		<license_delete>確定要刪除此授權嗎？</license_delete>
 		<save_delete>確定要刪除此保存資料嗎？</save_delete>
 		<eligible>有權</eligible>
 		<ineligible>無權</ineligible>
@@ -220,7 +222,7 @@
 
 	<compile_shaders>
 		<compiling_shaders>正在編譯著色器</compiling_shaders>
-		<shaders_compiled>個著色器已編譯</shaders_compiled>
+		<shaders_compiled>已編譯{}個著色器</shaders_compiled>
 	</compile_shaders>
 
 	<content_manager name="內容管理">
@@ -278,7 +280,9 @@
 		<gui>圖形化使用者介面</gui>
 		<full_screen>全螢幕</full_screen>
 		<toggle_touch>切換觸碰</toggle_touch>
+		<toggle_touch_note>在背觸和前觸之間切換。</toggle_touch_note>
 		<toggle_gui_visibility>切換圖形化使用者介面可見性</toggle_gui_visibility>
+		<toggle_gui_visibility_note>在應用程式運行时，在螢幕頂部顯示和隱藏圖形化使用者介面之間切換。</toggle_gui_visibility_note>
 		<error>錯誤</error>
 		<error_duplicate_key>此按鈕已繫結至其他按鈕或已被保留。</error_duplicate_key>
 	</controls>
@@ -337,6 +341,7 @@
 		<by_type>依類型</by_type>
 		<commercial>商業</commercial>
 		<homebrew>自製</homebrew>
+		<by_compatibility_state>依相容性狀況</by_compatibility_state>
 		<ver>版本</ver>
 		<cat>類別</cat>
 		<comp>相容性</comp>
@@ -372,6 +377,7 @@
 
 	<install_dialog>
 		<firmware_install>
+			<firmware_installation>Firmware Installation</firmware_installation>
 			<firmware_installing>Installation in progress, please wait...</firmware_installing>
 			<successed_install_firmware>Firmware successfully installed.</successed_install_firmware>
 			<firmware_version>Firmware version:</firmware_version>
@@ -521,7 +527,8 @@ Please download and install it.</no_font_exist>
 	<trophy_collection>
 		<search>搜尋</search>
 		<delete_trophy>刪除獎盃</delete_trophy>
-		<trophy_deleted>刪除該使用者已保存的獎杯資訊。</trophy_deleted>
+		<trophy_deleted>刪除此使用者已保存的獎杯資訊。</trophy_deleted>
+		<locked>未解鎖</locked>
 		<details>詳細內容</details>
 		<earned>獲得日</earned>
 		<name>名稱</name>
@@ -546,7 +553,7 @@ Please download and install it.</no_font_exist>
 		<delete_user>刪除使用者</delete_user>
 		<user_delete>請選擇要刪除的使用者。</user_delete>
 		<user_delete_msg>將刪除以下使用者。</user_delete_msg>
-		<user_delete_message>若刪除該用戶，該使用者的保存資料、獎盃也會一併被刪除。</user_delete_message>
+		<user_delete_message>若刪除使用者，此使用者的保存資料、獎盃也會一併被刪除。</user_delete_message>
 		<user_delete_warn>刪除使用者。
 確定要繼續嗎？</user_delete_warn>
 		<user_deleted>已刪除使用者。</user_deleted>

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -466,13 +466,13 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
             }
             if (ImGui::BeginMenu(common["delete"].c_str())) {
                 if (ImGui::MenuItem(app_str["title"].c_str()))
-                    context_dialog = "app";
+                    context_dialog = lang["app_delete"];
                 if (fs::exists(ADDCONT_PATH) && ImGui::MenuItem(lang["addcont"].c_str()))
-                    fs::remove_all(ADDCONT_PATH);
+                    context_dialog = lang["addcont_delete"];
                 if (fs::exists(LICENSE_PATH) && ImGui::MenuItem(lang["license"].c_str()))
-                    fs::remove_all(LICENSE_PATH);
+                    context_dialog = lang["license_delete"];
                 if (fs::exists(SAVE_DATA_PATH) && ImGui::MenuItem(savedata_str["title"].c_str()))
-                    context_dialog = "save";
+                    context_dialog = lang["save_delete"];
                 if (fs::exists(SHADER_CACHE_PATH) && ImGui::MenuItem(lang["shaders_cache"].c_str()))
                     fs::remove_all(SHADER_CACHE_PATH);
                 if (fs::exists(SHADER_LOG_PATH) && ImGui::MenuItem(lang["shaders_log"].c_str()))
@@ -544,12 +544,11 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
             ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(APP_INDEX->stitle.c_str()).x / 2.f), ICON_MARGIN + PUPOP_ICON_SIZE.y + (4.f * SCALE.y)));
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", APP_INDEX->stitle.c_str());
             ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
-            const auto ask_delete = context_dialog == "save" ? lang["save_delete"].c_str() : lang["app_delete"].c_str();
-            ImGui::SetCursorPos(ImVec2(WINDOW_SIZE.x / 2 - ImGui::CalcTextSize(ask_delete, 0, false, WINDOW_SIZE.x - (108.f * SCALE.x)).x / 2, (WINDOW_SIZE.y / 2) + 10));
+            ImGui::SetCursorPos(ImVec2(WINDOW_SIZE.x / 2 - ImGui::CalcTextSize(context_dialog.c_str(), 0, false, WINDOW_SIZE.x - (108.f * SCALE.x)).x / 2, (WINDOW_SIZE.y / 2) + 10));
             ImGui::PushTextWrapPos(WINDOW_SIZE.x - (54.f * SCALE.x));
-            ImGui::TextColored(GUI_COLOR_TEXT, "%s", ask_delete);
+            ImGui::TextColored(GUI_COLOR_TEXT, "%s", context_dialog.c_str());
             ImGui::PopTextWrapPos();
-            if ((context_dialog == "app") && ImGui::IsItemHovered())
+            if ((context_dialog == lang["app_delete"]) && ImGui::IsItemHovered())
                 ImGui::SetTooltip("%s", lang["app_delete_note"].c_str());
             ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
             ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2) - (BUTTON_SIZE.x + (20.f * SCALE.x)), WINDOW_SIZE.y - BUTTON_SIZE.y - (24.0f * SCALE.y)));
@@ -560,9 +559,13 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
             ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) + (20.f * SCALE.x));
         }
         if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(emuenv.cfg.keyboard_button_cross)) {
-            if (context_dialog == "app")
+            if (context_dialog == lang["app_delete"])
                 delete_app(gui, emuenv, app_path);
-            else if (context_dialog == "save")
+            if (context_dialog == lang["addcont_delete"])
+                fs::remove_all(ADDCONT_PATH);
+            if (context_dialog == lang["license_delete"])
+                fs::remove_all(LICENSE_PATH);
+            else if (context_dialog == lang["save_delete"])
                 fs::remove_all(SAVE_DATA_PATH);
             context_dialog.clear();
         }

--- a/vita3k/gui/src/compile_shaders.cpp
+++ b/vita3k/gui/src/compile_shaders.cpp
@@ -89,7 +89,8 @@ void draw_shaders_count_compiled(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(emuenv.viewport_pos.x + (2.f * emuenv.dpi_scale), emuenv.viewport_pos.y + emuenv.viewport_size.y - (42.f * emuenv.dpi_scale)));
     ImGui::SetNextWindowBgAlpha(0.6f);
     ImGui::Begin("##shaders_compiled", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::Text("%lu %s", gui.shaders_compiled_display[Count], gui.lang.compile_shaders["shaders_compiled"].c_str());
+    const auto shaders_compiled_str = fmt::format(fmt::runtime(gui.lang.compile_shaders["shaders_compiled"].c_str()), gui.shaders_compiled_display[Count]);
+    ImGui::Text("%s", shaders_compiled_str.c_str());
     ImGui::End();
 }
 

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -153,10 +153,10 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::Text("%-16s    %-16s", lang["full_screen"].c_str(), "F11");
     ImGui::Text("%-16s    %-16s", lang["toggle_touch"].c_str(), "T");
     if (ImGui::IsItemHovered())
-        ImGui::SetTooltip("Toggles between back touch and screen touch.");
+        ImGui::SetTooltip("%s", lang["toggle_touch_note"].c_str());
     ImGui::Text("%-16s    %-16s", lang["toggle_gui_visibility"].c_str(), "G");
     if (ImGui::IsItemHovered())
-        ImGui::SetTooltip("Toggles between showing and hiding the GUI at the top of the screen while the app is running.");
+        ImGui::SetTooltip("%s", lang["toggle_gui_visibility_note"].c_str());
 
     const char *error_text = lang["error_duplicate_key"].c_str();
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f, ImGui::GetIO().DisplaySize.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
@@ -165,7 +165,7 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::NewLine();
         static const auto BUTTON_SIZE = ImVec2(120.f * emuenv.dpi_scale, 0.f);
         ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (BUTTON_SIZE.x / 2.f));
-        if (ImGui::Button(gui.lang.welcome["close"].c_str(), BUTTON_SIZE)) {
+        if (ImGui::Button(emuenv.common_dialog.lang.common["ok"].c_str(), BUTTON_SIZE)) {
             ImGui::CloseCurrentPopup();
         }
         ImGui::EndPopup();

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -46,6 +46,7 @@ static void get_firmware_version(EmuEnvState &emuenv) {
 
 void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     auto lang = gui.lang.install_dialog.firmware_install;
+    auto firmware_installation = lang["firmware_installation"].c_str();
     auto common = emuenv.common_dialog.lang.common;
 
     host::dialog::filesystem::Result result = host::dialog::filesystem::Result::CANCEL;
@@ -83,8 +84,8 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     }
 
     if (!finished_installing) {
-        ImGui::OpenPopup("Firmware Installation");
-        if (ImGui::BeginPopupModal("Firmware Installation", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::OpenPopup(firmware_installation);
+        if (ImGui::BeginPopupModal(firmware_installation, nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["firmware_installing"].c_str());
             ImGui::PushStyleColor(ImGuiCol_PlotHistogram, GUI_PROGRESS_BAR);
             ImGui::SetCursorPosX((ImGui::GetWindowContentRegionWidth() / 2) - (150 / 2) + 10);
@@ -95,8 +96,8 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     } else {
         static const auto BUTTON_SIZE = ImVec2(60.f, 0.f);
 
-        ImGui::OpenPopup("Firmware Installation");
-        if (ImGui::BeginPopupModal("Firmware Installation", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::OpenPopup(firmware_installation);
+        if (ImGui::BeginPopupModal(firmware_installation, nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["successed_install_firmware"].c_str());
             if (!fw_version.empty())
                 ImGui::TextColored(GUI_COLOR_TEXT, "%s %s", lang["firmware_version"].c_str(), fw_version.c_str());

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -660,7 +660,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     else {
                         ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
                         ImGui::PushID(trophy.id.c_str());
-                        if (ImGui::Selectable("Locked", false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0.f, SIZE_TROPHY_LIST.y))) {
+                        if (ImGui::Selectable(lang["locked"].c_str(), false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0.f, SIZE_TROPHY_LIST.y))) {
                             trophy_id_selected = trophy.id;
                             scroll_pos["trophy"] = ImGui::GetScrollY();
                         }
@@ -692,7 +692,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::Image(gui.trophy_list[trophy_id_selected], SIZE_TROPHY_LIST);
                 else {
                     ImGui::SetCursorPosY((SIZE_TROPHY_LIST.y / 2.f) - (15.f * SCALE.y));
-                    ImGui::TextColored(GUI_COLOR_TEXT, "Lock");
+                    ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["locked"].c_str());
                 }
                 const auto hidden_trophy = (!trophy_info[trophy_id_selected].earned && (trophy_info[trophy_id_selected].hidden == "yes"));
                 const auto CALC_NAME = ImGui::CalcTextSize(hidden_trophy ? hidden_trophy_str : trophy_info[trophy_id_selected].name.c_str(), nullptr, false, SIZE_INFO.x - SIZE_TROPHY_LIST.x - 48.f).y / 2.f;
@@ -794,9 +794,8 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::Separator();
                 ImGui::Spacing();
                 if (ImGui::MenuItem(gui.lang.indicator["delete_all"].c_str())) {
-                    if (fs::remove_all(TROPHY_PATH)) {
+                    if (fs::remove_all(TROPHY_PATH))
                         LOG_INFO("Delete all trophies successfully.");
-                    }
                 }
             } else {
                 if (ImGui::MenuItem(lang["original"].c_str(), nullptr, trophy_sort == "original")) {

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -146,7 +146,7 @@ struct LangState {
         { "edit", "Edit" },
         { "remove", "Remove" },
         { "open_folder", "Open Folder" },
-        { "addcont", "DLCs" },
+        { "addcont", "DLC" },
         { "license", "License" },
         { "shaders_cache", "Shaders Cache" },
         { "shaders_log", "Shaders Log" },
@@ -155,6 +155,8 @@ struct LangState {
         { "information", "Information" },
         { "app_delete", "This application and all related data, including saved data, will be deleted." },
         { "app_delete_note", "Deleting a application may take a while\ndepending on its size and your hardware." },
+        { "addcont_delete", "Do you want to delete this add-on data?" },
+        { "license_delete", "Do you want to delete this license?" },
         { "save_delete", "Do you want to delete this saved data?" },
         { "eligible", "Eligible" },
         { "ineligible", "Ineligible" },
@@ -186,7 +188,7 @@ struct LangState {
     Compatibility compatibility;
     std::map<std::string, std::string> compile_shaders = {
         { "compiling_shaders", "Compiling Shaders" },
-        { "shaders_compiled", "shaders compiled" }
+        { "shaders_compiled", "{} shaders compiled" }
     };
     struct ContentManager {
         std::map<std::string, std::string> main = {
@@ -248,7 +250,9 @@ struct LangState {
         { "gui", "GUI" },
         { "full_screen", "Full Screen" },
         { "toggle_touch", "Toggle Touch" },
+        { "toggle_touch_note", "Toggles between back touch and screen touch." },
         { "toggle_gui_visibility", "Toggle GUI Visibility" },
+        { "toggle_gui_visibility_note", "Toggles between showing and hiding the GUI at the top of the screen while the app is running." },
         { "error", "Error" },
         { "error_duplicate_key", "The key is used for other bindings or it is reserved." }
     };
@@ -299,6 +303,7 @@ struct LangState {
     };
     struct InstallDialog {
         std::map<std::string, std::string> firmware_install = {
+            { "firmware_installation", "Firmware Installation" },
             { "firmware_installing", "Installation in progress, please wait..." },
             { "successed_install_firmware", "Firmware successfully installed." },
             { "firmware_version", "Firmware version:" },
@@ -447,6 +452,7 @@ struct LangState {
         { "search", "Search" },
         { "delete_trophy", "Delete Trophy" },
         { "trophy_deleted", "This trophy information saved on this user will be deleted." },
+        { "locked", "Locked" },
         { "details", "Details" },
         { "earned", "Earned" },
         { "name", "Name" },


### PR DESCRIPTION
# About
this is pr with #1827, add the 'Delete DLC' dialog to avoid deleting DLC(addcont)/license by mistake, and to keep or delete the DLC/license, and also update lang strings

# Result
- PSVita (devkit/testkit fw)
![2022-06-09-161706](https://user-images.githubusercontent.com/61804715/172800875-500093d0-248a-4112-9f5d-1e7e12325b06.jpg)

- Vita3K
![image](https://user-images.githubusercontent.com/61804715/228702157-ca4046e3-ef40-47a4-822b-55f4b0091b0f.png)
![image](https://user-images.githubusercontent.com/61804715/228702083-effc7334-cb41-467e-b087-0ca4050ee63c.png)
