### PR TITLE
gui/controllers dialog: Add custom LED color support.

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -150,6 +150,7 @@ enum PerfomanceOverleyPosition {
 // When adding in a new macro for generation, ALL options must be stated.
 #define CONFIG_VECTOR(code)                                                                             \
     code(std::vector<short>, "controller-binds", std::vector<short>{}, controller_binds)                \
+    code(std::vector<int>, "controller-led-color", std::vector<int>{}, controller_led_color)            \
     code(std::vector<std::string>, "lle-modules", std::vector<std::string>{}, lle_modules)              \
     code(std::vector<uint64_t>, "ime-langs", std::vector<uint64_t>{4}, ime_langs)                       \
     code(std::vector<std::string>, "tracy-advanced-profiling-modules", std::vector<std::string>{}, tracy_advanced_profiling_modules)

--- a/vita3k/ctrl/include/ctrl/state.h
+++ b/vita3k/ctrl/include/ctrl/state.h
@@ -39,6 +39,7 @@ struct Controller {
     int port;
     bool has_accel;
     bool has_gyro;
+    bool has_led;
 };
 
 struct ControllerBinding {
@@ -46,7 +47,13 @@ struct ControllerBinding {
     uint32_t button;
 };
 
-typedef std::map<SDL_JoystickGUID, Controller> ControllerList;
+struct SDL_JoystickGUIDComparator {
+    bool operator()(const SDL_JoystickGUID &a, const SDL_JoystickGUID &b) const {
+        return memcmp(&a, &b, sizeof(a)) < 0;
+    }
+};
+
+typedef std::map<SDL_JoystickGUID, Controller, SDL_JoystickGUIDComparator> ControllerList;
 
 struct CtrlState {
     std::mutex mutex;

--- a/vita3k/ctrl/src/ctrl.cpp
+++ b/vita3k/ctrl/src/ctrl.cpp
@@ -44,10 +44,6 @@ SceCtrlExternalInputMode get_type_of_controller(const int idx) {
     return (type == SDL_CONTROLLER_TYPE_PS4) || (type == SDL_CONTROLLER_TYPE_PS5) ? SCE_CTRL_TYPE_DS4 : SCE_CTRL_TYPE_DS3;
 }
 
-static bool operator<(const SDL_JoystickGUID &a, const SDL_JoystickGUID &b) {
-    return memcmp(&a, &b, sizeof(a)) < 0;
-}
-
 void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
     // Remove disconnected controllers
     bool found_gyro = false;
@@ -85,6 +81,15 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
                 new_controller.has_accel = SDL_GameControllerHasSensor(controller.get(), SDL_SENSOR_ACCEL);
                 if (new_controller.has_accel)
                     SDL_GameControllerSetSensorEnabled(controller.get(), SDL_SENSOR_ACCEL, SDL_TRUE);
+
+                new_controller.has_led = SDL_GameControllerHasLED(controller.get());
+                if (new_controller.has_led) {
+                    auto &color = emuenv.cfg.controller_led_color;
+                    if (!color.empty()) {
+                        color.resize(3);
+                        SDL_GameControllerSetLED(controller.get(), color[0], color[1], color[2]);
+                    }
+                }
 
                 found_gyro |= new_controller.has_gyro;
                 found_accel |= new_controller.has_accel;


### PR DESCRIPTION
# About
gui/controllers dialog: Add custom LED color support.
- Add checkbox for enable custom color.
- Fix End() pos.

# Result
![image](https://github.com/Vita3K/Vita3K/assets/5261759/7d4cce3b-547e-4d77-8264-fdb578868a51)
