### PR TITLE
modules/sceMotion: Fix wrong sizeof usage on memset

### DIFF
--- a/vita3k/modules/SceDriverUser/SceMotion.cpp
+++ b/vita3k/modules/SceDriverUser/SceMotion.cpp
@@ -93,7 +93,7 @@ EXPORT(int, sceMotionGetSensorState, SceMotionSensorState *sensorState, int numR
         sensorState->dataInfo = 0;
     } else {
         // some default values
-        memset(sensorState, 0, sizeof(sensorState));
+        memset(sensorState, 0, sizeof(*sensorState));
         sensorState->accelerometer.z = -1.0;
 
         std::chrono::time_point<std::chrono::steady_clock> ts = std::chrono::steady_clock::now();


### PR DESCRIPTION
forgor the *, pretty sure it didn't mean to set only a few bytes to 0 :D