### PR TITLE
render: fix swizzle of RGB1 and BGR1

### DIFF
--- a/vita3k/renderer/src/gl/texture_formats.cpp
+++ b/vita3k/renderer/src/gl/texture_formats.cpp
@@ -56,8 +56,8 @@ static const GLint swizzle_rgba[4] = { GL_ALPHA, GL_BLUE, GL_GREEN, GL_RED };
 static const GLint swizzle_bgra[4] = { GL_GREEN, GL_BLUE, GL_ALPHA, GL_RED };
 static const GLint swizzle_1bgr[4] = { GL_RED, GL_GREEN, GL_BLUE, GL_ONE };
 static const GLint swizzle_1rgb[4] = { GL_BLUE, GL_GREEN, GL_RED, GL_ONE };
-static const GLint swizzle_rgb1[4] = { GL_ONE, GL_BLUE, GL_GREEN, GL_RED };
-static const GLint swizzle_bgr1[4] = { GL_ONE, GL_RED, GL_GREEN, GL_BLUE };
+static const GLint swizzle_1gba[4] = { GL_ALPHA, GL_BLUE, GL_GREEN, GL_ONE };
+static const GLint swizzle_1abg[4] = { GL_GREEN, GL_BLUE, GL_ALPHA, GL_ONE };
 
 // SceGxmTextureSwizzleYUV420Mode
 // TODO I don't know what these should be.
@@ -158,9 +158,9 @@ static const GLint *translate_swizzle(SceGxmTextureSwizzle4Mode mode) {
     case SCE_GXM_TEXTURE_SWIZZLE4_1RGB:
         return swizzle_1rgb;
     case SCE_GXM_TEXTURE_SWIZZLE4_RGB1:
-        return swizzle_rgb1;
+        return swizzle_1gba;
     case SCE_GXM_TEXTURE_SWIZZLE4_BGR1:
-        return swizzle_bgr1;
+        return swizzle_1abg;
     }
 
     return swizzle_abgr;

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -277,8 +277,8 @@ static constexpr vk::ComponentMapping swizzle_rgba = { Swizzle::eR, Swizzle::eG,
 static constexpr vk::ComponentMapping swizzle_bgra = { Swizzle::eB, Swizzle::eG, Swizzle::eR, Swizzle::eA };
 static constexpr vk::ComponentMapping swizzle_abgr = { Swizzle::eA, Swizzle::eB, Swizzle::eG, Swizzle::eR };
 static constexpr vk::ComponentMapping swizzle_gbar = { Swizzle::eG, Swizzle::eB, Swizzle::eA, Swizzle::eR };
-static constexpr vk::ComponentMapping swizzle_1bgr = { Swizzle::eOne, Swizzle::eB, Swizzle::eG, Swizzle::eR };
-static constexpr vk::ComponentMapping swizzle_1rgb = { Swizzle::eOne, Swizzle::eR, Swizzle::eG, Swizzle::eB };
+static constexpr vk::ComponentMapping swizzle_abg1 = { Swizzle::eA, Swizzle::eB, Swizzle::eG, Swizzle::eOne };
+static constexpr vk::ComponentMapping swizzle_gba1 = { Swizzle::eG, Swizzle::eB, Swizzle::eA, Swizzle::eOne };
 
 namespace color {
 
@@ -574,9 +574,9 @@ static const vk::ComponentMapping translate_swizzle4(SceGxmTextureSwizzle4Mode m
     case SCE_GXM_TEXTURE_SWIZZLE4_1RGB:
         return swizzle_bgr1;
     case SCE_GXM_TEXTURE_SWIZZLE4_RGB1:
-        return swizzle_1bgr;
+        return swizzle_abg1;
     case SCE_GXM_TEXTURE_SWIZZLE4_BGR1:
-        return swizzle_1rgb;
+        return swizzle_gba1;
     default:
         LOG_ERROR("Unknown swizzle mode {}", log_hex(mode));
         return {};


### PR DESCRIPTION
# About
- fix wrong swizzle on this 2 format 

finally fix color and face broken on this hyperdimension game during some moment, like here or when finish one level
fix also pause in to love ru BE

# Result
- Master
![image](https://github.com/Vita3K/Vita3K/assets/5261759/4c80c47f-b2b4-4b13-86ad-15e353f56bf8)
- PR
![image](https://github.com/Vita3K/Vita3K/assets/5261759/62519f26-bcb2-4708-9ed4-3ff24d29f218)
