### PR TITLE
renderer/vulkan: Fix potential freeze

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -206,6 +206,8 @@ struct VKContext : public renderer::Context {
     vk::CommandBuffer render_cmd{};
     // command buffer used for commands that need to be executed before render_cmd (mostly because they can't be done during a render pass)
     vk::CommandBuffer prerender_cmd{};
+    // next fence to be used to wait for the current scene
+    vk::Fence next_fence{};
     VKRenderTarget *cmd_target = nullptr;
 
     // used for macroblock sync emulation

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -156,7 +156,7 @@ void VKTextureCacheState::prepare_staging_buffer(bool is_configure) {
         && staging_buffer->frame_timestamp != ~0
         && staging_buffer->frame_timestamp > context->frame_timestamp - MAX_FRAMES_RENDERING
         && staging_buffer->scene_timestamp > last_waited_scene;
-    const vk::Fence current_fence = context->render_target->fences[context->render_target->fence_idx];
+    const vk::Fence current_fence = context->next_fence;
 
     if (need_wait) {
         if (staging_buffer->scene_timestamp == current_scene_timestamp) {
@@ -212,7 +212,7 @@ void VKTextureCacheState::prepare_staging_buffer(bool is_configure) {
 
         if (staging_buffer->buffer.size < current_texture->memory_needed) {
             // we need to create a bigger buffer
-            // destroy the previous one if there is, no need to defer destroy it as we now it is no longer being used
+            // destroy the previous one if there is, no need to defer destroy it as we know it is no longer being used
             staging_buffer->buffer.destroy();
 
             staging_buffer->buffer.size = current_texture->memory_needed;


### PR DESCRIPTION
Fix a potential (very rare) freeze that can happen when using the vulkan renderer.
Basically, if when using the vulkan renderer, a scene using macroblock tile sync is using a lot (but not too much) new textures, this will cause a fence which is never signaled to be waited for.

I am not aware of anyone getting a freeze cause by this.