### PR TITLE
ctrl: Improve accuracy of controller functions

### DIFF
--- a/vita3k/ctrl/CMakeLists.txt
+++ b/vita3k/ctrl/CMakeLists.txt
@@ -9,5 +9,5 @@ add_library(
 
 target_include_directories(ctrl PUBLIC include)
 target_link_libraries(ctrl PUBLIC emuenv sdl2 util)
-target_link_libraries(ctrl PRIVATE config dialog)
+target_link_libraries(ctrl PRIVATE config dialog display kernel)
 

--- a/vita3k/ctrl/include/ctrl/ctrl.h
+++ b/vita3k/ctrl/include/ctrl/ctrl.h
@@ -79,7 +79,7 @@ struct SceCtrlData2 {
     SceUInt8 rx; //!< R analog controller (X-axis)
     SceUInt8 ry; //!< R analog controller (Y-axis)
     SceUInt8 up; //!< Up press value
-    SceUInt8 right; ///!< Right epress value
+    SceUInt8 right; ///!< Right press value
     SceUInt8 down; //!< Down press value
     SceUInt8 left; //!< Left press value
     SceUInt8 l2; //!< L2 press value

--- a/vita3k/ctrl/include/ctrl/functions.h
+++ b/vita3k/ctrl/include/ctrl/functions.h
@@ -21,6 +21,5 @@
 #include <emuenv/state.h>
 
 SceCtrlExternalInputMode get_type_of_controller(const int idx);
-int peek_data(EmuEnvState &emuenv, int port, SceCtrlData *&pad_data, int count, bool negative, bool from_ext_function);
-int peek_data(EmuEnvState &emuenv, int port, SceCtrlData2 *&pad_data, int count, bool negative, bool from_ext_function);
+int ctrl_get(const SceUID thread_id, EmuEnvState &emuenv, int port, SceCtrlData2 *pData, SceUInt32 count, bool negative, bool is_peek, bool is_v2, bool from_ext);
 void refresh_controllers(CtrlState &state);

--- a/vita3k/ctrl/include/ctrl/state.h
+++ b/vita3k/ctrl/include/ctrl/state.h
@@ -50,4 +50,7 @@ struct CtrlState {
     bool free_ports[SCE_CTRL_MAX_WIRELESS_NUM] = { true, true, true, true };
     SceCtrlPadInputMode input_mode = SCE_CTRL_MODE_DIGITAL;
     SceCtrlPadInputMode input_mode_ext = SCE_CTRL_MODE_DIGITAL;
+
+    // last vsync the data was read
+    uint64_t last_vcount[5] = {};
 };

--- a/vita3k/modules/SceCtrl/SceCtrl.cpp
+++ b/vita3k/modules/SceCtrl/SceCtrl.cpp
@@ -107,14 +107,12 @@ EXPORT(int, sceCtrlGetSamplingModeExt, SceCtrlPadInputMode *mode) {
 
 EXPORT(int, sceCtrlGetWirelessControllerInfo, SceCtrlWirelessControllerInfo *pInfo) {
     TRACY_FUNC(sceCtrlGetWirelessControllerInfo, pInfo);
+    memset(pInfo->connected, SCE_CTRL_WIRELESS_INFO_NOT_CONNECTED, sizeof(pInfo->connected));
     if (emuenv.cfg.current_config.pstv_mode) {
         CtrlState &state = emuenv.ctrl;
         refresh_controllers(state);
-        if (state.controllers_num) {
-            for (auto i = 0; i < state.controllers_num; i++)
-                pInfo->connected[i] = SCE_CTRL_WIRELESS_INFO_CONNECTED;
-        } else
-            pInfo->connected[0] = SCE_CTRL_WIRELESS_INFO_NOT_CONNECTED;
+        for (auto i = 0; i < state.controllers_num; i++)
+            pInfo->connected[i] = SCE_CTRL_WIRELESS_INFO_CONNECTED;
     }
 
     return 0;
@@ -127,98 +125,62 @@ EXPORT(bool, sceCtrlIsMultiControllerSupported) {
 
 EXPORT(int, sceCtrlPeekBufferNegative, int port, SceCtrlData *pad_data, int count) {
     TRACY_FUNC(sceCtrlPeekBufferNegative, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, true, false);
+    return ctrl_get(thread_id, emuenv, port, reinterpret_cast<SceCtrlData2 *>(pad_data), count, true, true, false, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferNegative2, int port, SceCtrlData2 *pad_data, int count) {
     TRACY_FUNC(sceCtrlPeekBufferNegative2, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, true, false);
+    return ctrl_get(thread_id, emuenv, port, pad_data, count, true, true, true, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositive, int port, SceCtrlData *pad_data, int count) {
     TRACY_FUNC(sceCtrlPeekBufferPositive, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, false, false);
+    return ctrl_get(thread_id, emuenv, port, reinterpret_cast<SceCtrlData2 *>(pad_data), count, false, true, false, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositive2, int port, SceCtrlData2 *pad_data, int count) {
     TRACY_FUNC(sceCtrlPeekBufferPositive2, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, false, false);
+    return ctrl_get(thread_id, emuenv, port, pad_data, count, false, true, true, false);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositiveExt, int port, SceCtrlData *pad_data, int count) {
     TRACY_FUNC(sceCtrlPeekBufferPositiveExt, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, false, true);
+    return ctrl_get(thread_id, emuenv, port, reinterpret_cast<SceCtrlData2 *>(pad_data), count, false, true, false, true);
 }
 
 EXPORT(int, sceCtrlPeekBufferPositiveExt2, int port, SceCtrlData2 *pad_data, int count) {
     TRACY_FUNC(sceCtrlPeekBufferPositiveExt2, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, false, true);
+    return ctrl_get(thread_id, emuenv, port, pad_data, count, false, true, true, true);
 }
 
 EXPORT(int, sceCtrlReadBufferNegative, int port, SceCtrlData *pad_data, int count) {
     TRACY_FUNC(sceCtrlReadBufferNegative, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, true, false);
+    return ctrl_get(thread_id, emuenv, port, reinterpret_cast<SceCtrlData2 *>(pad_data), count, true, false, false, false);
 }
 
 EXPORT(int, sceCtrlReadBufferNegative2, int port, SceCtrlData2 *pad_data, int count) {
     TRACY_FUNC(sceCtrlReadBufferNegative2, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, true, false);
+    return ctrl_get(thread_id, emuenv, port, pad_data, count, true, false, true, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositive, int port, SceCtrlData *pad_data, int count) {
     TRACY_FUNC(sceCtrlReadBufferPositive, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, false, false);
+    return ctrl_get(thread_id, emuenv, port, reinterpret_cast<SceCtrlData2 *>(pad_data), count, false, false, false, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositive2, int port, SceCtrlData2 *pad_data, int count) {
     TRACY_FUNC(sceCtrlReadBufferPositive2, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, false, false);
+    return ctrl_get(thread_id, emuenv, port, pad_data, count, false, false, true, false);
 }
 
 EXPORT(int, sceCtrlReadBufferPositiveExt, int port, SceCtrlData *pad_data, int count) {
     TRACY_FUNC(sceCtrlReadBufferPositiveExt, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, false, true);
+    return ctrl_get(thread_id, emuenv, port, reinterpret_cast<SceCtrlData2 *>(pad_data), count, false, false, false, true);
 }
 
 EXPORT(int, sceCtrlReadBufferPositiveExt2, int port, SceCtrlData2 *pad_data, int count) {
     TRACY_FUNC(sceCtrlReadBufferPositiveExt2, port, pad_data, count);
-    if (port > 1 && !emuenv.cfg.current_config.pstv_mode) {
-        return RET_ERROR(SCE_CTRL_ERROR_NO_DEVICE);
-    }
-    return peek_data(emuenv, port, pad_data, count, false, true);
+    return ctrl_get(thread_id, emuenv, port, pad_data, count, false, false, true, true);
 }
 
 EXPORT(int, sceCtrlRegisterBdRMCCallback) {


### PR DESCRIPTION
Improve accuracy of the peak/read functions.
In particular, the read function can cause the calling thread to enter a wait state and the number of buffer returned can be lower than the number of buffer asked. Also return correct timestamps.

This allows A-men games to be playable.