### PR TITLE
touch: Add touchpad support.

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -95,6 +95,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "discord-rich-presence", true, discord_rich_presence)                                    \
     code(bool, "wait-for-debugger", false, wait_for_debugger)                                           \
     code(bool, "color-surface-debug", false, color_surface_debug)                                       \
+    code(bool, "show-touchpad-cursor", true, show_touchpad_cursor)                                      \
     code(bool, "performance-overlay", false, performance_overlay)                                       \
     code(int, "perfomance-overlay-detail", static_cast<int>(MINIMUM), performance_overlay_detail)       \
     code(int, "perfomance-overlay-position", static_cast<int>(TOP_LEFT), performance_overlay_position)  \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -180,6 +180,7 @@ public:
         bool v_sync = true;
         int anisotropic_filtering = 1;
         bool stretch_the_display_area = false;
+        bool show_touchpad_cursor = true;
         int psn_status = SCE_NP_SERVICE_STATE_UNKNOWN;
     };
 

--- a/vita3k/gui/CMakeLists.txt
+++ b/vita3k/gui/CMakeLists.txt
@@ -51,5 +51,5 @@ add_library(
 
 target_include_directories(gui PUBLIC include ${CMAKE_SOURCE_DIR}/vita3k)
 target_link_libraries(gui PUBLIC app compat config dialog emuenv https ime imgui glutil lang regmgr np)
-target_link_libraries(gui PRIVATE audio ctrl kernel miniz psvpfsparser pugixml::pugixml stb renderer packages sdl2 vkutil host::dialog)
+target_link_libraries(gui PRIVATE audio ctrl kernel miniz psvpfsparser pugixml::pugixml stb renderer packages sdl2 touch vkutil host::dialog)
 target_link_libraries(gui PUBLIC tracy)

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -124,6 +124,7 @@ void draw_reinstall_dialog(GenericDialogState *status, GuiState &gui, EmuEnvStat
 void draw_pre_compiling_shaders_progress(GuiState &gui, EmuEnvState &emuenv, const uint32_t &total);
 void draw_shaders_count_compiled(GuiState &gui, EmuEnvState &emuenv);
 void draw_trophies_unlocked(GuiState &gui, EmuEnvState &emuenv);
+void draw_touchpad_cursor(EmuEnvState &emuenv);
 void draw_perf_overlay(GuiState &gui, EmuEnvState &emuenv);
 
 ImTextureID load_image(GuiState &gui, const char *data, const std::uint32_t size);

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -32,6 +32,7 @@
 #include <lang/functions.h>
 #include <packages/sfo.h>
 #include <regmgr/functions.h>
+#include <touch/functions.h>
 #include <util/fs.h>
 #include <util/log.h>
 #include <util/string_utils.h>
@@ -736,6 +737,23 @@ void draw_begin(GuiState &gui, EmuEnvState &emuenv) {
 void draw_end(GuiState &gui, SDL_Window *window) {
     ImGui::Render();
     ImGui_ImplSdl_RenderDrawData(gui.imgui_state.get());
+}
+
+void draw_touchpad_cursor(EmuEnvState &emuenv) {
+    SceTouchPortType port;
+    const auto touchpad_fingers_pos = get_touchpad_fingers_pos(port);
+    if (touchpad_fingers_pos.empty())
+        return;
+
+    const ImVec2 RES_SCALE(emuenv.viewport_size.x / emuenv.res_width_dpi_scale, emuenv.viewport_size.y / emuenv.res_height_dpi_scale);
+    const ImVec2 SCALE(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
+
+    const auto color = (port == SCE_TOUCH_PORT_FRONT) ? IM_COL32(0.f, 102.f, 204.f, 255.f) : IM_COL32(255.f, 0.f, 0.f, 255.f);
+    for (const auto &pos : touchpad_fingers_pos) {
+        auto x = emuenv.viewport_pos.x + (pos.x * emuenv.viewport_size.x);
+        auto y = emuenv.viewport_pos.y + (pos.y * emuenv.viewport_size.y);
+        ImGui::GetForegroundDrawList()->AddCircle(ImVec2(x, y), 20.f * SCALE.x, color, 0, 4.f * SCALE.x);
+    }
 }
 
 void draw_vita_area(GuiState &gui, EmuEnvState &emuenv) {

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -180,6 +180,7 @@ static bool get_custom_config(GuiState &gui, EmuEnvState &emuenv, const std::str
             if (!config_child.child("emulator").empty()) {
                 const auto emulator_child = config_child.child("emulator");
                 config.ngs_enable = emulator_child.attribute("enable-ngs").as_bool();
+                config.show_touchpad_cursor = emulator_child.attribute("show-touchpad-cursor").as_bool();
             }
 
             // Load Network Config
@@ -227,6 +228,7 @@ void init_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
         config.anisotropic_filtering = emuenv.cfg.anisotropic_filtering;
         config.pstv_mode = emuenv.cfg.pstv_mode;
         config.ngs_enable = emuenv.cfg.ngs_enable;
+        config.show_touchpad_cursor = emuenv.cfg.show_touchpad_cursor;
         config.psn_status = emuenv.cfg.psn_status;
     }
     get_modules_list(gui, emuenv);
@@ -292,6 +294,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         // Emulator
         auto emulator_child = config_child.append_child("emulator");
         emulator_child.append_attribute("enable-ngs") = config.ngs_enable;
+        emulator_child.append_attribute("show-touchpad-cursor") = config.show_touchpad_cursor;
 
         // Network
         auto network_child = config_child.append_child("network");
@@ -312,6 +315,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         emuenv.cfg.v_sync = config.v_sync;
         emuenv.cfg.anisotropic_filtering = config.anisotropic_filtering;
         emuenv.cfg.ngs_enable = config.ngs_enable;
+        emuenv.cfg.show_touchpad_cursor = config.show_touchpad_cursor;
         emuenv.cfg.psn_status = config.psn_status;
     }
 
@@ -369,6 +373,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.cfg.current_config.v_sync = emuenv.cfg.v_sync;
         emuenv.cfg.current_config.anisotropic_filtering = emuenv.cfg.anisotropic_filtering;
         emuenv.cfg.current_config.ngs_enable = emuenv.cfg.ngs_enable;
+        emuenv.cfg.current_config.show_touchpad_cursor = emuenv.cfg.show_touchpad_cursor;
         emuenv.cfg.current_config.psn_status = emuenv.cfg.psn_status;
     }
 
@@ -764,6 +769,10 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Uncheck the box to disable the display of the compile shaders dialog.");
         ImGui::Spacing();
+        ImGui::Checkbox("Show Touchpad Cursor", &config.show_touchpad_cursor);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Uncheck the box to disable showing the touchpad cursor on-screen.");
+        ImGui::SameLine();
         ImGui::Checkbox("Log Compatibility Warnings", &emuenv.cfg.log_compat_warn);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Check the box to log issues related to the app compatibility database.");

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -714,6 +714,9 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             break;
 
         case SDL_CONTROLLERBUTTONDOWN:
+            if (!emuenv.kernel.is_threads_paused() && (event.cbutton.button == SDL_CONTROLLER_BUTTON_TOUCHPAD))
+                toggle_touchscreen();
+
             if (ImGui::GetIO().WantTextInput)
                 continue;
 
@@ -759,18 +762,18 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             }
             break;
 
+        case SDL_CONTROLLERTOUCHPADDOWN:
+        case SDL_CONTROLLERTOUCHPADMOTION:
+        case SDL_CONTROLLERTOUCHPADUP:
+            handle_touchpad_event(event.ctouchpad);
+            break;
+
         case SDL_WINDOWEVENT:
             handle_window_event(emuenv, event.window);
             break;
 
         case SDL_FINGERDOWN:
-            handle_touch_event(event.tfinger);
-            break;
-
         case SDL_FINGERMOTION:
-            handle_touch_event(event.tfinger);
-            break;
-
         case SDL_FINGERUP:
             handle_touch_event(event.tfinger);
             break;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -432,6 +432,9 @@ int main(int argc, char *argv[]) {
         if (emuenv.cfg.performance_overlay && !emuenv.kernel.is_threads_paused() && (emuenv.common_dialog.status != SCE_COMMON_DIALOG_STATUS_RUNNING))
             gui::draw_perf_overlay(gui, emuenv);
 
+        if (emuenv.cfg.current_config.show_touchpad_cursor && !emuenv.kernel.is_threads_paused())
+            gui::draw_touchpad_cursor(emuenv);
+
         if (emuenv.display.imgui_render) {
             gui::draw_ui(gui, emuenv);
         }

--- a/vita3k/touch/include/touch/functions.h
+++ b/vita3k/touch/include/touch/functions.h
@@ -3,6 +3,8 @@
 #include <emuenv/state.h>
 #include <touch/touch.h>
 
+std::vector<SceFVector2> get_touchpad_fingers_pos(SceTouchPortType &port);
+int handle_touchpad_event(SDL_ControllerTouchpadEvent &touchpad);
 void touch_vsync_update(const EmuEnvState &emuenv);
 int handle_touch_event(SDL_TouchFingerEvent &finger);
 int toggle_touchscreen();

--- a/vita3k/touch/include/touch/touch.h
+++ b/vita3k/touch/include/touch/touch.h
@@ -21,6 +21,7 @@
 
 #define SCE_TOUCH_MAX_REPORT 8
 
+struct SDL_ControllerTouchpadEvent;
 struct SDL_TouchFingerEvent;
 
 enum SceTouchSamplingState {

--- a/vita3k/touch/src/touch.cpp
+++ b/vita3k/touch/src/touch.cpp
@@ -32,29 +32,33 @@ constexpr int MAX_TOUCH_BUFFER_SAVED = 64;
 static SceTouchData touch_buffers[MAX_TOUCH_BUFFER_SAVED][2];
 int touch_buffer_idx = 0;
 
-static uint64_t timestamp;
 static SDL_TouchFingerEvent finger_buffer[8];
 static uint8_t finger_count = 0;
-static SDL_FingerID finger_id_ref;
 static auto touchscreen_port = SCE_TOUCH_PORT_FRONT;
 static bool is_touched[2] = { false, false };
+// Used for mouse support
 static int curr_touch_id[2] = { 0, 0 };
+// Used for the touch screen
+static int next_touch_id = 1;
 static uint64_t last_vcount[2] = { 0, 0 };
 static bool forceTouchEnabled[2] = { false, false };
 
-static SceTouchData recover_touch_events() {
+static SceTouchData recover_touch_events(const EmuEnvState &emuenv) {
     SceTouchData touch_data;
-    touch_data.timeStamp = timestamp;
+    touch_data.status = 0;
 
     for (uint8_t i = 0; i < finger_count; i++) {
-        touch_data.report[i].id = static_cast<uint8_t>(finger_buffer[i].fingerId - finger_id_ref);
-        touch_data.report[i].force = static_cast<uint8_t>(1 + finger_buffer[i].pressure * 127);
-        touch_data.report[i].x = static_cast<uint16_t>(finger_buffer[i].x * 1920);
+        touch_data.report[i].id = static_cast<uint8_t>(finger_buffer[i].touchId);
+        touch_data.report[i].force = forceTouchEnabled[touchscreen_port] ? 128 : 0;
+
+        float x = (finger_buffer[i].x * emuenv.drawable_size.x - emuenv.viewport_pos.x) / emuenv.viewport_size.x;
+        float y = (finger_buffer[i].y * emuenv.drawable_size.y - emuenv.viewport_pos.y) / emuenv.viewport_size.y;
+        touch_data.report[i].x = static_cast<uint16_t>(x * 1920);
 
         if (touchscreen_port == SCE_TOUCH_PORT_FRONT) {
-            touch_data.report[i].y = static_cast<uint16_t>(finger_buffer[i].y * 1088);
+            touch_data.report[i].y = static_cast<uint16_t>(y * 1088);
         } else {
-            touch_data.report[i].y = static_cast<uint16_t>(108 + finger_buffer[i].y * 781);
+            touch_data.report[i].y = static_cast<uint16_t>(108 + y * 781);
         }
     }
 
@@ -64,63 +68,77 @@ static SceTouchData recover_touch_events() {
 }
 
 void touch_vsync_update(const EmuEnvState &emuenv) {
-    SceIVector2 touch_pos_window = { 0, 0 };
-    const uint32_t buttons = SDL_GetMouseState(&touch_pos_window.x, &touch_pos_window.y);
-
     std::chrono::time_point<std::chrono::steady_clock> ts = std::chrono::steady_clock::now();
     uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(ts.time_since_epoch()).count();
 
-    for (int port = 0; port < 2; port++) {
-        // do it for both the front and the back touchscreen
-        SceTouchData *data = &touch_buffers[(touch_buffer_idx + 1) % MAX_TOUCH_BUFFER_SAVED][port];
-        memset(data, 0, sizeof(SceTouchData));
-        data->timeStamp = timestamp;
+    if (finger_count > 0) {
+        SceTouchData touch_data = recover_touch_events(emuenv);
+        touch_data.timeStamp = timestamp;
 
-        const uint32_t mask = (port == SCE_TOUCH_PORT_BACK) ? SDL_BUTTON_RMASK : SDL_BUTTON_LMASK;
-        if ((buttons & mask) && emuenv.renderer_focused) {
-            if (!is_touched[port]) {
-                curr_touch_id[port]++;
-                // the touch id must be between 0 and 127
-                curr_touch_id[port] %= 128;
-                is_touched[port] = true;
-            }
+        SceTouchData *buffers = touch_buffers[(touch_buffer_idx + 1) % MAX_TOUCH_BUFFER_SAVED];
+        for (int port = 0; port < 2; port++) {
+            buffers[port].status = 0;
+            buffers[port].reportNum = 0;
+            buffers[port].timeStamp = timestamp;
+        }
+        buffers[touchscreen_port] = touch_data;
 
-            SceIVector2 SDL_window_size = { 0, 0 };
-            SDL_Window *const window = SDL_GetMouseFocus();
-            SDL_GetWindowSize(window, &SDL_window_size.x, &SDL_window_size.y);
+    } else {
+        SceIVector2 touch_pos_window = { 0, 0 };
+        const uint32_t buttons = SDL_GetMouseState(&touch_pos_window.x, &touch_pos_window.y);
 
-            SceFVector2 scale = { 1, 1 };
-            if ((SDL_window_size.x > 0) && (SDL_window_size.y > 0)) {
-                scale.x = static_cast<float>(emuenv.drawable_size.x) / SDL_window_size.x;
-                scale.y = static_cast<float>(emuenv.drawable_size.y) / SDL_window_size.y;
-            }
+        for (int port = 0; port < 2; port++) {
+            // do it for both the front and the back touchscreen
+            SceTouchData *data = &touch_buffers[(touch_buffer_idx + 1) % MAX_TOUCH_BUFFER_SAVED][port];
+            memset(data, 0, sizeof(SceTouchData));
+            data->timeStamp = timestamp;
 
-            const SceFVector2 touch_pos_drawable = {
-                touch_pos_window.x * scale.x,
-                touch_pos_window.y * scale.y
-            };
-
-            const SceFVector2 touch_pos_viewport = {
-                (touch_pos_drawable.x - emuenv.viewport_pos.x) / emuenv.viewport_size.x,
-                (touch_pos_drawable.y - emuenv.viewport_pos.y) / emuenv.viewport_size.y
-            };
-
-            if ((touch_pos_viewport.x >= 0) && (touch_pos_viewport.y >= 0) && (touch_pos_viewport.x < 1) && (touch_pos_viewport.y < 1)) {
-                data->report[data->reportNum].x = static_cast<uint16_t>(touch_pos_viewport.x * 1920);
-                if (port == SCE_TOUCH_PORT_FRONT) {
-                    data->report[data->reportNum].y = static_cast<uint16_t>(touch_pos_viewport.y * 1088);
-                } else {
-                    data->report[data->reportNum].y = static_cast<uint16_t>(108 + touch_pos_viewport.y * 781);
+            const uint32_t mask = (port == SCE_TOUCH_PORT_BACK) ? SDL_BUTTON_RMASK : SDL_BUTTON_LMASK;
+            if ((buttons & mask) && emuenv.renderer_focused) {
+                if (!is_touched[port]) {
+                    curr_touch_id[port]++;
+                    // the touch id must be between 0 and 127
+                    curr_touch_id[port] %= 128;
+                    is_touched[port] = true;
                 }
-                data->report[data->reportNum].id = curr_touch_id[port];
-                ++data->reportNum;
-            }
 
-            if (!emuenv.touch.touch_mode[port]) {
-                data->reportNum = 0;
+                SceIVector2 SDL_window_size = { 0, 0 };
+                SDL_Window *const window = SDL_GetMouseFocus();
+                SDL_GetWindowSize(window, &SDL_window_size.x, &SDL_window_size.y);
+
+                SceFVector2 scale = { 1, 1 };
+                if ((SDL_window_size.x > 0) && (SDL_window_size.y > 0)) {
+                    scale.x = static_cast<float>(emuenv.drawable_size.x) / SDL_window_size.x;
+                    scale.y = static_cast<float>(emuenv.drawable_size.y) / SDL_window_size.y;
+                }
+
+                const SceFVector2 touch_pos_drawable = {
+                    touch_pos_window.x * scale.x,
+                    touch_pos_window.y * scale.y
+                };
+
+                const SceFVector2 touch_pos_viewport = {
+                    (touch_pos_drawable.x - emuenv.viewport_pos.x) / emuenv.viewport_size.x,
+                    (touch_pos_drawable.y - emuenv.viewport_pos.y) / emuenv.viewport_size.y
+                };
+
+                if ((touch_pos_viewport.x >= 0) && (touch_pos_viewport.y >= 0) && (touch_pos_viewport.x < 1) && (touch_pos_viewport.y < 1)) {
+                    data->report[data->reportNum].x = static_cast<uint16_t>(touch_pos_viewport.x * 1920);
+                    if (port == SCE_TOUCH_PORT_FRONT) {
+                        data->report[data->reportNum].y = static_cast<uint16_t>(touch_pos_viewport.y * 1088);
+                    } else {
+                        data->report[data->reportNum].y = static_cast<uint16_t>(108 + touch_pos_viewport.y * 781);
+                    }
+                    data->report[data->reportNum].id = curr_touch_id[port];
+                    ++data->reportNum;
+                }
+
+                if (!emuenv.touch.touch_mode[port]) {
+                    data->reportNum = 0;
+                }
+            } else {
+                is_touched[port] = false;
             }
-        } else {
-            is_touched[port] = false;
         }
     }
 
@@ -131,13 +149,14 @@ void touch_vsync_update(const EmuEnvState &emuenv) {
 int handle_touch_event(SDL_TouchFingerEvent &finger) {
     switch (finger.type) {
     case SDL_FINGERDOWN: {
-        if (finger_count == 0) {
-            finger_id_ref = finger.fingerId;
-        }
+        if (finger_count >= 8)
+            // best we can do is clean everything
+            finger_count = 0;
 
         finger_buffer[finger_count] = finger;
+        finger_buffer[finger_count].touchId = next_touch_id;
+        next_touch_id = (next_touch_id + 1) % 128;
         finger_count++;
-
         break;
     }
     case SDL_FINGERUP: {
@@ -146,18 +165,21 @@ int handle_touch_event(SDL_TouchFingerEvent &finger) {
             if (finger.fingerId == finger_buffer[i].fingerId) {
                 finger_index = i;
             }
-            if (finger_index > -1) {
+            if (finger_index != -1) {
                 finger_buffer[i] = finger_buffer[i + 1];
             }
         }
-        finger_count--;
+        if (finger_count > 0)
+            finger_count--;
         break;
     }
 
     case SDL_FINGERMOTION: {
         for (int i = 0; i < finger_count; i++) {
             if (finger.fingerId == finger_buffer[i].fingerId) {
+                SDL_TouchID touch_id = finger_buffer[i].touchId;
                 finger_buffer[i] = finger;
+                finger_buffer[i].touchId = touch_id;
             }
         }
         break;
@@ -165,14 +187,6 @@ int handle_touch_event(SDL_TouchFingerEvent &finger) {
     }
 
     return 0;
-}
-
-static bool registered_touch() {
-    if (finger_count > 0) {
-        return true;
-    }
-
-    return false;
 }
 
 int toggle_touchscreen() {
@@ -207,37 +221,24 @@ int touch_get(const SceUID thread_id, EmuEnvState &emuenv, const SceUInt32 &port
         last_vcount[port_idx] = emuenv.display.vblank_count;
     }
 
-    if (registered_touch() && port == touchscreen_port) {
-        // less accurate implementation, but which is able to take a real touchscreen as the input
-        pData[0] = recover_touch_events();
-        for (int32_t i = 0; i < nb_returned_data; i++) {
-            memcpy(&pData[i], &pData[0], sizeof(SceTouchData));
-            if (forceTouchEnabled[port_idx]) {
-                for (uint32_t j = 0; j < pData[i].reportNum; j++) {
-                    pData[i].report[j].force = 128;
-                }
-            }
-        }
+    int corr_buffer_idx;
+    if (is_peek) {
+        corr_buffer_idx = touch_buffer_idx;
     } else {
-        int corr_buffer_idx;
-        if (is_peek) {
-            corr_buffer_idx = touch_buffer_idx;
-        } else {
-            // give the oldest buffer first
-            corr_buffer_idx = (touch_buffer_idx - nb_returned_data + 1 + MAX_TOUCH_BUFFER_SAVED) % MAX_TOUCH_BUFFER_SAVED;
+        // give the oldest buffer first
+        corr_buffer_idx = (touch_buffer_idx - nb_returned_data + 1 + MAX_TOUCH_BUFFER_SAVED) % MAX_TOUCH_BUFFER_SAVED;
+    }
+    for (int32_t i = 0; i < nb_returned_data; i++) {
+        memcpy(&pData[i], &touch_buffers[corr_buffer_idx][port_idx], sizeof(SceTouchData));
+        if (forceTouchEnabled[port_idx]) {
+            for (int32_t j = 0; j < pData[i].reportNum; j++) {
+                pData[i].report[j].force = 128;
+            }
         }
-        for (int32_t i = 0; i < nb_returned_data; i++) {
-            memcpy(&pData[i], &touch_buffers[corr_buffer_idx][port_idx], sizeof(SceTouchData));
-            if (forceTouchEnabled[port_idx]) {
-                for (uint32_t j = 0; j < pData[i].reportNum; j++) {
-                    pData[i].report[j].force = 128;
-                }
-            }
-            // if peek, repeat the last buffer
-            if (!is_peek) {
-                corr_buffer_idx++;
-                corr_buffer_idx %= MAX_TOUCH_BUFFER_SAVED;
-            }
+        // if peek, repeat the last buffer
+        if (!is_peek) {
+            corr_buffer_idx++;
+            corr_buffer_idx %= MAX_TOUCH_BUFFER_SAVED;
         }
     }
 


### PR DESCRIPTION
# About
- touch: Fix and improve finger touch. by @Macdu  from Android version.
- touch: Add touchpad support.
Allow double touch in pc with using touchpad of DS/4.
Add draw touchpad cursor when is used.
Add config for allow disable show this cursor per game.

Using click on touchpad for switch to rear/front touchport
