### PR TITLE
modules/SceThreadMgr: Fix sceKernelOpenTimer

### DIFF
--- a/vita3k/kernel/include/kernel/sync_primitives.h
+++ b/vita3k/kernel/include/kernel/sync_primitives.h
@@ -217,6 +217,7 @@ SceInt32 simple_event_delete(KernelState &kernel, const char *export_name, SceUI
 
 // Timer
 SceUID timer_create(KernelState &kernel, MemState &mem, const char *export_name, const char *name, SceUID thread_id, SceUInt32 attr);
+SceUID timer_find(KernelState &kernel, const char *export_name, const char *pName);
 SceInt32 timer_waitorpoll(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID event_id, SceUInt32 bit_pattern, SceUInt32 *result_pattern, SceUInt64 *user_data, SceUInt32 *timeout, bool is_wait);
 SceInt32 timer_clear(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID event_id, SceUInt32 clear_pattern);
 SceInt32 timer_set(KernelState &kernel, const char *export_name, SceUID thread_id, SceUID timer_handle, SceUID type, SceKernelSysClock *interval, SceInt32 repeats);

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -1268,24 +1268,9 @@ EXPORT(int, sceKernelOpenSimpleEvent) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(SceUID, sceKernelOpenTimer, const char *name) {
-    TRACY_FUNC(sceKernelOpenTimer, name);
-    STUBBED("References not implemented.");
-
-    SceUID timer_handle = -1;
-    TimerPtr timer_info;
-
-    const std::lock_guard<std::mutex> guard(emuenv.kernel.mutex);
-    for (const auto &timer : emuenv.kernel.timers) {
-        if (timer.second->name == name) {
-            timer_handle = timer.first;
-            timer_info = timer.second;
-            break;
-        }
-    }
-    emuenv.kernel.mutex.unlock();
-
-    return timer_handle;
+EXPORT(SceUID, sceKernelOpenTimer, const char *pName) {
+    TRACY_FUNC(sceKernelOpenTimer, pName);
+    return timer_find(emuenv.kernel, export_name, pName);
 }
 
 EXPORT(int, sceKernelPollSema, SceUID semaid, int32_t needCount) {


### PR DESCRIPTION
sceKernelOpenTimer had a few issues. By a few issues I mean calling it would softlock the emulator, this was due to:
- String comparaison was done by comparing the string pointers, which always failed so this function would never find a matching timer even when one existed.
- There is a random mutex unlock in the code with no matching mutex lock, causing a softlock....

Fortunately enough, before making the emulator more accurate with #2723 , this function was never called.
This PR fixes these issues, make sceKernelOpenTimer look like the other kernel open functions.
This fixes the regression in Mortal Kombat and allows it to be playable again.