### PR TITLE
gui: using msyh font in monospaced font (only windows)

### DIFF
--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -155,7 +155,7 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
     ImGuiIO &io = ImGui::GetIO();
 
     ImFontConfig mono_font_config{};
-    mono_font_config.SizePixels = 24.f;
+    mono_font_config.SizePixels = 21.f;
 
 #ifdef _WIN32
     const auto monospaced_font_path = "C:\\Windows\\Fonts\\msyh.ttc";

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -155,11 +155,11 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
     ImGuiIO &io = ImGui::GetIO();
 
     ImFontConfig mono_font_config{};
-    mono_font_config.SizePixels = 13.f;
+    mono_font_config.SizePixels = 24.f;
 
 #ifdef _WIN32
-    const auto monospaced_font_path = "C:\\Windows\\Fonts\\consola.ttf";
-    gui.monospaced_font = io.Fonts->AddFontFromFileTTF(monospaced_font_path, mono_font_config.SizePixels, &mono_font_config, io.Fonts->GetGlyphRangesJapanese());
+    const auto monospaced_font_path = "C:\\Windows\\Fonts\\msyh.ttc";
+    gui.monospaced_font = io.Fonts->AddFontFromFileTTF(monospaced_font_path, mono_font_config.SizePixels, &mono_font_config, io.Fonts->GetGlyphRangesChineseFull());
 #else
     gui.monospaced_font = io.Fonts->AddFontDefault(&mono_font_config);
 #endif

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -211,7 +211,7 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SetCursorPosY((WINDOW_SIZE.y / 2.f) - ImGui::GetFontSize());
         ImGui::Checkbox("Info Bar Visible", &emuenv.cfg.show_info_bar);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("Check the box to show info bar inside app selector.\nInfo bar is clock, battery level and notification center");
+            ImGui::SetTooltip("Check the box to show info bar inside app selector.\nInfo bar is clock, battery level and notification center.");
         ImGui::SameLine();
         ImGui::Checkbox("Live Area App Screen", &emuenv.cfg.show_live_area_screen);
         if (ImGui::IsItemHovered())

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -953,10 +953,10 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::SliderInt("HTTP Timeout Attempts", &emuenv.cfg.http_timeout_attempts, 0, 100);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("How many attempts to do when the server doesn't respond. Could be useful if you have very unstable or VERY SLOW internet.");
+            ImGui::SetTooltip("How many attempts to do when the server doesn't respond.\nCould be useful if you have very unstable or VERY SLOW internet.");
         ImGui::SliderInt("HTTP Timeout Sleep", &emuenv.cfg.http_timeout_sleep_ms, 50, 3000);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("Attempt sleep time when the server doesn't answer. Could be useful if you have very unstable or VERY SLOW internet.");
+            ImGui::SetTooltip("Attempt sleep time when the server doesn't answer.\nCould be useful if you have very unstable or VERY SLOW internet.");
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();


### PR DESCRIPTION
- gui: using msyh font in monospaced font (only windows): can display normal jpn and cn text, but can not display russian and korean in monospaced font.
![image](https://github.com/Vita3K/Vita3K/assets/108606103/4e5d44bb-d3be-45cc-8468-f41eca16891f)

- fixed small text.