### PR TITLE
external/codec: Update ffmpeg

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -308,6 +308,7 @@ target_include_directories(vma INTERFACE
 	"${CMAKE_CURRENT_SOURCE_DIR}/VulkanMemoryAllocator-Hpp/VulkanMemoryAllocator/include")
 
 add_subdirectory(ffmpeg)
+
 add_subdirectory(psvpfstools)
 set_property(TARGET psvpfsparser PROPERTY FOLDER externals)
 set_property(TARGET libzRIF PROPERTY FOLDER externals)

--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -64,12 +64,10 @@ struct DecoderState {
 
     virtual uint32_t get(DecoderQuery query);
 
-    // TODO: proper error handling (return bool?)
     virtual void flush();
     virtual bool send(const uint8_t *data, uint32_t size) = 0;
     virtual bool receive(uint8_t *data, DecoderSize *size = nullptr) = 0;
     virtual uint32_t get_es_size();
-    virtual void clear_context();
 
     virtual ~DecoderState();
 };
@@ -126,23 +124,20 @@ struct Atrac9DecoderState : public DecoderState {
     uint32_t get(DecoderQuery query) override;
     uint32_t get_es_size() override;
 
-    void clear_context() override;
-
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;
+    void flush() override;
 
     explicit Atrac9DecoderState(uint32_t config_data);
     ~Atrac9DecoderState() override;
 };
 
 struct Mp3DecoderState : public DecoderState {
-    AVCodec *codec;
+    const AVCodec *codec;
     uint32_t es_size_used;
 
     uint32_t get(DecoderQuery query) override;
     uint32_t get_es_size() override;
-
-    void clear_context() override;
 
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;
@@ -189,12 +184,11 @@ public:
 };
 
 struct AacDecoderState : public DecoderState {
-    AVCodec *codec;
+    const AVCodec *codec;
+    SwrContext *swr;
     AVFrame *frame;
     uint32_t es_size_used;
     uint32_t get(DecoderQuery query) override;
-
-    void clear_context() override;
 
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;

--- a/vita3k/codec/src/atrac9.cpp
+++ b/vita3k/codec/src/atrac9.cpp
@@ -56,7 +56,7 @@ uint32_t Atrac9DecoderState::get_es_size() {
     return es_size_used;
 }
 
-void Atrac9DecoderState::clear_context() {
+void Atrac9DecoderState::flush() {
     Atrac9CodecInfo *info = reinterpret_cast<Atrac9CodecInfo *>(atrac9_info);
     superframe_frame_idx = 0;
     superframe_data_left = info->superframeSize;

--- a/vita3k/codec/src/decoder.cpp
+++ b/vita3k/codec/src/decoder.cpp
@@ -33,14 +33,11 @@ uint32_t DecoderState::get_es_size() {
     return std::numeric_limits<uint32_t>::max();
 }
 
-void DecoderState::clear_context() {}
-
 void DecoderState::flush() {
     avcodec_flush_buffers(context);
 }
 
 DecoderState::~DecoderState() {
-    avcodec_close(context);
     avcodec_free_context(&context);
 }
 

--- a/vita3k/codec/src/h264.cpp
+++ b/vita3k/codec/src/h264.cpp
@@ -134,7 +134,7 @@ void H264DecoderState::get_pts(uint32_t &upper, uint32_t &lower) {
 }
 
 H264DecoderState::H264DecoderState(uint32_t width, uint32_t height) {
-    AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+    const AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_H264);
     assert(codec);
 
     parser = av_parser_init(codec->id);

--- a/vita3k/codec/src/mjpeg.cpp
+++ b/vita3k/codec/src/mjpeg.cpp
@@ -110,7 +110,7 @@ bool MjpegDecoderState::receive(uint8_t *data, DecoderSize *size) {
 }
 
 MjpegDecoderState::MjpegDecoderState() {
-    AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_MJPEG);
+    const AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_MJPEG);
     assert(codec);
 
     context = avcodec_alloc_context3(codec);

--- a/vita3k/codec/src/pcm.cpp
+++ b/vita3k/codec/src/pcm.cpp
@@ -296,18 +296,23 @@ PCMDecoderState::PCMDecoderState(const float dest_frequency)
     , source_channels(2)
     , source_frequency(48000.0f)
     , he_adpcm(false) {
+    AVChannelLayout layout_mono = AV_CHANNEL_LAYOUT_MONO;
+    AVChannelLayout layout_stereo = AV_CHANNEL_LAYOUT_STEREO;
+
     // we are not resampling, we don't care about the sample rate
-    swr_mono_to_stereo = swr_alloc_set_opts(nullptr,
-        AV_CH_LAYOUT_STEREO, AV_SAMPLE_FMT_FLT, 48000,
-        AV_CH_LAYOUT_MONO, AV_SAMPLE_FMT_S16, 48000,
+    int ret = swr_alloc_set_opts2(&swr_mono_to_stereo,
+        &layout_stereo, AV_SAMPLE_FMT_FLT, 48000,
+        &layout_mono, AV_SAMPLE_FMT_S16, 48000,
         0, nullptr);
+    assert(ret == 0);
 
     swr_init(swr_mono_to_stereo);
 
-    swr_stereo = swr_alloc_set_opts(nullptr,
-        AV_CH_LAYOUT_STEREO, AV_SAMPLE_FMT_FLT, 48000,
-        AV_CH_LAYOUT_STEREO, AV_SAMPLE_FMT_S16, 48000,
+    ret = swr_alloc_set_opts2(&swr_stereo,
+        &layout_stereo, AV_SAMPLE_FMT_FLT, 48000,
+        &layout_stereo, AV_SAMPLE_FMT_S16, 48000,
         0, nullptr);
+    assert(ret == 0);
 
     swr_init(swr_stereo);
 }

--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
@@ -120,7 +120,7 @@ EXPORT(int, sceAudiodecClearContext, SceAudiodecCtrl *ctrl) {
     const auto state = emuenv.kernel.obj_store.get<AudiodecState>();
     const DecoderPtr &decoder = lock_and_find(ctrl->handle, state->decoders, state->mutex);
 
-    decoder->clear_context();
+    decoder->flush();
 
     return 0;
 }

--- a/vita3k/ngs/src/modules/player.cpp
+++ b/vita3k/ngs/src/modules/player.cpp
@@ -240,12 +240,15 @@ bool Module::process(KernelState &kern, const MemState &mem, const SceUID thread
                         if (state->swr)
                             swr_free(&state->swr);
 
-                        state->swr = swr_alloc_set_opts(nullptr,
-                            AV_CH_LAYOUT_STEREO, AV_SAMPLE_FMT_FLT, sample_rate,
-                            AV_CH_LAYOUT_STEREO, AV_SAMPLE_FMT_FLT, src_sample_rate,
+                        AVChannelLayout layout_stereo = AV_CHANNEL_LAYOUT_STEREO;
+                        int ret = swr_alloc_set_opts2(&state->swr,
+                            &layout_stereo, AV_SAMPLE_FMT_FLT, sample_rate,
+                            &layout_stereo, AV_SAMPLE_FMT_FLT, src_sample_rate,
                             0, nullptr);
+                        assert(ret == 0);
 
-                        swr_init(state->swr);
+                        ret = swr_init(state->swr);
+                        assert(ret == 0);
                         state->reset_swr = false;
                     }
                     int scaled_samples_amount = swr_get_out_samples(state->swr, samples_count.samples);


### PR DESCRIPTION
Update ffmpeg to 5.1.2 (from 4.4).
I updated the code to remove all calls and accesses to deprecated ffmepg functions and variable. Also I had to modify the decode call for the H264 decoder as we use an internal ffmpeg function whose location changed.
I also did a bit of cleanup in the codec files.

The new ffmpeg prebuilt are better optimized and should be much faster for some cases.