### PR TITLE
ci: fix bad ccache hit rate on macOS

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           brew install boost ccache ninja molten-vk openssl create-dmg
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+          ccache --set-config=compiler_check=content
         if: matrix.os == 'macos-latest'
 
       - name: Set up build environment (ubuntu-latest)


### PR DESCRIPTION
macOS CI's ccache hit rate was bad(about 0.00%) because Compiler mtime was changed on every CI run. So changing ccache's compiler check from mtime to content will make cache work on macOS.

I did 5 CI run on my forked repo and it took average 10 min to finish. Surprisingly, on all 5 run macOS finished faster than Windows.

First CI run after this PR merged will take time because previous cache is not usable.