### PR TITLE
renderer: Decompress YUV as RGBX

### DIFF
--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -693,13 +693,13 @@ void upload_bound_texture(const TextureCacheState &cache, const SceGxmTexture &g
             case SCE_GXM_TEXTURE_FORMAT_YVU420P3_CSC0:
             case SCE_GXM_TEXTURE_FORMAT_YUV420P3_CSC1:
             case SCE_GXM_TEXTURE_FORMAT_YVU420P3_CSC1: {
-                yuv_texture_pixels.resize(width * height * 3);
+                yuv_texture_pixels.resize(width * height * 4);
                 renderer::texture::yuv420_texture_to_rgb(yuv_texture_pixels.data(),
                     reinterpret_cast<const uint8_t *>(pixels), width, height);
                 pixels = yuv_texture_pixels.data();
                 pixels_per_stride = width;
-                bpp = 24;
-                upload_format = SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8;
+                bpp = 32;
+                upload_format = SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8;
                 break;
             }
 

--- a/vita3k/renderer/src/texture_yuv.cpp
+++ b/vita3k/renderer/src/texture_yuv.cpp
@@ -44,7 +44,7 @@ SwsContext *get_sws_context(size_t width, size_t height) {
             sws_freeContext(s_render_sws_context);
             s_render_sws_context = nullptr;
         }
-        s_render_sws_context = sws_getContext(width, height, AV_PIX_FMT_YUV420P, width, height, AV_PIX_FMT_RGB24,
+        s_render_sws_context = sws_getContext(width, height, AV_PIX_FMT_YUV420P, width, height, AV_PIX_FMT_RGB0,
             0, nullptr, nullptr, nullptr);
     }
     return s_render_sws_context;
@@ -71,7 +71,7 @@ void yuv420_texture_to_rgb(uint8_t *dst, const uint8_t *src, size_t width, size_
     };
 
     const int dst_strides[] = {
-        static_cast<int>(width * 3),
+        static_cast<int>(width * 4),
     };
 
     int error = sws_scale(context, slices, strides, 0, height, dst_slices, dst_strides);


### PR DESCRIPTION
24-bit packed rgb is not supported on modern desktop GPUs, this causes the renderer to do a conversion from 24-bit format to 32-bit, in the background for opengl or done ourself when using vulkan.

So we might as well directly decompress the YUV image to 32-bit RGBX format, this avoids an intermediate step.