### PR TITLE
regmgr: Add more id on get category and name by id.

### DIFF
--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -519,6 +519,8 @@ void init_home(GuiState &gui, EmuEnvState &emuenv) {
 
     init_app_background(gui, emuenv, "NPXS10015");
 
+    regmgr::init_regmgr(emuenv.regmgr, emuenv.pref_path);
+
     const auto is_cmd = emuenv.cfg.run_app_path || emuenv.cfg.content_path;
     if (!gui.users.empty() && (gui.users.find(emuenv.cfg.user_id) != gui.users.end()) && (is_cmd || emuenv.cfg.auto_user_login)) {
         init_user(gui, emuenv, emuenv.cfg.user_id);
@@ -712,7 +714,6 @@ void init(GuiState &gui, EmuEnvState &emuenv) {
     get_sys_apps_title(gui, emuenv);
 
     init_home(gui, emuenv);
-    regmgr::init_regmgr(emuenv.regmgr, emuenv.pref_path);
 
     // Initialize trophy callback
     emuenv.np.trophy_state.trophy_unlock_callback = [&gui](NpTrophyUnlockCallbackData &callback_data) {

--- a/vita3k/modules/SceRegistryMgr/SceRegMgr.cpp
+++ b/vita3k/modules/SceRegistryMgr/SceRegMgr.cpp
@@ -108,21 +108,21 @@ EXPORT(int, sceRegMgrResetRegistryLv) {
 
 EXPORT(int, sceRegMgrSetKeyBin, const char *category, const char *name, const void *buf, SceSize bufSize) {
     TRACY_FUNC(sceRegMgrSetKeyBin, category, name, buf, bufSize);
-    regmgr::set_bin_value(emuenv.regmgr, emuenv.pref_path, category, name, buf, bufSize);
+    regmgr::set_bin_value(emuenv.regmgr, category, name, buf, bufSize);
 
     return 0;
 }
 
 EXPORT(int, sceRegMgrSetKeyInt, const char *category, const char *name, const SceInt32 buf) {
     TRACY_FUNC(sceRegMgrSetKeyInt, category, name, buf);
-    regmgr::set_int_value(emuenv.regmgr, emuenv.pref_path, category, name, buf);
+    regmgr::set_int_value(emuenv.regmgr, category, name, buf);
 
     return 0;
 }
 
 EXPORT(int, sceRegMgrSetKeyStr, const char *category, const char *name, char *buf, const SceSize bufSize) {
     TRACY_FUNC(sceRegMgrSetKeyStr, category, name, buf, bufSize);
-    regmgr::set_str_value(emuenv.regmgr, emuenv.pref_path, category, name, buf, bufSize);
+    regmgr::set_str_value(emuenv.regmgr, category, name, buf, bufSize);
 
     return 0;
 }
@@ -130,7 +130,7 @@ EXPORT(int, sceRegMgrSetKeyStr, const char *category, const char *name, char *bu
 EXPORT(int, sceRegMgrSetKeys, const char *category, const Keys *keys, const SceInt32 elementsNumber) {
     TRACY_FUNC(sceRegMgrSetKeys, category, keys, elementsNumber);
     for (auto i = 0; i < elementsNumber; i++) {
-        regmgr::set_int_value(emuenv.regmgr, emuenv.pref_path, category, keys[i].name.get(emuenv.mem), keys[i].value);
+        regmgr::set_int_value(emuenv.regmgr, category, keys[i].name.get(emuenv.mem), keys[i].value);
     }
 
     return 0;

--- a/vita3k/modules/SceRegistryMgr/SceRegMgrForGame.cpp
+++ b/vita3k/modules/SceRegistryMgr/SceRegMgrForGame.cpp
@@ -53,7 +53,7 @@ EXPORT(int, sceRegMgrSystemParamGetStr, const int id, char *buf, const SceSize b
 EXPORT(int, sceRegMgrSystemParamSetBin, const int id, const void *buf, const SceSize bufSize) {
     TRACY_FUNC(sceRegMgrSystemParamSetBin, id, buf, bufSize);
     const auto [category, name] = regmgr::get_category_and_name_by_id(id, export_name);
-    regmgr::set_bin_value(emuenv.regmgr, emuenv.pref_path, category, name, buf, bufSize);
+    regmgr::set_bin_value(emuenv.regmgr, category, name, buf, bufSize);
 
     return 0;
 }
@@ -61,7 +61,7 @@ EXPORT(int, sceRegMgrSystemParamSetBin, const int id, const void *buf, const Sce
 EXPORT(int, sceRegMgrSystemParamSetInt, const int id, const SceInt32 buf) {
     TRACY_FUNC(sceRegMgrSystemParamSetInt, id, buf);
     const auto [category, name] = regmgr::get_category_and_name_by_id(id, export_name);
-    regmgr::set_int_value(emuenv.regmgr, emuenv.pref_path, category, name, buf);
+    regmgr::set_int_value(emuenv.regmgr, category, name, buf);
 
     return 0;
 }
@@ -69,7 +69,7 @@ EXPORT(int, sceRegMgrSystemParamSetInt, const int id, const SceInt32 buf) {
 EXPORT(int, sceRegMgrSystemParamSetStr, const int id, const char *buf, const SceSize bufSize) {
     TRACY_FUNC(sceRegMgrSystemParamSetStr, id, buf, bufSize);
     const auto [category, name] = regmgr::get_category_and_name_by_id(id, export_name);
-    regmgr::set_str_value(emuenv.regmgr, emuenv.pref_path, category, name, buf, bufSize);
+    regmgr::set_str_value(emuenv.regmgr, category, name, buf, bufSize);
 
     return 0;
 }

--- a/vita3k/modules/SceRegistryMgr/SceRegMgrForSDK.cpp
+++ b/vita3k/modules/SceRegistryMgr/SceRegMgrForSDK.cpp
@@ -49,7 +49,7 @@ EXPORT(int, sceRegMgrUtilityGetStr, const int id, char *buf, const SceSize bufSi
 EXPORT(int, sceRegMgrUtilitySetBin, const int id, const void *buf, const SceSize bufSize) {
     TRACY_FUNC(sceRegMgrUtilitySetBin, id, buf, bufSize);
     const auto [category, name] = regmgr::get_category_and_name_by_id(id, export_name);
-    regmgr::set_bin_value(emuenv.regmgr, emuenv.pref_path, category, name, buf, bufSize);
+    regmgr::set_bin_value(emuenv.regmgr, category, name, buf, bufSize);
 
     return 0;
 }
@@ -57,7 +57,7 @@ EXPORT(int, sceRegMgrUtilitySetBin, const int id, const void *buf, const SceSize
 EXPORT(int, sceRegMgrUtilitySetInt, const int id, SceInt32 buf) {
     TRACY_FUNC(sceRegMgrUtilitySetInt, id, buf);
     const auto [category, name] = regmgr::get_category_and_name_by_id(id, export_name);
-    regmgr::set_int_value(emuenv.regmgr, emuenv.pref_path, category, name, buf);
+    regmgr::set_int_value(emuenv.regmgr, category, name, buf);
 
     return 0;
 }
@@ -65,7 +65,7 @@ EXPORT(int, sceRegMgrUtilitySetInt, const int id, SceInt32 buf) {
 EXPORT(int, sceRegMgrUtilitySetStr, const int id, const char *buf, const SceSize bufSize) {
     TRACY_FUNC(sceRegMgrUtilitySetStr, id, buf, bufSize);
     const auto [category, name] = regmgr::get_category_and_name_by_id(id, export_name);
-    regmgr::set_str_value(emuenv.regmgr, emuenv.pref_path, category, name, buf, bufSize);
+    regmgr::set_str_value(emuenv.regmgr, category, name, buf, bufSize);
 
     return 0;
 }

--- a/vita3k/regmgr/include/regmgr/functions.h
+++ b/vita3k/regmgr/include/regmgr/functions.h
@@ -28,15 +28,15 @@ void init_regmgr(RegMgrState &regmgr, const std::wstring &pref_path);
 
 // Getters and setters for binary values
 void get_bin_value(RegMgrState &regmgr, const std::string &category, const std::string &name, void *buf, uint32_t bufSize);
-void set_bin_value(RegMgrState &regmgr, const std::wstring &pref_path, const std::string &category, const std::string &name, const void *buf, uint32_t bufSize);
+void set_bin_value(RegMgrState &regmgr, const std::string &category, const std::string &name, const void *buf, uint32_t bufSize);
 
 // Geters and setters for int values
 int32_t get_int_value(RegMgrState &regmgr, const std::string &category, const std::string &name);
-void set_int_value(RegMgrState &regmgr, const std::wstring &pref_path, const std::string &category, const std::string &name, int32_t value);
+void set_int_value(RegMgrState &regmgr, const std::string &category, const std::string &name, int32_t value);
 
 // Getters and setters for string values
 std::string get_str_value(RegMgrState &regmgr, const std::string &category, const std::string &name);
-void set_str_value(RegMgrState &regmgr, const std::wstring &pref_path, const std::string &category, const std::string &name, const char *value, const uint32_t bufSize);
+void set_str_value(RegMgrState &regmgr, const std::string &category, const std::string &name, const char *value, const uint32_t bufSize);
 
 // Getters of category and name by id
 std::pair<std::string, std::string> get_category_and_name_by_id(const int id, const std::string &export_name);

--- a/vita3k/regmgr/include/regmgr/state.h
+++ b/vita3k/regmgr/include/regmgr/state.h
@@ -17,19 +17,14 @@
 
 #pragma once
 
+#include <map>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include <vector>
-
-struct RegValue {
-    std::string name;
-    uint32_t size;
-    std::string value;
-};
 
 struct RegMgrState {
     std::mutex mutex;
+    std::wstring system_dreg_path;
 
-    std::unordered_map<std::string, std::unordered_map<std::string, std::vector<char>>> system_dreg;
+    std::map<std::string, std::map<std::string, std::vector<char>>> system_dreg;
 };

--- a/vita3k/regmgr/src/regmgr.cpp
+++ b/vita3k/regmgr/src/regmgr.cpp
@@ -22,7 +22,7 @@
 
 namespace regmgr {
 
-const std::array<unsigned char, 16> xorKey = { 0x89, 0xFA, 0x95, 0x48, 0xCB, 0x6D, 0x77, 0x9D, 0xA2, 0x25, 0x34, 0xFD, 0xA9, 0x35, 0x59, 0x6E };
+constexpr std::array<unsigned char, 16> xorKey = { 0x89, 0xFA, 0x95, 0x48, 0xCB, 0x6D, 0x77, 0x9D, 0xA2, 0x25, 0x34, 0xFD, 0xA9, 0x35, 0x59, 0x6E };
 
 static std::string decryptRegistryFile(const fs::path reg_path) {
     std::ifstream file(reg_path.string(), std::ios::binary);
@@ -57,10 +57,20 @@ static std::string decryptRegistryFile(const fs::path reg_path) {
     return res;
 }
 
-static std::unordered_map<std::string, std::vector<RegValue>> reg_template;
+struct RegValue {
+    std::string name;
+    uint32_t size;
+    std::string value;
+};
+
+static std::vector<std::string> reg_category_template;
+static std::map<std::string, std::vector<RegValue>> reg_template;
 
 void init_reg_template(RegMgrState &regmgr, const std::string &reg) {
-    std::unordered_map<int, std::string> reg_map;
+    reg_category_template.clear();
+    reg_template.clear();
+
+    std::map<int, std::string> reg_map;
 
     std::istringstream iss(reg);
     std::string line;
@@ -114,6 +124,11 @@ void init_reg_template(RegMgrState &regmgr, const std::string &reg) {
                             values.push_back(s);
                     }
 
+                    const auto add_category_template = [&](const std::string &category) {
+                        if (std::find(reg_category_template.begin(), reg_category_template.end(), category) == reg_category_template.end())
+                            reg_category_template.push_back(category);
+                    };
+
                     const auto valueSize = static_cast<uint32_t>(std::stoi(values[1]));
                     const std::regex categoryRangePattern(R"((.*\/)([0-9]{2})-([0-9]{2})(\/.*))");
                     std::smatch matches;
@@ -126,9 +141,12 @@ void init_reg_template(RegMgrState &regmgr, const std::string &reg) {
                         for (int i = firstNum; i <= secondNum; i++) {
                             const std::string categoryName = fmt::format("{}{:0>2d}{}", cat_begin, i, cat_end);
                             reg_template[categoryName].push_back({ valueName, valueSize, values.back() });
+                            add_category_template(categoryName);
                         }
-                    } else
+                    } else {
                         reg_template[category].push_back({ valueName, valueSize, values.back() });
+                        add_category_template(category);
+                    }
                 }
             }
         }
@@ -142,9 +160,8 @@ static uint32_t get_space_size(const uint32_t str_size) {
     return spaceSize > str_size ? spaceSize - str_size : ((str_size / line) + 1) * line - str_size;
 }
 
-static bool load_system_dreg(RegMgrState &regmgr, const std::wstring &pref_path) {
-    const auto system_dreg_path{ fs::path(pref_path) / "vd0/registry/system.dreg" };
-    fs::ifstream file(system_dreg_path, std::ios::in | std::ios::binary);
+static bool load_system_dreg(RegMgrState &regmgr) {
+    fs::ifstream file(regmgr.system_dreg_path, std::ios::in | std::ios::binary);
     if (file.is_open()) {
         char buf = 0;
 
@@ -153,14 +170,14 @@ static bool load_system_dreg(RegMgrState &regmgr, const std::wstring &pref_path)
             file.read(&buf, 1);
         }
 
-        for (const auto &reg : reg_template) {
+        for (const auto &cat : reg_category_template) {
             // Read the category
-            const uint32_t cat_size = static_cast<uint32_t>(reg.first.size());
+            const uint32_t cat_size = static_cast<uint32_t>(cat.size());
             std::vector<char> category(cat_size);
             file.read(category.data(), cat_size);
             const auto category_str = std::string(category.begin(), category.end());
-            if (category_str != reg.first) {
-                LOG_ERROR("Invalid category: {}, expected: {}", category_str, reg.first);
+            if (category_str != cat) {
+                LOG_ERROR("Invalid category: {}, expected: {}", category_str, cat);
                 return false;
             }
 
@@ -170,14 +187,14 @@ static bool load_system_dreg(RegMgrState &regmgr, const std::wstring &pref_path)
                 file.read(&buf, 1);
             }
 
-            for (const auto &entry : reg.second) {
+            for (const auto &entry : reg_template[cat]) {
                 // Read the name
                 const uint32_t name_size = static_cast<uint32_t>(entry.name.size());
                 std::vector<char> name(name_size);
                 file.read(name.data(), name_size);
                 const auto name_str = std::string(name.begin(), name.end());
                 if (name_str != entry.name) {
-                    LOG_ERROR("Invalid entry name: {}, expected: {}", name_str, entry.name);
+                    LOG_ERROR("Invalid entry name: {}, expected: {}, in category: {}", name_str, entry.name, cat);
                     return false;
                 }
 
@@ -189,7 +206,7 @@ static bool load_system_dreg(RegMgrState &regmgr, const std::wstring &pref_path)
 
                 // Read the value
                 const uint32_t value_size = entry.size;
-                auto &value = regmgr.system_dreg[reg.first][entry.name];
+                auto &value = regmgr.system_dreg[cat][entry.name];
                 value.resize(value_size);
                 file.read(value.data(), value_size);
 
@@ -207,9 +224,8 @@ static bool load_system_dreg(RegMgrState &regmgr, const std::wstring &pref_path)
     return !regmgr.system_dreg.empty();
 }
 
-static void save_system_dreg(RegMgrState &regmgr, const std::wstring pref_path) {
-    const auto system_dreg_path{ fs::path(pref_path) / "vd0/registry/system.dreg" };
-    fs::ofstream file(system_dreg_path, std::ios::out | std::ios::binary);
+static void save_system_dreg(RegMgrState &regmgr) {
+    fs::ofstream file(regmgr.system_dreg_path, std::ios::out | std::ios::binary);
     if (file.is_open()) {
         const char buf = 0;
 
@@ -219,12 +235,12 @@ static void save_system_dreg(RegMgrState &regmgr, const std::wstring pref_path) 
         }
 
         // Write each category
-        for (const auto &reg : reg_template) {
+        for (const auto &cat : reg_category_template) {
             // Write the category
-            const uint32_t cat_size = static_cast<uint32_t>(reg.first.size());
+            const uint32_t cat_size = static_cast<uint32_t>(cat.size());
             std::vector<char> category(cat_size);
-            strncpy(category.data(), reg.first.c_str(), cat_size);
-            file.write(reg.first.c_str(), cat_size);
+            strncpy(category.data(), cat.c_str(), cat_size);
+            file.write(cat.c_str(), cat_size);
 
             // Write the space
             const auto diff_cat = get_space_size(cat_size);
@@ -233,7 +249,7 @@ static void save_system_dreg(RegMgrState &regmgr, const std::wstring pref_path) 
             }
 
             // Write each entry
-            for (const auto &entry : reg.second) {
+            for (const auto &entry : reg_template[cat]) {
                 // Write the name
                 const uint32_t name_size = static_cast<uint32_t>(entry.name.size());
                 std::vector<char> name(name_size);
@@ -248,7 +264,7 @@ static void save_system_dreg(RegMgrState &regmgr, const std::wstring pref_path) 
 
                 // Write the value
                 const uint32_t value_size = entry.size;
-                file.write(regmgr.system_dreg[reg.first][entry.name].data(), value_size);
+                file.write(regmgr.system_dreg[cat][entry.name].data(), value_size);
 
                 // Write the space
                 const auto diff_value = get_space_size(value_size);
@@ -262,9 +278,8 @@ static void save_system_dreg(RegMgrState &regmgr, const std::wstring pref_path) 
     }
 }
 
-static void init_system_dreg(RegMgrState &regmgr, const std::wstring pref_path) {
-    regmgr.system_dreg.clear();
-
+static void init_system_dreg(RegMgrState &regmgr) {
+    // Initialize the system.dreg with the default values from the template
     for (const auto &reg : reg_template) {
         for (const auto &entry : reg.second) {
             auto &value = regmgr.system_dreg[reg.first][entry.name];
@@ -273,62 +288,117 @@ static void init_system_dreg(RegMgrState &regmgr, const std::wstring pref_path) 
         }
     }
 
-    save_system_dreg(regmgr, pref_path);
+    save_system_dreg(regmgr);
+}
+
+static bool category_or_name_is_empty(const std::string &category, const std::string &name) {
+    return category.empty() || name.empty();
 }
 
 static std::string fix_category(const std::string &category) {
     return category.back() == '/' ? category : category + '/';
 }
 
+static std::string set_default_value(RegMgrState &regmgr, const std::string &category, const std::string &name) {
+    if (category_or_name_is_empty(category, name))
+        return {};
+
+    const auto &reg = std::find_if(reg_template[category].begin(), reg_template[category].end(), [&](const auto &n) {
+        return n.name == name;
+    });
+
+    if (reg == reg_template[category].end()) {
+        LOG_ERROR("No default value found for {}{}", category, name);
+        return {};
+    }
+
+    auto &sys = regmgr.system_dreg[category][name];
+    sys.clear();
+    sys.resize(reg->size);
+    sys.assign(reg->value.begin(), reg->value.end());
+
+    LOG_INFO("Successfully set default value for {}{}", category, name);
+
+    save_system_dreg(regmgr);
+
+    return reg->value;
+}
+
 void get_bin_value(RegMgrState &regmgr, const std::string &category, const std::string &name, void *buf, uint32_t bufSize) {
+    if (category_or_name_is_empty(category, name))
+        return;
+
     std::lock_guard<std::mutex> lock(regmgr.mutex);
     const auto &sys = regmgr.system_dreg[fix_category(category)][name];
 
     memcpy(buf, sys.data(), bufSize);
 }
 
-void set_bin_value(RegMgrState &regmgr, const std::wstring &pref_path, const std::string &category, const std::string &name, const void *buf, const uint32_t bufSize) {
+void set_bin_value(RegMgrState &regmgr, const std::string &category, const std::string &name, const void *buf, const uint32_t bufSize) {
+    if (category_or_name_is_empty(category, name))
+        return;
+
     std::lock_guard<std::mutex> lock(regmgr.mutex);
 
     const char *data = reinterpret_cast<const char *>(buf);
     regmgr.system_dreg[fix_category(category)][name].assign(data, data + bufSize);
 
-    save_system_dreg(regmgr, pref_path);
+    save_system_dreg(regmgr);
 }
 
 int32_t get_int_value(RegMgrState &regmgr, const std::string &category, const std::string &name) {
+    if (category_or_name_is_empty(category, name))
+        return 0;
+
     std::lock_guard<std::mutex> lock(regmgr.mutex);
 
-    const auto &sys = regmgr.system_dreg[fix_category(category)][name];
-    const auto value_str = std::string(sys.begin(), sys.end());
+    const auto cat = fix_category(category);
+    const auto &sys = regmgr.system_dreg[cat][name];
+    auto value_str = std::string(sys.begin(), sys.end());
+    if (!std::all_of(value_str.begin(), value_str.end(), [](unsigned char c) { return std::isdigit(c) || (c == '\0'); })) {
+        LOG_ERROR("Invalid value for {}{}: {}, attempt using default value!", cat, name, value_str);
+        value_str = set_default_value(regmgr, cat, name);
+        if (value_str.empty())
+            return 0;
+    }
 
     return std::stoi(value_str);
 }
 
-void set_int_value(RegMgrState &regmgr, const std::wstring &pref_path, const std::string &category, const std::string &name, int32_t value) {
+void set_int_value(RegMgrState &regmgr, const std::string &category, const std::string &name, int32_t value) {
+    if (category_or_name_is_empty(category, name))
+        return;
+
     std::lock_guard<std::mutex> lock(regmgr.mutex);
 
     const auto str_value = std::to_string(value);
     regmgr.system_dreg[fix_category(category)][name].assign(str_value.begin(), str_value.end());
 
-    save_system_dreg(regmgr, pref_path);
+    save_system_dreg(regmgr);
 }
 
 std::string get_str_value(RegMgrState &regmgr, const std::string &category, const std::string &name) {
+    if (category_or_name_is_empty(category, name))
+        return {};
+
     std::lock_guard<std::mutex> lock(regmgr.mutex);
     const auto &sys = regmgr.system_dreg[fix_category(category)][name];
 
     return std::string(sys.begin(), sys.end());
 }
 
-void set_str_value(RegMgrState &regmgr, const std::wstring &pref_path, const std::string &category, const std::string &name, const char *value, const uint32_t bufSize) {
+void set_str_value(RegMgrState &regmgr, const std::string &category, const std::string &name, const char *value, const uint32_t bufSize) {
+    if (category_or_name_is_empty(category, name))
+        return;
+
     std::lock_guard<std::mutex> lock(regmgr.mutex);
     regmgr.system_dreg[fix_category(category)][name].assign(value, value + bufSize);
 
-    save_system_dreg(regmgr, pref_path);
+    save_system_dreg(regmgr);
 }
 
 void init_regmgr(RegMgrState &regmgr, const std::wstring &pref_path) {
+    // Load the registry template
     const auto reg = decryptRegistryFile(fs::path(pref_path) / "os0/kd/registry.db0");
     if (reg.empty()) {
         return;
@@ -338,9 +408,11 @@ void init_regmgr(RegMgrState &regmgr, const std::wstring &pref_path) {
     init_reg_template(regmgr, reg);
 
     // Initialize the system.dreg
-    if (!load_system_dreg(regmgr, pref_path)) {
+    regmgr.system_dreg_path = pref_path + L"vd0/registry/system.dreg";
+    regmgr.system_dreg.clear();
+    if (!load_system_dreg(regmgr)) {
         LOG_WARN("Failed to load system.dreg, attempting to create it");
-        init_system_dreg(regmgr, pref_path);
+        init_system_dreg(regmgr);
     }
 }
 
@@ -348,28 +420,130 @@ std::pair<std::string, std::string> get_category_and_name_by_id(const int id, co
     switch (id) {
     case 0x00023FC2:
         return { "/CONFIG/ACCESSIBILITY/", "large_text" };
+    case 0x00033818:
+        return { "/CONFIG/NP/", "env" };
     case 0x00037502:
         return { "/CONFIG/SYSTEM/", "language" };
+    case 0x000504E4:
+        return { "/CONFIG/NP2/TELEPORT/", "passcode_client" };
+    case 0x00068303:
+        return { "/CONFIG/BROWSER/ADDIN/TRENDMICRO/", "tm_ec_ttl" };
     case 0x00088776:
         return { "/CONFIG/DATE/", "date_format" };
+    case 0x000A0495:
+        return { "/CONFIG/NP/", "nav_only" };
+    case 0x000B6ECD:
+        return { "/CONFIG/NP/", "np_ad_clock_diff" };
+    case 0x000B73CD:
+        return { "/CONFIG/NP/", "debug" };
+    case 0x000D18E5:
+        return { "/CONFIG/NP/", "np_geo_filtering" };
+    case 0x00100591:
+        return { "/CONFIG/DATE/", "time_zone" };
+    case 0x00134C03:
+        return { "/CONFIG/NET/", "pspnet_adhoc_ssid_prefix" };
+    case 0x00146E23:
+        return { "/CONFIG/GAME/", "show_debug_info" };
+    case 0x00154A2C:
+        return { "/CONFIG/GAME/", "fake_free_space" };
+    case 0x00156489:
+        return { "/CONFIG/NP/", "debug_ingame_commerce2" };
+    case 0x00168B9B:
+        return { "/CONFIG/NP2/", "tpps_proxy_password" };
     case 0x00186122:
         return { "/CONFIG/SECURITY/PARENTAL/", "passcode" };
+    case 0x001B2292:
+        return { "/CONFIG/BROWSER/ADDIN/TRENDMICRO/", "tm_ec_ttl_update_time" };
     case 0x00229142:
         return { "/CONFIG/SYSTEM/", "button_assign" };
+    case 0x0022B191:
+        return { "/CONFIG/NP2/", "tpps_proxy_port" };
+    case 0x0025CE9A:
+        return { "/CONFIG/GAME/", "fake_free_space_quota" };
+    case 0x002FDFB4:
+        return { "/CONFIG/DISPLAY/", "hdmi_out_scaling_ratio" };
+    case 0x00313905:
+        return { "/CONFIG/NP2/", "test_patch" };
+    case 0x003317A1:
+        return { "/CONFIG/NP2/", "trophy_setup_dialog_debug" };
+    case 0x0036F14E:
+        return { "/CONFIG/NP2/TELEPORT/", "enable_media_transfer" };
+    case 0x003CB6A4:
+        return { "/DEVENV/TOOL/", "gpi_switch" };
+    case 0x00424500:
+        return { "/CONFIG/GAME/", "fake_sdslot_broken" };
     case 0x00450F32:
         return { "/CONFIG/NP/", "account_id" };
+    case 0x004E7A16:
+        return { "/CONFIG/NP2/TELEPORT/", "target_name" };
+    case 0x004F7E60:
+        return { "/CONFIG/PS4LINK/", "counter" };
+    case 0x00505BCE:
+        return { "/CONFIG/NP2/", "fake_ratelimit" };
+    case 0x0051F6AE:
+        return { "/CONFIG/SPECIFIC/", "idu_mode" };
+    case 0x00528C0D:
+        return { "/CONFIG/NP2/", "ignore_titleid" };
     case 0x00563BFE:
         return { "/CONFIG/NET/", "ssl_cert_ignorable" };
     case 0x00598438:
         return { "/CONFIG/SYSTEM/", "username" };
+    case 0x005F6737:
+        return { "/CONFIG/NP2/TWITTER/", "access_token" };
     case 0x00611DC9:
         return { "/CONFIG/ACCESSIBILITY/", "bold_text" };
+    case 0x00612B3E:
+        return { "/CONFIG/BROWSER/", "web_security_status" };
+    case 0x00646A8E:
+        return { "/CONFIG/NP2/", "tpps_proxy_server" };
     case 0x00668503:
         return { "/CONFIG/DATE/", "time_format" };
     case 0x00683DCD:
         return { "/CONFIG/SYSTEM/", "key_pad" };
+    case 0x006FF829:
+        return { "/CONFIG/NP2/", "tpps_proxy_flag" };
+    case 0x00711659:
+        return { "/CONFIG/SECURITY/PARENTAL/", "content_start_control" };
+    case 0x00760538:
+        return { "/CONFIG/DATE/", "summer_time" };
+    case 0x007C9764:
+        return { "/CONFIG/NP2/", "fake_plus" };
+    case 0x007D12C4:
+        return { "/CONFIG/GAME/", "fake_contents_max" };
+    case 0x007F9315:
+        return { "/CONFIG/DATE/", "is_summer_time" };
+    case 0x0081649F:
+        return { "/CONFIG/BROWSER/ADDIN/TRENDMICRO/", "tm_service" };
+    case 0x00872621:
+        return { "/CONFIG/BROWSER/ADDIN/TRENDMICRO/", "tm_service_sub_status" };
+    case 0x0089C9CF:
+        return { "/CONFIG/SECURITY/PARENTAL/", "store_start_control" };
     case 0x008A2AD7:
         return { "/CONFIG/ACCESSIBILITY/", "contrast" };
+    case 0x008C3860:
+        return { "/CONFIG/BROWSER/DEBUG/", "net_dbg_config" };
+    case 0x008D89EB:
+        return { "/CONFIG/NP2/TELEPORT/", "wol_target_mac_address" };
+    case 0x008E3939:
+        return { "/CONFIG/MUSIC/MUSIC_APP/", "impose_audio_balance" };
+    case 0x008EB468:
+        return { "/CONFIG/NP2/", "tpps_proxy_user_name" };
+    case 0x008F94F9:
+        return { "/CONFIG/NP/", "country" };
+    case 0x0091F34F:
+        return { "/CONFIG/NP2/TWITTER/", "access_token_secret" };
+    case 0x0093C981:
+        return { "/CONFIG/PSM/", "revocation_check_req" };
+    case 0x0094E320:
+        return { "/CONFIG/PS4LINK/", "keys" };
+    case 0x009623D0:
+        return { "/CONFIG/GAME/", "fake_no_memory_card" };
+    case 0x00971FA1:
+        return { "/CONFIG/SHELL/", "voice_priority" };
+    case 0x00987180:
+        return { "/CONFIG/NP2/TELEPORT/", "initial_target" };
+    case 0x00988B81:
+        return { "/CONFIG/PSNOW/", "app_cached_url" };
     default:
         LOG_WARN("{}: unknown id: {}", export_name, log_hex(id));
         return { "", "" };


### PR DESCRIPTION
# About
- regmgr: Add more id on get category and name by id.
Fix crash when category/name is empty.
Fix crash when category/name is empty.
Fix init regmgr when change pref path.
Fix crash if value is not int for get int.
Add Set default value if value is corrupted.
Using vector for reg category template for keep order instead unordered map for fix broken file when switch pref path directory.