### PR TITLE
external: fix the path to openssl from the extracted archive.

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -348,7 +348,7 @@ if(NOT OPENSSL_FOUND)
 				WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/openssl")
 		endif()
 
-		set(OPENSSL_ROOT_DIR "${CMAKE_BINARY_DIR}/external/openssl/openssl-3/x64")
+		set(OPENSSL_ROOT_DIR "${CMAKE_BINARY_DIR}/external/openssl/openssl-3.0/x64")
 	endif()
 
 	find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
# About
spotted by @german77, and see again by myself, archive downloaded have now diferent name for directory inside, move from openssl-3 to openssl-3.0

- fix cmake gen if using this download zip.