### PR TITLE
shader/renderer: Implement DEPTHF instruction and some depth buffer fixes

### DIFF
--- a/tools/usse-decoder-gen/grammar.yaml
+++ b/tools/usse-decoder-gen/grammar.yaml
@@ -1586,6 +1586,73 @@ LIMM:
         - imm_value_first_21bits:
             size: 21
             offset: 0
+
+DEPTHF:
+    description: Depth Replacement instruction
+    members:
+        - op1: '11111'
+        - op2:
+            match: '011'
+            size: 3
+            offset: 56
+        - sync:
+            size: 1
+            offset: 55
+            type: bool
+        - opcat: 
+            match: '11'
+            size: 2
+            offset: 52
+        - src0_bank_ext:
+            size: 1
+            offset: 51
+            type: bool
+        - end:
+            size: 1
+            offset: 50
+            type: bool
+        - src1_bank_ext:
+            size: 1
+            offset: 49
+        - src2_bank_ext:
+            size: 1
+            offset: 48
+        - nosched:
+            size: 1
+            offset: 43
+            type: bool
+        - pred:
+            type: ShortPredicate
+            size: 2
+            offset: 41
+        - two_sided:
+            size: 1
+            offset: 37
+            type: bool
+        - feedback:
+            size: 2
+            offset: 35
+        - src0_bank:
+            size: 1
+            offset: 34
+        - src1_bank:
+            size: 2
+            offset: 30
+        - src2_bank:
+            size: 2
+            offset: 28
+        - dest_n:
+            size: 7
+            offset: 21
+        - src0_n:
+            size: 7
+            offset: 14
+        - src1_n:
+            size: 7
+            offset: 7
+        - src2_n:
+            size: 7
+            offset: 0
         
 SPEC:
     description: Special

--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -323,12 +323,18 @@ enum SceGxmTextureAddrMode : uint32_t {
     SCE_GXM_TEXTURE_ADDR_CLAMP_HALF_BORDER = 0x00000007u
 };
 
+enum SceGxmMultisampleMode : uint16_t {
+    SCE_GXM_MULTISAMPLE_NONE,
+    SCE_GXM_MULTISAMPLE_2X,
+    SCE_GXM_MULTISAMPLE_4X
+};
+
 struct SceGxmRenderTargetParams {
     uint32_t flags;
     uint16_t width;
     uint16_t height;
     uint16_t scenesPerFrame;
-    uint16_t multisampleMode;
+    SceGxmMultisampleMode multisampleMode;
     uint32_t multisampleLocations;
     SceUID driverMemBlock;
 };
