### PR TITLE
modules/SceDriverUser/SceAppMgrUser: Stub sceAppMgrReceiveEventNum.

### DIFF
--- a/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
+++ b/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
@@ -522,9 +522,13 @@ EXPORT(int, sceAppMgrReceiveEvent) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceAppMgrReceiveEventNum) {
-    TRACY_FUNC(sceAppMgrReceiveEventNum);
-    return UNIMPLEMENTED();
+EXPORT(int, sceAppMgrReceiveEventNum, SceUInt32 *eventNum) {
+    TRACY_FUNC(sceAppMgrReceiveEventNum, eventNum);
+
+    // Vita3K does not yet manage events
+    *eventNum = 0;
+
+    return STUBBED("Set eventNum to 0");
 }
 
 EXPORT(int, sceAppMgrReceiveNotificationRequestForShell) {


### PR DESCRIPTION
# About
after reverse in ghidra, see this function send enventNum with value particular very big, causing big freeze in very long loop of call recieve event function
![image](https://github.com/Vita3K/Vita3K/assets/5261759/3163ed1e-28b7-414f-abfa-80a3cb6025f8)

So Accorded with @CreepNT , event is not implemented to Vita3K, so just set 0 for can skip it and stop freeze
