### PR TITLE
gui/themes: refactor display background, allow respect aspect ratio.

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -105,6 +105,7 @@ void draw_vita_area(GuiState &gui, EmuEnvState &emuenv);
 void draw_ui(GuiState &gui, EmuEnvState &emuenv);
 
 void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path);
+void draw_background(GuiState &gui, EmuEnvState &emuenv);
 void draw_common_dialog(GuiState &gui, EmuEnvState &emuenv);
 void draw_ime(Ime &ime, EmuEnvState &emuenv);
 void draw_info_message(GuiState &gui, EmuEnvState &emuenv);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -339,6 +339,14 @@ struct GuiState {
     std::uint64_t current_user_bg;
     std::map<std::string, ImGui_Texture> user_backgrounds;
 
+    struct UserBackgroundInfos {
+        ImVec2 prev_pos;
+        ImVec2 pos;
+        ImVec2 prev_size;
+        ImVec2 size;
+    };
+    std::map<std::string, UserBackgroundInfos> user_backgrounds_infos;
+
     std::map<std::string, std::map<std::string, ImGui_Texture>> trophy_np_com_id_list_icons;
     std::map<std::string, ImGui_Texture> trophy_list;
 

--- a/vita3k/gui/src/home_screen.cpp
+++ b/vita3k/gui/src/home_screen.cpp
@@ -381,14 +381,11 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
     const auto SCALE = ImVec2(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
     const auto INFORMATION_BAR_HEIGHT = 32.f * SCALE.y;
-    const auto MENUBAR_BG_HEIGHT = (!emuenv.cfg.show_info_bar && emuenv.display.imgui_render) || !gui.vita_area.information_bar ? 22.f * SCALE.x : INFORMATION_BAR_HEIGHT;
-
-    const auto is_background = (gui.users[emuenv.io.user_id].use_theme_bg && !gui.theme_backgrounds.empty()) || !gui.user_backgrounds.empty();
 
     ImGui::SetNextWindowPos(ImVec2(0, INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(display_size.x, display_size.y - INFORMATION_BAR_HEIGHT), ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
-    ImGui::SetNextWindowBgAlpha(is_background ? emuenv.cfg.background_alpha : 0.f);
+    ImGui::SetNextWindowBgAlpha(emuenv.cfg.background_alpha);
     ImGui::Begin("##home_screen", &gui.vita_area.home_screen, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
     if (!emuenv.display.imgui_render || ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows))
         gui.vita_area.information_bar = true;
@@ -419,27 +416,14 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
         while (last_time["home"] + emuenv.cfg.delay_background < current_time()) {
             last_time["home"] += emuenv.cfg.delay_background;
 
-            if (gui.users[emuenv.io.user_id].use_theme_bg) {
-                if (gui.current_theme_bg < uint64_t(gui.theme_backgrounds.size() - 1))
-                    ++gui.current_theme_bg;
-                else
-                    gui.current_theme_bg = 0;
-            } else {
-                if (gui.user_backgrounds.size() > 1) {
-                    if (gui.current_user_bg < uint64_t(gui.user_backgrounds.size() - 1))
-                        ++gui.current_user_bg;
-                    else
-                        gui.current_user_bg = 0;
-                }
-            }
+            if (gui.users[emuenv.io.user_id].use_theme_bg)
+                gui.current_theme_bg = ++gui.current_theme_bg % uint64_t(gui.theme_backgrounds.size());
+            else if (gui.user_backgrounds.size() > 1)
+                gui.current_user_bg = ++gui.current_user_bg % uint64_t(gui.user_backgrounds.size());
         }
     }
 
-    if (is_background)
-        ImGui::GetBackgroundDrawList()->AddImage((gui.users[emuenv.io.user_id].use_theme_bg && !gui.theme_backgrounds.empty()) ? gui.theme_backgrounds[gui.current_theme_bg] : gui.user_backgrounds[gui.users[emuenv.io.user_id].backgrounds[gui.current_user_bg]],
-            ImVec2(0.f, MENUBAR_BG_HEIGHT), display_size);
-    else
-        ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, MENUBAR_BG_HEIGHT), display_size, IM_COL32(11.f, 90.f, 252.f, 160.f), 0.f, ImDrawFlags_RoundCornersAll);
+    draw_background(gui, emuenv);
 
     const ImVec2 VIEWPORT_RES_SCALE(emuenv.viewport_size.x / emuenv.res_width_dpi_scale, emuenv.viewport_size.y / emuenv.res_height_dpi_scale);
     const ImVec2 VIEWPORT_SCALE(VIEWPORT_RES_SCALE.x * emuenv.dpi_scale, VIEWPORT_RES_SCALE.y * emuenv.dpi_scale);

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -518,23 +518,18 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 display_size = ImGui::GetIO().DisplaySize;
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
     const auto SCALE = ImVec2(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
-    const auto INFORMATION_BAR_HEIGHT = 32.f * SCALE.y;
 
     const auto app_path = gui.apps_list_opened[gui.current_app_selected];
     const VitaIoDevice app_device = app_path.find("NPXS") != std::string::npos ? VitaIoDevice::vs0 : VitaIoDevice::ux0;
-    const auto is_background = (gui.users[emuenv.io.user_id].use_theme_bg && !gui.theme_backgrounds.empty()) || !gui.user_backgrounds.empty();
 
     ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
 
-    ImGui::SetNextWindowBgAlpha(is_background ? 0.5f : 0.f);
+    ImGui::SetNextWindowBgAlpha(0.3f);
     ImGui::Begin("##live_area", &gui.vita_area.live_area_screen, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
-    if (is_background)
-        ImGui::GetBackgroundDrawList()->AddImage((gui.users[emuenv.io.user_id].use_theme_bg && !gui.theme_backgrounds.empty()) ? gui.theme_backgrounds[gui.current_theme_bg] : gui.user_backgrounds[gui.users[emuenv.io.user_id].backgrounds[gui.current_user_bg]],
-            ImVec2(0.f, 32.f), display_size);
-    else
-        ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, INFORMATION_BAR_HEIGHT), display_size, IM_COL32(11.f, 90.f, 252.f, 180.f), 0.f, ImDrawFlags_RoundCornersAll);
+    // Draw background
+    ImGui::GetBackgroundDrawList()->AddRectFilled(ImVec2(0.f, 0.f), display_size, IM_COL32(11.f, 90.f, 252.f, 160.f), 0.f, ImDrawFlags_RoundCornersAll);
 
     const auto background_pos = ImVec2(900.0f * SCALE.x, 500.0f * SCALE.y);
     const auto pos_bg = ImVec2(display_size.x - background_pos.x, display_size.y - background_pos.y);

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -613,6 +613,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     const auto bg = std::find(gui.users[emuenv.io.user_id].backgrounds.begin(), gui.users[emuenv.io.user_id].backgrounds.end(), delete_user_background);
                     gui.users[emuenv.io.user_id].backgrounds.erase(bg);
                     gui.user_backgrounds.erase(delete_user_background);
+                    gui.user_backgrounds_infos.erase(delete_user_background);
                     if (gui.users[emuenv.io.user_id].backgrounds.size())
                         gui.current_user_bg = 0;
                     else if (!gui.theme_backgrounds.empty())
@@ -621,13 +622,16 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     delete_user_background.clear();
                 }
 
