### PR TITLE
shader: Implement the shader store operation

### DIFF
--- a/vita3k/renderer/include/renderer/commands.h
+++ b/vita3k/renderer/include/renderer/commands.h
@@ -68,6 +68,7 @@ enum class CommandOpcode : std::uint8_t {
 
     SetContext,
     SyncSurfaceData,
+    MidSceneFlush,
 
     /**
      * Signal sync object that fragment has been done.

--- a/vita3k/renderer/include/renderer/driver_functions.h
+++ b/vita3k/renderer/include/renderer/driver_functions.h
@@ -61,6 +61,7 @@ COMMAND(handle_memory_unmap);
 // Scene
 COMMAND(handle_set_context);
 COMMAND(handle_sync_surface_data);
+COMMAND(handle_mid_scene_flush);
 
 COMMAND(handle_draw);
 

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -165,7 +165,7 @@ struct GxmRecordState {
 };
 
 struct Context {
-    const RenderTarget *current_render_target{};
+    RenderTarget *current_render_target{};
     GxmRecordState record;
 
     CommandList command_list;

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -35,6 +35,7 @@ bool create(std::unique_ptr<FragmentProgram> &fp, VKState &state, const SceGxmPr
 void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format,
     Ptr<void> indices, size_t count, uint32_t instance_count, MemState &mem, const Config &config);
 
+void mid_scene_flush(VKContext &context, const SceGxmNotification notification);
 void new_frame(VKContext &context);
 
 void set_context(VKContext &context, MemState &mem, VKRenderTarget *rt, const FeatureState &features);

--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -72,6 +72,7 @@ void process_batch(renderer::State &state, const FeatureState &features, MemStat
     const static std::map<CommandOpcode, CommandHandlerFunc *> handlers = {
         { CommandOpcode::SetContext, cmd_handle_set_context },
         { CommandOpcode::SyncSurfaceData, cmd_handle_sync_surface_data },
+        { CommandOpcode::MidSceneFlush, cmd_handle_mid_scene_flush },
         { CommandOpcode::CreateContext, cmd_handle_create_context },
         { CommandOpcode::CreateRenderTarget, cmd_handle_create_render_target },
         { CommandOpcode::MemoryMap, cmd_handle_memory_map },

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -46,9 +46,7 @@ COMMAND(handle_set_context) {
     const SceGxmColorSurface *color_surface = helper.pop<SceGxmColorSurface *>();
     const SceGxmDepthStencilSurface *depth_stencil_surface = helper.pop<SceGxmDepthStencilSurface *>();
 
-    if (rt) {
-        render_context->current_render_target = rt;
-    }
+    render_context->current_render_target = rt;
 
     if (color_surface && !color_surface->disabled) {
         render_context->record.color_surface = *color_surface;
@@ -185,6 +183,21 @@ COMMAND(handle_sync_surface_data) {
 
     if (helper.cmd->status) {
         complete_command(renderer, helper, 0);
+    }
+}
+
+COMMAND(handle_mid_scene_flush) {
+    TRACY_FUNC_COMMANDS(handle_mid_scene_flush);
+
+    if (!renderer.features.support_memory_mapping) {
+        // handle it like a simple notification
+        cmd_handle_notification(renderer, mem, config, helper, features, render_context, base_path, title_id, self_name);
+        return;
+    }
+
+    const SceGxmNotification notification = helper.pop<SceGxmNotification>();
+    if (renderer.current_backend == Backend::Vulkan) {
+        vulkan::mid_scene_flush(*reinterpret_cast<vulkan::VKContext *>(render_context), notification);
     }
 }
 

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -337,7 +337,7 @@ vk::RenderPass PipelineCache::retrieve_render_pass(vk::Format format, uint32_t z
         .finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal
     };
 
-    std::array<vk::SubpassDependency, 3> dependencies;
+    std::array<vk::SubpassDependency, 4> dependencies;
 
     // external dependency
     // we want the previous render pass to be done when we reach the fragment stage / stencil*depth testing
@@ -381,6 +381,17 @@ vk::RenderPass PipelineCache::retrieve_render_pass(vk::Format format, uint32_t z
         .srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite,
         .dstAccessMask = vk::AccessFlagBits::eInputAttachmentRead,
         .dependencyFlags = vk::DependencyFlagBits::eByRegion
+    };
+
+    // mid-scene flush
+    // unity games use it to write to a buffer in a vertex shader then use it as the vertex input in the next draw
+    dependencies[3] = {
+        .srcSubpass = 0,
+        .dstSubpass = 0,
+        .srcStageMask = vk::PipelineStageFlagBits::eVertexShader,
+        .dstStageMask = vk::PipelineStageFlagBits::eVertexInput,
+        .srcAccessMask = vk::AccessFlagBits::eShaderWrite,
+        .dstAccessMask = vk::AccessFlagBits::eVertexAttributeRead
     };
 
     vk::RenderPassCreateInfo pass_info{};

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -47,6 +47,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debug_callback(
         "VUID-vkCmdDrawIndexed-None-02721", // using r8g8b8a8 with non-multiple of 4 stride
         "VUID-VkImageViewCreateInfo-usage-02275", // srgb does not support the storage format
         "VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251", // srgb does not support the storage format
+        "VUID-vkCmdPipelineBarrier-pDependencies-02285", // shader write -> vertex input read self-dependency, wrong error
     };
 
     if (message_severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -35,10 +35,11 @@ struct SpirvUtilFunctions {
     spv::Function *pack_fx8{ nullptr };
     spv::Function *unpack_fx8{ nullptr };
 
-    // buffer_addres_vec[i] contains the buffer pointer with an array of vec_i and stride 16 bytes
+    // buffer_addres_vec[i][1] contains the buffer pointer with an array of vec_i and stride 16 bytes
+    // 0 in the last index is for the read buffer, 1 is for the write buffer
     // this is technically not a function but is the best place to put it
     // buffer_address_vec[0] is for a packed float[] array
-    spv::Id buffer_address_vec[5] = {};
+    spv::Id buffer_address_vec[5][2] = {};
 };
 
 spv::Id finalize(spv::Builder &b, spv::Id first, spv::Id second, const Swizzle4 swizz, const int offset, const Imm4 dest_mask);
@@ -52,7 +53,7 @@ spv::Id unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureStat
 spv::Id pack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id vec, const DataType source_type);
 
 spv::Id fetch_memory(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, spv::Id addr);
-void buffer_address_load(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand &dest, spv::Id addr, uint32_t component_size, uint32_t nb_components, bool is_fragment, int buffer_idx = -1);
+void buffer_address_access(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand &dest, spv::Id addr, uint32_t component_size, uint32_t nb_components, bool is_fragment, int buffer_idx = -1, bool is_buffer_store = false);
 
 spv::Id make_vector_or_scalar_type(spv::Builder &b, spv::Id component, int size);
 

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -53,7 +53,7 @@ spv::Id unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureStat
 spv::Id pack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState &features, spv::Id vec, const DataType source_type);
 
 spv::Id fetch_memory(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, spv::Id addr);
-void buffer_address_access(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand &dest, spv::Id addr, uint32_t component_size, uint32_t nb_components, bool is_fragment, int buffer_idx = -1, bool is_buffer_store = false);
+void buffer_address_access(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand dest, int dest_offset, spv::Id addr, uint32_t component_size, uint32_t nb_components, bool is_fragment, int buffer_idx = -1, bool is_buffer_store = false);
 
 spv::Id make_vector_or_scalar_type(spv::Builder &b, spv::Id component, int size);
 

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1015,7 +1015,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                     .type = DataType::F32,
                 };
                 const uint32_t copy_size = std::min(buffer.reg_block_size, REG_SA_COUNT - buffer.reg_start_offset);
-                usse::utils::buffer_address_access(b, spv_params, utils, features, dest, b.makeIntConstant(0), sizeof(uint32_t), copy_size, translation_state.is_fragment, buffer.index);
+                usse::utils::buffer_address_access(b, spv_params, utils, features, dest, 0, b.makeIntConstant(0), sizeof(uint32_t), copy_size, translation_state.is_fragment, buffer.index);
             } else {
                 const uint32_t reg_block_size_in_f32v = std::min<uint32_t>(buffer.reg_block_size + 3, REG_SA_COUNT) / 4;
                 const auto spv_buffer = utils::create_access_chain(b, spv::StorageClassStorageBuffer, spv_params.buffer_container,

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1015,7 +1015,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
                     .type = DataType::F32,
                 };
                 const uint32_t copy_size = std::min(buffer.reg_block_size, REG_SA_COUNT - buffer.reg_start_offset);
-                usse::utils::buffer_address_load(b, spv_params, utils, features, dest, b.makeIntConstant(0), sizeof(uint32_t), copy_size, translation_state.is_fragment, buffer.index);
+                usse::utils::buffer_address_access(b, spv_params, utils, features, dest, b.makeIntConstant(0), sizeof(uint32_t), copy_size, translation_state.is_fragment, buffer.index);
             } else {
                 const uint32_t reg_block_size_in_f32v = std::min<uint32_t>(buffer.reg_block_size + 3, REG_SA_COUNT) / 4;
                 const auto spv_buffer = utils::create_access_chain(b, spv::StorageClassStorageBuffer, spv_params.buffer_container,

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -561,7 +561,7 @@ static spv::Id make_or_get_buffer_ptr(spv::Builder &b, shader::usse::utils::Spir
     return utils.buffer_address_vec[buffer_utils_idx][is_write];
 }
 
-void shader::usse::utils::buffer_address_access(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand &dest, spv::Id addr, uint32_t component_size, uint32_t nb_components, bool is_fragment, int buffer_idx, bool is_buffer_store) {
+void shader::usse::utils::buffer_address_access(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand dest, int dest_offset, spv::Id addr, uint32_t component_size, uint32_t nb_components, bool is_fragment, int buffer_idx, bool is_buffer_store) {
     const spv::Id i32 = b.makeIntType(32);
     const spv::Id zero = b.makeIntConstant(0);
 
@@ -592,11 +592,11 @@ void shader::usse::utils::buffer_address_access(spv::Builder &b, const SpirvShad
                 spv::Id accessed = utils::create_access_chain(b, spv::StorageClassPhysicalStorageBuffer, buffer_address_vec4, { zero, b.makeIntConstant(buffer_idx_vec4) });
 
                 if (is_buffer_store) {
-                    spv::Id data = load(b, params, utils, features, dest, 0b1111, 0);
+                    spv::Id data = load(b, params, utils, features, dest, 0b1111, dest_offset);
                     b.createStore(data, accessed, spv::MemoryAccessAlignedMask, spv::ScopeMax, 4);
                 } else {
                     accessed = b.createLoad(accessed, spv::NoPrecision, spv::MemoryAccessAlignedMask, spv::ScopeMax, 4);
-                    store(b, params, utils, features, dest, accessed, 0b1111, 0);
+                    store(b, params, utils, features, dest, accessed, 0b1111, dest_offset);
                 }
 
                 dest.num += 4;
@@ -614,11 +614,11 @@ void shader::usse::utils::buffer_address_access(spv::Builder &b, const SpirvShad
             spv::Id accessed = utils::create_access_chain(b, spv::StorageClassPhysicalStorageBuffer, buffer_address_vec, { zero, b.makeIntConstant(buffer_idx_vec4) });
 
             if (is_buffer_store) {
-                spv::Id data = load(b, params, utils, features, dest, (1 << nb_components) - 1, 0);
+                spv::Id data = load(b, params, utils, features, dest, (1 << nb_components) - 1, dest_offset);
                 b.createStore(data, accessed, spv::MemoryAccessAlignedMask, spv::ScopeMax, 4);
             } else {
                 accessed = b.createLoad(accessed, spv::NoPrecision, spv::MemoryAccessAlignedMask, spv::ScopeMax, 4);
-                store(b, params, utils, features, dest, accessed, (1 << nb_components) - 1, 0);
+                store(b, params, utils, features, dest, accessed, (1 << nb_components) - 1, dest_offset);
             }
         }
     } else {
@@ -663,7 +663,7 @@ void shader::usse::utils::buffer_address_access(spv::Builder &b, const SpirvShad
                 } else {
                     component_vec = b.createCompositeConstruct(b.makeVectorType(i32, loaded_components.size()), loaded_components);
                 }
-                store(b, params, utils, features, dest, component_vec, (1 << loaded_components.size()) - 1, 0);
+                store(b, params, utils, features, dest, component_vec, (1 << loaded_components.size()) - 1, dest_offset);
 
                 dest.num += component_size;
                 loaded_components.clear();


### PR DESCRIPTION
Implement the shader store operation, which is used by shaders to modify the content of buffers.
This obviously only works with memory mapping enabled, as without it, shaders only have access to a copy of the buffer that gets recreated every draw.

This fixes games using this features, mainly 3D Unity games.
However, only half of them are fixed as we still don't implement properly the repeat count for shader stores. This is a bit harder than I thought it would be to reverse engineer, so I will do it in another PR.