### PR TITLE
modules/SceGxm, renderer: Improve accuracy of depth stencil surface

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
@@ -87,7 +87,7 @@ public:
     void read_pipeline_cache();
     void save_pipeline_cache();
 
-    vk::RenderPass retrieve_render_pass(vk::Format format, uint32_t zls_control, bool no_color = false);
+    vk::RenderPass retrieve_render_pass(vk::Format format, bool force_load, bool force_store, bool no_color = false);
     vk::Pipeline retrieve_pipeline(VKContext &context, SceGxmPrimitiveType &type, MemState &mem);
 
     bool precompile_shader(const Sha256Hash &hash);

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -372,7 +372,7 @@ void set_context(GLState &state, GLContext &context, const MemState &mem, const 
     }
 
     SceGxmDepthStencilSurface *ds_surface_fin = &context.record.depth_stencil_surface;
-    if ((ds_surface_fin->depthData.address() == 0) && (ds_surface_fin->stencilData.address() == 0)) {
+    if ((ds_surface_fin->depth_data.address() == 0) && (ds_surface_fin->stencil_data.address() == 0)) {
         ds_surface_fin = nullptr;
     }
 

--- a/vita3k/renderer/src/gl/surface_cache.cpp
+++ b/vita3k/renderer/src/gl/surface_cache.cpp
@@ -528,7 +528,7 @@ GLuint GLSurfaceCache::retrieve_depth_stencil_texture_handle(const State &state,
     force_width *= state.res_multiplier;
     force_height *= state.res_multiplier;
 
-    bool packed_ds = (surface.control.content & SceGxmDepthStencilControl::format_bits) == SCE_GXM_DEPTH_STENCIL_FORMAT_S8D24;
+    bool packed_ds = surface.get_format() == SCE_GXM_DEPTH_STENCIL_FORMAT_S8D24;
 
     if (force_width < 0) {
         force_width = target->width;
@@ -538,13 +538,13 @@ GLuint GLSurfaceCache::retrieve_depth_stencil_texture_handle(const State &state,
         force_height = target->height;
     }
 
-    const bool is_stencil_only = surface.depthData.address() == 0;
+    const bool is_stencil_only = surface.depth_data.address() == 0;
     std::size_t found_index = static_cast<std::size_t>(-1);
 
     // The whole depth stencil struct is reserved for future use
     for (std::size_t i = 0; i < depth_stencil_textures.size(); i++) {
-        if ((!is_stencil_only && depth_stencil_textures[i].surface.depthData == surface.depthData)
-            || (is_stencil_only && depth_stencil_textures[i].surface.stencilData == surface.stencilData)) {
+        if ((!is_stencil_only && depth_stencil_textures[i].surface.depth_data == surface.depth_data)
+            || (is_stencil_only && depth_stencil_textures[i].surface.stencil_data == surface.stencil_data)) {
             found_index = i;
             break;
         }

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -58,19 +58,15 @@ COMMAND(handle_set_context) {
     if (color_surface)
         delete color_surface;
 
-    if (depth_stencil_surface) {
+    if (depth_stencil_surface && !depth_stencil_surface->disabled()) {
         render_context->record.depth_stencil_surface = *depth_stencil_surface;
-        delete depth_stencil_surface;
     } else {
-        static const SceGxmDepthStencilSurface default_ds{
-            .zlsControl = 0,
-            .depthData = Ptr<void>(0),
-            .stencilData = Ptr<void>(0),
-            .backgroundDepth = 1.0f,
-            .control = { SceGxmDepthStencilControl::mask_bit }
-        };
-        render_context->record.depth_stencil_surface = default_ds;
+        render_context->record.depth_stencil_surface.depth_data.reset();
+        render_context->record.depth_stencil_surface.stencil_data.reset();
     }
+
+    if (depth_stencil_surface)
+        delete depth_stencil_surface;
 
     switch (renderer.current_backend) {
     case Backend::OpenGL:

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -285,11 +285,8 @@ vk::PipelineLayout PipelineCache::retrieve_pipeline_layout(const uint16_t vert_t
     return pipeline_layouts[vert_texture_count][frag_texture_count];
 }
 
-vk::RenderPass PipelineCache::retrieve_render_pass(vk::Format format, uint32_t zls_control, bool no_color) {
-    bool force_loaded = (zls_control & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED) != 0;
-    bool force_stored = (zls_control & SCE_GXM_DEPTH_STENCIL_FORCE_STORE_ENABLED) != 0;
-
-    auto &render_passes_map = no_color ? shader_interlock_pass : render_passes[force_loaded][force_stored];
+vk::RenderPass PipelineCache::retrieve_render_pass(vk::Format format, bool force_load, bool force_store, bool no_color) {
+    auto &render_passes_map = no_color ? shader_interlock_pass : render_passes[force_load][force_store];
 
     auto it = render_passes_map.find(format);
 
@@ -324,8 +321,8 @@ vk::RenderPass PipelineCache::retrieve_render_pass(vk::Format format, uint32_t z
         .finalLayout = vk::ImageLayout::eGeneral
     };
 
-    vk::AttachmentLoadOp load_op = force_loaded ? vk::AttachmentLoadOp::eLoad : vk::AttachmentLoadOp::eClear;
-    vk::AttachmentStoreOp store_op = force_stored ? vk::AttachmentStoreOp::eStore : vk::AttachmentStoreOp::eDontCare;
+    vk::AttachmentLoadOp load_op = force_load ? vk::AttachmentLoadOp::eLoad : vk::AttachmentLoadOp::eClear;
+    vk::AttachmentStoreOp store_op = force_store ? vk::AttachmentStoreOp::eStore : vk::AttachmentStoreOp::eDontCare;
     vk::AttachmentDescription ds_attachment{
         .format = vk::Format::eD32SfloatS8Uint,
         .samples = vk::SampleCountFlagBits::e1,

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -389,7 +389,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
 
     if (context.is_first_scene_draw && context.state.features.support_shader_interlock) {
         // update the render pass to load and store the depth and stencil
-        context.current_render_pass = context.state.pipeline_cache.retrieve_render_pass(context.current_color_attachment->format, ~0U);
+        context.current_render_pass = context.state.pipeline_cache.retrieve_render_pass(context.current_color_attachment->format, true, true);
         context.is_first_scene_draw = false;
     }
 

--- a/vita3k/renderer/src/vulkan/sync_state.cpp
+++ b/vita3k/renderer/src/vulkan/sync_state.cpp
@@ -103,8 +103,7 @@ void sync_mask(VKContext &context, const MemState &mem) {
     if (!context.state.features.use_mask_bit)
         return;
 
-    auto control = context.record.depth_stencil_surface.control.content;
-    float initial_val = (control & SceGxmDepthStencilControl::mask_bit) ? 1.0f : 0.0f;
+    float initial_val = context.record.depth_stencil_surface.mask ? 1.0f : 0.0f;
 
     std::array<float, 4> clear_bytes = { initial_val, initial_val, initial_val, initial_val };
     vk::ClearColorValue clear_color{ clear_bytes };
@@ -121,12 +120,11 @@ void sync_depth_bias(VKContext &context) {
 }
 
 void sync_depth_data(VKContext &context) {
-    // If force load is enabled to load saved depth and depth data memory exists (the second condition is just for safe, may sometimes contradict its usefulness, hopefully won't)
-    if ((context.record.depth_stencil_surface.zlsControl & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED) || (!context.record.depth_stencil_surface.depthData))
+    if (context.record.depth_stencil_surface.force_load)
         return;
 
     vk::ClearDepthStencilValue clear_value{
-        .depth = context.record.depth_stencil_surface.backgroundDepth
+        .depth = context.record.depth_stencil_surface.background_depth
     };
     vk::ClearAttachment clear_attachment{
         .aspectMask = vk::ImageAspectFlagBits::eDepth,
@@ -143,11 +141,11 @@ void sync_depth_data(VKContext &context) {
 }
 
 void sync_stencil_data(VKContext &context, const MemState &mem) {
-    if (context.record.depth_stencil_surface.zlsControl & SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED)
+    if (context.record.depth_stencil_surface.force_load)
         return;
 
     vk::ClearDepthStencilValue clear_value{
-        .stencil = context.record.depth_stencil_surface.control.content & SceGxmDepthStencilControl::stencil_bits
+        .stencil = context.record.depth_stencil_surface.stencil
     };
     vk::ClearAttachment clear_attachment{
         .aspectMask = vk::ImageAspectFlagBits::eStencil,

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -101,8 +101,8 @@ void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTe
     } else {
         // Try to retrieve S24D8 texture
         SceGxmDepthStencilSurface lookup_temp;
-        lookup_temp.depthData = data_addr;
-        lookup_temp.stencilData.reset();
+        lookup_temp.depth_data = data_addr;
+        lookup_temp.stencil_data.reset();
 
         image = context.state.surface_cache.retrieve_depth_stencil_texture_handle(mem, lookup_temp, width, height, true);
     }


### PR DESCRIPTION
- Fix an issue where the 4 upper bits of the stencil were always cleared with force_load disabled
- Update the SceGxmDepthStencilSurface to make it nicer and have the same layout as SceGxm
- Handle disabled stencil surfaces in the renderer, can potentially slightly improve performance on tiled renderers