### PR TITLE
modules/SceNgs: Do not return error for sceNgsVoiceGetStateData if mem is null

### DIFF
--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -690,10 +690,9 @@ EXPORT(SceInt32, sceNgsVoiceGetStateData, SceNgsVoiceHandle voice_handle, const 
     if (!storage)
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
 
-    if (!mem)
-        return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
+    if (mem)
+        memcpy(mem, storage->voice_state_data.data(), std::min<std::size_t>(mem_size, storage->voice_state_data.size()));
 
-    std::memcpy(mem, storage->voice_state_data.data(), std::min<std::size_t>(mem_size, storage->voice_state_data.size()));
     return SCE_NGS_OK;
 }
 


### PR DESCRIPTION
This allows Trails of Cold Steel 2 to go ingame and fixes its sound.