### PR TITLE
modules/SceSysmodule: Improve sceSysmoduleIsLoaded check

### DIFF
--- a/vita3k/kernel/include/kernel/types.h
+++ b/vita3k/kernel/include/kernel/types.h
@@ -409,7 +409,7 @@ enum SceKernelMemBlockType {
     SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW = 0x09408060
 };
 
-enum SceSysmoduleModuleId {
+enum SceSysmoduleModuleId : uint16_t {
     SCE_SYSMODULE_INVALID = 0x0000,
     SCE_SYSMODULE_NET = 0x0001,
     SCE_SYSMODULE_HTTP = 0x0002,


### PR DESCRIPTION
The Caligula effect initializes NGS only if the NGS submodule is not loaded yet.
By returning HLEd submodule as unloaded before  the matching load is called, this allows the game to boot further.