### PR TITLE
util/log: Replace log_hex with log_hex_fast

### DIFF
--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -264,7 +264,6 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
 
     if (requiredSizeKiB)
         // requiredSizeKiB must be set to 0 if there is enough space available
-        // else we need to set it to the space needed in KiB (TODO)
         *requiredSizeKiB = 0;
 
     for (unsigned int i = 0; i < fileNum; i++) {

--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -67,29 +67,45 @@ int ret_error_impl(const char *name, const char *error_str, std::uint32_t error_
 
 #define RET_ERROR(error) logging::ret_error_impl(export_name, #error, error)
 
+// Using stringstream as its 2x faster than fmt::format
+
+/*
+    returns: A string with the input number formatted in hexadecimal
+    Examples:
+        * `12` returns: `"0xC"`
+        * `1337` returns: `"0x539"`
+        * `72742069` returns: `"0x455F4B5"`
+*/
 template <typename T>
 std::string log_hex(T val) {
     using unsigned_type = typename std::make_unsigned<T>::type;
-    return fmt::format("0x{:0X}", static_cast<unsigned_type>(val));
+    std::stringstream ss;
+    ss << "0x";
+    ss << std::hex << static_cast<unsigned_type>(val);
+    return ss.str();
 }
 
+/*
+    returns: A string with the input number formatted in hexadecimal with padding of the inputted type size
+    Examples:
+        * `uint8_t 5` returns: `"0x05"`
+        * `uint8_t 15` returns: `"0x0F"`
+        * `uint8_t 255` returns: `"0xFF"`
+
+        * `uint16_t 15` returns: `"0x000F"`
+        * `uint16_t 1337` returns: `"0x0539"`
+        * `uint16_t 65535` returns: `"0xFFFF"`
+
+
+        * `uint32_t 15` returns: `"0x0000000F"`
+        * `uint32_t 1337` returns: `"0x00000539"`
+        * `uint32_t 65535` returns: `"0x0000FFFF"`
+        * `uint32_t 134217728` returns: `"0x08000000"`
+*/
 template <typename T>
 std::string log_hex_full(T val) {
     std::stringstream ss;
     ss << "0x";
     ss << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex << val;
-    return ss.str();
-}
-
-// same as log_hex_full but without the padding.
-// using a stringstream is 2x faster than fmt.
-// mainly here to print pointers addresses into tracy
-// TODO: get rid of log_hex in for this faster one
-template <typename T>
-std::string log_hex_fast(T val) {
-    using unsigned_type = typename std::make_unsigned<T>::type;
-    std::stringstream ss;
-    ss << "0x";
-    ss << std::hex << static_cast<unsigned_type>(val);
     return ss.str();
 }

--- a/vita3k/util/include/util/tracy.h
+++ b/vita3k/util/include/util/tracy.h
@@ -35,7 +35,7 @@ std::string to_debug_str(const MemState &mem, T data) {
 template <typename U>
 std::string to_debug_str(const MemState &mem, U *data) {
     std::stringstream datass;
-    datass << log_hex_fast(Ptr<U>(data, mem).address()); // Convert host ptr to guest
+    datass << log_hex(Ptr<U>(data, mem).address()); // Convert host ptr to guest
     return datass.str();
 }
 
@@ -43,13 +43,13 @@ std::string to_debug_str(const MemState &mem, U *data) {
 template <typename U>
 std::string to_debug_str(const MemState &mem, Ptr<U> data) {
     std::stringstream datass;
-    datass << log_hex_fast(data.address());
+    datass << log_hex(data.address());
     return datass.str();
 }
 
 template <>
 inline std::string to_debug_str(const MemState &mem, Ptr<char> data) {
-    return std::string(data.address() ? log_hex_fast(data.address()) + " " + data.get(mem) : "0x0 NULLPTR");
+    return std::string(data.address() ? log_hex(data.address()) + " " + data.get(mem) : "0x0 NULLPTR");
 }
 
 // Override for char pointers as the contents are readable
@@ -57,13 +57,13 @@ template <>
 inline std::string to_debug_str(const MemState &mem, char *data) {
     // Format for correct char* should be "(address in hex (0x12345)) (string)", this is just in the
     // extreme case that the string is actually "0x0 NULLPTR" and be confusing
-    return std::string(data ? log_hex_fast(Ptr<char *>(data, mem).address()) + " " + data : "0x0 NULLPTR");
+    return std::string(data ? log_hex(Ptr<char *>(data, mem).address()) + " " + data : "0x0 NULLPTR");
 }
 
 // Override for char pointers as the contents are readable
 template <>
 inline std::string to_debug_str(const MemState &mem, const char *data) {
-    return std::string(data ? log_hex_fast(Ptr<const char *>(data, mem).address()) + " " + data : "0x0 NULLPTR");
+    return std::string(data ? log_hex(Ptr<const char *>(data, mem).address()) + " " + data : "0x0 NULLPTR");
 }
 
 template <>


### PR DESCRIPTION
They produce the EXACT same output, but using stringstream is just wayy faster than using fmt::format, also decided to add a bit of documentation to them. in theory it should make games that do a lot of logging and that logging includes this function be a tiny bit faster