### PR TITLE
cpu: Remove unicorn fallback for dynarmic

### DIFF
--- a/vita3k/cpu/include/cpu/impl/dynarmic_cpu.h
+++ b/vita3k/cpu/include/cpu/impl/dynarmic_cpu.h
@@ -34,7 +34,6 @@ class ArmDynarmicCP15;
 class DynarmicCPU : public CPUInterface {
     friend class ArmDynarmicCallback;
 
-    UnicornCPU fallback;
     CPUState *parent;
 
     std::unique_ptr<Dynarmic::A32::Jit> jit;


### PR DESCRIPTION
A few years ago, this may have been useful. However, now dynarmic is more accurate and feature-complete compared to unicorn. If we reach an invalid opcode, it means for 99% of the cases that we did something wrong previously and even in the 1% left switching to unicorn won't help.
Also it produces a huge unreadable backlog.