### PR TITLE
ngs: Save Atrac9 decoder state

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -123,6 +123,10 @@ struct MjpegDecoderState : public DecoderState {
     MjpegDecoderState();
 };
 
+struct Atrac9DecoderSavedState {
+    double prev_values[2][256]{};
+};
+
 struct Atrac9DecoderState : public DecoderState {
     uint32_t config_data;
     void *decoder_handle;
@@ -138,6 +142,9 @@ struct Atrac9DecoderState : public DecoderState {
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;
     void flush() override;
+
+    void export_state(Atrac9DecoderSavedState *dest);
+    void load_state(const Atrac9DecoderSavedState *src);
 
     explicit Atrac9DecoderState(uint32_t config_data);
     ~Atrac9DecoderState() override;

--- a/vita3k/ngs/include/ngs/modules/atrac9.h
+++ b/vita3k/ngs/include/ngs/modules/atrac9.h
@@ -20,6 +20,8 @@
 #include <ngs/system.h>
 #include <ngs/types.h>
 
+#include <codec/state.h>
+
 enum {
     SCE_NGS_AT9_END_OF_DATA = 0,
     SCE_NGS_AT9_SWAPPED_BUFFER = 1,
@@ -64,11 +66,14 @@ struct SceNgsAT9States {
     // INTERNAL
     uint32_t decoded_samples_pending = 0;
     uint32_t decoded_passed = 0;
+    uint32_t nb_channels = 0;
     // used if the input must be resampled
     SwrContext *swr = nullptr;
     int8_t current_loop_count = 0;
     // set to true if all the input has been read but not all data has been processed
     bool is_finished = false;
+    // necessary if the decoder is using multiple states
+    Atrac9DecoderSavedState saved_state{};
 };
 
 namespace ngs {
@@ -77,6 +82,7 @@ private:
     std::unique_ptr<Atrac9DecoderState> decoder;
     uint32_t last_config = 0;
     std::vector<uint8_t> temp_buffer;
+    SceNgsAT9States *last_state = nullptr;
 
     static SwrContext *swr_mono_to_stereo;
     static SwrContext *swr_stereo;


### PR DESCRIPTION
Even when decoding a new atrac9 superframe, the atrac9 decoder needs the data from the previous frame to decode the next one. We were using the same atrac9 decoder in ngs for multiple voice, causing the previous frame data to be incorrect when switching between voices and leading to some audio noise when two or more atrac9 voices overlaps.

This PR adds an Atrac9 state saved by each voice to prevent this issue.
This fixes the audio issues in Persona dancing, Dragon's crown and many over games.