### PR TITLE
renderer: Add virtual destructor to base filter class

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/screen_filters.h
+++ b/vita3k/renderer/include/renderer/vulkan/screen_filters.h
@@ -35,6 +35,7 @@ public:
     virtual void on_resize(){};
     virtual void render(bool is_pre_renderpass, vk::ImageView src_img, vk::ImageLayout src_layout, const Viewport &viewport) = 0;
     virtual std::string_view get_name() = 0;
+    virtual ~ScreenFilter() = default;
     // do we need the render pass not to clear the swapchain content ?
     virtual bool need_post_processing_render_pass() {
         return false;


### PR DESCRIPTION
mainly to get rid of a warning about `delete called on 'ScreenFilter' that is abstract but has non-virtual destructor`