### PR TITLE
renderer/scene: Implement convert linear to swizzled for transfercopy.

### DIFF
--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -185,6 +185,8 @@ void tiled_texture_to_linear_texture(uint8_t *dest, const uint8_t *src, uint16_t
 
 uint16_t get_upload_mip(const uint16_t true_mip, const uint16_t width, const uint16_t height, const SceGxmTextureBaseFormat base_format);
 
+uint32_t decode_morton2_x(uint32_t code);
+uint32_t decode_morton2_y(uint32_t code);
 void upload_bound_texture(const TextureCacheState &cache, const SceGxmTexture &gxm_texture, const MemState &mem);
 void cache_and_bind_texture(TextureCacheState &cache, const SceGxmTexture &gxm_texture, MemState &mem);
 size_t bits_per_pixel(SceGxmTextureBaseFormat base_format);

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -223,44 +223,109 @@ COMMAND(handle_transfer_copy) {
     const SceGxmTransferType src_type = helper.pop<SceGxmTransferType>();
     const SceGxmTransferType dst_type = helper.pop<SceGxmTransferType>();
 
+    const auto src_is_linear = src_type == SCE_GXM_TRANSFER_LINEAR;
+    const auto dest_is_linear = dst_type == SCE_GXM_TRANSFER_LINEAR;
+    const auto src_is_swizzled = src_type == SCE_GXM_TRANSFER_SWIZZLED;
+    const auto dest_is_swizzled = dst_type == SCE_GXM_TRANSFER_SWIZZLED;
+
+    // Get bits per pixel of source and destination
+    const auto src_bpp = gxm::get_bits_per_pixel(src->format);
+    const auto dest_bpp = gxm::get_bits_per_pixel(dest->format);
+
+    // Set bytes per pixel of source and destination
+    const uint32_t src_bytes_per_pixel = (src_bpp + 7) >> 3;
+    const uint32_t dest_bytes_per_pixel = (dest_bpp + 7) >> 3;
+
+    // Set width and height of source and destination
+    const uint32_t src_width = src->width;
+    const uint32_t src_height = src->height;
+    const uint32_t dest_width = dest->width;
+    const uint32_t dest_height = dest->height;
+
+    const auto copy_pixel = [&](const uint32_t src_offset, const uint32_t dest_offset) {
+        // Set pointer of source and destination
+        const auto src_ptr = (uint8_t *)src->address.get(mem) + src_offset;
+        auto dest_ptr = (uint8_t *)dest->address.get(mem) + dest_offset;
+
+        // Set color of source
+        const auto src_color = *(uint32_t *)src_ptr;
+
+        // Copy result in destination depending color Key
+        switch (colorKeyMode) {
+        case SCE_GXM_TRANSFER_COLORKEY_NONE:
+            std::memcpy(dest_ptr, src_ptr, dest_bytes_per_pixel);
+            break;
+        case SCE_GXM_TRANSFER_COLORKEY_PASS:
+            if ((src_color & colorKeyMask) == colorKeyValue)
+                std::memcpy(dest_ptr, src_ptr, dest_bytes_per_pixel);
+            break;
+        case SCE_GXM_TRANSFER_COLORKEY_REJECT:
+            if ((src_color & colorKeyMask) != colorKeyValue)
+                std::memcpy(dest_ptr, src_ptr, dest_bytes_per_pixel);
+            break;
+        default: break;
+        }
+    };
+
     if (src_type == dst_type) {
-        const auto src_bpp = gxm::get_bits_per_pixel(src->format);
-        const auto dest_bpp = gxm::get_bits_per_pixel(dest->format);
-        const uint32_t src_bytes_per_pixel = (src_bpp + 7) >> 3;
-        const uint32_t dest_bytes_per_pixel = (dest_bpp + 7) >> 3;
-
-        for (uint32_t x = 0; x < src->width; x++) {
-            for (uint32_t y = 0; y < src->height; y++) {
+        for (uint32_t x = 0; x < src_width; x++) {
+            for (uint32_t y = 0; y < src_height; y++) {
                 // Set offset of source and destination
-                const auto src_offset = ((x + src->x) * src_bytes_per_pixel) + ((y + src->y) * src->stride);
-                const auto dest_offset = ((x + dest->x) * dest_bytes_per_pixel) + ((y + dest->y) * dest->stride);
+                const uint32_t src_offset = ((x + src->x) * src_bytes_per_pixel) + ((y + src->y) * src->stride);
+                const uint32_t dest_offset = ((x + dest->x) * dest_bytes_per_pixel) + ((y + dest->y) * dest->stride);
 
-                // Set pointer of source and destination
-                const auto src_ptr = (uint8_t *)src->address.get(mem) + src_offset;
-                auto dest_ptr = (uint8_t *)dest->address.get(mem) + dest_offset;
-
-                // Set color of source
-                const auto src_color = *(uint32_t *)src_ptr;
-
-                // Copy result in destination depending color Key
-                switch (colorKeyMode) {
-                case SCE_GXM_TRANSFER_COLORKEY_NONE:
-                    memcpy(dest_ptr, src_ptr, dest_bytes_per_pixel);
-                    break;
-                case SCE_GXM_TRANSFER_COLORKEY_PASS:
-                    if ((src_color & colorKeyMask) == colorKeyValue)
-                        memcpy(dest_ptr, src_ptr, dest_bytes_per_pixel);
-                    break;
-                case SCE_GXM_TRANSFER_COLORKEY_REJECT:
-                    if ((src_color & colorKeyMask) != colorKeyValue)
-                        memcpy(dest_ptr, src_ptr, dest_bytes_per_pixel);
-                    break;
-                default: break;
-                }
+                // Copy pixel from source to destination
+                copy_pixel(src_offset, dest_offset);
             }
         }
+    } else if (src_is_linear && dest_is_swizzled) {
+        if ((dest->x != 0) || (dest->y != 0)) {
+            LOG_WARN("Unimplemented transfercopy from linear to swizzled with dest shift offset, report it to developer!");
+            return;
+        }
+
+        // Set the minimum between width and height of source
+        const uint32_t min = std::min(src_width, src_height);
+
+        // Set mask
+        const uint32_t mask = min - 1;
+
+        // Set the log2 of minimum
+        const size_t k = static_cast<size_t>(log2(min));
+
+        for (uint32_t i = 0; i < (src_width * src_height); i++) {
+            // Set aligned i
+            const uint32_t i_aligned = i >> (2 * k) << (2 * k);
+                        
+            // Decode morton 2 x/y of i and mask it
+            const uint32_t masked_dm_x = texture::decode_morton2_x(i) & mask;
+            const uint32_t masked_dm_y = texture::decode_morton2_y(i) & mask;
+
+            // Get x/y of source
+            uint32_t x, y;
+            if (src_height < src_width) {
+                const uint32_t j = i_aligned | masked_dm_y << k | masked_dm_x;
+                x = j / src_height;
+                y = j % src_height;
+            } else {
+                const uint32_t j = i_aligned | masked_dm_x << k | masked_dm_y;
+                x = j % src_width;
+                y = j / src_width;
+            }
+
+            // Check if x/y are out of bounds
+            if (y >= src_height || x >= src_width)
+                continue;
+
+            // Set offset of source and destination
+            const uint32_t src_offset = ((x + src->x) * src_bytes_per_pixel) + ((y + src->y) * src->stride);
+            const uint32_t dest_offset = i * dest_bytes_per_pixel;
+
+            // Copy pixel from source to destination
+            copy_pixel(src_offset, dest_offset);
+        }
     } else
-        LOG_WARN("No convertion of SceGxmTransferType support yet");
+        LOG_WARN("No convertion from SceGxmTransferType {} to {} is supported yet", (int)src_type, (int)dst_type);
 
     // TODO: handle case where dest is a cached surface
 

--- a/vita3k/renderer/src/texture_format.cpp
+++ b/vita3k/renderer/src/texture_format.cpp
@@ -169,11 +169,11 @@ static uint32_t compact_one_by_one(uint32_t x) {
     return x;
 }
 
-static uint32_t decode_morton2_x(uint32_t code) {
+uint32_t decode_morton2_x(uint32_t code) {
     return compact_one_by_one(code >> 0);
 }
 
-static uint32_t decode_morton2_y(uint32_t code) {
+uint32_t decode_morton2_y(uint32_t code) {
     return compact_one_by_one(code >> 1);
 }
 


### PR DESCRIPTION
# About
- Implement convert linear to swizzled for transfercopy.

# Result
- fix transition screen of angry birst stars wars
![image](https://user-images.githubusercontent.com/5261759/232227637-4c6583ab-d75f-4c45-816f-f54e835af257.png)
![image](https://user-images.githubusercontent.com/5261759/232227641-bd716327-2942-4968-a4bc-49402b9fa478.png)
- fix render of background on &: Sora no Mukou de Saki Masuyou ni 
![image](https://user-images.githubusercontent.com/5261759/232666929-dce7b385-f668-414d-bdf0-bbc553e57355.png)

