### PR TITLE
modules/SceDisplay: Improve accuracy of FrameBuf functions

### DIFF
--- a/vita3k/modules/SceDisplay/SceDisplay.cpp
+++ b/vita3k/modules/SceDisplay/SceDisplay.cpp
@@ -52,9 +52,9 @@ static int display_wait(EmuEnvState &emuenv, SceUID thread_id, int vcount, const
     return SCE_DISPLAY_ERROR_OK;
 }
 
-EXPORT(SceInt32, _sceDisplayGetFrameBuf, SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync) {
-    TRACY_FUNC(_sceDisplayGetFrameBuf, pFrameBuf, sync);
-    if (pFrameBuf->size != sizeof(SceDisplayFrameBuf))
+EXPORT(SceInt32, _sceDisplayGetFrameBuf, SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync, uint32_t *pFrameBuf_size) {
+    TRACY_FUNC(_sceDisplayGetFrameBuf, pFrameBuf, sync, pFrameBuf_size);
+    if (pFrameBuf->size != sizeof(SceDisplayFrameBuf) && pFrameBuf->size != sizeof(SceDisplayFrameBuf2))
         return RET_ERROR(SCE_DISPLAY_ERROR_INVALID_VALUE);
     else if (sync != SCE_DISPLAY_SETBUF_NEXTFRAME && sync != SCE_DISPLAY_SETBUF_IMMEDIATE)
         return RET_ERROR(SCE_DISPLAY_ERROR_INVALID_UPDATETIMING);
@@ -93,11 +93,11 @@ EXPORT(int, _sceDisplayGetResolutionInfoInternal) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(SceInt32, _sceDisplaySetFrameBuf, const SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync) {
-    TRACY_FUNC(_sceDisplaySetFrameBuf, pFrameBuf, sync);
+EXPORT(SceInt32, _sceDisplaySetFrameBuf, const SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync, uint32_t *pFrameBuf_size) {
+    TRACY_FUNC(_sceDisplaySetFrameBuf, pFrameBuf, sync, pFrameBuf_size);
     if (!pFrameBuf)
         return SCE_DISPLAY_ERROR_OK;
-    if (pFrameBuf->size != sizeof(SceDisplayFrameBuf)) {
+    if (pFrameBuf->size != sizeof(SceDisplayFrameBuf) && pFrameBuf->size != sizeof(SceDisplayFrameBuf2)) {
         return RET_ERROR(SCE_DISPLAY_ERROR_INVALID_VALUE);
     }
     if (!pFrameBuf->base) {

--- a/vita3k/modules/SceDisplay/SceDisplay.h
+++ b/vita3k/modules/SceDisplay/SceDisplay.h
@@ -60,8 +60,14 @@ struct SceDisplayFrameBuf {
     SceUInt32 height = 0;
 };
 
-EXPORT(SceInt32, _sceDisplayGetFrameBuf, SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync);
-EXPORT(SceInt32, _sceDisplaySetFrameBuf, const SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync);
+// Only BigSky uses this version of the structure
+struct SceDisplayFrameBuf2 : public SceDisplayFrameBuf {
+    // BigSky uses this field and sets it to a value between 0 and 5, in practice always 1
+    SceUInt32 unkn = 0;
+};
+
+EXPORT(SceInt32, _sceDisplayGetFrameBuf, SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync, uint32_t *pFrameBuf_size);
+EXPORT(SceInt32, _sceDisplaySetFrameBuf, const SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync, uint32_t *pFrameBuf_size);
 
 BRIDGE_DECL(_sceDisplayGetFrameBuf)
 BRIDGE_DECL(_sceDisplayGetFrameBufInternal)

--- a/vita3k/modules/SceDriverUser/SceDisplayUser.cpp
+++ b/vita3k/modules/SceDriverUser/SceDisplayUser.cpp
@@ -23,7 +23,8 @@ TRACY_MODULE_NAME(SceDisplayUser);
 
 EXPORT(SceInt32, sceDisplayGetFrameBuf, SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync) {
     TRACY_FUNC(sceDisplayGetFrameBuf, pFrameBuf, sync);
-    return CALL_EXPORT(_sceDisplayGetFrameBuf, pFrameBuf, sync);
+    uint32_t pFrameBuf_size = pFrameBuf->size;
+    return CALL_EXPORT(_sceDisplayGetFrameBuf, pFrameBuf, sync, &pFrameBuf_size);
 }
 
 EXPORT(int, sceDisplayGetFrameBufInternal) {
@@ -43,7 +44,8 @@ EXPORT(int, sceDisplayGetResolutionInfoInternal) {
 
 EXPORT(SceInt32, sceDisplaySetFrameBuf, const SceDisplayFrameBuf *pFrameBuf, SceDisplaySetBufSync sync) {
     TRACY_FUNC(sceDisplaySetFrameBuf, pFrameBuf, sync);
-    return CALL_EXPORT(_sceDisplaySetFrameBuf, pFrameBuf, sync);
+    uint32_t pFrameBuf_size = pFrameBuf->size;
+    return CALL_EXPORT(_sceDisplaySetFrameBuf, pFrameBuf, sync, &pFrameBuf_size);
 }
 
 EXPORT(int, sceDisplaySetFrameBufForCompat) {


### PR DESCRIPTION
Improve the accuracy of the FrameBuf functions, they take one more argument compared the the user driver version. 
Moreover, Big Sky uses the SceDisplayFrameBuf with an additional field that I have not fully reversed engineered. 

This allows Big Sky to go ingame.