### PR TITLE
modules/SceNpTrophy: Fix platinum trophy unlock.

### DIFF
--- a/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
+++ b/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
@@ -469,13 +469,12 @@ EXPORT(int, sceNpTrophyUnlockTrophy, np::trophy::ContextHandle context_handle, S
         }
     }
 
-    *platinum_id = -1; // SCE_NP_TROPHY_INVALID_TROPHY_ID
-
-    if ((context->platinum_trophy_id >= 0) && (context->total_trophy_unlocked() == context->trophy_count)) {
+    if ((context->platinum_trophy_id != SCE_NP_TROPHY_INVALID_TROPHY_ID) && (context->total_trophy_unlocked() == (context->trophy_count - 1))) {
         // Force unlock platinum trophy
         context->unlock_trophy(context->platinum_trophy_id, &error, true);
         *platinum_id = context->platinum_trophy_id;
-    }
+    } else
+        *platinum_id = SCE_NP_TROPHY_INVALID_TROPHY_ID;
 
     const int err = do_trophy_callback(emuenv, context, trophy_id);
 
@@ -483,7 +482,7 @@ EXPORT(int, sceNpTrophyUnlockTrophy, np::trophy::ContextHandle context_handle, S
         return err;
     }
 
-    if (*platinum_id != -1) {
+    if (*platinum_id != SCE_NP_TROPHY_INVALID_TROPHY_ID) {
         // Do trophy callback for platinum too! But this time, ignore the error
         do_trophy_callback(emuenv, context, context->platinum_trophy_id);
     }

--- a/vita3k/np/include/np/common.h
+++ b/vita3k/np/include/np/common.h
@@ -57,6 +57,8 @@ struct CommunicationConfig {
     Ptr<void> unk1;
 };
 
+#define SCE_NP_TROPHY_INVALID_TROPHY_ID -1
+
 enum class NpTrophyError {
     TROPHY_ERROR_NONE = 0,
     TROPHY_CONTEXT_EXIST = 1,

--- a/vita3k/np/include/np/trophy/context.h
+++ b/vita3k/np/include/np/trophy/context.h
@@ -63,7 +63,7 @@ struct Context {
     std::array<uint64_t, MAX_TROPHIES> unlock_timestamps;
     std::array<SceNpTrophyGrade, MAX_TROPHIES> trophy_kinds;
 
-    int32_t platinum_trophy_id{ -1 };
+    int32_t platinum_trophy_id{ SCE_NP_TROPHY_INVALID_TROPHY_ID };
 
     std::string trophy_progress_output_file_path;
     std::string trophy_detail_xml;

--- a/vita3k/np/src/trophy/context.cpp
+++ b/vita3k/np/src/trophy/context.cpp
@@ -116,7 +116,7 @@ bool Context::init_info_from_trp() {
     std::fill(trophy_count_by_group.begin(), trophy_count_by_group.end(), 0);
     std::fill(unlock_timestamps.begin(), unlock_timestamps.end(), 0);
     std::fill(trophy_kinds.begin(), trophy_kinds.end(), SceNpTrophyGrade::SCE_NP_TROPHY_GRADE_UNKNOWN);
-    platinum_trophy_id = -1;
+    platinum_trophy_id = SCE_NP_TROPHY_INVALID_TROPHY_ID;
 
     group_count = 0;
     trophy_count = 0;


### PR DESCRIPTION
# About
- modules/SceNpTrophy: Fix platinum trophy unlock.
Unlock platinum trophy compare if trophies count is same as total unlocked, but that's not possible, because trophy counting includes platinum.
So need remove 1 from the trophy count to check that only one is missing.