### PR TITLE
renderer/screen_filters: fix memory leak

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/screen_filters.h
+++ b/vita3k/renderer/include/renderer/vulkan/screen_filters.h
@@ -31,6 +31,7 @@ protected:
 
 public:
     ScreenFilter(ScreenRenderer &screen_renderer);
+    virtual ~ScreenFilter() = default;
     virtual void init() = 0;
     virtual void on_resize(){};
     virtual void render(bool is_pre_renderpass, vk::ImageView src_img, vk::ImageLayout src_layout, const Viewport &viewport) = 0;

--- a/vita3k/renderer/src/vulkan/screen_filters.cpp
+++ b/vita3k/renderer/src/vulkan/screen_filters.cpp
@@ -44,7 +44,6 @@ SinglePassScreenFilter::~SinglePassScreenFilter() {
     vk::Device device = screen.state.device;
     // this will only happen when the user changes the option in the GUI, we can afford to waitIdle
     device.waitIdle();
-    vao.destroy();
     device.destroy(pipeline);
     device.destroy(pipeline_layout);
     device.freeDescriptorSets(descriptor_pool, descriptor_sets);


### PR DESCRIPTION
It seems that destructors of ScreenFilter and it's descendants are newer called. (`vao.destroy` is called automatically on call `vao` destructor, so double `destroy()` caused crash)