### PR TITLE
interface, kernel: Fixes

### DIFF
--- a/vita3k/gdbstub/src/gdb.cpp
+++ b/vita3k/gdbstub/src/gdb.cpp
@@ -491,7 +491,7 @@ static std::string cmd_continue(EmuEnvState &state, PacketCommand &command) {
                 auto thread = state.kernel.get_thread(state.gdb.inferior_thread);
                 LOG_INFO("GDB Breakpoint trigger (thread name: {}, thread_id: {})", thread->name, thread->id);
                 LOG_INFO("PC: {} LR: {}", read_pc(*thread->cpu), read_lr(*thread->cpu));
-                LOG_INFO("{}", thread->log_stack_traceback(state.kernel));
+                LOG_INFO("{}", thread->log_stack_traceback());
 
                 // stop the world
                 {

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -139,8 +139,8 @@ ThreadStatePtr KernelState::create_thread(MemState &mem, const char *name, Ptr<c
 }
 
 ThreadStatePtr KernelState::create_thread(MemState &mem, const char *name, Ptr<const void> entry_point, int init_priority, SceInt32 affinity_mask, int stack_size, const SceKernelThreadOptParam *option) {
-    ThreadStatePtr thread = std::make_shared<ThreadState>(get_next_uid(), mem);
-    if (thread->init(*this, name, entry_point, init_priority, affinity_mask, stack_size, option) < 0)
+    ThreadStatePtr thread = std::make_shared<ThreadState>(get_next_uid(), *this, mem);
+    if (thread->init(name, entry_point, init_priority, affinity_mask, stack_size, option) < 0)
         return nullptr;
     const auto lock = std::lock_guard(mutex);
     threads.emplace(thread->id, thread);
@@ -169,7 +169,7 @@ Ptr<Ptr<void>> KernelState::get_thread_tls_addr(MemState &mem, SceUID thread_id,
 void KernelState::exit_delete_all_threads() {
     const std::lock_guard<std::mutex> lock(mutex);
     for (auto [_, thread] : threads) {
-        thread->exit_delete(*this);
+        thread->exit_delete();
     }
 }
 

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2531,7 +2531,7 @@ static int SDLCALL thread_function(void *data) {
         // Now run callback
         const ThreadStatePtr display_thread = params.kernel->get_thread(params.thid);
         if (display_thread) {
-            display_thread->run_guest_function(*params.kernel, display_callback->pc, display_callback->data);
+            display_thread->run_guest_function(display_callback->pc, display_callback->data);
         } else {
             LOG_ERROR("display_thread not found. thid:{} display_callback function: {}", params.thid, log_hex(display_callback->pc));
         }
@@ -4553,7 +4553,7 @@ EXPORT(int, sceGxmTerminate) {
     emuenv.gxm.display_queue.abort();
     SDL_WaitThread(emuenv.gxm.sdl_thread, nullptr);
     emuenv.gxm.sdl_thread = nullptr;
-    emuenv.kernel.get_thread(emuenv.gxm.display_queue_thread)->exit_delete(emuenv.kernel);
+    emuenv.kernel.get_thread(emuenv.gxm.display_queue_thread)->exit_delete();
     return 0;
 }
 

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -713,7 +713,7 @@ EXPORT(int, _sceKernelStartThread, SceUID thid, SceSize arglen, Ptr<void> argp) 
         return SCE_KERNEL_ERROR_RUNNING;
     }
 
-    const int res = thread->start(emuenv.kernel, arglen, argp);
+    const int res = thread->start(arglen, argp, true);
     if (res < 0) {
         return RET_ERROR(res);
     }
@@ -1131,7 +1131,7 @@ EXPORT(int, sceKernelDeleteThread, SceUID thid) {
     if (!thread || thread->status != ThreadStatus::dormant) {
         return SCE_KERNEL_ERROR_NOT_DORMANT;
     }
-    thread->exit_delete(emuenv.kernel, false);
+    thread->exit_delete(false);
     return 0;
 }
 
@@ -1146,7 +1146,7 @@ EXPORT(int, sceKernelDeleteTimer, SceUID timer_handle) {
 EXPORT(int, sceKernelExitDeleteThread, int status) {
     TRACY_FUNC(sceKernelExitDeleteThread, status);
     const ThreadStatePtr thread = lock_and_find(thread_id, emuenv.kernel.threads, emuenv.kernel.mutex);
-    thread->exit_delete(emuenv.kernel);
+    thread->exit_delete();
 
     return status;
 }

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgrCoredumpTime.cpp
@@ -25,7 +25,7 @@ TRACY_MODULE_NAME(SceThreadmgrCoredumpTime);
 EXPORT(int, sceKernelExitThread, int status) {
     TRACY_FUNC(sceKernelExitThread, status);
     const ThreadStatePtr thread = emuenv.kernel.get_thread(thread_id);
-    thread->exit(emuenv.kernel, status);
+    thread->exit(status);
 
     // the thread exits, the return value is not read anyway
     return 0;

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -200,8 +200,8 @@ uint32_t start_module(EmuEnvState &emuenv, const std::shared_ptr<SceKernelModule
         // module_start is always called from new thread
         const ThreadStatePtr module_thread = emuenv.kernel.create_thread(emuenv.mem, module_name, module_start, priority, affinity, stack_size, nullptr);
 
-        const auto ret = module_thread->run_guest_function(emuenv.kernel, module_start.address(), args, argp);
-        module_thread->exit_delete(emuenv.kernel);
+        const auto ret = module_thread->run_guest_function(module_start.address(), args, argp);
+        module_thread->exit_delete(false);
 
         LOG_INFO("Module {} (at \"{}\") module_start returned {}", module_name, module->path, log_hex(ret));
         return ret;


### PR DESCRIPTION
Fix a regression caused by the fact that preloaded modules were not registered, causing some game to see them unloaded and try to load them again, causing a freeze.

Also put the thread callbacks at the right location (run_callback can only be called in the thread and run_guest_function is not appropriate here).

Also some fixes, there is no reason to pass the kernel state to all the thread functions.

This fixes regression in spiderman.