### PR TITLE
gui/settings dialog: Fix refresh option stretch the display area.

### DIFF
--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -89,8 +89,8 @@ struct State {
     void set_surface_sync_state(bool disable) {
         disable_surface_sync = disable;
     }
-    void set_stretch_display(bool disable) {
-        stretch_the_display_area = disable;
+    void set_stretch_display(bool enable) {
+        stretch_the_display_area = enable;
     }
     virtual bool map_memory(MemState &mem, Ptr<void> address, uint32_t size) {
         return true;


### PR DESCRIPTION
# About
- Fix allow Apply change stretch display area state in real time.
Fix refresh module list when open setting dialog.