### PR TITLE
Vita3k: Using FreeConsole for Windows for execv and updater and little more

### DIFF
--- a/vita3k/Vita3K.rc
+++ b/vita3k/Vita3K.rc
@@ -87,7 +87,7 @@ BEGIN
             VALUE "FileDescription", "Vita3K PSVita Emulator"
             VALUE "FileVersion", FILE_VERSION_STR "\0"
             VALUE "InternalName", "Vita3K.exe"
-            VALUE "LegalCopyright", "Copyright (C) 2022"
+            VALUE "LegalCopyright", "Copyright (C) 2018-2023"
             VALUE "OriginalFilename", "Vita3K.exe"
             VALUE "ProductName", "Vita3K"
             VALUE "ProductVersion", FILE_VERSION_STR "\0"

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -74,7 +74,9 @@ static void run_execv(char *argv[], EmuEnvState &emuenv) {
     } else
         args[3] = NULL;
 
+    // Execute the emulator again with some arguments
 #ifdef WIN32
+    FreeConsole();
     _execv(argv[0], args);
 #elif defined(__unix__) || defined(__APPLE__) && defined(__MACH__)
     execv(argv[0], args);

--- a/vita3k/script/update-windows.bat
+++ b/vita3k/script/update-windows.bat
@@ -1,5 +1,6 @@
 @echo off
 color 2
+title Vita3K Updater
 echo ============================================================
 echo ====================== Vita3K Updater ======================
 echo ============================================================
@@ -61,4 +62,7 @@ if exist vita3k-latest.zip (
 ) else if %boot% EQU 0 (
     echo Download failed, please try again by running the script as administrator.
 )
-pause
+
+if %boot% EQU 0 (
+    pause
+)

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -82,6 +82,7 @@ ExitCode init(const Root &root_paths, bool use_stdout) {
 #ifdef WIN32
     // set console codepage to UTF-8
     SetConsoleOutputCP(65001);
+    SetConsoleTitle("Vita3K PSVita Emulator");
 #endif
 
     register_log_exception_handler();


### PR DESCRIPTION
# About
- Vita3k: Using FreeConsole for Windows for execv and updater
- Set console title.
- should fix load exec with using windows 11 terminal.