### PR TITLE
gui: Correctly apply DPI scaling to fonts

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -148,9 +148,9 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         state.display.fullscreen = true;
         window_type |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
-#if defined(WIN32) || defined(__LINUX__)
+#if defined(WIN32) || defined(__linux__)
     const auto isSteamDeck = []() {
-#ifdef __LINUX__
+#ifdef __linux__
         std::ifstream file("/etc/os-release");
         if (file.is_open()) {
             std::string line;

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -154,7 +154,7 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
     ImGuiIO &io = ImGui::GetIO();
 
     ImFontConfig mono_font_config{};
-    mono_font_config.SizePixels = 13.f * emuenv.dpi_scale;
+    mono_font_config.SizePixels = 13.f;
 
 #ifdef _WIN32
     const auto monospaced_font_path = "C:\\Windows\\Fonts\\consola.ttf";
@@ -164,7 +164,7 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
 #endif
 
     // Set Large Font
-    static const ImWchar large_font_chars[] = { L'0', L'1', L'2', L'3', L'4', L'5', L'6', L'7', L'8', L'9', L':', L'A', L'M', L'P' };
+    static const ImWchar large_font_chars[] = { L'0', L'1', L'2', L'3', L'4', L'5', L'6', L'7', L'8', L'9', L':', L'A', L'M', L'P', 0 };
 
     // Set Fw font paths
     const auto fw_font_path{ fs::path(emuenv.pref_path) / "sa0/data/font/pvf" };
@@ -221,7 +221,7 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
         // Add fw font to imgui
 
         gui.fw_font = true;
-        font_config.SizePixels = 19.2f * emuenv.dpi_scale;
+        font_config.SizePixels = 19.2f;
 
         gui.vita_font = io.Fonts->AddFontFromFileTTF(latin_fw_font_path.string().c_str(), font_config.SizePixels, &font_config, latin_range);
         font_config.MergeMode = true;
@@ -235,22 +235,22 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
             io.Fonts->AddFontFromFileTTF((fw_font_path / "cn0.pvf").string().c_str(), font_config.SizePixels, &font_config, chinese_range);
         font_config.MergeMode = false;
 
-        large_font_config.SizePixels = 116.f * emuenv.dpi_scale;
+        large_font_config.SizePixels = 116.f;
         gui.large_font = io.Fonts->AddFontFromFileTTF(latin_fw_font_path.string().c_str(), large_font_config.SizePixels, &large_font_config, large_font_chars);
     } else {
         LOG_WARN("Could not find firmware font file at \"{}\", install firmware fonts package to fix this.", latin_fw_font_path.string());
-        font_config.SizePixels = 22.f * emuenv.dpi_scale;
+        font_config.SizePixels = 22.f;
 
         // Set up default font path
         const auto default_font_path{ fs::path(emuenv.base_path) / "data/fonts/mplus-1mn-bold.ttf" };
         // Check existence of default font file
         if (fs::exists(default_font_path)) {
-            gui.vita_font = io.Fonts->AddFontFromFileTTF(default_font_path.string().c_str(), 22.f * emuenv.dpi_scale, &font_config, latin_range);
+            gui.vita_font = io.Fonts->AddFontFromFileTTF(default_font_path.string().c_str(), font_config.SizePixels, &font_config, latin_range);
             font_config.MergeMode = true;
             io.Fonts->AddFontFromFileTTF(default_font_path.string().c_str(), font_config.SizePixels, &font_config, japanes_and_extra_ranges.Data);
             font_config.MergeMode = false;
 
-            large_font_config.SizePixels = 134.f * emuenv.dpi_scale;
+            large_font_config.SizePixels = 134.f;
             gui.large_font = io.Fonts->AddFontFromFileTTF(default_font_path.string().c_str(), large_font_config.SizePixels, &large_font_config, large_font_chars);
 
             LOG_INFO("Using default Vita3K font.");
@@ -262,6 +262,7 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
     io.Fonts->Build();
 
     // DPI scaling
+    io.FontGlobalScale = emuenv.dpi_scale;
     io.DisplayFramebufferScale = { emuenv.dpi_scale, emuenv.dpi_scale };
 }
 


### PR DESCRIPTION
Correctly apply the DPI scaling by scaling the original font instead of using a huge font atlas which for high enough DPI caused the font not to render.

Also do not use `__LINUX__` which is defined by SDL and not for Android, use `__linux__` instead.