### PR TITLE
ctrl: Drop inputs while rebinding menu is open

### DIFF
--- a/vita3k/ctrl/include/ctrl/state.h
+++ b/vita3k/ctrl/include/ctrl/state.h
@@ -60,6 +60,7 @@ struct CtrlState {
     ControllerList controllers;
     int controllers_num = 0;
     bool has_motion_support = false;
+    bool drop_inputs = false;
     const char *controllers_name[SCE_CTRL_MAX_WIRELESS_NUM];
     bool free_ports[SCE_CTRL_MAX_WIRELESS_NUM] = { true, true, true, true };
     SceCtrlPadInputMode input_mode = SCE_CTRL_MODE_DIGITAL;

--- a/vita3k/ctrl/src/ctrl.cpp
+++ b/vita3k/ctrl/src/ctrl.cpp
@@ -268,6 +268,7 @@ static void retrieve_ctrl_data(EmuEnvState &emuenv, int port, bool is_v2, bool n
     axes.fill(0);
 
     const auto reset_axes = [&]() {
+        // Re-center joysticks to (128,128). Range is (0-255,0-255).
         SceCtrlPadInputMode mode = from_ext_function ? state.input_mode_ext : state.input_mode;
         if (mode == SCE_CTRL_MODE_DIGITAL) {
             lx = 0x80;
@@ -282,7 +283,7 @@ static void retrieve_ctrl_data(EmuEnvState &emuenv, int port, bool is_v2, bool n
         }
     };
 
-    if (emuenv.common_dialog.status == SCE_COMMON_DIALOG_STATUS_RUNNING) {
+    if (emuenv.common_dialog.status == SCE_COMMON_DIALOG_STATUS_RUNNING || emuenv.ctrl.drop_inputs) {
         if (negative)
             buttons ^= ~0;
         reset_axes();

--- a/vita3k/gui/src/controllers_dialog.cpp
+++ b/vita3k/gui/src/controllers_dialog.cpp
@@ -361,6 +361,8 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
         reset_controller_binding(emuenv);
 
     ImGui::End();
+
+    ctrl.drop_inputs = rebinds_is_open; // if the dialog is active, drop inputs from passing to ctrl
 }
 
 } // namespace gui

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -20,6 +20,7 @@
 #include <SDL_scancode.h>
 #include <config/functions.h>
 #include <config/state.h>
+#include <ctrl/state.h>
 #include <emuenv/state.h>
 #include <gui/functions.h>
 #include <interface.h>
@@ -104,6 +105,7 @@ static void remapper_button(GuiState &gui, EmuEnvState &emuenv, int *button, con
         std::array<int, total_key_entries> original_state;
         prepare_map_array(emuenv, original_state);
         while (gui.is_capturing_keys) {
+            emuenv.ctrl.drop_inputs = false; // set ctrl.drop_inputs to false, so they don't get discarded while rebinding
             handle_events(emuenv, gui);
             *button = gui.captured_key;
             if (*button < 0 || *button > 231)
@@ -204,6 +206,8 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
     }
 
     ImGui::End();
+
+    emuenv.ctrl.drop_inputs = gui.controls_menu.controls_dialog;
 }
 
 } // namespace gui

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -619,7 +619,7 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             return false;
 
         case SDL_KEYDOWN: {
-            if (ImGui::GetIO().WantTextInput || gui.is_key_locked)
+            if (ImGui::GetIO().WantTextInput || gui.is_key_locked || emuenv.ctrl.drop_inputs)
                 continue;
 
             const auto get_sce_ctrl_btn_from_scancode = [&emuenv](const SDL_Scancode scancode) {
@@ -717,7 +717,7 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             if (!emuenv.kernel.is_threads_paused() && (event.cbutton.button == SDL_CONTROLLER_BUTTON_TOUCHPAD))
                 toggle_touchscreen();
 
-            if (ImGui::GetIO().WantTextInput)
+            if (ImGui::GetIO().WantTextInput || emuenv.ctrl.drop_inputs)
                 continue;
 
             for (const auto &binding : get_controller_bindings_ext(emuenv)) {


### PR DESCRIPTION
Make it so that when the rebinds menu is open that it does not affect the GUI and in-game events.

Currently I have it set up so that events get dropped when the controller BIND menu is up, and not the controller LIST menu, but this can be easily changed.