### PR TITLE
renderer/vulkan: Add additional FP16 check

### DIFF
--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -435,6 +435,13 @@ bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state
             }
         }
 
+        support_fsr &= static_cast<bool>(physical_device_features.shaderInt16);
+        if (support_fsr) {
+            // double check for FP16 support
+            auto props = physical_device.getFeatures2KHR<vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceShaderFloat16Int8Features>();
+            support_fsr = static_cast<bool>(props.get<vk::PhysicalDeviceShaderFloat16Int8Features>().shaderFloat16);
+        }
+
         // We use subpass input to get something similar to direct fragcolor access (there is no difference for the shader)
         features.direct_fragcolor = true;
 


### PR DESCRIPTION
Add an additional FP16 check for FSR, didn't think there would be GPUs which support int8 but not fp16.

This should fix #2602 .