### PR TITLE
gui/home screen: Add app filter by compat state.

### DIFF
--- a/lang/en-gb.xml
+++ b/lang/en-gb.xml
@@ -341,6 +341,7 @@ Do not power off the system or close the application.</warning_saving>
 		<by_type>By Type</by_type>
 		<commercial>Commercial</commercial>
 		<homebrew>Homebrew</homebrew>
+		<by_compatibility_state>By Compatibility State</by_compatibility_state>
 		<ver>Ver</ver>
 		<cat>Cat</cat>
 		<comp>Comp</comp>

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -341,6 +341,7 @@ Do not power off the system or close the application.</warning_saving>
 		<by_type>By Type</by_type>
 		<commercial>Commercial</commercial>
 		<homebrew>Homebrew</homebrew>
+		<by_compatibility_state>By Compatibility State</by_compatibility_state>
 		<ver>Ver</ver>
 		<cat>Cat</cat>
 		<comp>Comp</comp>

--- a/lang/fr.xml
+++ b/lang/fr.xml
@@ -282,6 +282,26 @@ Ne pas éteindre le système, ni fermer l'application.</warning_saving>
 		<data_delete>Données à supprimer :</data_delete>
 	</game_data>
 
+	<home_screen>
+		<filter>Filtre</filter>
+		<sort_app>Trier les applications par</sort_app>
+		<all>Toutes</all>
+		<by_region>Par région</by_region>
+		<usa>USA</usa>
+		<europe>Europe</europe>
+		<japan>Japon</japan>
+		<asia>Asie</asia>
+		<by_type>Par type</by_type>
+		<commercial>Commercial</commercial>
+		<homebrew>Homebrew</homebrew>
+		<by_compatibility_state>Par état de compatibilité</by_compatibility_state>
+		<ver>Ver</ver>
+		<cat>Cat</cat>
+		<comp>Comp</comp>
+		<last_time>Dernière fois</last_time>
+		<refresh>Rafraîchir</refresh>
+	</home_screen>
+
 	<indicator>
 		<app_added_home>L'application a été ajoutée à l'écran d'accueil.</app_added_home>
 		<delete_all>Supprimer tout</delete_all>

--- a/lang/ja.xml
+++ b/lang/ja.xml
@@ -336,6 +336,7 @@ SDL2に対応したコントローラーを接続してください。</not_conn
 		<by_type>種類</by_type>
 		<commercial>商用ゲーム</commercial>
 		<homebrew>自作ゲーム</homebrew>
+		<by_compatibility_state>互換性状態別</by_compatibility_state>
 		<ver>Ver</ver>
 		<cat>カテゴリー</cat>
 		<comp>互換性</comp>

