### PR TITLE
vita3k: specify minimum version of the target on macOS

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -45,7 +45,11 @@ jobs:
 
       - name: Set up build environment (macos-latest)
         run: |
-          brew install boost ccache ninja molten-vk openssl create-dmg
+          brew install ccache ninja create-dmg
+          brew fetch --force --bottle-tag=big_sur boost openssl@3 molten-vk
+          brew install $(brew --cache --bottle-tag=big_sur boost)
+          brew install $(brew --cache --bottle-tag=big_sur molten-vk)
+          brew reinstall $(brew --cache --bottle-tag=big_sur openssl@3)
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
           ccache --set-config=compiler_check=content
         if: matrix.os == 'macos-latest'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ ProcessorCount(CPU_COUNT)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
 
 option(USE_DISCORD_RICH_PRESENCE "Build Vita3K with Discord Rich Presence" ON)
 option(USE_VITA3K_UPDATE "Build Vita3K with updater." ON)


### PR DESCRIPTION
Due to discord game SDK and homebrew, possible macOS minimum target version is macOS 11, but CI is automatically setting target version to 12.6 which is OS version of CI environment. So it will manually specify minimum target version for macOS.

But if homebrew remove support for big_sur bottles, we have to change target version corresponding to brew bottles, or we have to build OpenSSL and boost ourselves.