### PR TITLE
renderer: Fix OOB access on texture cache

### DIFF
--- a/vita3k/renderer/src/texture_cache.cpp
+++ b/vita3k/renderer/src/texture_cache.cpp
@@ -117,8 +117,10 @@ bool TextureCache::init(const bool hashless_texture_cache) {
 
     // initialize the doubly linked list
     for (int i = 0; i < TextureCacheSize; i++) {
-        infoes[i].prev = &infoes[i - 1];
-        infoes[i].next = &infoes[i + 1];
+        if (i > 0)
+            infoes[i].prev = &infoes[i - 1];
+        if (i < TextureCacheSize - 1)
+            infoes[i].next = &infoes[i + 1];
     }
     // fix the first and last elements
     infoes[0].prev = &infoes[TextureCacheSize - 1];


### PR DESCRIPTION
This is my last resort of fixing this weird bug that only happens on the AUR, AND I DONT KNOW WHY asserts are being compiled, i checked every compiler flag and it still doesn't make sense to why it happens on a release build, but anyways, i didnt want to modify upstream but here i am, doing exactly that, i give up, this is only needed for that one specific case of being compiled using makepkg

fixes https://github.com/Vita3K/Vita3K/issues/2922