### PR TITLE
renderer: Fix issue when sampling stencil without depth buffer

### DIFF
--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -538,11 +538,13 @@ GLuint GLSurfaceCache::retrieve_depth_stencil_texture_handle(const State &state,
         force_height = target->height;
     }
 
+    const bool is_stencil_only = surface.depthData.address() == 0;
     std::size_t found_index = static_cast<std::size_t>(-1);
 
     // The whole depth stencil struct is reserved for future use
     for (std::size_t i = 0; i < depth_stencil_textures.size(); i++) {
-        if (depth_stencil_textures[i].surface.depthData == surface.depthData) {
+        if ((!is_stencil_only && depth_stencil_textures[i].surface.depthData == surface.depthData)
+            || (is_stencil_only && depth_stencil_textures[i].surface.stencilData == surface.stencilData)) {
             found_index = i;
             break;
         }

--- a/vita3k/renderer/src/vulkan/surface_cache.cpp
+++ b/vita3k/renderer/src/vulkan/surface_cache.cpp
@@ -587,11 +587,14 @@ vkutil::Image *VKSurfaceCache::retrieve_depth_stencil_texture_handle(const MemSt
         height *= state.res_multiplier;
     }
 
+    const bool is_stencil_only = surface.depthData.address() == 0;
     size_t found_index = -1;
 
     // The whole depth stencil struct is reserved for future use
     for (size_t i = 0; i < depth_stencil_textures.size(); i++) {
-        if ((depth_stencil_textures[i].surface.depthData == surface.depthData) || (is_reading && !packed_ds && surface.depthData == depth_stencil_textures[i].surface.stencilData)) {
+        if ((!is_stencil_only && depth_stencil_textures[i].surface.depthData == surface.depthData)
+            || (is_stencil_only && depth_stencil_textures[i].surface.stencilData == surface.stencilData)
+            || (is_reading && !packed_ds && surface.depthData == depth_stencil_textures[i].surface.stencilData)) {
             found_index = i;
             break;
         }


### PR DESCRIPTION
Persona 4 dancing uses a surface with a separate depth and stencil buffer, then only the stencil buffer is used in a separate scene.
Adapt the code to handle this case, this fixes the Depth-Of-Field effect on Persona 4 Dancing (using vulkan).