### PR TITLE
shader: use `std::bit_set`,  return `nullptr` after `assert`

### DIFF
--- a/vita3k/shader/include/shader/usse_constant_table.h
+++ b/vita3k/shader/include/shader/usse_constant_table.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <util/bit_cast.h>
+
 #include <cstdint>
 
 namespace shader::usse {
@@ -24,8 +26,8 @@ namespace shader::usse {
 static const std::uint32_t NaN_raw = 0x7FFF7FFF;
 static const std::uint32_t neg_NaN_raw = 0xFFFFFFFF;
 
-static const float NaN = *reinterpret_cast<const float *>(&NaN_raw);
-static const float neg_NaN = *reinterpret_cast<const float *>(&neg_NaN_raw);
+static const float NaN = std::bit_cast<float>(NaN_raw);
+static const float neg_NaN = std::bit_cast<float>(neg_NaN_raw);
 
 constexpr std::uint32_t f32_constant_table_bank_0_raw[] = {
     0x00000000,

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -244,6 +244,7 @@ static spv::Function *make_unpack_func(spv::Builder &b, const FeatureState &feat
     }
     default:
         assert(false);
+        return nullptr;
     }
 
     spv::Function *unpack_func = b.makeFunctionEntry(
@@ -336,6 +337,7 @@ static spv::Function *make_pack_func(spv::Builder &b, const FeatureState &featur
     }
     default:
         assert(false);
+        return nullptr;
     }
 
     spv::Function *pack_func = b.makeFunctionEntry(

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -20,6 +20,7 @@
 #include <shader/usse_program_analyzer.h>
 #include <shader/usse_utilities.h>
 
+#include <util/bit_cast.h>
 #include <util/log.h>
 
 #include <SPIRV/GLSL.std.450.h>
@@ -853,7 +854,7 @@ spv::Id shader::usse::utils::load(spv::Builder &b, const SpirvShaderParameters &
                 else if (integral_signed)
                     return b.makeIntConstant(value);
                 else
-                    return b.makeFloatConstant(*reinterpret_cast<const float *>(&value));
+                    return b.makeFloatConstant(std::bit_cast<float>(value));
             };
 
             for (int i = 0; i < 4; i++) {
@@ -892,9 +893,9 @@ spv::Id shader::usse::utils::load(spv::Builder &b, const SpirvShaderParameters &
                 }
 
                 if (integral_unsigned)
-                    return b.makeUintConstant(*reinterpret_cast<const uint32_t *>(&value));
+                    return b.makeUintConstant(std::bit_cast<uint32_t>(value));
                 else if (integral_signed)
-                    return b.makeIntConstant(*reinterpret_cast<const int32_t *>(&value));
+                    return b.makeIntConstant(std::bit_cast<int32_t>(value));
                 else
                     return b.makeFloatConstant(value);
             };

--- a/vita3k/util/include/util/bit_cast.h
+++ b/vita3k/util/include/util/bit_cast.h
@@ -1,0 +1,35 @@
+// Vita3K emulator project
+// Copyright (C) 2023 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <bit>
+#include <cstring> // memcpy
+
+#ifndef __cpp_lib_bit_cast
+namespace std {
+template <typename T, typename U>
+T bit_cast(U &&u) {
+    static_assert(sizeof(T) == sizeof(U));
+    union {
+        T t;
+    }; // prevent construction
+    std::memcpy(&t, &u, sizeof(t));
+    return t;
+}
+} // namespace std
+#endif

--- a/vita3k/util/include/util/float_to_half.h
+++ b/vita3k/util/include/util/float_to_half.h
@@ -20,26 +20,12 @@
 // original source:https://stackoverflow.com/questions/1659440/32-bit-to-16-bit-floating-point-conversion
 // public domain
 
-#include <bit>
+#include "util/bit_cast.h"
+
 #include <climits> // CHAR_BIT
 #include <cstdint> // uint32_t, uint64_t, etc.
-#include <cstring> // memcpy
 #include <limits> // numeric_limits
 #include <utility> // is_integral_v, is_floating_point_v, forward
-
-#ifndef __cpp_lib_bit_cast
-namespace std {
-template <typename T, typename U>
-T bit_cast(U &&u) {
-    static_assert(sizeof(T) == sizeof(U));
-    union {
-        T t;
-    }; // prevent construction
-    std::memcpy(&t, &u, sizeof(t));
-    return t;
-}
-} // namespace std
-#endif
 
 namespace util {
 template <typename T>


### PR DESCRIPTION
Fixes ` warning: dereferencing type-punned pointer will break
strict-aliasing rules [-Wstrict-aliasing]` when compiling with `-Wall`.

`assert()` is ignored on release builds.
Fixes many `may be used uninitialized` warnings.