### PR TITLE
modules: Describe and partial implememt SceRtabi module

### DIFF
--- a/vita3k/module/src/write_return_value.cpp
+++ b/vita3k/module/src/write_return_value.cpp
@@ -37,6 +37,18 @@ void write_return_value(CPUState &cpu, uint64_t ret) {
     write_reg(cpu, 1, ret >> 32);
 }
 
+void write_return_value(CPUState &cpu, std::div_t ret) {
+    write_reg(cpu, 0, ret.quot);
+    write_reg(cpu, 1, ret.rem);
+}
+
+void write_return_value(CPUState &cpu, std::lldiv_t ret) {
+    write_reg(cpu, 0, ret.quot & UINT32_MAX);
+    write_reg(cpu, 1, ret.quot >> 32);
+    write_reg(cpu, 2, ret.rem & UINT32_MAX);
+    write_reg(cpu, 3, ret.rem >> 32);
+}
+
 void write_return_value(CPUState &cpu, bool ret) {
     write_reg(cpu, 0, ret);
 }

--- a/vita3k/modules/CMakeLists.txt
+++ b/vita3k/modules/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SOURCE_LIST
 	SceLibKernel/SceLibKernel.cpp SceLibKernel/SceLibKernel.h
 	SceLibKernel/SceLibRng.cpp SceLibKernel/SceLibRng.h
 	SceLibKernel/SceLibSsp.cpp SceLibKernel/SceLibSsp.h
+	SceLibKernel/SceRtabi.cpp SceLibKernel/SceRtabi.h
 	SceLibMono/SceLibMono.cpp SceLibMono/SceLibMono.h
 	SceLibMonoBridge/SceLibMonoBridge.cpp SceLibMonoBridge/SceLibMonoBridge.h
 	SceLibMp4Recorder/SceLibMp4Recorder.cpp SceLibMp4Recorder/SceLibMp4Recorder.h

