### PR TITLE
modules/SceGxm, renderer/vulkan: Implement visibility increment mode

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1344,7 +1344,8 @@ static void gxmContextStateRestore(renderer::State &state, MemState &mem, SceGxm
     if (state.features.support_memory_mapping) {
         context->state.visibility_enable = false;
         context->state.visibility_index = 0;
-        renderer::set_visibility_index(state, context->renderer.get(), false, 0);
+        context->state.visibility_is_increment = true;
+        renderer::set_visibility_index(state, context->renderer.get(), false, 0, true);
     }
 
     if (context->state.vertex_program) {
@@ -3749,7 +3750,7 @@ EXPORT(void, sceGxmSetFrontVisibilityTestEnable, SceGxmContext *context, SceGxmV
     }
 
     context->state.visibility_enable = enable != SCE_GXM_VISIBILITY_TEST_DISABLED;
-    renderer::set_visibility_index(*emuenv.renderer, context->renderer.get(), context->state.visibility_enable, context->state.visibility_index);
+    renderer::set_visibility_index(*emuenv.renderer, context->renderer.get(), context->state.visibility_enable, context->state.visibility_index, context->state.visibility_is_increment);
 }
 
 EXPORT(void, sceGxmSetFrontVisibilityTestIndex, SceGxmContext *context, uint32_t index) {
@@ -3761,7 +3762,7 @@ EXPORT(void, sceGxmSetFrontVisibilityTestIndex, SceGxmContext *context, uint32_t
     }
 
     context->state.visibility_index = index;
-    renderer::set_visibility_index(*emuenv.renderer, context->renderer.get(), context->state.visibility_enable, context->state.visibility_index);
+    renderer::set_visibility_index(*emuenv.renderer, context->renderer.get(), context->state.visibility_enable, context->state.visibility_index, context->state.visibility_is_increment);
 }
 
 EXPORT(void, sceGxmSetFrontVisibilityTestOp, SceGxmContext *context, SceGxmVisibilityTestOp op) {
@@ -3772,8 +3773,8 @@ EXPORT(void, sceGxmSetFrontVisibilityTestOp, SceGxmContext *context, SceGxmVisib
         return;
     }
 
-    if (op != SCE_GXM_VISIBILITY_TEST_OP_SET)
-        STUBBED("SCE_GXM_VISIBILITY_TEST_OP_INCREMENT not supported");
+    context->state.visibility_is_increment = (op == SCE_GXM_VISIBILITY_TEST_OP_INCREMENT);
+    renderer::set_visibility_index(*emuenv.renderer, context->renderer.get(), context->state.visibility_enable, context->state.visibility_index, context->state.visibility_is_increment);
 }
 
 EXPORT(void, sceGxmSetPrecomputedFragmentState, SceGxmContext *context, Ptr<SceGxmPrecomputedFragmentState> state) {

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -78,7 +78,7 @@ void set_two_sided_enable(State &state, Context *ctx, SceGxmTwoSidedMode mode);
 void set_side_fragment_program_enable(State &state, Context *ctx, const bool is_front, SceGxmFragmentProgramMode mode);
 void set_uniform_buffer(State &state, Context *ctx, const bool is_vertex_uniform, const int block_num, const std::uint16_t buffer_size, const Ptr<const void> buffer);
 void set_visibility_buffer(State &state, Context *ctx, Ptr<uint32_t> visibility_address, uint32_t visibility_stride);
-void set_visibility_index(State &state, Context *ctx, bool enable, uint32_t index);
+void set_visibility_index(State &state, Context *ctx, bool enable, uint32_t index, bool is_increment);
 
 void set_context(State &state, Context *ctx, RenderTarget *target, SceGxmColorSurface *color_surface, SceGxmDepthStencilSurface *depth_stencil_surface);
 void set_vertex_stream(State &state, Context *ctx, const std::size_t index, const std::size_t data_len, const Ptr<const void> stream);

--- a/vita3k/renderer/include/renderer/gxm_types.h
+++ b/vita3k/renderer/include/renderer/gxm_types.h
@@ -232,6 +232,7 @@ struct GxmContextState {
     // Visibility buffer
     bool visibility_enable = false;
     uint32_t visibility_index;
+    bool visibility_is_increment = false;
 
     bool active = false;
 };

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -53,7 +53,7 @@ void sync_viewport_flat(VKContext &context);
 void sync_viewport_real(VKContext &context, const float xOffset, const float yOffset, const float zOffset,
     const float xScale, const float yScale, const float zScale);
 void sync_visibility_buffer(VKContext &context, Ptr<uint32_t> buffer, uint32_t stride);
-void sync_visibility_index(VKContext &context, bool enable, uint32_t index);
+void sync_visibility_index(VKContext &context, bool enable, uint32_t index, bool is_increment);
 
 void refresh_pipeline(VKContext &context);
 

--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -104,6 +104,7 @@ struct VisibilityBuffer {
     uint64_t buffer_offset;
     uint32_t size;
     vk::QueryPool query_pool;
+    std::vector<bool> queries_used; // the queries that were used in the current scene
 };
 
 // request to trigger a notification after the fence has been waited for
@@ -165,6 +166,7 @@ struct VKContext : public renderer::Context {
     int visibility_max_used_idx = -1;
     bool is_in_query = false;
     int current_query_idx = -1;
+    bool is_query_op_increment = false;
 
     // descriptor pool for dynamic uniforms (allocated once for the whole game)
     vk::DescriptorPool global_descriptor_pool;

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -140,8 +140,8 @@ void set_visibility_buffer(State &state, Context *ctx, Ptr<uint32_t> visibility_
     renderer::add_state_set_command(ctx, renderer::GXMState::VisibilityBuffer, visibility_address, visibility_stride);
 }
 
-void set_visibility_index(State &state, Context *ctx, bool enable, uint32_t index) {
-    renderer::add_state_set_command(ctx, renderer::GXMState::VisibilityIndex, index, enable);
+void set_visibility_index(State &state, Context *ctx, bool enable, uint32_t index, bool is_increment) {
+    renderer::add_state_set_command(ctx, renderer::GXMState::VisibilityIndex, index, enable, is_increment);
 }
 
 } // namespace renderer

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -525,9 +525,10 @@ COMMAND_SET_STATE(visibility_index) {
     TRACY_FUNC_COMMANDS_SET_STATE(visibility_index);
     const uint32_t index = helper.pop<uint32_t>();
     const bool enable = helper.pop<bool>();
+    const bool is_increment = helper.pop<bool>();
 
     if (renderer.current_backend == Backend::Vulkan) {
-        vulkan::sync_visibility_index(*reinterpret_cast<vulkan::VKContext *>(render_context), enable, index);
+        vulkan::sync_visibility_index(*reinterpret_cast<vulkan::VKContext *>(render_context), enable, index, is_increment);
     }
 }
 

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -345,7 +345,8 @@ bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state
             .fillModeNonSolid = physical_device_features.fillModeNonSolid,
             .wideLines = physical_device_features.wideLines,
             .samplerAnisotropy = physical_device_features.samplerAnisotropy,
-            .shaderInt16 = physical_device_features.shaderInt16
+            .occlusionQueryPrecise = physical_device_features.occlusionQueryPrecise,
+            .shaderInt16 = physical_device_features.shaderInt16,
         };
 
         // look for optional extensions


### PR DESCRIPTION
Implement the increment mode for the PS Vita visibility buffer (still only on vulkan with memory mapping).

Also improve the implementation of the visibility buffer, should fix crashes happening after it was implemented.

This allows characters to render properly in Ys 8.