### PR TITLE
modules/SceGxm, renderer/vulkan: Implement visibility buffer using occlusion queries

### DIFF
--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -77,6 +77,8 @@ void set_region_clip(State &state, Context *ctx, SceGxmRegionClipMode mode, unsi
 void set_two_sided_enable(State &state, Context *ctx, SceGxmTwoSidedMode mode);
 void set_side_fragment_program_enable(State &state, Context *ctx, const bool is_front, SceGxmFragmentProgramMode mode);
 void set_uniform_buffer(State &state, Context *ctx, const bool is_vertex_uniform, const int block_num, const std::uint16_t buffer_size, const Ptr<const void> buffer);
+void set_visibility_buffer(State &state, Context *ctx, Ptr<uint32_t> visibility_address, uint32_t visibility_stride);
+void set_visibility_index(State &state, Context *ctx, bool enable, uint32_t index);
 
 void set_context(State &state, Context *ctx, RenderTarget *target, SceGxmColorSurface *color_surface, SceGxmDepthStencilSurface *depth_stencil_surface);
 void set_vertex_stream(State &state, Context *ctx, const std::size_t index, const std::size_t data_len, const Ptr<const void> stream);

--- a/vita3k/renderer/include/renderer/gxm_types.h
+++ b/vita3k/renderer/include/renderer/gxm_types.h
@@ -229,6 +229,10 @@ struct GxmContextState {
     Ptr<SceGxmDeferredContextCallback> vdm_memory_callback;
     Ptr<void> memory_callback_userdata;
 
+    // Visibility buffer
+    bool visibility_enable = false;
+    uint32_t visibility_index;
+
     bool active = false;
 };
 

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -80,6 +80,8 @@ enum class GXMState : std::uint16_t {
     CullMode,
     UniformBuffer,
     FragmentProgramEnable,
+    VisibilityBuffer,
+    VisibilityIndex,
     TotalState
 };
 

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -52,6 +52,8 @@ void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTe
 void sync_viewport_flat(VKContext &context);
 void sync_viewport_real(VKContext &context, const float xOffset, const float yOffset, const float zOffset,
     const float xScale, const float yScale, const float zScale);
+void sync_visibility_buffer(VKContext &context, Ptr<uint32_t> buffer, uint32_t stride);
+void sync_visibility_index(VKContext &context, bool enable, uint32_t index);
 
 void refresh_pipeline(VKContext &context);
 

--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -97,6 +97,15 @@ struct MappedMemory {
 
 struct ColorSurfaceCacheInfo;
 
+// Use vulkan queries to implement visibility buffer
+struct VisibilityBuffer {
+    Address address;
+    vk::Buffer gpu_buffer;
+    uint64_t buffer_offset;
+    uint32_t size;
+    vk::QueryPool query_pool;
+};
+
 // request to trigger a notification after the fence has been waited for
 struct NotificationRequest {
     SceGxmNotification notifications[2];
@@ -149,6 +158,13 @@ struct VKContext : public renderer::Context {
 
     shader::RenderVertUniformBlockWithMapping current_vert_render_info;
     shader::RenderFragUniformBlockWithMapping current_frag_render_info;
+
+    // used to implement the Visibility Buffer
+    std::map<Address, VisibilityBuffer> visibility_buffers;
+    VisibilityBuffer *current_visibility_buffer = nullptr;
+    int visibility_max_used_idx = -1;
+    bool is_in_query = false;
+    int current_query_idx = -1;
 
     // descriptor pool for dynamic uniforms (allocated once for the whole game)
     vk::DescriptorPool global_descriptor_pool;

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -136,4 +136,12 @@ void set_uniform_buffer(State &state, Context *ctx, const bool is_vertex_uniform
     renderer::add_state_set_command(ctx, renderer::GXMState::UniformBuffer, buffer, is_vertex_uniform, block_number, bytes_to_copy_and_pad);
 }
 
+void set_visibility_buffer(State &state, Context *ctx, Ptr<uint32_t> visibility_address, uint32_t visibility_stride) {
+    renderer::add_state_set_command(ctx, renderer::GXMState::VisibilityBuffer, visibility_address, visibility_stride);
+}
+
+void set_visibility_index(State &state, Context *ctx, bool enable, uint32_t index) {
+    renderer::add_state_set_command(ctx, renderer::GXMState::VisibilityIndex, index, enable);
+}
+
 } // namespace renderer

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -511,6 +511,26 @@ COMMAND_SET_STATE(fragment_program_enable) {
     }
 }
 
+COMMAND_SET_STATE(visibility_buffer) {
+    TRACY_FUNC_COMMANDS_SET_STATE(visibility_buffer);
+    const Ptr<uint32_t> buffer = helper.pop<Ptr<uint32_t>>();
+    const uint32_t stride = helper.pop<uint32_t>();
+
+    if (renderer.current_backend == Backend::Vulkan) {
+        vulkan::sync_visibility_buffer(*reinterpret_cast<vulkan::VKContext *>(render_context), buffer, stride);
+    }
+}
+
+COMMAND_SET_STATE(visibility_index) {
+    TRACY_FUNC_COMMANDS_SET_STATE(visibility_index);
+    const uint32_t index = helper.pop<uint32_t>();
+    const bool enable = helper.pop<bool>();
+
+    if (renderer.current_backend == Backend::Vulkan) {
+        vulkan::sync_visibility_index(*reinterpret_cast<vulkan::VKContext *>(render_context), enable, index);
+    }
+}
+
 COMMAND(handle_set_state) {
     // TRACY_FUNC_COMMANDS(handle_set_state); All set state commands have tracy so kinda redundant
     renderer::GXMState gxm_state_to_set = helper.pop<renderer::GXMState>();
@@ -532,7 +552,9 @@ COMMAND(handle_set_state) {
         { GXMState::CullMode, cmd_set_state_cull_mode },
         { GXMState::VertexStream, cmd_set_state_vertex_stream },
         { GXMState::UniformBuffer, cmd_set_state_uniform_buffer },
-        { GXMState::FragmentProgramEnable, cmd_set_state_fragment_program_enable }
+        { GXMState::FragmentProgramEnable, cmd_set_state_fragment_program_enable },
+        { GXMState::VisibilityBuffer, cmd_set_state_visibility_buffer },
+        { GXMState::VisibilityIndex, cmd_set_state_visibility_index }
     };
 
     auto result = handlers.find(gxm_state_to_set);

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -351,6 +351,17 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
     constexpr bool replaced_indices = false;
 #endif
 
+    if (context.current_query_idx != -1 && !context.is_in_query) {
+        if (context.visibility_max_used_idx == -1) {
+            // for the first time, reset the visibility buffer in the prerender command
+            context.prerender_cmd.resetQueryPool(context.current_visibility_buffer->query_pool, 0, context.current_visibility_buffer->size);
+        }
+        context.visibility_max_used_idx = std::max(context.visibility_max_used_idx, context.current_query_idx);
+
+        context.render_cmd.beginQuery(context.current_visibility_buffer->query_pool, context.current_query_idx, vk::QueryControlFlags());
+        context.is_in_query = true;
+    }
+
     // do we need to check for a pipeline change?
     if (context.refresh_pipeline || !context.in_renderpass || type != context.last_primitive) {
         context.refresh_pipeline = false;


### PR DESCRIPTION
Implement the PS Vita visibility buffer using Vulkan occlusion queries.
This divides by 2 the number of draws in Gravity Rush.