### PR TITLE
renderer/vulkan/sync state: stub SCE_GXM_REGION_CLIP_INSIDE.

### DIFF
--- a/vita3k/renderer/src/vulkan/sync_state.cpp
+++ b/vita3k/renderer/src/vulkan/sync_state.cpp
@@ -54,8 +54,8 @@ void sync_clipping(VKContext &context) {
         break;
     case SCE_GXM_REGION_CLIP_INSIDE:
         // TODO: Implement SCE_GXM_REGION_CLIP_INSIDE
-        LOG_WARN("Unimplemented region clip mode used: SCE_GXM_REGION_CLIP_INSIDE");
-        context.scissor = vk::Rect2D{};
+        LOG_WARN("STUB SCE_GXM_REGION_CLIP_INSIDE");
+        context.scissor = vk::Rect2D{ { 0, 0 }, { context.render_target->width, context.render_target->height } };
         break;
     }
 


### PR DESCRIPTION
# About
- renderer/vulkan/sync state: stub SCE_GXM_REGION_CLIP_INSIDE.
should fix Ridge racer render in vulkan backend.


# Result
- fix yellow screen issue in vulkan
![image](https://user-images.githubusercontent.com/5261759/235406331-11e7422f-397b-475d-b395-6c10665ee9c9.png)
![image](https://user-images.githubusercontent.com/5261759/235406386-20a050d6-81e7-4587-807b-9e0496f1f82f.png)
