### PR TITLE
external: switch to unicorn2

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -150,37 +150,6 @@ if(WIN32)
 	target_link_libraries(winsock INTERFACE WSOCK32 WS2_32 IPHLPAPI)
 endif()
 
-if(WIN32)
-	set(UNICORN_VER "4b52942b")
-
-	set(UNICORN_PREFIX "${CMAKE_BINARY_DIR}/external/unicorn")
-
-	if(NOT EXISTS "${UNICORN_PREFIX}")
-		message(STATUS "Downloading unicorn...")
-
-		file(DOWNLOAD
-			https://github.com/Vita3K/unicorn/releases/download/${UNICORN_VER}/vita3k-unicorn.zip
-			"${CMAKE_BINARY_DIR}/external/unicorn.zip" SHOW_PROGRESS)
-		execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/external/unicorn.zip"
-			WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external")
-	endif()
-
-	message(STATUS "Using bundled binaries at ${UNICORN_PREFIX}")
-
-	set(LIBUNICORN_INCLUDE_DIR "${UNICORN_PREFIX}/include" CACHE PATH "Path to Unicorn headers" FORCE)
-	set(LIBUNICORN_LIBRARY "${UNICORN_PREFIX}/lib/unicorn.lib" CACHE PATH "Path to Unicorn library" FORCE)
-	set(UNICORN_DLL_DIR "${UNICORN_PREFIX}/lib" CACHE PATH "Path to unicorn.dll" FORCE)
-
-	add_library(unicorn INTERFACE)
-	target_link_libraries(unicorn INTERFACE "${LIBUNICORN_LIBRARY}")
-	target_include_directories(unicorn INTERFACE "${LIBUNICORN_INCLUDE_DIR}")
-else()
-	option(UNICORN_BUILD_SHARED "Build shared instead of static library" OFF)
-	set(UNICORN_ARCH "arm")
-	add_subdirectory(unicorn)
-	target_include_directories(unicorn INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/unicorn/include")
-endif()
-
 set(DYNARMIC_TESTS OFF CACHE BOOL "")
 set(DYNARMIC_NO_BUNDLED_FMT ON CACHE BOOL "")
 set(DYNARMIC_FRONTENDS "A32" CACHE STRING "")
@@ -199,6 +168,10 @@ if(MSVC)
 		set_property(TARGET mcl PROPERTY COMPILE_OPTIONS ${MCL_COMPILE_OPTIONS})
 	endif()
 endif()
+
+set(UNICORN_ARCH "arm")
+add_subdirectory(unicorn EXCLUDE_FROM_ALL)
+set_property(TARGET unicorn PROPERTY FOLDER externals)
 
 add_library(vita-toolchain INTERFACE)
 target_include_directories(vita-toolchain INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/vita-toolchain/src")

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -243,10 +243,7 @@ elseif(WIN32)
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../data" "$<TARGET_FILE_DIR:vita3k>/data"
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../lang" "$<TARGET_FILE_DIR:vita3k>/lang"
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "$<TARGET_FILE_DIR:vita3k>/shaders-builtin"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/external/sdl/windows/lib/x64/SDL2.dll" "$<TARGET_FILE_DIR:vita3k>"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/unicorn.dll" "$<TARGET_FILE_DIR:vita3k>"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/libgcc_s_seh-1.dll" "$<TARGET_FILE_DIR:vita3k>"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UNICORN_DLL_DIR}/libwinpthread-1.dll" "$<TARGET_FILE_DIR:vita3k>")
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/external/sdl/windows/lib/x64/SDL2.dll" "$<TARGET_FILE_DIR:vita3k>")
 	if(USE_VITA3K_UPDATE)
 		add_custom_command(
 			TARGET vita3k

--- a/vita3k/cpu/include/cpu/impl/interface.h
+++ b/vita3k/cpu/include/cpu/impl/interface.h
@@ -55,7 +55,7 @@ struct CPUInterface {
 
     virtual CPUContext save_context() = 0;
     virtual void load_context(CPUContext context) = 0;
-    virtual void invalidate_jit_cache(Address start, size_t length) {}
+    virtual void invalidate_jit_cache(Address start, size_t length) = 0;
 
     virtual bool is_thumb_mode() = 0;
     virtual int step() = 0;

--- a/vita3k/cpu/include/cpu/impl/unicorn_cpu.h
+++ b/vita3k/cpu/include/cpu/impl/unicorn_cpu.h
@@ -97,6 +97,7 @@ public:
 
     CPUContext save_context() override;
     void load_context(CPUContext context) override;
+    void invalidate_jit_cache(Address start, size_t length) override;
 
     bool hit_breakpoint() override;
     void trigger_breakpoint() override;

--- a/vita3k/cpu/src/unicorn_cpu.cpp
+++ b/vita3k/cpu/src/unicorn_cpu.cpp
@@ -386,6 +386,10 @@ void UnicornCPU::load_context(CPUContext ctx) {
     set_pc(ctx.thumb() ? ctx.get_pc() | 1 : ctx.get_pc());
 }
 
+void UnicornCPU::invalidate_jit_cache(Address start, size_t length) {
+    uc_ctl_remove_cache(uc.get(), start, start + length);
+}
+
 bool UnicornCPU::hit_breakpoint() {
     return did_break;
 }


### PR DESCRIPTION
Update unicorn to unicorn2.
Benefits:
- About 5 times faster performance-wise (still a lot slower than dynarmic)
- On windows, build statically instead of using mingw prebuilts. Allow 3 dlls to be removed from the final zip.

I had to implement cache invalidation for Vita3K to work with unicorn2 (even though I don't understand how unicorn1 was working without cache invalidation after bookmist's changes anyway).

We are still using a custom repository for this as I had to do some modifications to unicorn CMakeList for it to build with our CI.