### PR TITLE
renderer/vulkan: Implement shader interlock

### DIFF
--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -77,6 +77,9 @@ struct State {
         const GxmState &gxm, MemState &mem)
         = 0;
     virtual void swap_window(SDL_Window *window) = 0;
+    virtual uint32_t get_device_id() {
+        return 0;
+    }
     // return a bitmask with the Filter enum values of the supported enum filters
     virtual int get_supported_filters() = 0;
     virtual void set_screen_filter(const std::string_view &filter) = 0;

--- a/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
@@ -54,6 +54,8 @@ private:
     // first index: 1 if depth-stencil is force loaded, 0 otherwise
     // second index: 1 if depth-stencil is force stored, 0 otherwise
     std::map<vk::Format, vk::RenderPass> render_passes[2][2];
+    // render passes used along shader interlock
+    std::map<vk::Format, vk::RenderPass> shader_interlock_pass;
     std::map<Sha256Hash, vk::ShaderModule> shaders;
     std::unordered_map<uint64_t, vk::Pipeline> pipelines;
 
@@ -85,7 +87,7 @@ public:
     void read_pipeline_cache();
     void save_pipeline_cache();
 
-    vk::RenderPass retrieve_render_pass(vk::Format format, uint32_t zls_control);
+    vk::RenderPass retrieve_render_pass(vk::Format format, uint32_t zls_control, bool no_color = false);
     vk::Pipeline retrieve_pipeline(VKContext &context, SceGxmPrimitiveType &type, MemState &mem);
 
     bool precompile_shader(const Sha256Hash &hash);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -89,6 +89,7 @@ struct VKState : public renderer::State {
     void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem) override;
     void swap_window(SDL_Window *window) override;
+    uint32_t get_device_id() override;
     int get_supported_filters() override;
     void set_screen_filter(const std::string_view &filter) override;
     int get_max_anisotropic_filtering() override;

--- a/vita3k/renderer/include/renderer/vulkan/surface_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/surface_cache.h
@@ -39,6 +39,13 @@ struct SurfaceCacheInfo {
     vkutil::Image texture;
 };
 
