### PR TITLE
renderer: Remove debug color

### DIFF
--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -127,7 +127,7 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
     glClearDepth(1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     // should not be needed, but just in case
-    glClearColor(0.968627450f, 0.776470588f, 0.0f, 0.0f);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 
     const auto &shader = enable_fxaa ? m_render_shader_fxaa : m_render_shader_nofilter;
 

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -703,7 +703,7 @@ GLuint GLSurfaceCache::retrieve_framebuffer_handle(const State &state, const Mem
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
         LOG_ERROR("Framebuffer is not completed. Proceed anyway...");
 
-    glClearColor(0.968627450f, 0.776470588f, 0.0f, 0.0f);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     glClearDepth(1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/vita3k/renderer/src/vulkan/creation.cpp
+++ b/vita3k/renderer/src/vulkan/creation.cpp
@@ -187,7 +187,7 @@ VKRenderTarget::VKRenderTarget(VKState &state, const SceGxmRenderTargetParams &p
     {
         color.transition_to(cmd_buffer, vkutil::ImageLayout::TransferDst);
 
-        vk::ClearColorValue clear_color{ std::array<float, 4>({ 0.968627450f, 0.776470588f, 0.0f, 0.0f }) };
+        vk::ClearColorValue clear_color{ std::array<float, 4>({ 0.0f, 0.0f, 0.0f, 0.0f }) };
         cmd_buffer.clearColorImage(color.image, vk::ImageLayout::eTransferDstOptimal, clear_color, vkutil::color_subresource_range);
         color.transition_to(cmd_buffer, vkutil::ImageLayout::ColorAttachmentReadWrite);
     }

--- a/vita3k/renderer/src/vulkan/surface_cache.cpp
+++ b/vita3k/renderer/src/vulkan/surface_cache.cpp
@@ -509,7 +509,7 @@ vkutil::Image *VKSurfaceCache::retrieve_color_surface_texture_handle(MemState &m
     // must do a first transition to draw the placeholder color
     image.transition_to(cmd_buffer, vkutil::ImageLayout::TransferDst);
 
-    vk::ClearColorValue clear_color{ std::array<float, 4>({ 0.968627450f, 0.776470588f, 0.0f, 0.0f }) };
+    vk::ClearColorValue clear_color{ std::array<float, 4>({ 0.0f, 0.0f, 0.0f, 0.0f }) };
     cmd_buffer.clearColorImage(image.image, vk::ImageLayout::eTransferDstOptimal, clear_color, vkutil::color_subresource_range);
     image.transition_to(cmd_buffer, vkutil::ImageLayout::ColorAttachmentReadWrite);
 


### PR DESCRIPTION
This yellow color is not useful to debug graphical issues.
Moreover it causes itself graphical issues in many games (screen borders in P4D, Ys8, transitions in Dragon's crown, Trails games...)