### PR TITLE
renderer/texture: convert U8U3U3U2 to U8U8U8U8.

### DIFF
--- a/vita3k/renderer/src/gl/texture_formats.cpp
+++ b/vita3k/renderer/src/gl/texture_formats.cpp
@@ -391,8 +391,7 @@ GLenum translate_type(SceGxmTextureBaseFormat base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
         return GL_UNSIGNED_SHORT_4_4_4_4_REV;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U8U3U3U2:
-        LOG_WARN("Unhandled base format SCE_GXM_TEXTURE_BASE_FORMAT_U8U3U3U2");
-        return GL_UNSIGNED_SHORT_4_4_4_4_REV;
+        return GL_UNSIGNED_BYTE;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U1U5U5U5:
         return GL_UNSIGNED_SHORT_1_5_5_5_REV;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U5U6U5:
@@ -411,7 +410,7 @@ GLenum translate_type(SceGxmTextureBaseFormat base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_F16:
         return GL_HALF_FLOAT;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8:
-        return GL_UNSIGNED_INT_8_8_8_8_REV;
+        return GL_UNSIGNED_BYTE;
     case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8S8:
         return GL_BYTE;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U2U10U10U10:

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -670,6 +670,7 @@ vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format) {
         return translate_swizzle3_bgr(static_cast<SceGxmTextureSwizzle3Mode>(swizzle));
 
     // 4 components
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U3U3U2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8:
     case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8S8:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U16U16U16U16:
@@ -683,7 +684,6 @@ vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP:
     // TODO: the following 2 are not fully supported
     case SCE_GXM_TEXTURE_BASE_FORMAT_U1U5U5U5:
-    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U3U3U2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U2U10U10U10:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U2F10F10F10:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC1:
@@ -765,6 +765,7 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format) {
         return vk::Format::eE5B9G9R9UfloatPack32;
 
     // the following formats are all decompressed to u8u8u8u8
+    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U3U3U2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8:
     case SCE_GXM_TEXTURE_BASE_FORMAT_P8:
     case SCE_GXM_TEXTURE_BASE_FORMAT_P4:
@@ -780,10 +781,6 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format) {
     // Because of the lack of support of s8s8s8, an alpha channel is added to this texture
     case SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8:
         return vk::Format::eR8G8B8A8Snorm;
-
-    case SCE_GXM_TEXTURE_BASE_FORMAT_U8U3U3U2:
-        LOG_WARN("Unhandled base format SCE_GXM_TEXTURE_BASE_FORMAT_U8U3U3U2");
-        return vk::Format::eR4G4B4A4UnormPack16;
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
         return vk::Format::eR4G4B4A4UnormPack16;


### PR DESCRIPTION
# About:
- Convert texture for can correct handle it
should fix this texture format.

# Result:
![image](https://github.com/Vita3K/Vita3K/assets/5261759/0f0fd804-cdcd-4209-a788-ccf779a724ad)
![image](https://github.com/Vita3K/Vita3K/assets/5261759/11c1ad6c-0db4-405e-bcf5-d67999e029a4)
![image](https://github.com/Vita3K/Vita3K/assets/5261759/9fedec3a-54be-4a76-85d2-4e919cc3e20f)
