### PR TITLE
renderer/vulkan: Set line width when needed

### DIFF
--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -343,7 +343,7 @@ COMMAND_SET_STATE(point_line_width) {
         break;
 
     case Backend::Vulkan:
-        vulkan::refresh_pipeline(*reinterpret_cast<vulkan::VKContext *>(render_context));
+        vulkan::sync_point_line_width(*reinterpret_cast<vulkan::VKContext *>(render_context), is_front);
         break;
 
     default:

--- a/vita3k/renderer/src/vulkan/sync_state.cpp
+++ b/vita3k/renderer/src/vulkan/sync_state.cpp
@@ -167,7 +167,7 @@ void sync_point_line_width(VKContext &context, const bool is_front) {
     if (!context.is_recording)
         return;
 
-    if (is_front)
+    if (is_front && context.state.physical_device_features.wideLines)
         context.render_cmd.setLineWidth(static_cast<float>(context.record.line_width));
 }
 


### PR DESCRIPTION
When receiving a line_width command, the vulkan renderer was refreshing the pipeline, which is wrong as it is a dynamic state.

Also only call the setLineWidth command if it is supported by the GPU, this should fix some crashes with Metal on Mac.