### PR TITLE
renderer/vulkan, vutil: Fix texture memory leak

### DIFF
--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -330,6 +330,10 @@ void VKTextureCache::configure_texture(const SceGxmTexture &gxm_texture) {
     current_texture->memory_needed = align(memory_needed, 16);
     vkutil::Image &image = current_texture->texture;
 
+    // In case the cache is full, no need to put the previous image in the destroy queue
+    // as it shouldn't have been used for a while
+    image.destroy();
+
     // manually initialize the image
     image.allocator = state.allocator;
     image.width = width;

--- a/vita3k/vkutil/src/objects.cpp
+++ b/vita3k/vkutil/src/objects.cpp
@@ -144,8 +144,10 @@ void Buffer::destroy() {
     if (!destroy_on_deletion || !allocator)
         return;
 
-    if (buffer)
+    if (buffer) {
         allocator.destroyBuffer(buffer, allocation);
+        buffer = nullptr;
+    }
 }
 
 Buffer::~Buffer() {


### PR DESCRIPTION
Fix a memory leak causing the texture cache not to free previous textures when it is full.
Also correct the behavior of the destroy function of vulkan buffers.