### PR TITLE
ngs: Double param buffer size for the equalizer

### DIFF
--- a/vita3k/ngs/include/ngs/modules/equalizer.h
+++ b/vita3k/ngs/include/ngs/modules/equalizer.h
@@ -44,7 +44,11 @@ public:
     uint32_t module_id() const override { return 0x5CEC; }
 
     static constexpr uint32_t get_max_parameter_size() {
-        return std::max(sizeof(SceNgsParamEqParams), sizeof(SceNgsParamEqParamsCoEff));
+        constexpr uint32_t max_size = std::max(sizeof(SceNgsParamEqParams), sizeof(SceNgsParamEqParamsCoEff));
+        // World of Final Fantasy acts as if the parameter buffer is followed by another parameter buffer
+        // Probably assuming something about the layout in ngs memory or how lock/unlock params works
+        // right now, just multiply by 2 this buffer size
+        return 2 * max_size;
     }
     uint32_t get_buffer_parameter_size() const override {
         return get_max_parameter_size();


### PR DESCRIPTION
World of Final Fantasy looks like it assumes something about the layout of the ngs memory: it acts as if it knows there is a second SceNgsParamEqParams right after the first one (see screenshot).

My guess is that the param buffer after is the real one (which is copied to after the call the unlock).
Double the size of the Equalizer paramter modules allows the game not to write to undefined memory.

This allows World of Final Fantasy to go ingame with ngs enabled.
![image](https://github.com/Vita3K/Vita3K/assets/5671744/0c590076-3cd7-4c1d-a2d9-8c7ac6c36b41)
