### PR TITLE
renderer/vulkan: Add additional check for valid buffer

### DIFF
--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -351,7 +351,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
     constexpr bool replaced_indices = false;
 #endif
 
-    if (context.current_query_idx != -1 && !context.is_in_query) {
+    if (context.current_visibility_buffer != nullptr && context.current_query_idx != -1 && !context.is_in_query) {
         if (context.current_visibility_buffer->queries_used[context.current_query_idx]) {
             static bool has_happened = false;
             LOG_WARN_IF(!has_happened, "Visibility buffer entry is used more than once in a scene");

--- a/vita3k/renderer/src/vulkan/sync_state.cpp
+++ b/vita3k/renderer/src/vulkan/sync_state.cpp
@@ -244,6 +244,12 @@ void sync_visibility_buffer(VKContext &context, Ptr<uint32_t> buffer, uint32_t s
 }
 
 void sync_visibility_index(VKContext &context, bool enable, uint32_t index, bool is_increment) {
+    if (context.current_visibility_buffer == nullptr) {
+        context.current_query_idx = enable ? index : -1;
+        context.is_query_op_increment = is_increment;
+        return;
+    }
+
     if (index >= context.current_visibility_buffer->size) {
         static bool has_happened = false;
         LOG_WARN_IF(!has_happened, "Using visibility index {} which is too big for the buffer");


### PR DESCRIPTION
Add some additional checks in case sceGxmSetVisibilityTestIndex is used before sceGxmSetVisibilityBuffer for the first time.
This fixes a crash in Freedom War.