@@ -1057,12 +1063,6 @@ enum SceGxmMemoryAttribFlags {
     SCE_GXM_MEMORY_ATTRIB_READ = 1,
     SCE_GXM_MEMORY_ATTRIB_WRITE = 2,
     SCE_GXM_MEMORY_ATTRIB_RW = (SCE_GXM_MEMORY_ATTRIB_READ | SCE_GXM_MEMORY_ATTRIB_WRITE)
-};
-
-enum SceGxmMultisampleMode {
-    SCE_GXM_MULTISAMPLE_NONE,
-    SCE_GXM_MULTISAMPLE_2X,
-    SCE_GXM_MULTISAMPLE_4X
 };
 
 enum SceGxmAttributeFormat {

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -211,7 +211,7 @@ struct ShadersHash {
 
 struct RenderTarget {
     int holder;
-    uint16_t multisample_mode;
+    SceGxmMultisampleMode multisample_mode;
     virtual ~RenderTarget() = default;
 };
 

--- a/vita3k/renderer/include/renderer/vulkan/surface_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/surface_cache.h
@@ -92,8 +92,10 @@ struct DepthSurfaceView {
 
 struct DepthStencilSurfaceCacheInfo : public SurfaceCacheInfo {
     SceGxmDepthStencilSurface surface;
-    int32_t width;
-    int32_t height;
+    // dimensions of the depth buffer in memory
+    int32_t memory_width;
+    int32_t memory_height;
+    SceGxmMultisampleMode multisample_mode;
 
     // used when reading from this depth stencil in a shader
     std::vector<DepthSurfaceView> read_surfaces;

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -54,6 +54,7 @@ COMMAND(handle_set_context) {
         render_context->record.color_surface = *color_surface;
     } else {
         render_context->record.color_surface.data = nullptr;
+        render_context->record.color_surface.downscale = false;
     }
 
     if (color_surface)

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -158,10 +158,10 @@ COMMAND_SET_STATE(viewport) {
 
         const float xOffset = helper.pop<float>() / divide_factor;
         const float yOffset = helper.pop<float>() / divide_factor;
-        const float zOffset = helper.pop<float>() / divide_factor;
+        const float zOffset = helper.pop<float>();
         const float xScale = helper.pop<float>() / divide_factor;
         const float yScale = helper.pop<float>() / divide_factor;
-        const float zScale = helper.pop<float>() / divide_factor;
+        const float zScale = helper.pop<float>();
 
         const float ymin = yOffset + yScale;
         const float ymax = yOffset - yScale - 1;

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -36,7 +36,7 @@ namespace shader {
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
-static constexpr uint32_t CURRENT_VERSION = 8;
+static constexpr uint32_t CURRENT_VERSION = 9;
 
 struct RenderVertUniformBlock {
     std::array<float, 4> viewport_flip;

--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -55,6 +55,7 @@ public:
 
     spv::Block *main_block;
     spv::Id out;
+    spv::Id frag_depth_id = 0;
 
     // Contains repeat increasement offset
     int repeat_increase[4][17];
@@ -775,6 +776,23 @@ public:
         Imm2 dest_bank,
         Imm7 dest_num,
         Imm21 imm_value_first_21bits);
+
+    bool depthf(bool sync,
+        bool src0_bank_ext,
+        bool end,
+        Imm1 src1_bank_ext,
+        Imm1 src2_bank_ext,
+        bool nosched,
+        ShortPredicate pred,
+        bool two_sided,
+        Imm2 feedback,
+        Imm1 src0_bank,
+        Imm2 src1_bank,
+        Imm2 src2_bank,
+        Imm7 dest_n,
+        Imm7 src0_n,
+        Imm7 src1_n,
+        Imm7 src2_n);
 
     bool spec(bool special,
         SpecialCategory category);

--- a/vita3k/shader/include/shader/usse_translator_entry.h
+++ b/vita3k/shader/include/shader/usse_translator_entry.h
@@ -44,7 +44,7 @@ struct SpirvUtilFunctions;
 using NonDependentTextureQueryCallInfos = std::vector<NonDependentTextureQueryCallInfo>;
 
 void convert_gxp_usse_to_spirv(spv::Builder &b, const SceGxmProgram &program, const FeatureState &features, const SpirvShaderParameters &parameters, utils::SpirvUtilFunctions &utils,
-    spv::Function *begin_hook_func, spv::Function *end_hook_func, const NonDependentTextureQueryCallInfos &queries, const uint32_t render_info_id);
+    spv::Function *begin_hook_func, spv::Function *end_hook_func, const NonDependentTextureQueryCallInfos &queries, const uint32_t render_info_id, spv::Function *spv_func_main, std::vector<uint32_t> &interfaces);
 
 } // namespace usse
 } // namespace shader

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1251,9 +1251,9 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
 
 static void generate_shader_body(spv::Builder &b, const SpirvShaderParameters &parameters, const SceGxmProgram &program,
     const FeatureState &features, utils::SpirvUtilFunctions &utils, spv::Function *begin_hook_func, spv::Function *end_hook_func,
-    const NonDependentTextureQueryCallInfos &texture_queries, const spv::Id render_info_id) {
+    const NonDependentTextureQueryCallInfos &texture_queries, const spv::Id render_info_id, spv::Function *spv_func_main, std::vector<spv::Id> &interfaces) {
     // Do texture queries
-    usse::convert_gxp_usse_to_spirv(b, program, features, parameters, utils, begin_hook_func, end_hook_func, texture_queries, render_info_id);
+    usse::convert_gxp_usse_to_spirv(b, program, features, parameters, utils, begin_hook_func, end_hook_func, texture_queries, render_info_id, spv_func_main, interfaces);
 }
 
 static spv::Function *make_frag_finalize_function(spv::Builder &b, const SpirvShaderParameters &parameters,
@@ -1740,7 +1740,7 @@ static SpirvCode convert_gxp_to_spirv_impl(const SceGxmProgram &program, const s
             });
         }
 
-        generate_shader_body(b, parameters, program, features, utils, begin_hook_func, end_hook_func, texture_queries, translation_state.render_info_id);
+        generate_shader_body(b, parameters, program, features, utils, begin_hook_func, end_hook_func, texture_queries, translation_state.render_info_id, spv_func_main, translation_state.interfaces);
     } else {
         generate_update_mask_body(b, utils, features, translation_state);
     }


### PR DESCRIPTION
Implement the DEPTHF shader instruction, which allows modifying the depth in the fragment buffer.
Also contain some fixes concerning  depth buffer used when MSAA is enabled as their size is not the one expected.