### PR TITLE
gui & modules/save data dialog: Some fix and reworks.

### DIFF
--- a/vita3k/dialog/include/dialog/state.h
+++ b/vita3k/dialog/include/dialog/state.h
@@ -64,7 +64,7 @@ struct SavedataState {
     uint32_t button_id = SCE_SAVEDATA_DIALOG_BUTTON_ID_INVALID;
 
     std::vector<vfs::FileBuffer> icon_buffer;
-    std::vector<bool> icon_loaded;
+    std::vector<ImTextureID> icon_texture;
 
     uint32_t mode;
     uint32_t mode_to_display;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -422,11 +422,11 @@ int main(int argc, char *argv[]) {
         gui::set_shaders_compiled_display(gui, emuenv);
 
         gui::draw_begin(gui, emuenv);
-        if (!gui.vita_area.home_screen && !gui.vita_area.live_area_screen)
+        if (!emuenv.kernel.is_threads_paused())
             gui::draw_common_dialog(gui, emuenv);
         gui::draw_vita_area(gui, emuenv);
 
-        if (emuenv.cfg.performance_overlay && !gui.vita_area.home_screen && !gui.vita_area.live_area_screen && !gui.vita_area.start_screen && gui::get_sys_apps_state(gui) && (emuenv.common_dialog.status != SCE_COMMON_DIALOG_STATUS_RUNNING))
+        if (emuenv.cfg.performance_overlay && !emuenv.kernel.is_threads_paused() && (emuenv.common_dialog.status != SCE_COMMON_DIALOG_STATUS_RUNNING))
             gui::draw_perf_overlay(gui, emuenv);
 
         if (emuenv.display.imgui_render) {


### PR DESCRIPTION
# About
- gui & modules/save data dialog: Some fix and reworks.
fix crash on fixed mode with reworks navigate in button and set first switch of display mode.
fix icon missing in fixed mode for slot > 0 with reworks load icon texture.
fix clean preview info in SaveDataDialogInit with reset savedata struct.
fix dialog show one save of system data with this reset of struct.
disable common dialog when app is paused.
remove duplicate code of open save slot with set all inside cehck save file.