### PR TITLE
modules/sceJpegEncUser: fix sceJpegEncoderCsc inPitch misbehavior

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -247,7 +247,7 @@ struct PlayerState {
     ~PlayerState();
 };
 
-void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space);
+void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, int32_t inPitch);
 void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t width, uint32_t height, const DecoderColorSpace color_space);
 int convert_yuv_to_jpeg(const uint8_t *yuv, uint8_t *jpeg, uint32_t width, uint32_t height, uint32_t max_size, const DecoderColorSpace color_space);
 void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest);

--- a/vita3k/codec/src/mjpeg.cpp
+++ b/vita3k/codec/src/mjpeg.cpp
@@ -78,7 +78,7 @@ void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t width, uint3
     sws_freeContext(context);
 }
 
-void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space) {
+void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, int32_t inPitch) {
     AVPixelFormat format;
     int strides_divisor = 1;
     int slice_position = 8;
@@ -110,7 +110,7 @@ void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint3
     };
 
     int strides[] = {
-        static_cast<int>(width * 4),
+        static_cast<int>(inPitch * 4),
     };
 
     uint8_t *dst_slices[] = {

--- a/vita3k/modules/SceJpegEnc/SceJpegEncUser.cpp
+++ b/vita3k/modules/SceJpegEnc/SceJpegEncUser.cpp
@@ -71,10 +71,7 @@ EXPORT(int, sceJpegEncoderCsc, SceJpegEncoderContext *context, Ptr<uint8_t> outB
         return STUBBED("Only RGBA8888 to YCbCr is implemented.");
     }
 
-    int32_t width = inPitch;
-    int32_t height = context->inHeight * inPitch / context->inWidth;
-
-    convert_rgb_to_yuv(inBufferData, outBufferData, context->inWidth, context->inHeight, color_space);
+    convert_rgb_to_yuv(inBufferData, outBufferData, context->inWidth, context->inHeight, color_space, inPitch);
 
     return 0;
 }


### PR DESCRIPTION
Fixed issue when inPitch and width are different on modules/sceJpegEncUser/sceJpegEncoderCsc

Similar to PS Vita's handling of video files, if the input image is inPitch * height, it is used to crop and encode only the width * height portion of the image. (This is probably related to optimizing the utilization of the PS Vita hardware unit).

In the previous implementation, the handling of inPitch was missing.