### PR TITLE
shader: Round before converting to integer

### DIFF
--- a/vita3k/kernel/src/sync_primitives.cpp
+++ b/vita3k/kernel/src/sync_primitives.cpp
@@ -1157,7 +1157,6 @@ int semaphore_cancel(KernelState &kernel, const char *export_name, SceUID thread
 
     SceUInt32 nb_threads = 0;
     const std::lock_guard<std::mutex> semaphore_lock(semaphore->mutex);
-    LOG_TRACE("sema_cancel. waiting threads:{}", semaphore->waiting_threads->size());
     while (!semaphore->waiting_threads->empty()) {
         const auto &waiting_thread_data = *semaphore->waiting_threads->begin();
         const auto waiting_thread = waiting_thread_data.thread;

--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -47,7 +47,7 @@ public:
 
     spv::Id const_f32_v0[5];
 
-    utils::SpirvUtilFunctions m_util_funcs;
+    utils::SpirvUtilFunctions &m_util_funcs;
 
     spv::Block *main_block;
     spv::Id out;
@@ -81,8 +81,7 @@ public:
         // Set main block
         main_block = m_b.getBuildPoint();
 
-        // Import GLSL.std.450
-        std_builtins = m_b.import("GLSL.std.450");
+        std_builtins = utils.std_builtins;
 
         // Build common type here, so builder won't have to look it up later
         type_f32 = m_b.makeFloatType(32);

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -29,6 +29,7 @@ struct FeatureState;
 namespace shader::usse::utils {
 
 struct SpirvUtilFunctions {
+    spv::Id std_builtins{};
     std::map<DataType, spv::Function *> unpack_funcs;
     std::map<DataType, spv::Function *> pack_funcs;
     spv::Function *fetch_memory{ nullptr };
@@ -60,7 +61,7 @@ spv::Id make_vector_or_scalar_type(spv::Builder &b, spv::Id component, int size)
 spv::Id unwrap_type(spv::Builder &b, spv::Id type);
 
 spv::Id convert_to_float(spv::Builder &b, spv::Id opr, DataType type, bool normal);
-spv::Id convert_to_int(spv::Builder &b, spv::Id opr, DataType type, bool normal);
+spv::Id convert_to_int(spv::Builder &b, const SpirvUtilFunctions &utils, spv::Id opr, DataType type, bool normal);
 
 spv::Id add_uvec2_uint(spv::Builder &b, spv::Id vec, spv::Id to_add);
 

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -324,7 +324,7 @@ static spv::Id create_input_variable(spv::Builder &b, SpirvShaderParameters &par
         }
 
         if (is_integer_data_type(dest.type) && b.isFloatType(utils::unwrap_type(b, b.getTypeId(var))))
-            var = utils::convert_to_int(b, var, dest.type, true);
+            var = utils::convert_to_int(b, utils, var, dest.type, true);
 
         if (is_4th_component_1) {
             // set the 4th component to 1, because it's what the shader is expecting it to be
@@ -712,7 +712,7 @@ static void create_fragment_inputs(spv::Builder &b, SpirvShaderParameters &param
         auto store_source_result = [&](const bool direct_store = false) {
             if (source != spv::NoResult) {
                 if (!direct_store && !is_float_data_type(target_to_store.type)) {
-                    source = utils::convert_to_int(b, source, target_to_store.type, true);
+                    source = utils::convert_to_int(b, utils, source, target_to_store.type, true);
                 }
 
                 utils::store(b, parameters, utils, features, target_to_store, source, 0b1111, 0);
@@ -1734,6 +1734,7 @@ static SpirvCode convert_gxp_to_spirv_impl(const SceGxmProgram &program, const s
 
     NonDependentTextureQueryCallInfos texture_queries;
     utils::SpirvUtilFunctions utils;
+    utils.std_builtins = b.import("GLSL.std.450");
 
     std::string entry_point_name;
     spv::ExecutionModel execution_model;

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -1044,8 +1044,8 @@ bool USSETranslatorVisitor::sop2(
     auto color_res = apply_opcode(color_op, src_color_type, factored_rgb_lhs, factored_rgb_rhs);
     auto alpha_res = apply_opcode(alpha_op, src_alpha_type, factored_a_lhs, factored_a_rhs);
 
-    color_res = utils::convert_to_int(m_b, color_res, DataType::UINT8, true);
-    alpha_res = utils::convert_to_int(m_b, alpha_res, DataType::UINT8, true);
+    color_res = utils::convert_to_int(m_b, m_util_funcs, color_res, DataType::UINT8, true);
+    alpha_res = utils::convert_to_int(m_b, m_util_funcs, alpha_res, DataType::UINT8, true);
 
     // Final result. Do binary operation and then store
     store(inst.opr.dest, color_res, 0b0111, dest_repeat_offset);
@@ -1230,7 +1230,7 @@ bool shader::usse::USSETranslatorVisitor::sop2m(Imm2 pred,
         result = m_b.createTriOp(spv::OpVectorInsertDynamic, src_type, result, apply_opcode(alpha_op, alpha_type, a1, a2), alpha_index);
     }
 
-    result = utils::convert_to_int(m_b, result, DataType::UINT8, true);
+    result = utils::convert_to_int(m_b, m_util_funcs, result, DataType::UINT8, true);
 
     // Final result. Do binary operation and then store
     store(inst.opr.dest, result, wmask, 0);
@@ -1484,8 +1484,8 @@ bool shader::usse::USSETranslatorVisitor::sop3(Imm2 pred,
     auto color_res = apply_opcode(color_op, src_color_type, factored_rgb_lhs, factored_rgb_rhs);
     auto alpha_res = apply_opcode(alpha_op, src_alpha_type, factored_a_lhs, factored_a_rhs);
 
-    color_res = utils::convert_to_int(m_b, color_res, DataType::UINT8, true);
-    alpha_res = utils::convert_to_int(m_b, alpha_res, DataType::UINT8, true);
+    color_res = utils::convert_to_int(m_b, m_util_funcs, color_res, DataType::UINT8, true);
+    alpha_res = utils::convert_to_int(m_b, m_util_funcs, alpha_res, DataType::UINT8, true);
 
     // Final result. Do binary operation and then store
     store(inst.opr.dest, color_res, 0b0111, 0);

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -505,7 +505,7 @@ bool USSETranslatorVisitor::vpck(
 
     // source is float destination is int
     if (!is_float_data_type(inst.opr.dest.type) && is_float_data_type(inst.opr.src1.type)) {
-        source = utils::convert_to_int(m_b, source, inst.opr.dest.type, scale);
+        source = utils::convert_to_int(m_b, m_util_funcs, source, inst.opr.dest.type, scale);
     }
 
     store(inst.opr.dest, source, dest_mask, dest_repeat_offset);

--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -142,7 +142,7 @@ spv::Id shader::usse::USSETranslatorVisitor::do_fetch_texture(const spv::Id tex,
     image_sample = m_b.createOp(op, type_f32_v[4], params);
 
     if (is_integer_data_type(dest_type))
-        image_sample = utils::convert_to_int(m_b, image_sample, dest_type, true);
+        image_sample = utils::convert_to_int(m_b, m_util_funcs, image_sample, dest_type, true);
 
     return image_sample;
 }
@@ -319,8 +319,8 @@ bool USSETranslatorVisitor::smp(
         const spv::Id lod_level = m_b.createUnaryOp(spv::OpConvertFToU, type_ui32, lod);
 
         // the result is stored as a vector of uint8, we must convert it
-        uv = utils::convert_to_int(m_b, uv, DataType::UINT8, true);
-        tri_frac = utils::convert_to_int(m_b, tri_frac, DataType::UINT8, true);
+        uv = utils::convert_to_int(m_b, m_util_funcs, uv, DataType::UINT8, true);
+        tri_frac = utils::convert_to_int(m_b, m_util_funcs, tri_frac, DataType::UINT8, true);
 
         const spv::Id u = m_b.createBinOp(spv::OpVectorExtractDynamic, type_ui32, uv, m_b.makeIntConstant(0));
         const spv::Id v = m_b.createBinOp(spv::OpVectorExtractDynamic, type_ui32, uv, m_b.makeIntConstant(1));


### PR DESCRIPTION
When converting (and normalizing) from float to integer, it looks like the value needs to be rounded.
Not doing that causes a bone index of value 308.999 to be rounded down to 308, causing the bone index to be wrong.
This PR also removes the unnecessary std 450 imports (that otherwise pollute the generated shader and could cause some issues with shader driver compilers).

I also removed the sema cancel because something that can happen multiple times per frame shouldn't be logged.
This fixes the vertex explosion in FIFA games.