### PR TITLE
kernel, modules: Improve nid performance

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -51,8 +51,9 @@ jobs:
 
       - name: Set up build environment (ubuntu-latest)
         run: |
+          sudo add-apt-repository -y ppa:mhier/libboost-latest
           sudo apt update
-          sudo apt -y install ccache libboost-filesystem-dev libboost-program-options-dev libboost-system-dev libgtk-3-dev libsdl2-dev ninja-build lld-11
+          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build lld-11
         if: matrix.os == 'ubuntu-latest'
 
       - uses: ilammy/msvc-dev-cmd@v1

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -39,6 +39,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <boost/version.hpp>
+
 struct ThreadState;
 
 struct Breakpoint;
@@ -59,7 +61,16 @@ typedef std::shared_ptr<SDL_Thread> ThreadPtr;
 typedef std::map<SceUID, ThreadPtr> ThreadPtrs;
 typedef std::map<SceUID, SceKernelModuleInfoPtr> SceKernelModuleInfoPtrs;
 typedef std::map<SceUID, CallbackPtr> CallbackPtrs;
+
+#if BOOST_VERSION >= 108100
+#include <boost/unordered/unordered_flat_map.hpp>
+// use a boost unordered_flat_map as performance really matters for this field
+typedef boost::unordered::unordered_flat_map<uint32_t, Address> ExportNids;
+#else
+// fallback in case someone is using an old boost version
 typedef std::unordered_map<uint32_t, Address> ExportNids;
+#endif
+
 typedef std::map<Address, uint32_t> NotFoundVars;
 typedef std::unique_ptr<CPUProtocol> CPUProtocolPtr;
 
@@ -122,7 +133,7 @@ struct KernelState {
     SceKernelModuleInfoPtrs loaded_modules;
     LoadedSysmodules loaded_sysmodules;
     ExportNids export_nids;
-    std::shared_mutex export_nids_mutex;
+    std::mutex export_nids_mutex;
     VarLateBindingInfos late_binding_infos;
     ModuleUidByNid module_uid_by_nid;
 

--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -75,7 +75,7 @@ static bool load_var_imports(const uint32_t *nids, const Ptr<uint32_t> *entries,
         const char *const name = import_name(nid);
         Address export_address;
         {
-            const std::unique_lock<std::shared_mutex> lock_exclusive(kernel.export_nids_mutex);
+            const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
             const ExportNids::iterator export_address_it = kernel.export_nids.find(nid);
             if (export_address_it != kernel.export_nids.end()) {
                 export_address = export_address_it->second;
@@ -231,7 +231,7 @@ static bool load_func_exports(SceKernelModuleInfo *kernel_module_info, const uin
         }
 
         {
-            const std::unique_lock<std::shared_mutex> lock(kernel.export_nids_mutex);
+            const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
             kernel.export_nids.emplace(nid, entry.address());
         }
 
@@ -274,7 +274,7 @@ static bool load_var_exports(const uint32_t *nids, const Ptr<uint32_t> *entries,
             LOG_DEBUG("\tNID {} ({}) at {}", log_hex(nid), name, log_hex(entry.address()));
         }
         {
-            const std::unique_lock<std::shared_mutex> lock(kernel.export_nids_mutex);
+            const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
 
             if (!kernel.late_binding_infos.contains(nid)) {
                 kernel.export_nids.emplace(nid, entry.address());
@@ -657,7 +657,7 @@ SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std
         kernel.loaded_modules.emplace(uid, sceKernelModuleInfo);
     }
     {
-        const std::lock_guard<std::shared_mutex> lock(kernel.export_nids_mutex);
+        const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
         kernel.module_uid_by_nid.emplace(module_info->module_nid, uid);
     }
     return uid;

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -87,7 +87,7 @@ const std::array<VarExport, var_exports_size> &get_var_exports() {
  * \return Resolved address, 0 if not found
  */
 Address resolve_export(KernelState &kernel, uint32_t nid) {
-    const std::shared_lock<std::shared_mutex> lock(kernel.export_nids_mutex);
+    const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
     const ExportNids::iterator export_address = kernel.export_nids.find(nid);
     if (export_address == kernel.export_nids.end()) {
         return 0;


### PR DESCRIPTION
Resolving the NID during an HLE (or first LLE) call takes a non-negligeable amount of time (on android the current implementation was taking almost 10-15% of many threads processing time), here are two performance improvements (the first being already used on Android):
- using a shared-mutex is not a good idea because of its implementation, it shouldn't be used to lock something which is quite fast (like nid resolving) as it amounts basically to two consecutive mutex locks. Replace it by a standard mutex, it is in practise much faster.
- Use a faster data structure for the nid map: a boost::unordered_flat_map is around 3 times faster than a std::unordered_map.

Also updates the boost requirement to 1.81.0 as boost::unordered_flat_map was added at this version.