### PR TITLE
kernel: Implement sceClibMemcpy_safe

### DIFF
--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -173,7 +173,7 @@ EXPORT(Ptr<void>, sceClibMemcpy_safe, Ptr<void> dst, const Ptr<void> src, SceSiz
     should be 1:1 to real hw, asserts are in the same position as decompiled code,
     still call memcpy when the breakpoint happens just like in real hw, should practically
     be the same as just calling memcpy, but with a bit more checks for the developers,
-    asserts do get annoying if the game is tend to do memcpy on overlapping pointers, which is weird,
+    asserts do get annoying if the game tends to do memcpy on overlapping pointers, which is weird,
     if they in fact do get annoying very easily they can just be deleted, we still have the log_error
     */
     if (len == 0)


### PR DESCRIPTION
some games use HLE libc, the ones that do sometimes use the safe variant, and the safe variant is just not a simple memcpy, it does some checks to alert memory overlaps and has breakpoints for games that are in the development process, so i decided to replicate this, also technically the memcpy still happens whatever the overlap is, should be 1:1 to real hw (afaik), mainly pr just in case a game actually has memory overlaps due to bugs on emu side and other devs dont pull their hairs out because of memory corruption. should have no effect for game compatibility