### PR TITLE
shader: Implement workaround for literal buffer address

### DIFF
--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -248,7 +248,17 @@ ProgramInput get_program_input(const SceGxmProgram &program) {
         const SceGxmUniformBufferInfo *buffer_info = &buffer_infoes[i];
         const uint32_t offset = base_offset + buffer_info->ldst_base_offset;
 
-        const auto buffer = uniform_buffers.find(buffer_info->reside_buffer);
+        auto buffer = uniform_buffers.find(buffer_info->reside_buffer);
+
+        if (buffer == uniform_buffers.end() && buffer_info->reside_buffer == 16) {
+            // literals buffer address
+            // this is not implemented yet but at least we can use (if one exists) another buffer
+            // address instead so that we don't get garbage values / crash
+            LOG_WARN("Shader is using a literals buffer address, this is not supported yet");
+            // use a placeholder address
+            buffer = uniform_buffers.begin();
+        }
+
         // buffer = null seems to happen when there's a leftover uniform buffer (uniform buffer that's not used in shader code)
         // This case needs more investigation
         if (buffer != uniform_buffers.end()) {


### PR DESCRIPTION
World of final fantasy uses a literal buffer address which is not yet implemented in the shader recompiler and its implementation will be a bit tricky.
For the time being, use a buffer address as a placeholder instead of doing nothing.

This allows World of Final Fantasy to go ingame with the Vulkan renderer and memory mapping.