### PR TITLE
io: use copy_options instead of copy_option

### DIFF
--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -712,7 +712,7 @@ bool copy_directories(const fs::path &src_path, const fs::path &dst_path) {
             LOG_INFO("Copy {}", dst_path.string());
 
             if (fs::is_regular_file(src))
-                fs::copy_file(src, dst_path, fs::copy_option::overwrite_if_exists);
+                fs::copy_file(src, dst_path, fs::copy_options::overwrite_existing);
             else if (!fs::exists(dst_path))
                 fs::create_directory(dst_path);
         }

--- a/vita3k/packages/src/license.cpp
+++ b/vita3k/packages/src/license.cpp
@@ -76,7 +76,7 @@ bool copy_license(EmuEnvState &emuenv, const fs::path &license_path) {
 
         const auto license_dst_path{ dst_path / fmt::format("{}.rif", emuenv.license_content_id) };
         if (license_path != license_dst_path) {
-            fs::copy_file(license_path, license_dst_path, fs::copy_option::overwrite_if_exists);
+            fs::copy_file(license_path, license_dst_path, fs::copy_options::overwrite_existing);
             if (fs::exists(license_dst_path)) {
                 LOG_INFO("Success copy license file to: {}", license_dst_path.string());
                 return true;

--- a/vita3k/renderer/src/shaders.cpp
+++ b/vita3k/renderer/src/shaders.cpp
@@ -214,7 +214,7 @@ shader::GeneratedShader load_shader_generic(shader::Target target, const SceGxmP
         if (fs::exists(shader_base_path)) {
             try {
                 const auto shader_dst_path = fs_utils::construct_file_name(base_path, shaders_cache_path, hash_hex_ver.c_str(), shader_type_str);
-                fs::copy_file(shader_base_path, shader_dst_path, fs::copy_option::overwrite_if_exists);
+                fs::copy_file(shader_base_path, shader_dst_path, fs::copy_options::overwrite_existing);
                 fs::remove(shader_base_path);
             } catch (std::exception &e) {
                 LOG_ERROR("Failed to moved shaders file: \n{}", e.what());


### PR DESCRIPTION
the use of copy_option enum was depracated in boost 1.74.0
> **Deprecated:** The `copy_option` enumeration that is used with the `copy_file` operation is deprecated. As a replacement, the new enum `copy_options` (note the trailing 's') has been added. The new enum contains values similar to the `copy_options` enum from C++20. The old enum values are mapped onto the new enum. The old enum will be removed in a future release.