### PR TITLE
renderer/vulkan, shader: Fix texture viewport without memory mapping

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -68,7 +68,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "archive-log", false, archive_log)                                                       \
     code(std::string, "backend-renderer", "OpenGL", backend_renderer)                                   \
     code(int, "gpu-idx", 0, gpu_idx)                                                                    \
-    code(bool, "high-accuracy", false, high_accuracy)                                                   \
+    code(bool, "high-accuracy", true, high_accuracy)                                                    \
     code(int, "resolution-multiplier", 1, resolution_multiplier)                                        \
     code(bool, "disable-surface-sync", true, disable_surface_sync)                                      \
     code(std::string, "screen-filter", "Bilinear", screen_filter)                                       \

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -80,6 +80,8 @@ struct VKState : public renderer::State {
     vkutil::Buffer default_buffer;
 
     bool support_fsr = false;
+    // support for the VK_KHR_uniform_buffer_standard_layout extension, needed for memory mapping and texture viewport
+    bool support_standard_layout = false;
 
     VKState(int gpu_idx);
 

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -612,11 +612,6 @@ bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state
 void VKState::late_init(const Config &cfg) {
     bool use_high_accuracy = cfg.current_config.high_accuracy;
 
-    if (!support_standard_layout) {
-        LOG_INFO("Standard layout extension is not supported, using high renderer accuracy");
-        use_high_accuracy = true;
-    }
-
     // shader interlock is more accurate but slower
     if (features.support_shader_interlock && use_high_accuracy) {
         LOG_INFO("Using shader interlock for accurate framebuffer fetch emulation");
@@ -627,9 +622,10 @@ void VKState::late_init(const Config &cfg) {
     }
 
     // texture viewport is faster but not entirely accurate
-    features.use_texture_viewport = !use_high_accuracy;
-    if (features.use_texture_viewport)
-        LOG_INFO("The vulkan renderer is using texture viewport for better performance");
+    if (support_standard_layout && !use_high_accuracy) {
+        LOG_INFO("The Vulkan renderer is using texture viewport for better performance");
+        features.use_texture_viewport = true;
+    }
 
     pipeline_cache.init();
     texture_cache.init(false);

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -963,12 +963,15 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     spv::Id render_buf_type;
     int curr_field_id = 0;
 
+    const uint16_t uniform_buffer_count = features.support_memory_mapping ? buffer_count : 0;
+    const uint16_t uniform_texture_count = features.use_texture_viewport ? texture_count : 0;
+
     if (program_type == SceGxmProgramType::Vertex) {
         // Create the default reg uniform buffer
         std::vector<spv::Id> uniform_composition = { v4, f32, f32, f32, f32, f32 };
-        if (features.support_memory_mapping && buffer_count > 0)
+        if (uniform_buffer_count > 0)
             uniform_composition.push_back(buffer_addresses_type);
-        if (features.use_texture_viewport && texture_count > 0) {
+        if (uniform_texture_count > 0) {
             uniform_composition.push_back(viewport_fields_type);
             uniform_composition.push_back(viewport_fields_type);
         }
@@ -991,15 +994,15 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         ADD_VERT_UNIFORM_MEMBER(z_scale);
 
 #undef ADD_VERT_UNIFORM_MEMBER
-#define ADD_EXT_UNIFORM_MEMBER(name)                                                                                                                                \
-    spv_params.name##_id = curr_field_id;                                                                                                                           \
-    b.addMemberDecoration(render_buf_type, curr_field_id, spv::DecorationOffset, RenderVertUniformBlockExtended::get_##name##_offset(buffer_count, texture_count)); \
+#define ADD_EXT_UNIFORM_MEMBER(name)                                                                                                                                                \
+    spv_params.name##_id = curr_field_id;                                                                                                                                           \
+    b.addMemberDecoration(render_buf_type, curr_field_id, spv::DecorationOffset, RenderVertUniformBlockExtended::get_##name##_offset(uniform_buffer_count, uniform_texture_count)); \
     b.addMemberName(render_buf_type, curr_field_id++, #name)
 
-        if (features.support_memory_mapping && buffer_count > 0) {
+        if (uniform_buffer_count > 0) {
             ADD_EXT_UNIFORM_MEMBER(buffer_addresses);
         }
-        if (features.use_texture_viewport && texture_count > 0) {
+        if (uniform_texture_count > 0) {
             ADD_EXT_UNIFORM_MEMBER(viewport_ratio);
             ADD_EXT_UNIFORM_MEMBER(viewport_offset);
         }
@@ -1015,9 +1018,9 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
 
     if (program_type == SceGxmProgramType::Fragment) {
         std::vector<spv::Id> uniform_composition = { f32, f32, f32, f32, f32 };
-        if (features.support_memory_mapping && buffer_count > 0)
+        if (uniform_buffer_count > 0)
             uniform_composition.push_back(buffer_addresses_type);
-        if (features.use_texture_viewport && texture_count > 0) {
+        if (uniform_texture_count > 0) {
             uniform_composition.push_back(viewport_fields_type);
             uniform_composition.push_back(viewport_fields_type);
         }
@@ -1040,15 +1043,15 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
         ADD_FRAG_UNIFORM_MEMBER(res_multiplier);
 
 #undef ADD_FRAG_UNIFORM_MEMBER
-#define ADD_EXT_UNIFORM_MEMBER(name)                                                                                                                                \
-    spv_params.name##_id = curr_field_id;                                                                                                                           \
-    b.addMemberDecoration(render_buf_type, curr_field_id, spv::DecorationOffset, RenderFragUniformBlockExtended::get_##name##_offset(buffer_count, texture_count)); \
+#define ADD_EXT_UNIFORM_MEMBER(name)                                                                                                                                                \
+    spv_params.name##_id = curr_field_id;                                                                                                                                           \
+    b.addMemberDecoration(render_buf_type, curr_field_id, spv::DecorationOffset, RenderFragUniformBlockExtended::get_##name##_offset(uniform_buffer_count, uniform_texture_count)); \
     b.addMemberName(render_buf_type, curr_field_id++, #name)
 
-        if (features.support_memory_mapping && buffer_count > 0) {
+        if (uniform_buffer_count > 0) {
             ADD_EXT_UNIFORM_MEMBER(buffer_addresses);
         }
-        if (features.use_texture_viewport && texture_count > 0) {
+        if (uniform_texture_count > 0) {
             ADD_EXT_UNIFORM_MEMBER(viewport_ratio);
             ADD_EXT_UNIFORM_MEMBER(viewport_offset);
         }


### PR DESCRIPTION
Fix an issue where the offset in the generated shader was wrong when using texture viewport without memory mapping. Also add memory mapping support in the feature mask. This should fix #2943 .

The second commit sets by default the renderer accuracy to high. On desktop, performance is already fine with the accuracy set to high (except when upscaling a lot I guess), so it does not make too much sense to set it to standard by default.