### PR TITLE
net: Fix max epoll nfd number on wait

### DIFF
--- a/vita3k/net/src/epoll.cpp
+++ b/vita3k/net/src/epoll.cpp
@@ -61,7 +61,7 @@ int Epoll::wait(SceNetEpollEvent *events, int maxevents, int timeout_microsecond
     timeval timeout;
     timeout.tv_sec = timeout_microseconds / 1000000;
     timeout.tv_usec = timeout_microseconds % 1000000;
-    auto ret = select(maxFd, &readFds, &writeFds, &exceptFds, &timeout);
+    auto ret = select(maxFd + 1, &readFds, &writeFds, &exceptFds, &timeout);
     if (ret < 0) {
         // TODO: translate error code
         return -1;


### PR DESCRIPTION
turns out that the `nfds` param needs to be the highest fd PLUS ONE, 
linux says this in its documentation, but on windows its missing this tiny detail, i've seen other people use select and having it only work if adding 1 to nfds, so its the same as linux
https://man7.org/linux/man-pages/man2/select.2.html
this fixes a forever waiting/loading on some homebrews with epoll waits (idk about commercial games)