### PR TITLE
modules/SceModuleMgr: Add check before calling module_start

### DIFF
--- a/vita3k/modules/SceKernelModulemgr/SceModulemgr.cpp
+++ b/vita3k/modules/SceKernelModulemgr/SceModulemgr.cpp
@@ -111,7 +111,9 @@ EXPORT(SceUID, _sceKernelLoadModule, char *path, int flags, SceKernelLMOption *o
 
 static SceUID start_module(KernelState &kernel, SceUID thread_id, const SceKernelModuleInfoPtr &module, SceSize args, const Ptr<void> argp, int *pRes) {
     const auto thread = kernel.get_thread(thread_id);
-    uint32_t result = thread->run_callback(module->start_entry.address(), { args, argp.address() });
+    uint32_t result = 0;
+    if (module->start_entry)
+        result = thread->run_callback(module->start_entry.address(), { args, argp.address() });
 
     LOG_INFO("Module {} (at \"{}\") module_start returned {}", module->module_name, module->path, log_hex(result));
 


### PR DESCRIPTION
God eater loads and starts the libdflt module, which has no module_start.

This allows the game to progress slightly further.