### PR TITLE
renderer/texture_cache: fix block size set and execute for UBC1/4.

### DIFF
--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -381,7 +381,7 @@ static void remove_compressed_arbitrary_blocks(SceGxmTextureBaseFormat fmt, void
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
     case SCE_GXM_TEXTURE_BASE_FORMAT_SBC4:
         block_size = 8;
-        return;
+        break;
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:


### PR DESCRIPTION
# About:
- fix stupid fail on typo for set block size and allow continue execute fonction


# Result:
- fix all background texture using UBC1 in arbitrary texture type.
![image](https://cdn.discordapp.com/attachments/442344583293304833/1106162363679375360/image.png)
![image](https://cdn.discordapp.com/attachments/442344583293304833/1106163236040085504/image.png)
![image](https://github.com/Vita3K/Vita3K/assets/5261759/57dff486-9ce6-4ea1-84e2-c5eec41a3630)