+struct Framebuffer {
+    // standard framebuffer, used most of the time
+    vk::Framebuffer standard;
+    // framenuffer used with shader interlock
+    vk::Framebuffer shader_interlock;
+};
+
 struct CastedTexture {
     vkutil::Image texture;
     // only used if an image to image copy is not possible
@@ -112,7 +119,7 @@ private:
 
     std::map<Address, ColorSurfaceCacheInfo> color_surface_textures;
     std::array<DepthStencilSurfaceCacheInfo, MAX_CACHE_SIZE_PER_CONTAINER> depth_stencil_textures;
-    std::map<std::pair<vk::ImageView, vk::ImageView>, vk::Framebuffer> framebuffer_array;
+    std::map<std::pair<vk::ImageView, vk::ImageView>, Framebuffer> framebuffer_array;
 
     std::vector<Address> last_use_color_surface_index;
     std::vector<size_t> last_use_depth_stencil_surface_index;
@@ -146,8 +153,8 @@ public:
     vkutil::Image *retrieve_depth_stencil_texture_handle(const MemState &mem, const SceGxmDepthStencilSurface &surface, int32_t width,
         int32_t height, const bool is_reading = false);
 
-    vk::Framebuffer retrieve_framebuffer_handle(MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
-        vk::RenderPass render_pass, vkutil::Image **color_texture_handle, vkutil::Image **ds_texture_handle,
+    Framebuffer &retrieve_framebuffer_handle(MemState &mem, SceGxmColorSurface *color, SceGxmDepthStencilSurface *depth_stencil,
+        vk::RenderPass standard_render_pass, vk::RenderPass interlock_render_pass, vkutil::Image **color_texture_handle, vkutil::Image **ds_texture_handle,
         uint16_t *stored_height, const uint32_t width, const uint32_t height);
 
     // If non-null, the return value must be sent as a PostSurfaceSyncRequest

--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -187,9 +187,11 @@ struct VKContext : public renderer::Context {
     SceGxmPrimitiveType last_primitive;
 
     vk::RenderPass current_render_pass;
+    vk::RenderPass current_shader_interlock_pass = nullptr;
     vk::Pipeline current_pipeline;
 
     vk::Framebuffer current_framebuffer;
+    vk::Framebuffer current_shader_interlock_framebuffer = nullptr;
     uint16_t current_framebuffer_height;
     vkutil::Image *current_color_attachment;
     vkutil::Image *current_ds_attachment;
@@ -202,6 +204,11 @@ struct VKContext : public renderer::Context {
     // command buffer used for commands that need to be executed before render_cmd (mostly because they can't be done during a render pass)
     vk::CommandBuffer prerender_cmd{};
     VKRenderTarget *cmd_target = nullptr;
+
+    // used if necessary to restart easily the render pass
+    vk::RenderPassBeginInfo curr_renderpass_info;
+    // only useful if shader interlock is enabled, to know if we need to transition
+    bool last_draw_was_framebuffer_fetch;
 
     // only used if memory mapping is enabled
     std::mutex new_frame_mutex;

--- a/vita3k/renderer/src/vulkan/creation.cpp
+++ b/vita3k/renderer/src/vulkan/creation.cpp
@@ -172,7 +172,10 @@ VKRenderTarget::VKRenderTarget(VKState &state, const SceGxmRenderTargetParams &p
     if (state.features.use_mask_bit)
         mask.init_image(vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eStorage);
 
-    color.init_image(vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eInputAttachment);
+    vk::ImageUsageFlags color_usage = vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eInputAttachment;
+    if (state.features.support_shader_interlock)
+        color_usage |= vk::ImageUsageFlagBits::eStorage;
+    color.init_image(color_usage);
     if (params.multisampleMode == SCE_GXM_MULTISAMPLE_4X) {
         // the depth buffer may need to be 4x bigger if we use a texture without downscale
         depthstencil.width *= 2;

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -185,14 +185,8 @@ void PipelineCache::read_pipeline_cache() {
 }
 
 void PipelineCache::save_pipeline_cache() {
-    size_t pipeline_size;
-    auto result = state.device.getPipelineCacheData(pipeline_cache, &pipeline_size, nullptr);
-    if (result != vk::Result::eSuccess) {
-        LOG_ERROR("Could not get pipeline cache data.");
-        assert(false);
-        return;
-    }
-    if (pipeline_size == 0)
+    const std::vector<uint8_t> pipeline_data = state.device.getPipelineCacheData(pipeline_cache);
+    if (pipeline_data.empty())
         // No pipeline was created
         return;
 
@@ -205,15 +199,8 @@ void PipelineCache::save_pipeline_cache() {
         return;
 
     LOG_INFO("Saving pipeline cache...");
-    std::vector<char> pipeline_data(pipeline_size);
-    result = state.device.getPipelineCacheData(pipeline_cache, &pipeline_size, pipeline_data.data());
-    if (result != vk::Result::eSuccess) {
-        LOG_ERROR("Could not get pipeline cache data.");
-        assert(false);
-        return;
-    }
 
-    pipeline_cache_file.write(pipeline_data.data(), pipeline_size);
+    pipeline_cache_file.write(reinterpret_cast<const char *>(pipeline_data.data()), pipeline_data.size());
     pipeline_cache_file.close();
     LOG_INFO("Pipeline cache saved");
 }

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -43,7 +43,6 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debug_callback(
     VkDebugUtilsMessageTypeFlagsEXT message_type,
     const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
     void *pUserData) {
-
     static const char *ignored_errors[] = {
         "VUID-vkCmdDrawIndexed-None-02721", // using r8g8b8a8 with non-multiple of 4 stride
         "VUID-VkImageViewCreateInfo-usage-02275", // srgb does not support the storage format
@@ -705,6 +704,10 @@ void VKState::swap_window(SDL_Window *window) {
 
         pipeline_cache.next_pipeline_cache_save = std::numeric_limits<uint64_t>::max();
     }
+}
+
+uint32_t VKState::get_device_id() {
+    return physical_device_properties.deviceID;
 }
 
 int VKState::get_supported_filters() {

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -36,7 +36,7 @@ namespace shader {
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
-static constexpr uint32_t CURRENT_VERSION = 10;
+static constexpr uint32_t CURRENT_VERSION = 11;
 
 struct RenderVertUniformBlock {
     std::array<float, 4> viewport_flip;


### PR DESCRIPTION
Implement shader interlock to emulate more accurately programmable blending on desktop GPUs.
This PR is overly complicated for the single reason that Vulkan does not allow a surface to be used both as a color attachment and a storage image (and barrier for this not supported case do not work).
So I have to duplicate all the vulkan structures (render pass, framebuffer...) for them to work with shader interlock.

This has been tested with a NVidia GPU on Windows and an AMD GPU on linux with a dev mesa build.

Without
![image](https://github.com/Vita3K/Vita3K/assets/5671744/4213b7f2-0bda-474d-baa1-efec190e8492)

With
![image](https://github.com/Vita3K/Vita3K/assets/5671744/b3156ad8-1efb-4fce-a025-023c617aa8bf)

I also improved the shader cache to be cleared when using a different GPUs as shader will now most likely not be compatible anymore.
There shouldn't be any graphical regressions, but shader interlock may have a moderate performance impact.

This should fix the 'boxes' issues caused by geometry overlapping in a single draw in all games which had it.