### PR TITLE
renderer/vulkan: Peform rgba->rgb conversion using ffmpeg

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/surface_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/surface_cache.h
@@ -21,6 +21,8 @@
 
 #include <vkutil/objects.h>
 
+struct SwsContext;
+
 namespace renderer::vulkan {
 
 struct VKRenderTarget;
@@ -75,6 +77,11 @@ struct ColorSurfaceCacheInfo : public SurfaceCacheInfo {
 
     // pointer shared with the memory trap indicating if this surface sync is needed
     std::shared_ptr<bool> need_surface_sync;
+
+    // pointer to decoder used for surface sync (if necessary)
+    SwsContext *sws_context = nullptr;
+
+    ~ColorSurfaceCacheInfo();
 };
 
 struct DepthSurfaceView {


### PR DESCRIPTION
Perform the rgba->rgb surface sync conversion using ffmpeg swscale.
Thanks to #2487 , this is much faster than the plain C implementation which is not optimized by compilers.

This allows Project Diva X to run at full speed with surface sync enabled.