--- a/vita3k/compat/include/compat/state.h
+++ b/vita3k/compat/include/compat/state.h
@@ -24,19 +24,19 @@
 namespace compat {
 
 enum CompatibilityState {
-    Unknown = -1,
-    Nothing,
-    Bootable,
-    Intro,
-    Menu,
-    Ingame_Less,
-    Ingame_More,
-    Playable,
+    UNKNOWN = -1,
+    NOTHING,
+    BOOTABLE,
+    INTRO,
+    MENU,
+    INGAME_LESS,
+    INGAME_MORE,
+    PLAYABLE,
 };
 
 struct Compatibility {
     uint32_t issue_id;
-    CompatibilityState state = Unknown;
+    CompatibilityState state = UNKNOWN;
     time_t updated_at;
 };
 
@@ -44,14 +44,14 @@ struct CompatState {
     bool compat_db_loaded = false;
     std::map<std::string, Compatibility> app_compat_db;
     std::map<CompatibilityState, ImVec4> compat_color{
-        { Unknown, ImVec4(0.54f, 0.54f, 0.54f, 1.f) },
-        { Nothing, ImVec4(1.00f, 0.00f, 0.00f, 1.f) }, // #ff0000
-        { Bootable, ImVec4(0.39f, 0.12f, 0.62f, 1.f) }, // #621fa5
-        { Intro, ImVec4(0.77f, 0.08f, 0.52f, 1.f) }, // #c71585
-        { Menu, ImVec4(0.11f, 0.46f, 0.85f, 1.f) }, // #1d76db
-        { Ingame_Less, ImVec4(0.88f, 0.54f, 0.12f, 1.f) }, // #e08a1e
-        { Ingame_More, ImVec4(1.00f, 0.84f, 0.00f, 1.f) }, // #ffd700
-        { Playable, ImVec4(0.05f, 0.54f, 0.09f, 1.f) }, // #0e8a16
+        { UNKNOWN, ImVec4(0.54f, 0.54f, 0.54f, 1.f) },
+        { NOTHING, ImVec4(1.00f, 0.00f, 0.00f, 1.f) }, // #ff0000
+        { BOOTABLE, ImVec4(0.39f, 0.12f, 0.62f, 1.f) }, // #621fa5
+        { INTRO, ImVec4(0.77f, 0.08f, 0.52f, 1.f) }, // #c71585
+        { MENU, ImVec4(0.11f, 0.46f, 0.85f, 1.f) }, // #1d76db
+        { INGAME_LESS, ImVec4(0.88f, 0.54f, 0.12f, 1.f) }, // #e08a1e
+        { INGAME_MORE, ImVec4(1.00f, 0.84f, 0.00f, 1.f) }, // #ffd700
+        { PLAYABLE, ImVec4(0.05f, 0.54f, 0.09f, 1.f) }, // #0e8a16
     };
 };
 

--- a/vita3k/compat/src/compat.cpp
+++ b/vita3k/compat/src/compat.cpp
@@ -80,19 +80,19 @@ bool load_compat_app_db(GuiState &gui, EmuEnvState &emuenv) {
             continue;
         }
 
-        auto state = CompatibilityState::Unknown;
+        auto state = CompatibilityState::UNKNOWN;
         const auto labels = app.child("labels");
         if (!labels.empty()) {
             for (const auto &label : labels) {
                 const auto label_id = static_cast<LabelIdState>(label.text().as_uint());
                 switch (label_id) {
-                case LabelIdState::Nothing: state = Nothing; break;
-                case LabelIdState::Bootable: state = Bootable; break;
-                case LabelIdState::Intro: state = Intro; break;
-                case LabelIdState::Menu: state = Menu; break;
-                case LabelIdState::Ingame_Less: state = Ingame_Less; break;
-                case LabelIdState::Ingame_More: state = Ingame_More; break;
-                case LabelIdState::Playable: state = Playable; break;
+                case LabelIdState::Nothing: state = NOTHING; break;
+                case LabelIdState::Bootable: state = BOOTABLE; break;
+                case LabelIdState::Intro: state = INTRO; break;
+                case LabelIdState::Menu: state = MENU; break;
+                case LabelIdState::Ingame_Less: state = INGAME_LESS; break;
+                case LabelIdState::Ingame_More: state = INGAME_MORE; break;
+                case LabelIdState::Playable: state = PLAYABLE; break;
                 default: break;
                 }
             }
@@ -100,7 +100,7 @@ bool load_compat_app_db(GuiState &gui, EmuEnvState &emuenv) {
         const auto updated_at = app.child("updated_at").text().as_llong();
 
         // Check if app missing a status label
-        if (state == Unknown)
+        if (state == UNKNOWN)
             LOG_WARN("App with title ID {} has an issue but no status label. Please check GitHub issue {} and request a status label to be added.", title_id, issue_id);
 
         // Check if app already exists in compatibility database
@@ -112,7 +112,7 @@ bool load_compat_app_db(GuiState &gui, EmuEnvState &emuenv) {
 
     // Update compatibility status of all user apps
     for (auto &app : gui.app_selector.user_apps)
-        app.compat = gui.compat.app_compat_db.contains(app.title_id) ? gui.compat.app_compat_db[app.title_id].state : CompatibilityState::Unknown;
+        app.compat = gui.compat.app_compat_db.contains(app.title_id) ? gui.compat.app_compat_db[app.title_id].state : CompatibilityState::UNKNOWN;
 
     return !gui.compat.app_compat_db.empty();
 }

--- a/vita3k/gui/src/about_dialog.cpp
+++ b/vita3k/gui/src/about_dialog.cpp
@@ -47,7 +47,7 @@ static std::vector<const char *> contributors_list = {
 void draw_about_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 display_size(emuenv.viewport_size.x, emuenv.viewport_size.y);
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
-  
+
     auto lang = gui.lang.about;
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin(lang["title"].c_str(), &gui.help_menu.about_dialog, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -297,9 +297,9 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
 
     const auto is_commercial_app = title_id.find("PCS") != std::string::npos;
     const auto has_state_report = gui.compat.compat_db_loaded ? gui.compat.app_compat_db.contains(title_id) : false;
-    const auto compat_state = has_state_report ? gui.compat.app_compat_db[title_id].state : compat::Unknown;
+    const auto compat_state = has_state_report ? gui.compat.app_compat_db[title_id].state : compat::UNKNOWN;
     const auto compat_state_color = gui.compat.compat_color[compat_state];
-    const auto compat_state_str = has_state_report ? lang_compat.states[compat_state] : lang_compat.states[compat::Unknown];
+    const auto compat_state_str = has_state_report ? lang_compat.states[compat_state] : lang_compat.states[compat::UNKNOWN];
 
     // App Context Menu
     if (ImGui::BeginPopupContextItem("##app_context_menu")) {

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -638,24 +638,23 @@ std::map<DateTime, std::string> get_date_time(GuiState &gui, EmuEnvState &emuenv
         const auto days_str = gui.lang.common.mday[date_time.tm_mday];
         const auto year = date_time.tm_year + 1900;
         const auto month = date_time.tm_mon + 1;
-        const auto days = date_time.tm_mday;
+        const auto day = date_time.tm_mday;
         switch (emuenv.cfg.sys_date_format) {
         case SCE_SYSTEM_PARAM_DATE_FORMAT_YYYYMMDD:
             date_time_str[DateTime::DATE_DETAIL] = fmt::format("{} {} ({})", month_str, days_str, day_str);
-            date_time_str[DateTime::DATE_MINI] = fmt::format("{}/{}/{}", year, month, days);
+            date_time_str[DateTime::DATE_MINI] = fmt::format("{}/{}/{}", year, month, day);
             break;
         case SCE_SYSTEM_PARAM_DATE_FORMAT_DDMMYYYY: {
             const auto small_month_str = gui.lang.common.small_ymonth[date_time.tm_mon];
-            const auto small_days_str = gui.lang.common.small_mday[date_time.tm_mon];
+            const auto small_days_str = gui.lang.common.small_mday[day];
             date_time_str[DateTime::DATE_DETAIL] = fmt::format("{} {} ({})", small_days_str, small_month_str, day_str);
-            date_time_str[DateTime::DATE_MINI] = fmt::format("{}/{}/{}", days, month, year);
+            date_time_str[DateTime::DATE_MINI] = fmt::format("{}/{}/{}", day, month, year);
             break;
         }
         case SCE_SYSTEM_PARAM_DATE_FORMAT_MMDDYYYY:
             date_time_str[DateTime::DATE_DETAIL] = fmt::format("{} {} ({})", month_str, days_str, day_str);
-            date_time_str[DateTime::DATE_MINI] = fmt::format("{}/{}/{}", month, days, year);
+            date_time_str[DateTime::DATE_MINI] = fmt::format("{}/{}/{}", month, day, year);
             break;
-        default: break;
         }
     }
     const auto is_afternoon = date_time.tm_hour > 12;

--- a/vita3k/gui/src/welcome_dialog.cpp
+++ b/vita3k/gui/src/welcome_dialog.cpp
@@ -27,7 +27,7 @@ namespace gui {
 void draw_welcome_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 display_size(emuenv.viewport_size.x, emuenv.viewport_size.y);
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
- 
+
     auto lang = gui.lang.welcome;
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);

--- a/vita3k/https/src/https.cpp
+++ b/vita3k/https/src/https.cpp
@@ -192,7 +192,7 @@ static Https init(const std::string url, const std::string method = "GET", const
         return {};
     }
 
-    // Free address info and ssl ctx 
+    // Free address info and ssl ctx
     freeaddrinfo(result);
     SSL_CTX_free(ctx);
 
@@ -409,7 +409,7 @@ bool download_file(std::string url, const std::string output_file_path, Progress
 
     // Close the output file
     outfile.close();
-    
+
     // Close SSL and socket connection
     close_ssl(https.ssl);
     close_socket(https.sockfd);

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -175,14 +175,14 @@ struct LangState {
     struct Compatibility {
         std::string name = "Compatibility";
         std::map<compat::CompatibilityState, std::string> states = {
-            { compat::Unknown, "Unknown" },
-            { compat::Nothing, "Nothing" },
-            { compat::Bootable, "Bootable" },
-            { compat::Intro, "Intro" },
-            { compat::Menu, "Menu" },
-            { compat::Ingame_Less, "Ingame -" },
-            { compat::Ingame_More, "Ingame +" },
-            { compat::Playable, "Playable" }
+            { compat::UNKNOWN, "Unknown" },
+            { compat::NOTHING, "Nothing" },
+            { compat::BOOTABLE, "Bootable" },
+            { compat::INTRO, "Intro" },
+            { compat::MENU, "Menu" },
+            { compat::INGAME_LESS, "Ingame -" },
+            { compat::INGAME_MORE, "Ingame +" },
+            { compat::PLAYABLE, "Playable" }
         };
     };
     Compatibility compatibility;
@@ -272,6 +272,7 @@ struct LangState {
         { "by_type", "By Type" },
         { "commercial", "Commercial" },
         { "homebrew", "Homebrew" },
+        { "by_compatibility_state", "By Compatibility State" },
         { "ver", "Ver" },
         { "cat", "Cat" },
         { "comp", "Comp" },


### PR DESCRIPTION
# About
- gui/home screen: Add app filter by compat state.
- compat: fix typo of enum.
- gui: fix day on format dd/mm/yyyy for start screen.


# Result
![image](https://user-images.githubusercontent.com/5261759/229256695-b91b00b5-c135-429d-93de-988c70f26883.png)
