### PR TITLE
gui/main menubar: Display Icons of app in emulation menu.

### DIFF
--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -848,7 +848,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SameLine();
         ImGui::Checkbox("Display System Apps", &emuenv.cfg.display_system_apps);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("Uncheck the box to disable showing system apps from the home screen to the main menu bar only.");
+            ImGui::SetTooltip("Uncheck the box to disable the display of system apps on the home screen.\nThey will be shown in the main menu bar only.");
         ImGui::Spacing();
         ImGui::Checkbox("Live Area app screen", &emuenv.cfg.show_live_area_screen);
         if (ImGui::IsItemHovered())


### PR DESCRIPTION
# About
- gui/main menubar: Display Icons of app in emulation menu.
Fix one typo in setting dialog.

# Result
![image](https://github.com/Vita3K/Vita3K/assets/5261759/d827c0c2-0232-4335-8a1b-ec92b193f959)