### PR TITLE
net/http: Some improvements

### DIFF
--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -490,8 +490,8 @@ typedef struct SceNetCheckDialogResult {
 
 EXPORT(int, sceNetCheckDialogGetResult, SceNetCheckDialogResult *result) {
     TRACY_FUNC(sceNetCheckDialogGetResult, result);
-    result->result = -1;
-    return STUBBED("result->result = -1, return 0");
+    result->result = 0;
+    return STUBBED("result->result = 0");
 }
 
 EXPORT(SceCommonDialogStatus, sceNetCheckDialogGetStatus) {

--- a/vita3k/modules/SceNetCtl/SceNetCtl.cpp
+++ b/vita3k/modules/SceNetCtl/SceNetCtl.cpp
@@ -19,6 +19,7 @@
 
 #include <kernel/state.h>
 #include <net/state.h>
+#include <net/types.h>
 #include <rtc/rtc.h>
 #include <util/lock_and_find.h>
 
@@ -262,13 +263,13 @@ EXPORT(int, sceNetCtlCheckCallback) {
 
     for (auto &callback : emuenv.netctl.callbacks) {
         if (callback.pc != 0) {
-            thread->run_callback(callback.pc, { 1, callback.arg });
+            thread->run_callback(callback.pc, { SCE_NET_CTL_EVENT_TYPE_DISCONNECTED, callback.arg });
         }
     }
 
     for (auto &callback : emuenv.netctl.adhocCallbacks) {
         if (callback.pc != 0) {
-            thread->run_callback(callback.pc, { 1, callback.arg });
+            thread->run_callback(callback.pc, { SCE_NET_CTL_EVENT_TYPE_DISCONNECTED, callback.arg });
         }
     }
 

--- a/vita3k/net/include/net/types.h
+++ b/vita3k/net/include/net/types.h
@@ -19,6 +19,11 @@
 
 #include <mem/ptr.h>
 
+// I dont know why, dont ask why, i dont want to know why, but for some reason a property name is getting treated as a define reference
+#ifdef _WIN32
+#undef s_addr
+#endif
+
 enum SceNetProtocol : uint32_t {
     SCE_NET_IPPROTO_IP = 0,
     SCE_NET_IPPROTO_ICMP = 1,
@@ -349,4 +354,10 @@ struct SceNetEpollEvent {
     unsigned int reserved;
     unsigned int system[4];
     SceNetEpollData data;
+};
+
+enum SceNetCtlEventType {
+    SCE_NET_CTL_EVENT_TYPE_DISCONNECTED = 1,
+    SCE_NET_CTL_EVENT_TYPE_DISCONNECT_REQ_FINISHED = 2,
+    SCE_NET_CTL_EVENT_TYPE_IPOBTAINED = 3,
 };


### PR DESCRIPTION
~Allows highschool dxd to go past the PSN screen, but then servers are down so i have to find a workaround for when servers of a game are down. i saw that games that use this compare to 0 and values above it, so -1 is kinda out of place, still tho, i prefer if more games were tested just to make sure this doesn't break any game that require PSN connectivity~

EDIT: 
* Make `sceNetCheckDialogGetResult` result be a valid number
* A bit better of http handling when its HLE and http disabled
* Implement IP OBTAINED callback 
* Fix http read body data always returning 0