### PR TITLE
Fix assertion in AacDecoderState::receive

### DIFF
--- a/vita3k/codec/src/aac.cpp
+++ b/vita3k/codec/src/aac.cpp
@@ -104,7 +104,7 @@ bool AacDecoderState::receive(uint8_t *data, DecoderSize *size) {
 
     if (data) {
         int ret = swr_convert(swr, &data, frame->nb_samples, const_cast<const uint8_t **>(frame->extended_data), frame->nb_samples);
-        assert(ret == 0);
+        assert(ret >= 0);
     }
 
     if (size) {


### PR DESCRIPTION
According to docs (https://ffmpeg.org/doxygen/3.2/group__lswr.html#gaa5bb6cab830146efa8c760fa66ee582a) swr_convert returns number of samples output per channel, negative value on error.
Not sure if this correct.
Fixes crash Zero Escape: The Nonary Games (it will crash anyway after few secs).