### PR TITLE
renderer: Add support of FMT UBC5 on translate (format/swizzle).

### DIFF
--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -690,6 +690,7 @@ vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
         return translate_swizzle4(static_cast<SceGxmTextureSwizzle4Mode>(swizzle));
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
@@ -807,6 +808,9 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format) {
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
         return vk::Format::eBc4UnormBlock;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
+        return vk::Format::eBc5UnormBlock;
 
     default:
         LOG_ERROR("Unknown format {}", log_hex(base_format));


### PR DESCRIPTION
# About:
- renderer: Add support of FMT UBC5 on translate (format/swizzle)
should fix crash with divide by zero on game using it.