### PR TITLE
gui/main_menubar: fix crash on "Emulation/Last Apps used" menu

### DIFF
--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -49,7 +49,7 @@ static void draw_emulation_menu(GuiState &gui, EmuEnvState &emuenv, const float 
                     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_TITLE);
                     const auto time_app = gui.time_apps[emuenv.io.user_id][i];
                     const auto app_index = get_app_index(gui, time_app.app);
-                    if ((app_index != gui.app_selector.user_apps.end()) && ImGui::MenuItem(app_index->title.c_str(), time_app.app.c_str(), false))
+                    if ((app_index != gui.app_selector.user_apps.end()) && (app_index != gui.app_selector.sys_apps.end()) && ImGui::MenuItem(app_index->title.c_str(), time_app.app.c_str(), false))
                         pre_load_app(gui, emuenv, emuenv.cfg.show_live_area_screen, time_app.app);
                     ImGui::PopStyleColor();
                 }


### PR DESCRIPTION
gui/main_menubar: fix crash on "Emulation/Last Apps used" menu when last open app is system app