### PR TITLE
cmake: Update minimum required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14.0)
 project(Vita3K)
 
 # Detects the amount of processors of the host machine and forwards the result to CPU_COUNT


### PR DESCRIPTION
glslang has the highest requirement (3.14.0)
https://github.com/KhronosGroup/glslang/blob/ca8d07d0bc1c6390b83915700439fa7719de6a2a/CMakeLists.txt#L36