### PR TITLE
mem: Free memory when it is freed on Linux

### DIFF
--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -547,8 +547,10 @@ void free(MemState &state, Address address) {
     const BOOL ret = VirtualFree(memory, page.size * state.page_size, MEM_DECOMMIT);
     LOG_CRITICAL_IF(!ret, "VirtualFree failed: {}", get_error_msg());
 #else
-    const int ret = mprotect(memory, page.size * state.page_size, PROT_NONE);
+    int ret = mprotect(memory, page.size * state.page_size, PROT_NONE);
     LOG_CRITICAL_IF(ret == -1, "mprotect failed: {}", get_error_msg());
+    ret = madvise(memory, page.size * state.page_size, MADV_DONTNEED);
+    LOG_CRITICAL_IF(ret == -1, "madvise failed: {}", get_error_msg());
 #endif
 }
 


### PR DESCRIPTION
On windows, when a free is called, VirtualFree is used with MEM_DECOMMIT to decommit (free) the memory. However, on Linux, the only thing done was to protect the memory range, which does not free the underlying memory.
Calling madvise with the MADV_DONTNEED flag does it. This should decrease the memory usage depending on the game.