### PR TITLE
renderer,shader: Improve Vita's MSAA handling

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -230,7 +230,7 @@ struct VKRenderTarget : public renderer::RenderTarget {
     // the command buffer index we're at in a frame
     int cmd_buffer_idx = 0;
 
-    VKRenderTarget(VKState &state, vma::Allocator allocator, uint16_t width, uint16_t height, uint16_t samples_per_frame);
+    VKRenderTarget(VKState &state, const SceGxmRenderTargetParams &params);
     ~VKRenderTarget() override = default;
 };
 

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -155,7 +155,13 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
     }
     frag_ublock.writing_mask = context.record.writing_mask;
     frag_ublock.use_raw_image = static_cast<float>(use_raw_image);
-    frag_ublock.res_multiplier = renderer.res_multiplier;
+    frag_ublock.res_multiplier = static_cast<float>(renderer.res_multiplier);
+    const bool has_msaa = context.render_target->multisample_mode;
+    const bool has_downscale = context.record.color_surface.downscale;
+    if (has_msaa && !has_downscale)
+        frag_ublock.res_multiplier *= 2;
+    else if (!has_msaa && has_downscale)
+        frag_ublock.res_multiplier /= 2;
 
     if (memcmp(&context.previous_frag_info, &frag_ublock, sizeof(shader::RenderFragUniformBlock)) != 0) {
         std::pair<std::uint8_t *, std::size_t> allocated_buffer = context.fragment_info_uniform_buffer.allocate(sizeof(shader::RenderFragUniformBlock));

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -334,7 +334,7 @@ bool create(GLState &state, std::unique_ptr<RenderTarget> &rt, const SceGxmRende
     glBindTexture(GL_TEXTURE_2D, render_target->masktexture[0]);
     // we need to make the masktexture format immutable, otherwise image load operations
     // won't work on mesa drivers
-    glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, params.width, params.height);
+    glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, params.width * state.res_multiplier, params.height * state.res_multiplier);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glBindFramebuffer(GL_FRAMEBUFFER, render_target->maskbuffer[0]);

--- a/vita3k/renderer/src/vulkan/creation.cpp
+++ b/vita3k/renderer/src/vulkan/creation.cpp
@@ -163,7 +163,7 @@ VKContext::VKContext(VKState &state, MemState &mem)
 }
 
 VKRenderTarget::VKRenderTarget(VKState &state, const SceGxmRenderTargetParams &params)
-    : mask(state.allocator, params.width, params.height, vk::Format::eR8G8B8A8Unorm)
+    : mask(state.allocator, params.width * state.res_multiplier, params.height * state.res_multiplier, vk::Format::eR8G8B8A8Unorm)
     , color(state.allocator, params.width * state.res_multiplier, params.height * state.res_multiplier, vk::Format::eR8G8B8A8Unorm)
     , depthstencil(state.allocator, params.width * state.res_multiplier, params.height * state.res_multiplier, vk::Format::eD32SfloatS8Uint) {
     width = params.width * state.res_multiplier;

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -410,10 +410,15 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
     }
 
     shader::RenderFragUniformBlockWithMapping &frag_ublock = context.current_frag_render_info;
-
     frag_ublock.writing_mask = context.record.writing_mask;
-    frag_ublock.use_raw_image = 0;
-    frag_ublock.res_multiplier = context.state.res_multiplier;
+    frag_ublock.res_multiplier = static_cast<float>(context.state.res_multiplier);
+    const bool has_msaa = context.render_target->multisample_mode;
+    const bool has_downscale = context.record.color_surface.downscale;
+    if (has_msaa && !has_downscale)
+        frag_ublock.res_multiplier *= 2;
+    else if (!has_msaa && has_downscale)
+        frag_ublock.res_multiplier /= 2;
+
     const size_t frag_ublock_size = use_memory_mapping ? sizeof(shader::RenderFragUniformBlockWithMapping) : sizeof(shader::RenderFragUniformBlock);
 
     if (memcmp(&context.previous_frag_info, &frag_ublock, frag_ublock_size) != 0) {

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -36,7 +36,7 @@ namespace shader {
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
-static constexpr uint32_t CURRENT_VERSION = 9;
+static constexpr uint32_t CURRENT_VERSION = 10;
 
 struct RenderVertUniformBlock {
     std::array<float, 4> viewport_flip;
@@ -64,11 +64,11 @@ enum VertUniformFieldId : uint32_t {
 };
 
 struct RenderFragUniformBlock {
-    float back_disabled = 0;
-    float front_disabled = 0;
-    float writing_mask = 0;
-    float use_raw_image = 0;
-    int32_t res_multiplier = 0;
+    float back_disabled;
+    float front_disabled;
+    float writing_mask;
+    float use_raw_image;
+    float res_multiplier;
 };
 
 struct RenderFragUniformBlockWithMapping : public RenderFragUniformBlock {


### PR DESCRIPTION
Improve the handling of MSAA'd non-downscaled surfaces and the opposite (downscaled non-MSAA'd surfaces) by both the renderer and the shaders.
This information is passed to the shader using the res_multiplier variable which now has to be a float. Moreover, the fragCoord variable used by the recompiled shader was not taking it into account previously.

I also had to make a few changes, like making the mask texture be upscaled in OpenGL for it to work as planned.

This should fix a lot of the special affects appearing only on the top-left corner. It does so for Gravity Rush and Samurai warrior 4.