### PR TITLE
renderer/vulkan: Fix depth stencil surfaces initialization

### DIFF
--- a/vita3k/renderer/src/vulkan/surface_cache.cpp
+++ b/vita3k/renderer/src/vulkan/surface_cache.cpp
@@ -110,6 +110,8 @@ void VKSurfaceCache::destroy_surface(DepthStencilSurfaceCacheInfo &info) {
 VKSurfaceCache::VKSurfaceCache(VKState &state)
     : state(state) {
     for (int i = 0; i < MAX_CACHE_SIZE_PER_CONTAINER; i++) {
+        depth_stencil_textures[i].surface.depthData = -1;
+        depth_stencil_textures[i].surface.stencilData = -1;
         depth_stencil_textures[i].flags = SurfaceCacheInfo::FLAG_FREE;
     }
 }


### PR DESCRIPTION
This fixes a validation error causing a crash on Persona 4 Dancing.