### PR TITLE
gui: Fix allocations dialog typo and incorrect type

### DIFF
--- a/vita3k/gui/src/allocations_dialog.cpp
+++ b/vita3k/gui/src/allocations_dialog.cpp
@@ -48,7 +48,7 @@ void draw_allocations_dialog(GuiState &gui, EmuEnvState &emuenv) {
             continue;
 
         if (ImGui::TreeNode(fmt::format("{}: {}", generation_num, generation_name).c_str())) {
-            ImGui::Text("Range %08llx - %08llx.", generation_num * KiB(4), (generation_num + page.size) * KiB(4));
+            ImGui::Text("Range 0x%08zx - 0x%08zx.", generation_num * KiB(4), (generation_num + page.size) * KiB(4));
             ImGui::Text("Size: %i KiB (%i page[s])", page.size * 4, page.size);
             if (ImGui::Selectable("View/Edit")) {
                 gui.memory_editor_start = generation_num * KiB(4);

--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -486,7 +486,7 @@ SceUID load_self(Ptr<const void> &entry_point, KernelState &kernel, MemState &me
         } else if (seg_header.p_type == PT_LOAD) {
             if (seg_header.p_memsz != 0) {
                 Address segment_address = 0;
-                auto alloc_name = fmt::format("{}:seg%d", self_path, seg_index);
+                auto alloc_name = fmt::format("{}:seg{}", self_path, seg_index);
 
                 // TODO: when the virtual process bringup is fixed, uncomment this
                 // Try allocating at image base for RELEXEC to avoid having to relocate the main module


### PR DESCRIPTION
ranges are 32 bit, not 64, also segment indicator wasnt working
![image](https://github.com/Vita3K/Vita3K/assets/30161277/219237d2-ad83-4a08-881b-03df16b6638e)
