### PR TITLE
kernel: Fix compressed self dump

### DIFF
--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -559,6 +559,7 @@ SceUID load_self(Ptr<const void> &entry_point, KernelState &kernel, MemState &me
     if (kernel.debugger.dump_elfs) {
         // Dump elf
         std::vector<uint8_t> dump_elf(self_bytes + self_header.header_len, self_bytes + self_header.self_filesize);
+        dump_elf.resize(self_header.elf_filesize);
         Elf32_Phdr *dump_segments = reinterpret_cast<Elf32_Phdr *>(dump_elf.data() + elf.e_phoff);
         uint16_t last_index = 0;
         for (const auto &[seg_index, segment] : segment_reloc_info) {


### PR DESCRIPTION
When the self file is compressed, the elf size is no longer equal to the self size (minus the self header). This causes the dumped elf to be corrupted and an out of bound write when dumping an elf.

This PR fixes elf dump for homebrew apps (which are to my knowledge the only self files with compressed segments).