### PR TITLE
renderer/vulkan: Emulate macroblock tile sync

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -329,6 +329,12 @@ enum SceGxmMultisampleMode : uint16_t {
     SCE_GXM_MULTISAMPLE_4X
 };
 
+enum SceGxmRenderTargetFlags : uint32_t {
+    SCE_GXM_RENDER_TARGET_CUSTOM_MULTISAMPLE_LOCATIONS = 0x00000001U,
+    SCE_GXM_RENDER_TARGET_MACROTILE_SYNC = 0x00000002U,
+    SCE_GXM_RENDER_TARGET_USE_DISPLAY_QUEUE_PARAMS = 0x00000010U
+};
+
 struct SceGxmRenderTargetParams {
     uint32_t flags;
     uint16_t width;

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -214,6 +214,9 @@ struct ShadersHash {
 struct RenderTarget {
     int holder;
     SceGxmMultisampleMode multisample_mode;
+    bool has_macroblock_sync;
+    uint16_t macroblock_width;
+    uint16_t macroblock_height;
     virtual ~RenderTarget() = default;
 };
 

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -116,6 +116,16 @@ COMMAND(handle_create_render_target) {
         break;
     }
     (*render_target)->multisample_mode = params->multisampleMode;
+    (*render_target)->has_macroblock_sync = (params->flags & SCE_GXM_RENDER_TARGET_MACROTILE_SYNC);
+    if ((*render_target)->has_macroblock_sync) {
+        // there are between 1 and 4 macroblocks in the x and y direction
+        uint16_t nb_macroblocks_x = (params->flags >> 8) & 0b111;
+        uint16_t nb_macroblocks_y = (params->flags >> 12) & 0b111;
+
+        // the width and height should be multiple of 128
+        (*render_target)->macroblock_width = (params->width / nb_macroblocks_x) * renderer.res_multiplier;
+        (*render_target)->macroblock_height = (params->height / nb_macroblocks_y) * renderer.res_multiplier;
+    }
 
     complete_command(renderer, helper, result);
 }

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -351,6 +351,17 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
     constexpr bool replaced_indices = false;
 #endif
 
+    context.check_for_macroblock_change();
+
+    if (!context.in_renderpass)
+        context.start_render_pass();
+
+    if (context.is_first_scene_draw && context.state.features.support_shader_interlock) {
+        // update the render pass to load and store the depth and stencil
+        context.current_render_pass = context.state.pipeline_cache.retrieve_render_pass(context.current_color_attachment->format, ~0U);
+        context.is_first_scene_draw = false;
+    }
+
     const SceGxmFragmentProgram &gxm_fragment_program = *context.record.fragment_program.get(mem);
     const SceGxmProgram &fragment_program_gxp = *gxm_fragment_program.program.get(mem);
     if (context.state.features.direct_fragcolor && fragment_program_gxp.is_frag_color_used()) {

--- a/vita3k/renderer/src/vulkan/surface_cache.cpp
+++ b/vita3k/renderer/src/vulkan/surface_cache.cpp
@@ -243,7 +243,6 @@ vkutil::Image *VKSurfaceCache::retrieve_color_surface_texture_handle(MemState &m
 
                 if (!castable) {
                     static bool has_happened = false;
-                    LOG_ERROR_IF(!has_happened, "Two surface formats requested=0x{:X} and inStore=0x{:X} are not castable!", base_format, info.format);
                     has_happened = true;
                     return nullptr;
                 }


### PR DESCRIPTION
Emulate macroblock tile sync basically by stopping and starting again the recording at every draw when the render target has the macroblock flag. This is accurate but kind of slow, I'll implement soon something better.