### PR TITLE
mem: Register signal handler also to SIGBUS on macOS

### DIFF
--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -646,6 +646,13 @@ static void register_access_violation_handler(AccessViolationHandler handler) {
     if (sigaction(SIGSEGV, &sa, NULL) == -1) {
         LOG_CRITICAL("Failed to register an exception handler");
     }
+#ifdef __APPLE__
+    // When accessing memory region which is PROT_NONE on macOS, it is raising SIGBUS not SIGSEGV.
+    // So apply same signal handler to SIGBUS
+    if (sigaction(SIGBUS, &sa, NULL) == -1) {
+        LOG_CRITICAL("Failed to register an exception handler to SIGBUS");
+    }
+#endif
 }
 
 #endif


### PR DESCRIPTION
On macOS, accessing PROT_NONE region raises SIGBUS not SIGSEGV. So registers same signal handler also to SIGBUS.

This will fix crash on PCSB01099 on macOS.
<img width="960" alt="image" src="https://github.com/Vita3K/Vita3K/assets/18005062/970476ee-93d5-4d1b-88e4-02d73f1b07b2">
