### PR TITLE
renderer: Fix stencil and depth sampling

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/surface_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/surface_cache.h
@@ -87,6 +87,8 @@ struct ColorSurfaceCacheInfo : public SurfaceCacheInfo {
 
 struct DepthSurfaceView {
     vkutil::Image depth_view;
+    // only contains an image view with the stencil aspect
+    vkutil::Image stencil_view;
     // used so that we copy the depth stencil at most once per scene
     uint64_t scene_timestamp;
 };

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -512,7 +512,7 @@ GLuint GLSurfaceCache::retrieve_depth_stencil_texture_handle(const State &state,
 
     // The whole depth stencil struct is reserved for future use
     for (std::size_t i = 0; i < depth_stencil_textures.size(); i++) {
-        if ((depth_stencil_textures[i].surface.depthData == surface.depthData) && (packed_ds || depth_stencil_textures[i].surface.stencilData == surface.stencilData)) {
+        if (depth_stencil_textures[i].surface.depthData == surface.depthData) {
             found_index = i;
             break;
         }


### PR DESCRIPTION
Fix depth sampling which was previously not working if there was a stencil component.
Also implement stencil rendering on the vulkan renderer.

This fixes most of the graphical issues left on Gravity Rush