### PR TITLE
savedata: Fix requiredKiB not being set to 0 when all executed nicely

### DIFF
--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -262,6 +262,11 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
     TRACY_FUNC(sceAppUtilSaveDataDataSave, slot, files, fileNum, mountPoint, requiredSizeKiB);
     SceUID fd;
 
+    if (requiredSizeKiB)
+        // requiredSizeKiB must be set to 0 if there is enough space available
+        // else we need to set it to the space needed in KiB (TODO)
+        *requiredSizeKiB = 0;
+
     for (unsigned int i = 0; i < fileNum; i++) {
         const auto file_path = construct_savedata0_path(files[i].dataPath.get(emuenv.mem));
         switch (files[i].mode) {


### PR DESCRIPTION
So turns out that requiredKiB is not always initialized to 0 ingame, so it ended up being a pointer to garbage and stayed garbage cause we dont do nothing to it, so we have to set it to 0 it ourselves, this fixes minecraft saying that theres no free space