### PR TITLE
renderer: Fix BCn textures

### DIFF
--- a/vita3k/renderer/src/gl/texture_formats.cpp
+++ b/vita3k/renderer/src/gl/texture_formats.cpp
@@ -506,6 +506,8 @@ const GLint *translate_swizzle(SceGxmTextureFormat fmt) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_F32M:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U32:
     case SCE_GXM_TEXTURE_BASE_FORMAT_S32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC4:
         return translate_swizzle(static_cast<SceGxmTextureSwizzle1Mode>(swizzle));
 
     // 2 components (red-green.)
@@ -516,6 +518,8 @@ const GLint *translate_swizzle(SceGxmTextureFormat fmt) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_F16F16:
     case SCE_GXM_TEXTURE_BASE_FORMAT_F32F32:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U32U32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
         return translate_swizzle(static_cast<SceGxmTextureSwizzle2Mode>(swizzle));
 
     // 2 components (depth-stencil.)
@@ -549,10 +553,6 @@ const GLint *translate_swizzle(SceGxmTextureFormat fmt) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC1:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
-    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC4:
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
-    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
     case SCE_GXM_TEXTURE_BASE_FORMAT_P4:
     case SCE_GXM_TEXTURE_BASE_FORMAT_P8:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U2F10F10F10:

--- a/vita3k/renderer/src/texture_format.cpp
+++ b/vita3k/renderer/src/texture_format.cpp
@@ -764,12 +764,9 @@ static void decompress_block_alpha_signed(const std::uint8_t *block_storage, std
 static void decompress_block_bc2(const std::uint8_t *block_storage, std::uint32_t *image) {
     decompress_block_bc1(block_storage + 8, image);
 
-    for (int i = 0; i < 16; i += 2) {
-        image[i] = (((block_storage[i] & 0x0F) | ((block_storage[i] & 0x0F) << 4)) << 24) | (image[i] & 0x00FFFFFF);
-    }
-
-    for (int i = 1; i < 16; i += 2) {
-        image[i] = (((block_storage[i] & 0xF0) | ((block_storage[i] & 0xF0) >> 4)) << 24) | (image[i] & 0x00FFFFFF);
+    for (int i = 0; i < 8; i++) {
+        image[2 * i] = (((block_storage[i] & 0x0F) | ((block_storage[i] & 0x0F) << 4)) << 24) | (image[2 * i] & 0x00FFFFFF);
+        image[2 * i + 1] = (((block_storage[i] & 0xF0) | ((block_storage[i] & 0xF0) >> 4)) << 24) | (image[2 * i + 1] & 0x00FFFFFF);
     }
 }
 
@@ -848,7 +845,7 @@ static void decompress_block_bc5s(const std::uint8_t *block_storage, std::uint32
 void decompress_bc_swizz_image(std::uint32_t width, std::uint32_t height, const std::uint8_t *block_storage, std::uint32_t *image, const std::uint8_t bc_type) {
     std::uint32_t block_count_x = (width + 3) / 4;
     std::uint32_t block_count_y = (height + 3) / 4;
-    std::size_t block_size = (bc_type != 1 && bc_type != 4 && bc_type != 5) ? 16 : 8;
+    std::size_t block_size = (bc_type != 1 && bc_type != 4) ? 16 : 8;
 
     std::uint32_t temp_block_result[16] = {};
 
@@ -916,7 +913,7 @@ void decompress_bc_swizz_image(std::uint32_t width, std::uint32_t height, const 
 void resolve_z_order_compressed_image(std::uint32_t width, std::uint32_t height, const std::uint8_t *src, std::uint8_t *dest, const std::uint8_t bc_type) {
     std::uint32_t block_count_x = (width + 3) / 4;
     std::uint32_t block_count_y = (height + 3) / 4;
-    std::size_t block_size = (bc_type != 1 && bc_type != 4 && bc_type != 5) ? 16 : 8;
+    std::size_t block_size = (bc_type != 1 && bc_type != 4) ? 16 : 8;
 
     size_t min = block_count_x < block_count_y ? block_count_x : block_count_y;
     size_t k = static_cast<size_t>(log2(min));

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -645,6 +645,8 @@ vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_S32:
     case SCE_GXM_TEXTURE_BASE_FORMAT_F32:
     case SCE_GXM_TEXTURE_BASE_FORMAT_F32M:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC4:
         return translate_swizzle1(static_cast<SceGxmTextureSwizzle1Mode>(swizzle));
 
     // 2 components
@@ -655,6 +657,8 @@ vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_F16F16:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U32U32:
     case SCE_GXM_TEXTURE_BASE_FORMAT_F32F32:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
         return translate_swizzle2(static_cast<SceGxmTextureSwizzle2Mode>(swizzle));
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_X8U24:
@@ -689,8 +693,6 @@ vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC1:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
         return translate_swizzle4(static_cast<SceGxmTextureSwizzle4Mode>(swizzle));
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
@@ -809,8 +811,14 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
         return vk::Format::eBc4UnormBlock;
 
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC4:
+        return vk::Format::eBc4SnormBlock;
+
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
         return vk::Format::eBc5UnormBlock;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
+        return vk::Format::eBc5SnormBlock;
 
     default:
         LOG_ERROR("Unknown format {}", log_hex(base_format));


### PR DESCRIPTION
Perform the following fixes:
- BC4 and BC5 have respectively 1 and 2 components but we apply a 4-component swizzle to them
- Add signed BC4 and BC5 to Vulkan
- Only BC1 and BC4 have 8-byte blocks
- When decompressing BC2, the alpha component is wrong and corrupts the whole texture (backport from Android, not an issue on PC as BC textures are never decompressed)

This fixes the text not showing in One Piece Burning Blood.