### PR TITLE
module: use LLE and fix module load for libsmart and libface

### DIFF
--- a/vita3k/interface.h
+++ b/vita3k/interface.h
@@ -57,5 +57,5 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui);
 std::vector<ContentInfo> install_archive(EmuEnvState &emuenv, GuiState *gui, const fs::path &archive_path, const std::function<void(ArchiveContents)> &progress_callback = nullptr);
 uint32_t install_contents(EmuEnvState &emuenv, GuiState *gui, const fs::path &path);
 
-ExitCode load_app(Ptr<const void> &entry_point, EmuEnvState &emuenv, const std::wstring &path);
-ExitCode run_app(EmuEnvState &emuenv, Ptr<const void> &entry_point);
+ExitCode load_app(int32_t &main_module_id, EmuEnvState &emuenv, const std::wstring &path);
+ExitCode run_app(EmuEnvState &emuenv, int32_t main_module_id);

--- a/vita3k/io/include/io/functions.h
+++ b/vita3k/io/include/io/functions.h
@@ -64,7 +64,7 @@ bool copy_directories(const fs::path &src_path, const fs::path &dst_path);
  * @return true Success
  * @return false Error
  */
-bool copy_path(const fs::path src_path, std::wstring pref_path, std::string app_title_id, std::string app_category);
+bool copy_path(const fs::path &src_path, const std::wstring &pref_path, const std::string &app_title_id, const std::string &app_category);
 
 SceUID open_file(IOState &io, const char *path, const int flags, const std::wstring &pref_path, const char *export_name);
 int read_file(void *data, IOState &io, SceUID fd, SceSize size, const char *export_name);

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -783,7 +783,7 @@ bool copy_directories(const fs::path &src_path, const fs::path &dst_path) {
     }
 }
 
