### PR TITLE
modules/SceGxm: Properly initialize all fields of linear strided textures

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -4886,6 +4886,10 @@ EXPORT(int, sceGxmTextureInitLinearStrided, SceGxmTexture *texture, Ptr<const vo
     texture->uaddr_mode = texture->vaddr_mode = SCE_GXM_TEXTURE_ADDR_CLAMP;
     texture->height = height - 1;
     texture->width = width - 1;
+    texture->mag_filter = SCE_GXM_TEXTURE_FILTER_POINT;
+    texture->gamma_mode = 0;
+    texture->lod_min0 = 0;
+    texture->lod_min1 = 0;
 
     return 0;
 }


### PR DESCRIPTION
Some fields of linear strided textures were left initialized, in particular the one controlling gamma correction. This caused the YUV planes used during God of War cutscenes to have gamma correction enabled, in turn causing the cutscenes to be green. 