### PR TITLE
[Needs Testing] Fix macOS updater

### DIFF
--- a/vita3k/script/update-macos.sh
+++ b/vita3k/script/update-macos.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
-DIR="$(dirname $0)"
-APP_PATH="$(dirname $0)/../../.."
+DIR="$(dirname "$0")"
+APP_PATH="$(dirname "$0")/../../.."
 
-if [ ! -e $DIR/vita3k-latest.dmg ]; then
-    curl -L https://github.com/Vita3K/Vita3K/releases/download/continuous/macos-latest.dmg -o $DIR/vita3k-latest.dmg
+if [ ! -e "$DIR"/vita3k-latest.dmg ]; then
+	curl -L https://github.com/Vita3K/Vita3K/releases/download/continuous/macos-latest.dmg -o "$DIR"/vita3k-latest.dmg
 fi
 
-hdiutil attach $DIR/vita3k-latest.dmg
-cp -Rf -p /Volumes/Vita3K\ Installer/Vita3K.app $APP_PATH
-diskutil eject Vita3K\ Installer
-rm -f $DIR/vita3k-latest.dmg
-xattr -d com.apple.quarantine $APP_PATH/Vita3K.app
-open $APP_PATH/Vita3K.app
+hdiutil attach "$DIR"/vita3k-latest.dmg
+cp -Rf -p /Volumes/Vita3K\ Installer/Vita3K.app "$APP_PATH"
+diskutil eject 'Vita3K Installer'
+rm -f "$DIR"/vita3k-latest.dmg
+xattr -d com.apple.quarantine "$APP_PATH"/Vita3K.app
+open "$APP_PATH"/Vita3K.app


### PR DESCRIPTION
I just add a few quotation marks to try to get `update-vita3k.sh` to recognise spaces in the path. 

Needs testing on macOS, especially when there are spaces in the path to the app bundle. 

Shouldn't affect Windows or Linux