### PR TITLE
renderer: Simplify batch and state function dispatch

### DIFF
--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -67,10 +67,9 @@ bool wait_cmd(MemState &mem, CommandList &command_list) {
 }
 
 void process_batch(renderer::State &state, const FeatureState &features, MemState &mem, Config &config, CommandList &command_list) {
-    using CommandHandlerFunc = std::function<void(renderer::State &, MemState &, Config &,
-        CommandHelper &, const FeatureState &, Context *, const char *, const char *, const char *)>;
+    using CommandHandlerFunc = decltype(cmd_handle_set_context);
 
-    const static std::map<CommandOpcode, CommandHandlerFunc> handlers = {
+    const static std::map<CommandOpcode, CommandHandlerFunc *> handlers = {
         { CommandOpcode::SetContext, cmd_handle_set_context },
         { CommandOpcode::SyncSurfaceData, cmd_handle_sync_surface_data },
         { CommandOpcode::CreateContext, cmd_handle_create_context },

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -511,10 +511,9 @@ COMMAND_SET_STATE(fragment_program_enable) {
 COMMAND(handle_set_state) {
     // TRACY_FUNC_COMMANDS(handle_set_state); All set state commands have tracy so kinda redundant
     renderer::GXMState gxm_state_to_set = helper.pop<renderer::GXMState>();
-    using StateChangeHandlerFunc = std::function<void(renderer::State &, MemState &, Config &, CommandHelper &,
-        Context *, const char *base_path, const char *title_id)>;
+    using StateChangeHandlerFunc = decltype(cmd_set_state_region_clip);
 
-    static const std::map<renderer::GXMState, StateChangeHandlerFunc> handlers = {
+    static const std::map<renderer::GXMState, StateChangeHandlerFunc *> handlers = {
         { GXMState::RegionClip, cmd_set_state_region_clip },
         { GXMState::Program, cmd_set_state_program },
         { GXMState::Viewport, cmd_set_state_viewport },


### PR DESCRIPTION
Replace the use of std::function with function pointers.
This simplifies the code thanks to the decltype keyword but also makes it faster as std::function adds a level of indirection (although I don't think it will be possible to feel the difference).

It ain't much but it's honest work.