### PR TITLE
renderer/vulkan: Add support for macroblock sync when a scissor is not specified

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -225,6 +225,8 @@ struct VKContext : public renderer::Context {
     // used for macroblock sync emulation
     uint16_t last_macroblock_x = ~0;
     uint16_t last_macroblock_y = ~0;
+    // special case where we can't determine the current macroblock
+    bool ignore_macroblock = false;
 
     // used if necessary to restart easily the render pass
     vk::RenderPassBeginInfo curr_renderpass_info;
@@ -253,7 +255,7 @@ struct VKContext : public renderer::Context {
     void stop_recording(const SceGxmNotification &notif1, const SceGxmNotification &notif2, bool submit = true);
 
     // check (when the render target has macroblock set) if we are drawing to another block
-    void check_for_macroblock_change();
+    void check_for_macroblock_change(bool is_draw);
 
 private:
     void wait_thread_function(const MemState &mem);

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -61,7 +61,7 @@ void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTe
     // in particular, we know that the scissor is the correct one for the upcoming draw
     // and the texture copy needs to be in the correct prerender command for it to render fine
     // so start a new recording right now if the macroblock has changed
-    context.check_for_macroblock_change();
+    context.check_for_macroblock_change(false);
 
     Address data_addr = texture.data_addr << 2;
     bool is_vertex = index >= SCE_GXM_MAX_TEXTURE_UNITS;


### PR DESCRIPTION
The game flower does not specify a scissor matching the current macroblock, so as a fallback this PR implement a workaround (quite inefficient, but it can't really do better, render each draw in its own render pass).

This fixes the graphical regressions in flower and also the blur issues (like other games using macroblock sync).