### PR TITLE
modules/sceJpegEncUser: Improve JPEG encoding more strictly

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -260,6 +260,6 @@ struct PlayerState {
 
 void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, int32_t inPitch);
 void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t width, uint32_t height, const DecoderColorSpace color_space);
-int convert_yuv_to_jpeg(const uint8_t *yuv, uint8_t *jpeg, uint32_t width, uint32_t height, uint32_t max_size, const DecoderColorSpace color_space);
+int convert_yuv_to_jpeg(const uint8_t *yuv, uint8_t *jpeg, uint32_t width, uint32_t height, uint32_t max_size, const DecoderColorSpace color_space, int32_t compress_ratio);
 void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest, const uint32_t width, const uint32_t height);
 std::string codec_error_name(int error);

--- a/vita3k/modules/SceJpegEnc/SceJpegEncUser.cpp
+++ b/vita3k/modules/SceJpegEnc/SceJpegEncUser.cpp
@@ -43,7 +43,7 @@ int sceJpegEncoderInitImpl(SceJpegEncoderContext *context, int32_t inWidth, int3
     context->outSize = outSize;
     context->option = option;
 
-    context->compressRatio = 255;
+    context->compressRatio = 64;
     context->headerMode = SCE_JPEGENC_HEADER_MODE_JPEG;
 
     return 0;
@@ -98,7 +98,7 @@ EXPORT(int, sceJpegEncoderEncode, SceJpegEncoderContext *context, Ptr<uint8_t> i
         return SCE_JPEGENC_ERROR_INVALID_PIXELFORMAT;
     }
 
-    uint32_t size = convert_yuv_to_jpeg(inBufferData, outBufferData, width, height, context->outSize, color_space);
+    uint32_t size = convert_yuv_to_jpeg(inBufferData, outBufferData, width, height, context->outSize, color_space, context->compressRatio);
 
     if (size == -1) {
         return SCE_JPEGENC_ERROR_INSUFFICIENT_BUFFER;
@@ -127,7 +127,6 @@ EXPORT(int, sceJpegEncoderInitWithParam, SceJpegEncoderContext *context, SceJpeg
     return sceJpegEncoderInitImpl(context, initParam->inWidth, initParam->inHeight, initParam->pixelFormat, initParam->outBuffer, initParam->outSize, initParam->option);
 }
 
-// TODO: CompressionRatio is ignored for the time being.
 EXPORT(int, sceJpegEncoderSetCompressionRatio, SceJpegEncoderContext *context, int32_t ratio) {
     TRACY_FUNC(sceJpegEncoderSetCompressionRatio, context, ratio);
     if (ratio < 0 || ratio > 255) {


### PR DESCRIPTION
- Fixes issue where sceJpegEncoderEncode would generate a still MJPEG instead of a JPEG
- Implement the behavior of sceJpegEncoderSetCompressionRatio