### PR TITLE
gui: Fix Ignore the ps key on the user management.

### DIFF
--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -791,7 +791,7 @@ void draw_vita_area(GuiState &gui, EmuEnvState &emuenv) {
     if (!gui.trophy_unlock_display_requests.empty())
         draw_trophies_unlocked(gui, emuenv);
 
-    if (emuenv.ime.state && !gui.vita_area.home_screen && !gui.vita_area.live_area_screen && get_sys_apps_state(gui))
+    if (emuenv.ime.state && !gui.vita_area.home_screen && !gui.vita_area.live_area_screen && !gui.vita_area.user_management && get_sys_apps_state(gui))
         draw_ime(emuenv.ime, emuenv);
 
     // System App
@@ -819,7 +819,7 @@ void draw_vita_area(GuiState &gui, EmuEnvState &emuenv) {
 
 void draw_ui(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PushFont(gui.vita_font);
-    if ((gui.vita_area.home_screen || !emuenv.io.app_path.empty()) && get_sys_apps_state(gui) && !gui.vita_area.live_area_screen && (!emuenv.cfg.show_info_bar || !gui.vita_area.information_bar))
+    if ((gui.vita_area.home_screen || !emuenv.io.app_path.empty()) && get_sys_apps_state(gui) && !gui.vita_area.live_area_screen && !gui.vita_area.user_management && (!emuenv.cfg.show_info_bar || !gui.vita_area.information_bar))
         draw_main_menu_bar(gui, emuenv);
 
     if (gui.controls_menu.controls_dialog)

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -617,7 +617,7 @@ void draw_information_bar(GuiState &gui, EmuEnvState &emuenv) {
     draw_list->AddRectFilled(ImVec2(VIEWPORT_POS.x + INFO_BAR_SIZE.x - (54.f * SCALE.x) - is_notif_pos, VIEWPORT_POS.y + (12.f * SCALE.y)), ImVec2(VIEWPORT_POS.x + INFO_BAR_SIZE.x - (50.f * SCALE.x) - is_notif_pos, VIEWPORT_POS.y + (20 * SCALE.y)), IM_COL32(81.f, 169.f, 32.f, 255.f));
     draw_list->AddRectFilled(ImVec2(VIEWPORT_POS.x + INFO_BAR_SIZE.x - (50.f * SCALE.x) - is_notif_pos, VIEWPORT_POS.y + (5.f * SCALE.y)), ImVec2(VIEWPORT_POS.x + INFO_BAR_SIZE.x - (12.f * SCALE.x) - is_notif_pos, VIEWPORT_POS.y + (27 * SCALE.y)), IM_COL32(81.f, 169.f, 32.f, 255.f), 2.f * SCALE.x, ImDrawFlags_RoundCornersAll);
 
-    if (emuenv.display.imgui_render && !gui.vita_area.start_screen && !gui.vita_area.live_area_screen && !gui.help_menu.vita3k_update && get_sys_apps_state(gui) && (ImGui::IsWindowHovered(ImGuiHoveredFlags_None) || ImGui::IsItemClicked(0)))
+    if (emuenv.display.imgui_render && !gui.vita_area.start_screen && !gui.vita_area.live_area_screen && !gui.vita_area.user_management && !gui.help_menu.vita3k_update && get_sys_apps_state(gui) && (ImGui::IsWindowHovered(ImGuiHoveredFlags_None) || ImGui::IsItemClicked(0)))
         gui.vita_area.information_bar = false;
 
     if (is_notif_pos)

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -39,7 +39,7 @@
 namespace gui {
 
 bool get_sys_apps_state(GuiState &gui) {
-    return !gui.vita_area.content_manager && !gui.vita_area.settings && !gui.vita_area.trophy_collection && !gui.vita_area.manual && !gui.vita_area.user_management;
+    return !gui.vita_area.content_manager && !gui.vita_area.settings && !gui.vita_area.trophy_collection && !gui.vita_area.manual;
 }
 
 struct FRAME {

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -619,9 +619,6 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             return false;
 
         case SDL_KEYDOWN: {
-            if (ImGui::GetIO().WantTextInput || gui.is_key_locked)
-                continue;
-
             const auto get_sce_ctrl_btn_from_scancode = [&emuenv](const SDL_Scancode scancode) {
                 if (scancode == emuenv.cfg.keyboard_button_up)
                     return SCE_CTRL_UP;
@@ -661,6 +658,10 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
                 }
                 gui.is_capturing_keys = false;
             }
+
+            if (ImGui::GetIO().WantTextInput || gui.is_key_locked)
+                continue;
+
             if (allow_switch_state) {
                 // toggle gui state
                 if (event.key.keysym.scancode == emuenv.cfg.keyboard_gui_toggle_gui)


### PR DESCRIPTION
# About
- gui: Fix Ignore the ps key on the user management.
should fix crash and double view in home when press ps with ignore it.
fix pos of ignore key pressed.