--- a/vita3k/modules/SceLibKernel/SceRtabi.cpp
+++ b/vita3k/modules/SceLibKernel/SceRtabi.cpp
@@ -1,0 +1,154 @@
+// Vita3K emulator project
+// Copyright (C) 2023 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "SceRtabi.h"
+#include <util/tracy.h>
+
+TRACY_MODULE_NAME(SceRtabi);
+
+EXPORT(int, __rtabi_lcmp) {
+    TRACY_FUNC(__rtabi_lcmp);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int, __rtabi_lmul) {
+    TRACY_FUNC(__rtabi_lmul);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int, __rtabi_lasr) {
+    TRACY_FUNC(__rtabi_lasr);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int, __rtabi_ulcmp) {
+    TRACY_FUNC(__rtabi_ulcmp);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int32_t, __rtabi_idiv, int32_t numerator, int32_t denominator) {
+    TRACY_FUNC(__rtabi_idiv, numerator, denominator);
+    if (denominator == 0) {
+        if (numerator == 0)
+            return 0;
+        else if (numerator > 0)
+            return INT32_MAX;
+        else
+            return INT32_MIN;
+    }
+    return numerator / denominator;
+}
+
+EXPORT(int, __rtabi_d2lz) {
+    TRACY_FUNC(__rtabi_d2lz);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int, __rtabi_f2ulz) {
+    TRACY_FUNC(__rtabi_f2ulz);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(std::div_t, __rtabi_idivmod, int32_t numerator, int32_t denominator) {
+    TRACY_FUNC(__rtabi_idivmod);
+    if (denominator == 0) {
+        if (numerator == 0)
+            return std::div_t{ .quot = 0, .rem = 0 };
+        else if (numerator > 0)
+            return std::div_t{ .quot = INT32_MAX, .rem = 0 };
+        else
+            return std::div_t{ .quot = INT32_MIN, .rem = 0 };
+    }
+    return div(numerator, denominator);
+}
+
+EXPORT(int, __rtabi_d2ulz) {
+    TRACY_FUNC(__rtabi_d2ulz);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(std::lldiv_t, __rtabi_ldivmod, int64_t numerator, int64_t denominator) {
+    TRACY_FUNC(__rtabi_ldivmod, numerator, denominator);
+    if (denominator == 0) {
+        if (numerator == 0)
+            return std::lldiv_t{ .quot = 0, .rem = 0 };
+        else if (numerator > 0)
+            return std::lldiv_t{ .quot = INT64_MAX, .rem = 0 };
+        else
+            return std::lldiv_t{ .quot = INT64_MIN, .rem = 0 };
+    }
+    return lldiv(numerator, denominator);
+}
+
+EXPORT(int, __rtabi_llsl) {
+    TRACY_FUNC(__rtabi_llsl);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int, __rtabi_f2lz) {
+    TRACY_FUNC(__rtabi_f2lz);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int, __rtabi_uidivmod, uint32_t numerator, uint32_t denominator) {
+    TRACY_FUNC(__rtabi_uidivmod, numerator, denominator);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int, __rtabi_llsr) {
+    TRACY_FUNC(__rtabi_llsr);
+    return UNIMPLEMENTED();
+}
+
+EXPORT(std::lldiv_t, __rtabi_uldivmod, uint64_t numerator, uint64_t denominator) {
+    TRACY_FUNC(__rtabi_uldivmod, numerator, denominator);
+    if (denominator == 0) {
+        if (numerator == 0)
+            return std::lldiv_t{ .quot = 0, .rem = 0 };
+        else
+            return std::lldiv_t{ .quot = -1, .rem = 0 };
+    }
+    return lldiv(numerator, denominator);
+}
+
+EXPORT(uint32_t, __rtabi_uidiv, uint32_t numerator, uint32_t denominator) {
+    TRACY_FUNC(__rtabi_uidiv, numerator, denominator);
+    if (denominator == 0) {
+        if (numerator == 0)
+            return 0;
+        else
+            return UINT32_MAX;
+    }
+    return numerator / denominator;
+}
+
+BRIDGE_IMPL(__rtabi_lcmp)
+BRIDGE_IMPL(__rtabi_lmul)
+BRIDGE_IMPL(__rtabi_lasr)
+BRIDGE_IMPL(__rtabi_ulcmp)
+BRIDGE_IMPL(__rtabi_idiv)
+BRIDGE_IMPL(__rtabi_d2lz)
+BRIDGE_IMPL(__rtabi_f2ulz)
+BRIDGE_IMPL(__rtabi_idivmod)
+BRIDGE_IMPL(__rtabi_d2ulz)
+BRIDGE_IMPL(__rtabi_ldivmod)
+BRIDGE_IMPL(__rtabi_llsl)
+BRIDGE_IMPL(__rtabi_f2lz)
+BRIDGE_IMPL(__rtabi_uidivmod)
+BRIDGE_IMPL(__rtabi_llsr)
+BRIDGE_IMPL(__rtabi_uldivmod)
+BRIDGE_IMPL(__rtabi_uidiv)

--- a/vita3k/modules/SceLibKernel/SceRtabi.h
+++ b/vita3k/modules/SceLibKernel/SceRtabi.h
@@ -17,20 +17,21 @@
 
 #pragma once
 
-#include <mem/ptr.h>
+#include <module/module.h>
 
-struct CPUState;
-
-void write_return_value(CPUState &cpu, int32_t ret);
-void write_return_value(CPUState &cpu, int64_t ret);
-void write_return_value(CPUState &cpu, uint32_t ret);
-void write_return_value(CPUState &cpu, uint64_t ret);
-void write_return_value(CPUState &cpu, std::div_t ret);
-void write_return_value(CPUState &cpu, std::lldiv_t ret);
-void write_return_value(CPUState &cpu, bool ret);
-void write_return_value(CPUState &cpu, float ret);
-
-template <typename Pointee>
-void write_return_value(CPUState &cpu, const Ptr<Pointee> &ret) {
-    write_return_value(cpu, ret.address());
-}
+BRIDGE_DECL(__rtabi_lcmp)
+BRIDGE_DECL(__rtabi_lmul)
+BRIDGE_DECL(__rtabi_lasr)
+BRIDGE_DECL(__rtabi_ulcmp)
+BRIDGE_DECL(__rtabi_idiv)
+BRIDGE_DECL(__rtabi_d2lz)
+BRIDGE_DECL(__rtabi_f2ulz)
+BRIDGE_DECL(__rtabi_idivmod)
+BRIDGE_DECL(__rtabi_d2ulz)
+BRIDGE_DECL(__rtabi_ldivmod)
+BRIDGE_DECL(__rtabi_llsl)
+BRIDGE_DECL(__rtabi_f2lz)
+BRIDGE_DECL(__rtabi_uidivmod)
+BRIDGE_DECL(__rtabi_llsr)
+BRIDGE_DECL(__rtabi_uldivmod)
+BRIDGE_DECL(__rtabi_uidiv)

--- a/vita3k/nids/include/nids/nids.inc
+++ b/vita3k/nids/include/nids/nids.inc
@@ -4249,6 +4249,23 @@ NID(sceSblGcAuthMgrSclkSetData2, 0xE088B0D0)
 NID(sceKernelGetRandomNumber, 0xB2700165)
 // Library "SceLibSsp"
 NID(sceLibSspStackChkFail, 0x39AD080B)
+// Library "SceRtabi"
+NID(__rtabi_lcmp, 0x0D4F0635)
+NID(__rtabi_lmul, 0x141BC4CE)
+NID(__rtabi_lasr, 0x21FF67B9)
+NID(__rtabi_ulcmp, 0x317B3774)
+NID(__rtabi_idiv, 0x38D62D60)
+NID(__rtabi_d2lz, 0x5024AB91)
+NID(__rtabi_f2ulz, 0x609CA961)
+NID(__rtabi_idivmod, 0x67104054)
+NID(__rtabi_d2ulz, 0x6BB838EF)
+NID(__rtabi_ldivmod, 0x6CBB0E84)
+NID(__rtabi_llsl, 0xA5DB3A86)
+NID(__rtabi_f2lz, 0xAA1F1B50)
+NID(__rtabi_uidivmod, 0xC33391D1)
+NID(__rtabi_llsr, 0xCBDA815C)
+NID(__rtabi_uldivmod, 0xCDF7708E)
+NID(__rtabi_uidiv, 0xFB311F87)
 // Module "SceLibMono"
 // Library "SceLibMono"
 NID(mono_security_enable_core_clr, 0x02A867BC)


### PR DESCRIPTION
used by driver_us.suprx
Return value of `__rtabi_ldivmod` is very unusual but it seems correct.
Behavior on division by zero is taken from original disasmed code.
original names of functions are `__aeabi_*` but they was renamed to not mix with same functions in other module with other nids