### PR TITLE
cmake: Remove specific code for unsupported compilers

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -263,12 +263,6 @@ add_subdirectory(pugixml)
 set_property(TARGET pugixml-static PROPERTY FOLDER externals)
 
 add_library(CLI11 INTERFACE)
-
-# See "Note: Special instructions for GCC 8" on https://github.com/CLIUtils/CLI11
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-	target_compile_definitions(CLI11 INTERFACE CLI11_HAS_FILESYSTEM=0)
-endif()
-
 target_include_directories(CLI11 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/cli11")
 
 add_library(vulkan INTERFACE)

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -151,9 +151,6 @@ target_link_libraries(vita3k PRIVATE app config ctrl display gdbstub gui gxm io 
 if(USE_DISCORD_RICH_PRESENCE)
 	target_link_libraries(vita3k PRIVATE discord-rpc)
 endif()
-if(LINUX)
-	target_link_libraries(vita3k PRIVATE stdc++fs)
-endif()
 
 set_target_properties(vita3k PROPERTIES OUTPUT_NAME Vita3K
 	ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"


### PR DESCRIPTION
We can safely remove this because:
- GNU implementation prior to 9.1 requires linking with -lstdc++fs and LLVM implementation prior to LLVM 9.0 requires linking with -lc++fs
- The dynarmic dependency uses consteval which requires at least GCC 10 and LLVM 11