### PR TITLE
renderer: Scale line width with resolution multiplier

### DIFF
--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -67,7 +67,7 @@ void sync_stencil_data(const renderer::GxmRecordState &state, const MemState &me
 void sync_stencil_func(const GxmStencilStateOp &state_op, const GxmStencilStateValues &state_vals, const MemState &mem, const bool is_back_stencil);
 void sync_mask(const GLState &state, GLContext &context, const MemState &mem);
 void sync_polygon_mode(const SceGxmPolygonMode mode, const bool front);
-void sync_point_line_width(const std::uint32_t size, const bool front);
+void sync_point_line_width(const GLState &state, const std::uint32_t size, const bool front);
 void sync_depth_bias(const int factor, const int unit, const bool front);
 void sync_blending(const GxmRecordState &state, const MemState &mem);
 void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config,

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -252,11 +252,11 @@ void sync_polygon_mode(const SceGxmPolygonMode mode, const bool front) {
     }
 }
 
-void sync_point_line_width(const std::uint32_t width, const bool is_front) {
+void sync_point_line_width(const GLState &state, const std::uint32_t width, const bool is_front) {
     // Point Line Width
     if (is_front) {
-        glLineWidth(static_cast<GLfloat>(width));
-        glPointSize(static_cast<GLfloat>(width));
+        glLineWidth(static_cast<GLfloat>(width * state.res_multiplier));
+        glPointSize(static_cast<GLfloat>(width * state.res_multiplier));
     }
 }
 

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -342,7 +342,7 @@ COMMAND_SET_STATE(point_line_width) {
 
     switch (renderer.current_backend) {
     case Backend::OpenGL:
-        gl::sync_point_line_width(width, is_front);
+        gl::sync_point_line_width(static_cast<gl::GLState &>(renderer), width, is_front);
         break;
 
     case Backend::Vulkan:

--- a/vita3k/renderer/src/vulkan/sync_state.cpp
+++ b/vita3k/renderer/src/vulkan/sync_state.cpp
@@ -166,7 +166,7 @@ void sync_point_line_width(VKContext &context, const bool is_front) {
         return;
 
     if (is_front && context.state.physical_device_features.wideLines)
-        context.render_cmd.setLineWidth(static_cast<float>(context.record.line_width));
+        context.render_cmd.setLineWidth(static_cast<float>(context.record.line_width * context.state.res_multiplier));
 }
 
 void sync_viewport_flat(VKContext &context) {


### PR DESCRIPTION
This fixes the score evolution in persona dancing not being visible on higher resolutions.