-bool copy_path(const fs::path src_path, std::wstring pref_path, std::string app_title_id, std::string app_category) {
+bool copy_path(const fs::path &src_path, const std::wstring &pref_path, const std::string &app_title_id, const std::string &app_category) {
     // Check if is path
     if (app_category.find("gp") != std::string::npos) {
         const auto app_path{ fs::path(pref_path) / "ux0/app" / app_title_id };
@@ -884,7 +884,7 @@ SceUID create_overlay(IOState &io, SceFiosProcessOverlay *fios_overlay) {
     };
 
     // find location where to put it
-    int overlay_index = 0;
+    size_t overlay_index = 0;
     // lower order first and in case of equality, last one inserted first
     while (overlay_index < io.overlays.size() && overlay.order < io.overlays[overlay_index].order)
         overlay_index++;
@@ -899,7 +899,7 @@ std::string resolve_path(IOState &io, const char *input, const bool is_write, co
 
     std::string curr_path = input;
 
-    int overlay_idx = 0;
+    size_t overlay_idx = 0;
     while (overlay_idx < io.overlays.size() && io.overlays[overlay_idx].order < min_order)
         overlay_idx++;
 

--- a/vita3k/kernel/include/kernel/load_self.h
+++ b/vita3k/kernel/include/kernel/load_self.h
@@ -27,4 +27,4 @@ struct MemState;
 template <class T>
 class Ptr;
 
-SceUID load_self(Ptr<const void> &entry_point, KernelState &kernel, MemState &mem, const void *self, const std::string &path);
+SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &path);

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -57,7 +57,6 @@ typedef std::map<SceUID, Ptr<Ptr<void>>> SlotToAddress;
 typedef std::map<SceUID, ThreadStatePtr> ThreadStatePtrs;
 typedef std::shared_ptr<SDL_Thread> ThreadPtr;
 typedef std::map<SceUID, ThreadPtr> ThreadPtrs;
-typedef std::shared_ptr<SceKernelModuleInfo> SceKernelModuleInfoPtr;
 typedef std::map<SceUID, SceKernelModuleInfoPtr> SceKernelModuleInfoPtrs;
 typedef std::map<SceUID, CallbackPtr> CallbackPtrs;
 typedef std::unordered_map<uint32_t, Address> ExportNids;

--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -114,8 +114,8 @@ struct ThreadState {
 
     // this function is called from another thread when this one is dormant
     // it is only used for module loading and gxm display queue right now
-    // support one argument
-    uint32_t run_guest_function(KernelState &kernel, Address callback_address, uint32_t arg = 0);
+    // args and argp are passed to thread->start as is
+    uint32_t run_guest_function(KernelState &kernel, Address callback_address, SceSize args = 0, const Ptr<void> argp = Ptr<void>{});
 
     void suspend();
     void resume(bool step = false);

--- a/vita3k/kernel/include/kernel/types.h
+++ b/vita3k/kernel/include/kernel/types.h
@@ -39,6 +39,7 @@
 
 #define SCE_KERNEL_STACK_SIZE_USER_MAIN KiB(256)
 #define SCE_KERNEL_STACK_SIZE_USER_DEFAULT KiB(4)
+#define SCE_KERNEL_THREAD_STACK_SIZE_MAX MiB(32)
 
 #define SCE_KERNEL_ATTR_TH_FIFO 0x00000000U
 #define SCE_KERNEL_ATTR_TH_PRIO 0x00002000U
@@ -589,6 +590,8 @@ struct SceKernelModuleInfo {
     SceKernelSegmentInfo segments[MODULE_INFO_NUM_SEGMENTS];
     SceUInt state; //!< see:SceKernelModuleState
 };
+
+typedef std::shared_ptr<SceKernelModuleInfo> SceKernelModuleInfoPtr;
 
 struct SceKernelStartModuleOpt {
     SceSize size;

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -135,8 +135,7 @@ ThreadStatePtr KernelState::get_thread(SceUID thread_id) {
 }
 
 ThreadStatePtr KernelState::create_thread(MemState &mem, const char *name, Ptr<const void> entry_point) {
-    constexpr size_t DEFAULT_STACK_SIZE = 0x1000;
-    return create_thread(mem, name, entry_point, SCE_KERNEL_DEFAULT_PRIORITY, SCE_KERNEL_THREAD_CPU_AFFINITY_MASK_DEFAULT, DEFAULT_STACK_SIZE, nullptr);
+    return create_thread(mem, name, entry_point, SCE_KERNEL_DEFAULT_PRIORITY, SCE_KERNEL_THREAD_CPU_AFFINITY_MASK_DEFAULT, SCE_KERNEL_STACK_SIZE_USER_MAIN, nullptr);
 }
 
 ThreadStatePtr KernelState::create_thread(MemState &mem, const char *name, Ptr<const void> entry_point, int init_priority, SceInt32 affinity_mask, int stack_size, const SceKernelThreadOptParam *option) {

--- a/vita3k/module/include/module/load_module.h
+++ b/vita3k/module/include/module/load_module.h
@@ -117,4 +117,5 @@ inline SysmodulePaths init_sysmodule_paths() {
 const SysmodulePaths sysmodule_paths = init_sysmodule_paths();
 
 bool is_lle_module(SceSysmoduleModuleId module_id, EmuEnvState &emuenv);
+bool is_lle_module(const std::string &module_name, EmuEnvState &emuenv);
 bool is_module_loaded(KernelState &kernel, SceSysmoduleModuleId module_id);

--- a/vita3k/module/src/load_module.cpp
+++ b/vita3k/module/src/load_module.cpp
@@ -22,26 +22,30 @@
 #include <kernel/load_self.h>
 #include <kernel/state.h>
 
+// Current modules works for loading
+static constexpr auto auto_lle_modules = {
+    SCE_SYSMODULE_SAS,
+    SCE_SYSMODULE_PGF,
+    SCE_SYSMODULE_SYSTEM_GESTURE,
+    SCE_SYSMODULE_XML,
+    SCE_SYSMODULE_MP4,
+    SCE_SYSMODULE_ATRAC,
+    SCE_SYSMODULE_AVPLAYER,
+    SCE_SYSMODULE_JSON,
+    SCE_SYSMODULE_HTTP,
+    SCE_SYSMODULE_SSL,
+    SCE_SYSMODULE_HTTPS,
+    SCE_SYSMODULE_SMART,
+    SCE_SYSMODULE_FACE,
+    SCE_SYSMODULE_ULT,
+    SCE_SYSMODULE_FIOS2
+};
+
 bool is_lle_module(SceSysmoduleModuleId module_id, EmuEnvState &emuenv) {
     const auto &paths = sysmodule_paths[module_id];
 
     // Do we know the module and its dependencies' paths?
     const bool have_paths = !paths.empty();
-
-    // Current modules works for loading
-    const auto auto_lle_modules = {
-        SCE_SYSMODULE_SAS,
-        SCE_SYSMODULE_PGF,
-        SCE_SYSMODULE_SYSTEM_GESTURE,
-        SCE_SYSMODULE_XML,
-        SCE_SYSMODULE_MP4,
-        SCE_SYSMODULE_ATRAC,
-        SCE_SYSMODULE_AVPLAYER,
-        SCE_SYSMODULE_JSON,
-        SCE_SYSMODULE_HTTP,
-        SCE_SYSMODULE_SSL,
-        SCE_SYSMODULE_HTTPS,
-    };
 
     if (have_paths) {
         if (emuenv.cfg.current_config.modules_mode != ModulesMode::MANUAL) {
@@ -57,6 +61,31 @@ bool is_lle_module(SceSysmoduleModuleId module_id, EmuEnvState &emuenv) {
         }
     }
 
+    return false;
+}
+
+std::vector<std::string> init_auto_lle_module_names() {
+    std::vector<std::string> auto_lle_module_names = { "libc", "libSceFt2", "libpvf" };
+    for (const auto module_id : auto_lle_modules) {
+        for (const auto module : sysmodule_paths[module_id]) {
+            auto_lle_module_names.emplace_back(module);
+        }
+    }
+    return auto_lle_module_names;
+}
+
+bool is_lle_module(const std::string &module_name, EmuEnvState &emuenv) {
+    static std::vector<std::string> auto_lle_module_names{};
+    if (auto_lle_module_names.empty())
+        auto_lle_module_names = init_auto_lle_module_names();
+    if (emuenv.cfg.current_config.modules_mode != ModulesMode::AUTOMATIC) {
+        if (std::find(emuenv.cfg.current_config.lle_modules.begin(), emuenv.cfg.current_config.lle_modules.end(), module_name) != emuenv.cfg.current_config.lle_modules.end())
+            return true;
+    }
+    if (emuenv.cfg.current_config.modules_mode != ModulesMode::MANUAL) {
+        if (std::find(auto_lle_module_names.begin(), auto_lle_module_names.end(), module_name) != auto_lle_module_names.end())
+            return true;
+    }
     return false;
 }
 

--- a/vita3k/modules/SceSysmodule/SceSysmodule.cpp
+++ b/vita3k/modules/SceSysmodule/SceSysmodule.cpp
@@ -185,9 +185,9 @@ EXPORT(int, sceSysmoduleLoadModule, SceSysmoduleModuleId module_id) {
     TRACY_FUNC(sceSysmoduleLoadModule, module_id);
     if (module_id < 0 || module_id > SYSMODULE_COUNT)
         return RET_ERROR(SCE_SYSMODULE_ERROR_INVALID_VALUE);
-
+    LOG_INFO("Loading module ID: {}", to_debug_str(emuenv.mem, module_id));
     if (is_modules_enable(emuenv, module_id)) {
-        if (load_module(emuenv, thread_id, module_id))
+        if (load_sys_module(emuenv, module_id))
             return SCE_SYSMODULE_LOADED;
         else
             return RET_ERROR(SCE_SYSMODULE_ERROR_FATAL);

--- a/vita3k/modules/include/modules/module_parent.h
+++ b/vita3k/modules/include/modules/module_parent.h
@@ -27,7 +27,25 @@ struct KernelState;
 
 void init_libraries(EmuEnvState &emuenv);
 void call_import(EmuEnvState &emuenv, CPUState &cpu, uint32_t nid, SceUID thread_id);
-bool load_module(EmuEnvState &emuenv, SceUID thread_id, SceSysmoduleModuleId module_id);
+
+/**
+ * \brief Loads a dynamic module into memory if it wasn't already loaded. If it was, find it and return it.
+ * \param emuenv PlayStation Vita emulated environment
+ * \param module_path Full path of module file (with device)
+ * \return UID of the loaded module object or SCE_ERROR on failure
+ */
+SceUID load_module(EmuEnvState &emuenv, const std::string &module_path);
+
+uint32_t start_module(EmuEnvState &emuenv, const std::shared_ptr<SceKernelModuleInfo> &module, SceSize args = 0, const Ptr<void> argp = Ptr<void>{});
+
+/**
+ * \brief Loads and run a system module
+ * \param emuenv PlayStation Vita emulated environment
+ * \param module_id System Module ID of the module to load
+ * \return False on failure, true on success
+ */
+bool load_sys_module(EmuEnvState &emuenv, SceSysmoduleModuleId module_id);
+
 Address resolve_export(KernelState &kernel, uint32_t nid);
 uint32_t resolve_nid(KernelState &kernel, Address addr);
 

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -15,11 +15,15 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include "io/functions.h"
+#include "io/io.h"
+
 #include <modules/module_parent.h>
 
 #include <cpu/functions.h>
 #include <emuenv/state.h>
 #include <io/device.h>
+#include <io/state.h>
 #include <io/vfs.h>
 #include <kernel/load_self.h>
 #include <kernel/state.h>
@@ -151,43 +155,86 @@ void call_import(EmuEnvState &emuenv, CPUState &cpu, uint32_t nid, SceUID thread
     }
 }
 
+SceUID load_module(EmuEnvState &emuenv, const std::string &module_path) {
+    // Check if module is already loaded
+    const auto &loaded_modules = emuenv.kernel.loaded_modules;
+    auto module_iter = std::find_if(loaded_modules.begin(), loaded_modules.end(), [&](const auto &p) {
+        return std::string(p.second->path) == module_path;
+    });
+
+    if (module_iter != loaded_modules.end()) {
+        return module_iter->first;
+    }
+    LOG_INFO("Loading module \"{}\"", module_path);
+    vfs::FileBuffer module_buffer;
+    bool res;
+    VitaIoDevice device = device::get_device(module_path);
+    auto translated_module_path = translate_path(module_path.c_str(), device, emuenv.io.device_paths);
+    if (device == VitaIoDevice::app0)
+        res = vfs::read_app_file(module_buffer, emuenv.pref_path, emuenv.io.app_path, translated_module_path);
+    else
+        res = vfs::read_file(device, module_buffer, emuenv.pref_path, translated_module_path);
+    if (!res) {
+        LOG_ERROR("Failed to read module file {}", module_path);
+        return SCE_ERROR_ERRNO_ENOENT;
+    }
+    SceUID module_id = load_self(emuenv.kernel, emuenv.mem, module_buffer.data(), module_path);
+    if (module_id >= 0) {
+        const auto module = emuenv.kernel.loaded_modules[module_id];
+        LOG_INFO("Module {} (at \"{}\") loaded", module->module_name, module_path);
+    } else {
+        LOG_ERROR("Failed to load module {}", module_path);
+    }
+    return module_id;
+}
+
+uint32_t start_module(EmuEnvState &emuenv, const std::shared_ptr<SceKernelModuleInfo> &module, SceSize args, const Ptr<void> argp) {
+    const auto module_start = module->start_entry;
+    if (module_start) {
+        const auto module_name = module->module_name;
+
+        LOG_DEBUG("Running module_start of library: {} at address {}", module_name, log_hex(module_start.address()));
+        SceInt32 priority = SCE_KERNEL_DEFAULT_PRIORITY_USER;
+        SceInt32 stack_size = SCE_KERNEL_STACK_SIZE_USER_MAIN;
+        SceInt32 affinity = SCE_KERNEL_THREAD_CPU_AFFINITY_MASK_DEFAULT;
+        // module_start is always called from new thread
+        const ThreadStatePtr module_thread = emuenv.kernel.create_thread(emuenv.mem, module_name, module_start, priority, affinity, stack_size, nullptr);
+
+        const auto ret = module_thread->run_guest_function(emuenv.kernel, module_start.address(), args, argp);
+        module_thread->exit_delete(emuenv.kernel);
+
+        LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(ret));
+        return ret;
+    }
+    return 0;
+}
+
 /**
  * \return False on failure, true on success
  */
-bool load_module(EmuEnvState &emuenv, SceUID thread_id, SceSysmoduleModuleId module_id) {
-    LOG_INFO("Loading module ID: {}", log_hex(module_id));
-
-    const auto module_paths = sysmodule_paths[module_id];
-
-    for (std::string module_path : module_paths) {
-        module_path = "sys/external/" + module_path + ".suprx";
-
-        vfs::FileBuffer module_buffer;
-        Ptr<const void> lib_entry_point;
-
-        if (vfs::read_file(VitaIoDevice::vs0, module_buffer, emuenv.pref_path, module_path)) {
-            SceUID loaded_module_uid = load_self(lib_entry_point, emuenv.kernel, emuenv.mem, module_buffer.data(), module_path);
-            if (loaded_module_uid < 0) {
-                LOG_ERROR("Error when loading module at \"{}\"", module_path);
-                return false;
-            }
-            const auto module = emuenv.kernel.loaded_modules[loaded_module_uid];
-            const auto module_name = module->module_name;
-            LOG_INFO("Module {} (at \"{}\") loaded", module_name, module_path);
-
-            if (lib_entry_point) {
-                LOG_DEBUG("Running module_start of module: {}", module_name);
-
-                Ptr<void> argp = Ptr<void>();
-                const auto thread = emuenv.kernel.get_thread(thread_id);
-                const auto ret = thread->run_callback(lib_entry_point.address(), { 0, argp.address() });
-                LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(ret));
-            }
-
+bool load_sys_module(EmuEnvState &emuenv, SceSysmoduleModuleId module_id) {
+    const auto &module_paths = sysmodule_paths[module_id];
+    for (const auto module_filename : module_paths) {
+        std::string module_path;
+        if (module_id == SCE_SYSMODULE_SMART || module_id == SCE_SYSMODULE_FACE || module_id == SCE_SYSMODULE_ULT) {
+            module_path = fmt::format("app0:sce_module/{}.suprx", module_filename);
         } else {
-            LOG_ERROR("Module at \"{}\" not present", module_path);
-            // ignore and assume it was loaded
+            module_path = fmt::format("vs0:sys/external/{}.suprx", module_filename);
         }
+
+        auto loaded_module_uid = load_module(emuenv, module_path);
+
+        if (loaded_module_uid < 0) {
+            if (module_id == SCE_SYSMODULE_ULT && loaded_module_uid == SCE_ERROR_ERRNO_ENOENT) {
+                module_path = fmt::format("vs0:sys/external/{}.suprx", module_filename);
+                loaded_module_uid = load_module(emuenv, module_path);
+                if (loaded_module_uid < 0)
+                    return false;
+            } else
+                return false;
+        }
+        const auto module = emuenv.kernel.loaded_modules[loaded_module_uid];
+        start_module(emuenv, module);
     }
 
     emuenv.kernel.loaded_sysmodules.push_back(module_id);


### PR DESCRIPTION
UPD: This PR now include big refactoring. See https://github.com/Vita3K/Vita3K/pull/2677#issuecomment-1632181174

This modules are not a part of firmware and distributed as part of game. AFAIK there is only two such modules.
libsmart is used in Vita AR games. libface is face recognition module.