### PR TITLE
renderer/vulkan: Implement surface sync

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -63,7 +63,7 @@ enum PerfomanceOverleyPosition {
     code(std::string, "backend-renderer", "OpenGL", backend_renderer)                                   \
     code(int, "gpu-idx", 0, gpu_idx)                                                                    \
     code(int, "resolution-multiplier", 1, resolution_multiplier)                                        \
-    code(bool, "disable-surface-sync", false, disable_surface_sync)                                     \
+    code(bool, "disable-surface-sync", true, disable_surface_sync)                                      \
     code(bool, "enable-fxaa", false, enable_fxaa)                                                       \
     code(bool, "enable-linear-filter", true, enable_linear_filter)                                      \
     code(bool, "v-sync", true, v_sync)                                                                  \

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -72,7 +72,7 @@ struct State {
     virtual void set_linear_filter(bool enable_linear_filter) = 0;
     virtual int get_max_anisotropic_filtering() = 0;
     virtual void set_anisotropic_filtering(int anisotropic_filtering) = 0;
-    virtual void set_surface_sync_state(bool disable) {
+    void set_surface_sync_state(bool disable) {
         disable_surface_sync = disable;
     }
     virtual bool map_memory(MemState &mem, Ptr<void> address, uint32_t size) {

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -37,7 +37,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
 
 void new_frame(VKContext &context);
 
-void set_context(VKContext &context, const MemState &mem, VKRenderTarget *rt, const FeatureState &features);
+void set_context(VKContext &context, MemState &mem, VKRenderTarget *rt, const FeatureState &features);
 void set_uniform_buffer(VKContext &context, const MemState &mem, const ShaderProgram *program, const bool vertex_shader, const int block_num, const int size, Ptr<uint8_t> data);
 
 void sync_clipping(VKContext &context);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -80,7 +80,6 @@ struct VKState : public renderer::State {
     void set_linear_filter(bool enable_linear_filter) override;
     int get_max_anisotropic_filtering() override;
     void set_anisotropic_filtering(int anisotropic_filtering) override;
-    void set_surface_sync_state(bool disable) override;
     bool map_memory(MemState &mem, Ptr<void> address, uint32_t size) override;
     void unmap_memory(MemState &mem, Ptr<void> address) override;
     // return the matching buffer and offset for the memory location

--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -95,6 +95,8 @@ struct MappedMemory {
     uint64_t buffer_address;
 };
 
+struct ColorSurfaceCacheInfo;
+
 // request to trigger a notification after the fence has been waited for
 struct NotificationRequest {
     SceGxmNotification notifications[2];
@@ -105,10 +107,14 @@ struct FrameDoneRequest {
     uint64_t frame_timestamp;
 };
 
+struct PostSurfaceSyncRequest {
+    ColorSurfaceCacheInfo *cache_info;
+};
+
 // A parallel thread is handling these request and telling other waiting threads
 // when they are done
 // only used if memory mapping is enabled
-typedef std::variant<NotificationRequest, FrameDoneRequest> WaitThreadRequest;
+typedef std::variant<NotificationRequest, FrameDoneRequest, PostSurfaceSyncRequest> WaitThreadRequest;
 
 struct VKContext : public renderer::Context {
     // GXM Context Info
@@ -201,7 +207,7 @@ struct VKContext : public renderer::Context {
     void stop_recording(const SceGxmNotification &notif1, const SceGxmNotification &notif2);
 
 private:
-    void wait_thread_function();
+    void wait_thread_function(const MemState &mem);
 };
 
 struct VKRenderTarget : public renderer::RenderTarget {

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -125,7 +125,7 @@ COMMAND(handle_sync_surface_data) {
         }
     }
 
-    if (renderer.disable_surface_sync) {
+    if (renderer.disable_surface_sync || renderer.current_backend == Backend::Vulkan) {
         if (helper.cmd->status)
             complete_command(renderer, helper, 0);
         return;
@@ -154,7 +154,6 @@ COMMAND(handle_sync_surface_data) {
         break;
 
     case Backend::Vulkan:
-        // not implemented for now
         break;
 
     default:

--- a/vita3k/renderer/src/vulkan/creation.cpp
+++ b/vita3k/renderer/src/vulkan/creation.cpp
@@ -48,7 +48,7 @@ VKContext::VKContext(VKState &state, MemState &mem)
         std::fill_n(vertex_stream_buffers, SCE_GXM_MAX_VERTEX_STREAMS, state.default_buffer.buffer);
 
         // also initialize the gpu wait thread
-        gpu_request_wait_thread = std::thread(&VKContext::wait_thread_function, this);
+        gpu_request_wait_thread = std::thread(&VKContext::wait_thread_function, this, std::ref(mem));
     } else {
         // these are not needed when using memory mapping
         vertex_stream_ring_buffer.create();

--- a/vita3k/util/CMakeLists.txt
+++ b/vita3k/util/CMakeLists.txt
@@ -1,28 +1,6 @@
 add_library(
 	util
 	STATIC
-	include/util/overloaded.h
-	include/util/align.h
-	include/util/bytes.h
-	include/util/safe_time.h
-	include/util/elf.h
-	include/util/exit_code.h
-	include/util/exec.h
-	include/util/find.h
-	include/util/float_to_half.h
-	include/util/fs.h
-	include/util/function_info.h
-	include/util/instrset_detect.h
-	include/util/lock_and_find.h
-	include/util/log.h
-	include/util/net_utils.h
-	include/util/preprocessor.h
-	include/util/pool.h
-	include/util/string_utils.h
-	include/util/system.h
-	include/util/tracy.h
-	include/util/types.h
-	include/util/vector_utils.h
 	src/util.cpp
 	src/instrset_detect.cpp
 )

--- a/vita3k/util/include/util/float_to_half.h
+++ b/vita3k/util/include/util/float_to_half.h
@@ -15,6 +15,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#pragma once
+
 // original source:https://stackoverflow.com/questions/1659440/32-bit-to-16-bit-floating-point-conversion
 // public domain
 

--- a/vita3k/util/include/util/keywords.h
+++ b/vita3k/util/include/util/keywords.h
@@ -1,0 +1,24 @@
+// Vita3K emulator project
+// Copyright (C) 2023 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#if defined(_MSC_VER)
+#define restrict __restrict
+#else
+#define restrict __restrict__
+#endif

--- a/vita3k/vkutil/src/objects.cpp
+++ b/vita3k/vkutil/src/objects.cpp
@@ -91,6 +91,11 @@ void Image::init_image(vk::ImageUsageFlags usage, vk::ComponentMapping mapping, 
 
     std::tie(image, allocation) = allocator.createImage(image_info, vma_auto_alloc);
 
+    // only create a view if one of these flags is set
+    constexpr vk::ImageUsageFlags view_usages = vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eStorage;
+    if (!(usage & view_usages))
+        return;
+
     vk::ImageSubresourceRange range = (format == vk::Format::eD32SfloatS8Uint) ? vkutil::ds_subresource_range : vkutil::color_subresource_range;
     vk::ImageViewCreateInfo view_info{
         .image = image,


### PR DESCRIPTION
Implement surface sync on the Vulkan renderer.
For many reasons (it is a lot easier to code and a lot more efficient), surface sync can be enabled only with memory mapping.

This implementation is far better than the opengl one. First, if upscaling is enabled, the surface is downscaled on the GPU instead of the CPU. Second, memory trapping is used so that surface sync is done only on surfaces that really need it.