-                ImGui::SetWindowFontScale(0.90f);
+                ImGui::SetWindowFontScale(0.80f);
                 ImGui::Columns(3, nullptr, false);
                 ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.5f, 1.0f));
                 for (const auto &background : gui.users[emuenv.io.user_id].backgrounds) {
-                    const auto IMAGE_POS = ImGui::GetCursorPosY();
-                    ImGui::Image(gui.user_backgrounds[background], SIZE_PACKAGE);
-                    ImGui::SetCursorPosY(IMAGE_POS);
+                    const auto IMAGE_POS = ImGui::GetCursorPos();
+                    const auto PREVIEW_POS = ImVec2(IMAGE_POS.x + (gui.user_backgrounds_infos[background].prev_pos.x * SCALE.x), IMAGE_POS.y + (gui.user_backgrounds_infos[background].prev_pos.y * SCALE.y));
+                    const auto PREVIEW_SIZE = ImVec2(gui.user_backgrounds_infos[background].prev_size.x * SCALE.x, gui.user_backgrounds_infos[background].prev_size.y * SCALE.y);
+                    ImGui::SetCursorPos(PREVIEW_POS);
+                    ImGui::Image(gui.user_backgrounds[background], PREVIEW_SIZE);
+                    ImGui::SetCursorPosY(IMAGE_POS.y);
                     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
                     ImGui::PushID(background.c_str());
                     if (ImGui::Selectable(theme_background.home_screen_backgrounds["delete_background"].c_str(), false, ImGuiSelectableFlags_None, SIZE_PACKAGE))
@@ -640,7 +644,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     std::filesystem::path background_path = "";
                     host::dialog::filesystem::Result result = host::dialog::filesystem::open_file(background_path, { { "Image file", { "bmp", "gif", "jpg", "png", "tif" } } });
 
-                    if ((result == host::dialog::filesystem::Result::SUCCESS) && (gui.user_backgrounds.find(background_path.string()) == gui.user_backgrounds.end())) {
+                    if ((result == host::dialog::filesystem::Result::SUCCESS) && (!gui.user_backgrounds.contains(background_path.string()))) {
                         if (init_user_background(gui, emuenv, emuenv.io.user_id, background_path.string())) {
                             gui.users[emuenv.io.user_id].backgrounds.push_back(background_path.string());
                             gui.users[emuenv.io.user_id].use_theme_bg = false;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -339,16 +339,12 @@ int main(int argc, char *argv[]) {
         const auto pos_min = ImVec2(emuenv.viewport_pos.x, emuenv.viewport_pos.y);
         const auto pos_max = ImVec2(pos_min.x + emuenv.viewport_size.x, pos_min.y + emuenv.viewport_size.y);
 
-        if (gui.apps_background.find(emuenv.io.app_path) != gui.apps_background.end())
+        if (gui.apps_background.contains(emuenv.io.app_path))
             // Display application background
             ImGui::GetBackgroundDrawList()->AddImage(gui.apps_background[emuenv.io.app_path], pos_min, pos_max);
         // Application background not found
-        else if (!gui.theme_backgrounds.empty())
-            // Display theme background if exist
-            ImGui::GetBackgroundDrawList()->AddImage(gui.theme_backgrounds[0], pos_min, pos_max);
-        else if (!gui.user_backgrounds.empty())
-            // Display user background if exist
-            ImGui::GetBackgroundDrawList()->AddImage(gui.user_backgrounds[gui.users[emuenv.io.user_id].backgrounds[0]], pos_min, pos_max);
+        else
+            gui::draw_background(gui, emuenv);
     };
 
     Ptr<const void> entry_point;


### PR DESCRIPTION
# About:
- Allow respect size of user background for no deforme it
- user management: small refactor of calculate size for keep aspect ratio.

# Result
- in preview
![image](https://github.com/Vita3K/Vita3K/assets/5261759/5418f751-e798-4e0b-820a-2d090ae376f6)


![image](https://github.com/Vita3K/Vita3K/assets/5261759/ac457009-f6bf-433b-aa3d-5521124c4a50)
![image](https://github.com/Vita3K/Vita3K/assets/5261759/da62ddeb-d524-490a-b731-98c21c0acbd7)
![image](https://github.com/Vita3K/Vita3K/assets/5261759/17d46e9f-8c33-403f-ab6c-931533a07d58)
![image](https://github.com/Vita3K/Vita3K/assets/5261759/dab4b763-f752-468b-a3a8-4eab29e53b4e)
