### PR TITLE
ngs: workaround crashes on invalid configurations

### DIFF
--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -62,6 +62,21 @@ ExitCode add_sink(const fs::path &log_path);
     if (flag)                      \
     LOG_CRITICAL(__VA_ARGS__)
 
+#define LOG_ONCE(log_function, ...)    \
+    do {                               \
+        static bool LOG_DONE = false;  \
+        if (!LOG_DONE)                 \
+            log_function(__VA_ARGS__); \
+        LOG_DONE = true;               \
+    } while (0)
+
+#define LOG_TRACE_ONCE(...) LOG_ONCE(LOG_TRACE, __VA_ARGS__)
+#define LOG_DEBUG_ONCE(...) LOG_ONCE(LOG_DEBUG, __VA_ARGS__)
+#define LOG_INFO_ONCE(...) LOG_ONCE(LOG_INFO, __VA_ARGS__)
+#define LOG_WARN_ONCE(...) LOG_ONCE(LOG_WARN, __VA_ARGS__)
+#define LOG_ERROR_ONCE(...) LOG_ONCE(LOG_ERROR, __VA_ARGS__)
+#define LOG_CRITICAL_ONCE(...) LOG_ONCE(LOG_CRITICAL_IF, __VA_ARGS__)
+
 int ret_error_impl(const char *name, const char *error_str, std::uint32_t error_val);
 } // namespace logging
 


### PR DESCRIPTION
util/log: LOG_*_ONCE macros
modules/SceNgs: implement sceNgsVoiceGetModuleType
ngs/modules/player: workaround crash if required playback frequency is invalid
ngs: stub for incomplete output paths (for Smart As [PCSF00216])
ngs: stub for null voice definition