### PR TITLE
SceVideodec: Fix resolution of video decode.

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -90,6 +90,9 @@ struct H264DecoderOptions {
 struct H264DecoderState : public DecoderState {
     AVCodecParserContext *parser{};
 
+    uint32_t width_in = 0;
+    uint32_t height_in = 0;
+
     uint32_t width_out = 0;
     uint32_t height_out = 0;
 
@@ -106,6 +109,7 @@ struct H264DecoderState : public DecoderState {
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size = nullptr) override;
     void configure(void *options);
+    void set_res(const uint32_t width, const uint32_t height);
     void get_res(uint32_t &width, uint32_t &height);
     void get_pts(uint32_t &upper, uint32_t &lower);
 
@@ -250,5 +254,5 @@ struct PlayerState {
 void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space);
 void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t width, uint32_t height, const DecoderColorSpace color_space);
 int convert_yuv_to_jpeg(const uint8_t *yuv, uint8_t *jpeg, uint32_t width, uint32_t height, uint32_t max_size, const DecoderColorSpace color_space);
-void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest);
+void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest, const uint32_t width, const uint32_t height);
 std::string codec_error_name(int error);

--- a/vita3k/codec/src/h264.cpp
+++ b/vita3k/codec/src/h264.cpp
@@ -25,18 +25,18 @@ extern "C" {
 
 #include <cassert>
 
-void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest) {
-    for (int32_t a = 0; a < frame->height; a++) {
-        memcpy(dest, &frame->data[0][frame->linesize[0] * a], frame->width);
-        dest += frame->width;
+void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest, const uint32_t width, const uint32_t height) {
+    for (uint32_t a = 0; a < height; a++) {
+        memcpy(dest, &frame->data[0][frame->linesize[0] * a], width);
+        dest += width;
     }
-    for (int32_t a = 0; a < frame->height / 2; a++) {
-        memcpy(dest, &frame->data[1][frame->linesize[1] * a], frame->width / 2);
-        dest += frame->width / 2;
+    for (uint32_t a = 0; a < height / 2; a++) {
+        memcpy(dest, &frame->data[1][frame->linesize[1] * a], width / 2);
+        dest += width / 2;
     }
-    for (int32_t a = 0; a < frame->height / 2; a++) {
-        memcpy(dest, &frame->data[2][frame->linesize[2] * a], frame->width / 2);
-        dest += frame->width / 2;
+    for (uint32_t a = 0; a < height / 2; a++) {
+        memcpy(dest, &frame->data[2][frame->linesize[2] * a], width / 2);
+        dest += width / 2;
     }
 }
 
@@ -104,7 +104,7 @@ bool H264DecoderState::receive(uint8_t *data, DecoderSize *size) {
     }
 
     if (data) {
-        copy_yuv_data_from_frame(frame, data);
+        copy_yuv_data_from_frame(frame, data, width_in, height_in);
     }
 
     if (size) {
@@ -125,6 +125,11 @@ void H264DecoderState::configure(void *options) {
 
     pts = static_cast<uint64_t>(opt->pts_upper) << 32u | static_cast<uint64_t>(opt->pts_lower);
     dts = static_cast<uint64_t>(opt->dts_upper) << 32u | static_cast<uint64_t>(opt->dts_lower);
+}
+
+void H264DecoderState::set_res(const uint32_t width, const uint32_t height) {
+    width_in = width;
+    height_in = height;
 }
 
 void H264DecoderState::get_res(uint32_t &width, uint32_t &height) {

--- a/vita3k/codec/src/player.cpp
+++ b/vita3k/codec/src/player.cpp
@@ -225,7 +225,7 @@ std::vector<uint8_t> PlayerState::receive_video() {
 
         data.resize(H264DecoderState::buffer_size(
             { { static_cast<uint32_t>(video_context->width), static_cast<uint32_t>(video_context->height) } }));
-        copy_yuv_data_from_frame(frame, data.data());
+        copy_yuv_data_from_frame(frame, data.data(), frame->width, frame->height);
 
         break;
     }

--- a/vita3k/modules/SceJpeg/SceJpegUser.cpp
+++ b/vita3k/modules/SceJpeg/SceJpegUser.cpp
@@ -181,8 +181,8 @@ EXPORT(int, sceJpegGetOutputInfo, const uint8_t *jpeg_data, uint32_t jpeg_size,
     } else {
         switch (output->color_space) {
         case SCE_JPEG_COLORSPACE_GRAYSCALE:
-			output->output_size = size.width * size.height;
-			break;
+            output->output_size = size.width * size.height;
+            break;
         case SCE_JPEG_COLORSPACE_YUV444:
             output->output_size = size.width * size.height * 3;
             break;
@@ -190,8 +190,8 @@ EXPORT(int, sceJpegGetOutputInfo, const uint8_t *jpeg_data, uint32_t jpeg_size,
             output->output_size = size.width * size.height * 2;
             break;
         case SCE_JPEG_COLORSPACE_YUV420:
-			output->output_size = size.width * size.height * 3 / 2;
-			break;
+            output->output_size = size.width * size.height * 3 / 2;
+            break;
         }
     }
 
@@ -199,7 +199,7 @@ EXPORT(int, sceJpegGetOutputInfo, const uint8_t *jpeg_data, uint32_t jpeg_size,
     if (mode & 0x70) {
         return STUBBED("The handling of image downscaling in this function is not yet implemented.");
     }
-    
+
     return 0;
 }
 

--- a/vita3k/modules/SceVideodec/SceVideodecUser.cpp
+++ b/vita3k/modules/SceVideodec/SceVideodecUser.cpp
@@ -203,8 +203,8 @@ EXPORT(int, sceAvcdecDecode, SceAvcdecCtrl *decoder, const SceAvcdecAu *au, SceA
     // TODO: decoding can be done async I think
     decoder_info->configure(&options);
     const auto send = decoder_info->send(reinterpret_cast<uint8_t *>(au->es.pBuf.get(emuenv.mem)), au->es.size);
+    decoder_info->set_res(pPicture->frame.frameWidth, pPicture->frame.frameHeight);
     if (send && decoder_info->receive(output)) {
-        decoder_info->get_res(pPicture->frame.frameWidth, pPicture->frame.frameHeight);
         decoder_info->get_res(pPicture->frame.horizontalSize, pPicture->frame.verticalSize);
         decoder_info->get_pts(pPicture->info.pts.upper, pPicture->info.pts.lower);
         picture->numOfOutput++;
@@ -305,13 +305,7 @@ EXPORT(int, sceAvcdecDecodeStop, SceAvcdecCtrl *decoder, SceAvcdecArrayPicture *
         SceAvcdecPicture *pPicture = picture->pPicture.get(emuenv.mem)[0].get(emuenv.mem);
         uint8_t *output = pPicture->frame.pPicture[0].cast<uint8_t>().get(emuenv.mem);
 
-        // the ps vita expects us to be able to return one frame, however ffmpeg does not allow it,so return a black frame instead
-        DecoderSize size;
-        size.width = decoder_info->get(DecoderQuery::WIDTH);
-        size.height = decoder_info->get(DecoderQuery::HEIGHT);
-        memset(output, 0, H264DecoderState::buffer_size(size));
         // we get the values from the last frame, maybe we should slightly increase the pts value?
-        decoder_info->get_res(pPicture->frame.frameWidth, pPicture->frame.frameHeight);
         decoder_info->get_res(pPicture->frame.horizontalSize, pPicture->frame.verticalSize);
         decoder_info->get_pts(pPicture->info.pts.upper, pPicture->info.pts.lower);
 


### PR DESCRIPTION
# About
- using resolution send by app for decode video
- should fix video resolution in lego game
- remove memset to 0 on last frame in sceAvcdecDecodeStop, should fix green screen regression.

# Result
- fix video broken in lego marvel
![image](https://github.com/Vita3K/Vita3K/assets/5261759/653b4d0d-ee93-4553-88be-720ab46c1c39)

- fix green screen when video finish
![image](https://github.com/Vita3K/Vita3K/assets/5261759/17b5fd7a-5887-44f0-8bd5-247713a60e7c)
![image](https://github.com/Vita3K/Vita3K/assets/5261759/be7144f3-e50f-4dad-b7fc-846102bcfea6)
