### PR TITLE
Implement support for XDG_DATA_DIRS under Linux

### DIFF
--- a/vita3k/app/include/app/functions.h
+++ b/vita3k/app/include/app/functions.h
@@ -38,6 +38,7 @@ enum class AppRunType {
     Extracted,
 };
 
+void init_paths(Root &root_paths);
 bool init(EmuEnvState &state, Config &cfg, const Root &root_paths);
 bool late_init(EmuEnvState &state);
 void destroy(EmuEnvState &emuenv, ImGui_State *imgui);

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -46,6 +46,7 @@
 #include <renderer/vulkan/functions.h>
 #include <util/string_utils.h>
 
+#include <SDL.h>
 #include <SDL_video.h>
 #include <SDL_vulkan.h>
 
@@ -101,11 +102,86 @@ void update_viewport(EmuEnvState &state) {
     }
 }
 
+void init_paths(Root &root_paths) {
+    const auto dir_sep = std::string{ fs::path::preferred_separator };
+    auto base_path = SDL_GetBasePath();
+    auto pref_path = SDL_GetPrefPath(org_name, app_name);
+    root_paths.set_base_path(string_utils::utf_to_wide(base_path));
+    root_paths.set_pref_path(string_utils::utf_to_wide(pref_path));
+    root_paths.set_log_path(string_utils::utf_to_wide(base_path));
+    root_paths.set_config_path(string_utils::utf_to_wide(base_path));
+    root_paths.set_shared_path(string_utils::utf_to_wide(base_path));
+    root_paths.set_cache_path(fs::path(string_utils::utf_to_wide(base_path)) / "cache" / dir_sep);
+    SDL_free(base_path);
+    SDL_free(pref_path);
+
+#if defined(__linux__) && !defined(__ANDROID__) && !defined(__APPLE__)
+    // XDG Data Dirs.
+    auto env_home = getenv("HOME");
+    auto env_data_dirs = getenv("XDG_DATA_DIRS");
+    auto env_data_home = getenv("XDG_DATA_HOME");
+    auto env_cache_home = getenv("XDG_CACHE_HOME");
+    auto env_config_home = getenv("XDG_CONFIG_HOME");
+
+    if (env_data_home != NULL)
+        root_paths.set_pref_path(fs::path(env_data_home) / app_name / app_name / dir_sep);
+
+    if (env_config_home != NULL)
+        root_paths.set_config_path(fs::path(env_config_home) / app_name / dir_sep);
+    else if (env_home != NULL)
+        root_paths.set_config_path(fs::path(env_home) / ".config" / app_name / dir_sep);
+
+    if (env_cache_home != NULL) {
+        root_paths.set_cache_path(fs::path(env_cache_home) / app_name / dir_sep);
+        root_paths.set_log_path(fs::path(env_cache_home) / app_name / dir_sep);
+    } else if (env_home != NULL) {
+        root_paths.set_cache_path(fs::path(env_home) / ".cache" / app_name / dir_sep);
+        root_paths.set_log_path(fs::path(env_home) / ".cache" / app_name / dir_sep);
+    }
+
+    // Don't assume that base_path is portable.
+    if (fs::exists(root_paths.get_base_path() / "data") && fs::exists(root_paths.get_base_path() / "lang") && fs::exists(root_paths.get_base_path() / "shaders-builtin"))
+        root_paths.set_shared_path(root_paths.get_base_path());
+    else if (env_home != NULL)
+        root_paths.set_shared_path(fs::path(env_home) / ".local/share" / app_name / dir_sep);
+
+    if (env_data_dirs != NULL) {
+        auto env_paths = string_utils::split_string(env_data_dirs, ':');
+        for (auto &i : env_paths) {
+            if (fs::exists(fs::path(i) / app_name)) {
+                root_paths.set_shared_path(fs::path(i) / app_name / dir_sep);
+                break;
+            }
+        }
+    } else if (env_data_home != NULL) {
+        if (fs::exists(fs::path(env_data_home) / app_name / "data") && fs::exists(fs::path(env_data_home) / app_name / "lang") && fs::exists(fs::path(env_data_home) / app_name / "shaders-builtin"))
+            root_paths.set_shared_path(fs::path(env_data_home) / app_name / dir_sep);
+    }
+#endif
+
+    // Create default preference and cache path for safety
+    if (!fs::exists(root_paths.get_config_path()))
+        fs::create_directories(root_paths.get_config_path());
+
+    if (!fs::exists(root_paths.get_cache_path()))
+        fs::create_directories(root_paths.get_cache_path());
+
+    if (!fs::exists(fs::path(root_paths.get_log_path()) / "shaderlog"))
+        fs::create_directories(fs::path(root_paths.get_log_path()) / "shaderlog");
+
+    if (!fs::exists(fs::path(root_paths.get_log_path()) / "texturelog"))
+        fs::create_directories(fs::path(root_paths.get_log_path()) / "texturelog");
+}
+
 bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
     state.cfg = std::move(cfg);
 
     state.base_path = root_paths.get_base_path_string();
     state.default_path = root_paths.get_pref_path_string();
+    state.log_path = string_utils::utf_to_wide(root_paths.get_log_path_string());
+    state.config_path = string_utils::utf_to_wide(root_paths.get_config_path_string());
+    state.cache_path = string_utils::utf_to_wide(root_paths.get_cache_path_string());
+    state.shared_path = root_paths.get_shared_path_string();
 
     // If configuration does not provide a preference path, use SDL's default
     if (state.cfg.pref_path == root_paths.get_pref_path() || state.cfg.pref_path.empty())
@@ -115,6 +191,19 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
             state.cfg.pref_path += '/';
         state.pref_path = string_utils::utf_to_wide(state.cfg.pref_path);
     }
+
+    LOG_INFO("Base path: {}", state.base_path.string());
+    LOG_INFO("Shared assets path: {}", state.shared_path.string());
+    LOG_INFO("Log path: {}", state.log_path.string());
+    LOG_INFO("User config path: {}", state.config_path.string());
+    LOG_INFO("User pref path: {}", state.pref_path.string());
+    LOG_INFO("User cache path: {}", state.cache_path.string());
+
+    if (ImGui::GetCurrentContext() == NULL) {
+        ImGui::CreateContext();
+    }
+    ImGuiIO &io = ImGui::GetIO();
+    io.IniFilename = NULL;
 
     state.backend_renderer = renderer::Backend::Vulkan;
 
@@ -179,7 +268,7 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
 
     // initialize the renderer first because we need to know if we need a page table
     if (!state.cfg.console) {
-        if (renderer::init(state.window.get(), state.renderer, state.backend_renderer, state.cfg, state.base_path.data())) {
+        if (renderer::init(state.window.get(), state.renderer, state.backend_renderer, state.cfg, root_paths)) {
             update_viewport(state);
         } else {
             switch (state.backend_renderer) {
@@ -199,7 +288,7 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         }
     }
 
-    if (!init(state.io, state.base_path, state.pref_path, state.cfg.console)) {
+    if (!init(state.io, state.cache_path, state.log_path, state.pref_path, state.cfg.console)) {
         LOG_ERROR("Failed to initialize file system for the emulator!");
         return false;
     }

--- a/vita3k/compat/src/compat.cpp
+++ b/vita3k/compat/src/compat.cpp
@@ -43,7 +43,7 @@ static std::string db_updated_at;
 static const uint32_t db_version = 1;
 
 bool load_app_compat_db(GuiState &gui, EmuEnvState &emuenv) {
-    const auto app_compat_db_path = fs::path(emuenv.base_path) / "cache/app_compat_db.xml";
+    const auto app_compat_db_path = emuenv.cache_path / "app_compat_db.xml";
     if (!fs::exists(app_compat_db_path)) {
         LOG_WARN("Compatibility database not found at {}.", app_compat_db_path.string());
         return false;
@@ -128,8 +128,7 @@ static const std::string latest_link = "https://api.github.com/repos/Vita3K/comp
 static const std::string app_compat_db_link = "https://github.com/Vita3K/compatibility/releases/download/compat_db/app_compat_db.xml";
 
 bool update_app_compat_db(GuiState &gui, EmuEnvState &emuenv) {
-    const auto cache_path = fs::path(emuenv.base_path) / "cache";
-    const auto app_compat_db_path = cache_path / "app_compat_db.xml";
+    const auto app_compat_db_path = emuenv.cache_path / "app_compat_db.xml";
     gui.info_message.function = SPDLOG_FUNCTION;
 
     auto &lang = gui.lang.compat_db;
@@ -152,7 +151,7 @@ bool update_app_compat_db(GuiState &gui, EmuEnvState &emuenv) {
 
     LOG_INFO("Applications compatibility database is {}, attempting to download latest updated at: {}", compat_db_exist ? "outdated" : "missing", updated_at);
 
-    const auto new_app_compat_db_path = cache_path / "new_app_compat_db.xml";
+    const auto new_app_compat_db_path = emuenv.cache_path / "new_app_compat_db.xml";
 
     if (!https::download_file(app_compat_db_link, new_app_compat_db_path.string())) {
         gui.info_message.level = spdlog::level::err;

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -118,12 +118,12 @@ ExitCode serialize_config(Config &cfg, const fs::path &output_path) {
 ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths) {
     // Always generate the default configuration file
     Config command_line{};
-    serialize_config(command_line, root_paths.get_base_path() / "data/config/default.yml");
-    // Load base path configuration by default; otherwise, move the default to the base path
-    if (fs::exists(check_path(root_paths.get_base_path())))
-        parse(cfg, root_paths.get_base_path(), root_paths.get_base_path());
+    serialize_config(command_line, root_paths.get_config_path() / "data/config/default.yml");
+    // Load config path configuration by default; otherwise, move the default to the config path
+    if (fs::exists(check_path(root_paths.get_config_path())))
+        parse(cfg, root_paths.get_config_path(), root_paths.get_pref_path());
     else
-        fs::copy(root_paths.get_base_path() / "data/config/default.yml", root_paths.get_base_path() / "config.yml");
+        fs::copy(root_paths.get_config_path() / "data/config/default.yml", root_paths.get_config_path() / "config.yml");
 
     // Declare all options
     CLI::App app{ "Vita3K Command Line Interface" }; // "--help,-h" is automatically generated
@@ -227,11 +227,11 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
         cfg.pkg_zrif = std::move(command_line.pkg_zrif);
         return QuitRequested;
     }
-    if (command_line.load_config || command_line.config_path != root_paths.get_base_path()) {
+    if (command_line.load_config || command_line.config_path != root_paths.get_config_path()) {
         if (command_line.config_path.empty()) {
-            command_line.config_path = root_paths.get_base_path();
+            command_line.config_path = root_paths.get_config_path();
         } else {
-            if (parse(command_line, command_line.config_path, root_paths.get_base_path()) != Success)
+            if (parse(command_line, command_line.config_path, root_paths.get_pref_path()) != Success)
                 return InitConfigFailed;
         }
     }

--- a/vita3k/emuenv/include/emuenv/state.h
+++ b/vita3k/emuenv/include/emuenv/state.h
@@ -23,6 +23,8 @@
 #include <set>
 #include <string>
 
+#include <util/fs.h>
+
 // forward declare everything used in EmuEnvState
 namespace sfo {
 struct SfoAppInfo;
@@ -110,9 +112,13 @@ public:
     std::string license_content_id{};
     std::string license_title_id{};
     std::string current_app_title{};
-    std::string base_path{};
-    std::string default_path{};
-    std::wstring pref_path{};
+    fs::path base_path{};
+    fs::path default_path{};
+    fs::path config_path{};
+    fs::path log_path{};
+    fs::path cache_path{};
+    fs::path pref_path{};
+    fs::path shared_path{};
     bool load_exec{};
     std::string load_app_path{};
     std::string load_exec_argv{};

--- a/vita3k/emuenv/src/emuenv.cpp
+++ b/vita3k/emuenv/src/emuenv.cpp
@@ -37,6 +37,7 @@
 #include <regmgr/state.h>
 #include <renderer/state.h>
 #include <touch/state.h>
+#include <util/string_utils.h>
 
 #include <gdbstub/state.h>
 

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -39,7 +39,7 @@ static std::map<double, std::string> update_history_infos;
 
 static bool get_update_history(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path) {
     update_history_infos.clear();
-    const auto change_info_path{ fs::path(emuenv.pref_path) / "ux0/app" / app_path / "sce_sys/changeinfo/" };
+    const auto change_info_path{ emuenv.pref_path / "ux0/app" / app_path / "sce_sys/changeinfo/" };
 
     std::string fname = fs::exists(change_info_path / fmt::format("changeinfo_{:0>2d}.xml", emuenv.cfg.sys_lang)) ? fmt::format("changeinfo_{:0>2d}.xml", emuenv.cfg.sys_lang) : "changeinfo.xml";
 
@@ -141,7 +141,7 @@ static std::string get_time_app_used(GuiState &gui, const int64_t &time_used) {
 
 void get_time_apps(GuiState &gui, EmuEnvState &emuenv) {
     gui.time_apps.clear();
-    const auto time_path{ fs::path(emuenv.pref_path) / "ux0/user/time.xml" };
+    const auto time_path{ emuenv.pref_path / "ux0/user/time.xml" };
 
     pugi::xml_document time_xml;
     if (fs::exists(time_path)) {
@@ -186,7 +186,7 @@ static void save_time_apps(GuiState &gui, EmuEnvState &emuenv) {
         }
     }
 
-    const auto time_path{ fs::path(emuenv.pref_path) / "ux0/user/time.xml" };
+    const auto time_path{ emuenv.pref_path / "ux0/user/time.xml" };
     const auto save_xml = time_xml.save_file(time_path.c_str());
     if (!save_xml)
         LOG_ERROR("Fail save xml");
@@ -217,29 +217,27 @@ void delete_app(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
     const auto APP_INDEX = get_app_index(gui, app_path);
     const auto title_id = APP_INDEX->title_id;
     try {
-        const auto PREF_PATH = fs::path(emuenv.pref_path);
-        fs::remove_all(PREF_PATH / "ux0/app" / app_path);
+        fs::remove_all(emuenv.pref_path / "ux0/app" / app_path);
 
-        const auto BASE_PATH = fs::path(emuenv.base_path);
-        const auto CUSTOM_CONFIG_PATH{ BASE_PATH / "config" / fmt::format("config_{}.xml", app_path) };
+        const auto CUSTOM_CONFIG_PATH{ emuenv.config_path / "config" / fmt::format("config_{}.xml", app_path) };
         if (fs::exists(CUSTOM_CONFIG_PATH))
             fs::remove_all(CUSTOM_CONFIG_PATH);
-        const auto ADDCONT_PATH{ PREF_PATH / "ux0/addcont" / APP_INDEX->addcont };
+        const auto ADDCONT_PATH{ emuenv.pref_path / "ux0/addcont" / APP_INDEX->addcont };
         if (fs::exists(ADDCONT_PATH))
             fs::remove_all(ADDCONT_PATH);
-        const auto LICENSE_PATH{ PREF_PATH / "ux0/license" / title_id };
+        const auto LICENSE_PATH{ emuenv.pref_path / "ux0/license" / title_id };
         if (fs::exists(LICENSE_PATH))
             fs::remove_all(LICENSE_PATH);
-        const auto PATCH_PATH{ PREF_PATH / "ux0/patch" / title_id };
+        const auto PATCH_PATH{ emuenv.pref_path / "ux0/patch" / title_id };
         if (fs::exists(PATCH_PATH))
             fs::remove_all(PATCH_PATH);
-        const auto SAVE_DATA_PATH{ PREF_PATH / "ux0/user" / emuenv.io.user_id / "savedata" / APP_INDEX->savedata };
+        const auto SAVE_DATA_PATH{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "savedata" / APP_INDEX->savedata };
         if (fs::exists(SAVE_DATA_PATH))
             fs::remove_all(SAVE_DATA_PATH);
-        const auto SHADER_CACHE_PATH{ BASE_PATH / "cache/shaders" / title_id };
+        const auto SHADER_CACHE_PATH{ emuenv.cache_path / "shaders" / title_id };
         if (fs::exists(SHADER_CACHE_PATH))
             fs::remove_all(SHADER_CACHE_PATH);
-        const auto SHADER_LOG_PATH{ BASE_PATH / "shaderlog" / title_id };
+        const auto SHADER_LOG_PATH{ emuenv.log_path / "shaderlog" / title_id };
         if (fs::exists(SHADER_LOG_PATH))
             fs::remove_all(SHADER_LOG_PATH);
 
@@ -288,14 +286,14 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
     const auto APP_INDEX = get_app_index(gui, app_path);
     const auto title_id = APP_INDEX->title_id;
 
-    const auto APP_PATH{ fs::path(emuenv.pref_path) / "ux0/app" / app_path };
-    const auto CUSTOM_CONFIG_PATH{ fs::path(emuenv.base_path) / "config" / fmt::format("config_{}.xml", app_path) };
-    const auto ADDCONT_PATH{ fs::path(emuenv.pref_path) / "ux0/addcont" / APP_INDEX->addcont };
-    const auto LICENSE_PATH{ fs::path(emuenv.pref_path) / "ux0/license" / title_id };
+    const auto APP_PATH{ emuenv.pref_path / "ux0/app" / app_path };
+    const auto CUSTOM_CONFIG_PATH{ emuenv.config_path / "config" / fmt::format("config_{}.xml", app_path) };
+    const auto ADDCONT_PATH{ emuenv.pref_path / "ux0/addcont" / APP_INDEX->addcont };
+    const auto LICENSE_PATH{ emuenv.pref_path / "ux0/license" / title_id };
     const auto MANUAL_PATH{ APP_PATH / "sce_sys/manual" };
-    const auto SAVE_DATA_PATH{ fs::path(emuenv.pref_path) / "ux0/user" / emuenv.io.user_id / "savedata" / APP_INDEX->savedata };
-    const auto SHADER_CACHE_PATH{ fs::path(emuenv.base_path) / "cache/shaders" / title_id };
-    const auto SHADER_LOG_PATH{ fs::path(emuenv.base_path) / "shaderlog" / title_id };
+    const auto SAVE_DATA_PATH{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "savedata" / APP_INDEX->savedata };
+    const auto SHADER_CACHE_PATH{ emuenv.cache_path / "shaders" / title_id };
+    const auto SHADER_LOG_PATH{ emuenv.log_path / "shaderlog" / title_id };
     const auto ISSUES_URL = "https://github.com/Vita3K/compatibility/issues";
 
     const ImVec2 display_size(emuenv.viewport_size.x, emuenv.viewport_size.y);

--- a/vita3k/gui/src/content_manager.cpp
+++ b/vita3k/gui/src/content_manager.cpp
@@ -46,7 +46,7 @@ auto get_recursive_directory_size(const T &path) {
 } // namespace
 
 void get_app_info(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path) {
-    const auto APP_PATH{ fs::path(emuenv.pref_path) / "ux0/app" / app_path };
+    const auto APP_PATH{ emuenv.pref_path / "ux0/app" / app_path };
     gui.app_selector.app_info = {};
 
     if (fs::exists(APP_PATH) && !fs::is_empty(APP_PATH)) {
@@ -59,12 +59,12 @@ void get_app_info(GuiState &gui, EmuEnvState &emuenv, const std::string &app_pat
 }
 
 size_t get_app_size(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path) {
-    const auto APP_PATH{ fs::path(emuenv.pref_path) / "ux0/app" / app_path };
+    const auto APP_PATH{ emuenv.pref_path / "ux0/app" / app_path };
     boost::uintmax_t app_size = 0;
     if (fs::exists(APP_PATH) && !fs::is_empty(APP_PATH)) {
         app_size += get_recursive_directory_size(APP_PATH);
     }
-    const auto ADDCONT_PATH{ fs::path(emuenv.pref_path) / "ux0/addcont" / get_app_index(gui, app_path)->title_id };
+    const auto ADDCONT_PATH{ emuenv.pref_path / "ux0/addcont" / get_app_index(gui, app_path)->title_id };
     if (fs::exists(ADDCONT_PATH) && !fs::is_empty(ADDCONT_PATH)) {
         app_size += get_recursive_directory_size(ADDCONT_PATH);
     }
@@ -97,7 +97,7 @@ static std::vector<SaveData> save_data_list;
 static void get_save_data_list(GuiState &gui, EmuEnvState &emuenv) {
     save_data_list.clear();
 
-    fs::path SAVE_PATH{ fs::path{ emuenv.pref_path } / "ux0/user" / emuenv.io.user_id / "savedata" };
+    fs::path SAVE_PATH{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "savedata" };
     if (!fs::exists(SAVE_PATH))
         return;
 
@@ -143,7 +143,7 @@ void init_content_manager(GuiState &gui, EmuEnvState &emuenv) {
     };
 
     const auto query_themes = [&emuenv] {
-        const auto THEME_PATH{ fs::path(emuenv.pref_path) / "ux0/theme" };
+        const auto THEME_PATH{ emuenv.pref_path / "ux0/theme" };
         if (fs::exists(THEME_PATH) && !fs::is_empty(THEME_PATH)) {
             return get_recursive_directory_size(THEME_PATH);
         }
@@ -193,13 +193,13 @@ struct AddCont {
 static std::map<std::string, AddCont> addcont_info;
 
 static void get_content_info(GuiState &gui, EmuEnvState &emuenv) {
-    const auto APP_PATH{ fs::path(emuenv.pref_path) / "ux0/app" / app_selected };
+    const auto APP_PATH{ emuenv.pref_path / "ux0/app" / app_selected };
     if (fs::exists(APP_PATH) && !fs::is_empty(APP_PATH)) {
         gui.app_selector.app_info.size = get_recursive_directory_size(APP_PATH);
     }
 
     addcont_info.clear();
-    const auto ADDCONT_PATH{ fs::path(emuenv.pref_path) / "ux0/addcont" / app_selected };
+    const auto ADDCONT_PATH{ emuenv.pref_path / "ux0/addcont" / app_selected };
     if (fs::exists(ADDCONT_PATH) && !fs::is_empty(ADDCONT_PATH)) {
         for (const auto &addcont : fs::directory_iterator(ADDCONT_PATH)) {
             const auto content_id = addcont.path().stem().string();
@@ -212,7 +212,7 @@ static void get_content_info(GuiState &gui, EmuEnvState &emuenv) {
 
             const auto content_path{ fs::path("addcont") / app_selected / content_id };
             vfs::FileBuffer params;
-            if (vfs::read_file(VitaIoDevice::ux0, params, emuenv.pref_path, content_path.string() + "/sce_sys/param.sfo")) {
+            if (vfs::read_file(VitaIoDevice::ux0, params, emuenv.pref_path.wstring(), content_path.string() + "sce_sys/param.sfo")) {
                 SfoFile sfo_handle;
                 sfo::load(sfo_handle, params);
                 if (!sfo::get_data_by_key(addcont_info[content_id].name, sfo_handle, fmt::format("TITLE_{:0>2d}", emuenv.cfg.sys_lang)))
@@ -361,12 +361,12 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
             for (const auto &content : contents_selected) {
                 if (content.second) {
                     if (menu == "app") {
-                        fs::remove_all(fs::path(emuenv.pref_path) / "ux0/app" / content.first);
-                        fs::remove_all(fs::path(emuenv.pref_path) / "ux0/addcont" / content.first);
+                        fs::remove_all(emuenv.pref_path / "ux0/app" / content.first);
+                        fs::remove_all(emuenv.pref_path / "ux0/addcont" / content.first);
                         gui.app_selector.user_apps.erase(get_app_index(gui, content.first));
                         gui.app_selector.user_apps_icon.erase(content.first);
                     }
-                    const auto SAVE_PATH{ fs::path(emuenv.pref_path) / "ux0/user" / emuenv.io.user_id / "savedata" / content.first };
+                    const auto SAVE_PATH{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "savedata" / content.first };
                     fs::remove_all(SAVE_PATH);
                 }
             }

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -33,7 +33,7 @@ bool delete_pup_file;
 std::filesystem::path pup_path = "";
 
 static void get_firmware_version(EmuEnvState &emuenv) {
-    fs::ifstream versionFile(emuenv.pref_path + L"/PUP_DEC/PUP/version.txt");
+    fs::ifstream versionFile(emuenv.pref_path / "PUP_DEC/PUP/version.txt");
 
     if (versionFile.is_open()) {
         std::getline(versionFile, fw_version);
@@ -41,7 +41,7 @@ static void get_firmware_version(EmuEnvState &emuenv) {
     } else
         LOG_WARN("Firmware Version file not found!");
 
-    fs::remove_all(fs::path(emuenv.pref_path) / "PUP_DEC");
+    fs::remove_all(emuenv.pref_path / "PUP_DEC");
 }
 
 void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
@@ -74,7 +74,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
 
         if (result == host::dialog::filesystem::Result::SUCCESS) {
             std::thread installation([&emuenv]() {
-                install_pup(emuenv.pref_path, pup_path.string(), progress_callback);
+                install_pup(emuenv.pref_path.wstring(), pup_path.string(), progress_callback);
                 std::lock_guard<std::mutex> lock(install_mutex);
                 finished_installing = true;
                 get_firmware_version(emuenv);
@@ -127,7 +127,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();
-            const auto fw_font_package{ fs::path(emuenv.pref_path) / "sa0" };
+            const auto fw_font_package{ emuenv.pref_path / "sa0" };
             if (!fs::exists(fw_font_package) || fs::is_empty(fw_font_package)) {
                 ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["no_font_exist"].c_str());
                 if (ImGui::Button(lang["download_firmware_font_package"].c_str()))

--- a/vita3k/gui/src/home_screen.cpp
+++ b/vita3k/gui/src/home_screen.cpp
@@ -842,7 +842,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
                 }
 
                 // Draw the custom config button
-                const auto IS_CUSTOM_CONFIG = fs::exists(fs::path(emuenv.base_path) / "config" / fmt::format("config_{}.xml", app.path));
+                const auto IS_CUSTOM_CONFIG = fs::exists(emuenv.config_path / "config" / fmt::format("config_{}.xml", app.path));
                 if (IS_CUSTOM_CONFIG) {
                     if (emuenv.cfg.apps_list_grid)
                         ImGui::SetCursorPosX(GRID_ICON_POS);

--- a/vita3k/gui/src/ime.cpp
+++ b/vita3k/gui/src/ime.cpp
@@ -454,7 +454,7 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
                 if (ImGui::MenuItem(get_ime_lang_index(ime, SceImeLanguage(lang))->second.c_str(), nullptr, emuenv.cfg.current_ime_lang == lang)) {
                     init_ime_lang(ime, SceImeLanguage(lang));
                     emuenv.cfg.current_ime_lang = lang;
-                    config::serialize_config(emuenv.cfg, emuenv.base_path);
+                    config::serialize_config(emuenv.cfg, emuenv.config_path);
                 }
             }
             ImGui::EndPopup();

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -67,12 +67,12 @@ static bool init_notice_icon(GuiState &gui, EmuEnvState &emuenv, const fs::path 
     int32_t height = 0;
     vfs::FileBuffer buffer;
 
-    if (!vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, content_path)) {
+    if (!vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), content_path)) {
         if (info.type == "trophy") {
             LOG_WARN("Icon no found for trophy id: {} on NpComId: {}", info.content_id, info.id);
             return false;
         } else {
-            if (!vfs::read_app_file(buffer, emuenv.pref_path, info.id, "sce_sys/icon0.png")) {
+            if (!vfs::read_app_file(buffer, emuenv.pref_path.wstring(), info.id, "sce_sys/icon0.png")) {
                 buffer = init_default_icon(gui, emuenv);
                 if (buffer.empty()) {
                     LOG_WARN("Not found defaut icon for this notice content: {}", info.content_id);
@@ -111,7 +111,7 @@ static bool set_notice_info(GuiState &gui, EmuEnvState &emuenv, const NoticeList
             msg = lang["install_complete"];
         }
         vfs::FileBuffer params;
-        if (vfs::read_file(VitaIoDevice::ux0, params, emuenv.pref_path, content_path / "sce_sys/param.sfo")) {
+        if (vfs::read_file(VitaIoDevice::ux0, params, emuenv.pref_path.wstring(), content_path / "sce_sys/param.sfo")) {
             SfoFile sfo_handle;
             sfo::load(sfo_handle, params);
             if (!sfo::get_data_by_key(name, sfo_handle, fmt::format("TITLE_{:0>2d}", emuenv.cfg.sys_lang)))
@@ -139,7 +139,7 @@ static bool set_notice_info(GuiState &gui, EmuEnvState &emuenv, const NoticeList
         default: break;
         }
 
-        const auto trophy_conf_id_path{ fs::path(emuenv.pref_path) / "ux0/user" / emuenv.io.user_id / "trophy/conf" / info.id };
+        const auto trophy_conf_id_path{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "trophy/conf" / info.id };
         const std::string sfm_name = fs::exists(trophy_conf_id_path / fmt::format("TROP_{:0>2d}.SFM", emuenv.cfg.sys_lang)) ? fmt::format("TROP_{:0>2d}.SFM", emuenv.cfg.sys_lang) : "TROP.SFM";
 
         pugi::xml_document doc;
@@ -205,7 +205,7 @@ void get_notice_list(EmuEnvState &emuenv) {
     notice_list.clear();
     notice_list_count_new.clear();
     notice_list_new.clear();
-    const auto notice_path{ fs::path(emuenv.pref_path) / "ux0/user/notice.xml" };
+    const auto notice_path{ emuenv.pref_path / "ux0/user/notice.xml" };
 
     if (fs::exists(notice_path)) {
         pugi::xml_document notice_xml;
@@ -264,7 +264,7 @@ void save_notice_list(EmuEnvState &emuenv) {
         }
     }
 
-    const auto notice_path{ fs::path(emuenv.pref_path) / "ux0/user/notice.xml" };
+    const auto notice_path{ emuenv.pref_path / "ux0/user/notice.xml" };
     const auto save_xml = notice_xml.save_file(notice_path.c_str());
     if (!save_xml)
         LOG_ERROR("Fail save xml");

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -95,9 +95,9 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
     const auto completed_setup = lang["completed_setup"].c_str();
 
     const auto is_default_path = emuenv.cfg.pref_path == emuenv.default_path;
-    const auto FW_PATH{ fs::path(emuenv.pref_path) / "vs0" };
+    const auto FW_PATH{ emuenv.pref_path / "vs0" };
     const auto FW_INSTALLED = fs::exists(FW_PATH) && !fs::is_empty(FW_PATH);
-    const auto FW_FONT_PATH{ fs::path(emuenv.pref_path) / "sa0" };
+    const auto FW_FONT_PATH{ emuenv.pref_path / "sa0" };
     const auto FW_FONT_INSTALLED = fs::exists(FW_FONT_PATH) && !fs::is_empty(FW_FONT_PATH);
 
     ImGui::PushFont(gui.vita_font);
@@ -176,9 +176,9 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         if (!is_default_path) {
             ImGui::SameLine(0, 40.f * SCALE.x);
             if (ImGui::Button("Reset Emulator Path", BIG_BUTTON_SIZE)) {
-                if (string_utils::utf_to_wide(emuenv.default_path) != emuenv.pref_path) {
-                    emuenv.pref_path = string_utils::utf_to_wide(emuenv.default_path);
-                    emuenv.cfg.pref_path = emuenv.default_path;
+                if (emuenv.default_path != emuenv.pref_path) {
+                    emuenv.pref_path = emuenv.default_path;
+                    emuenv.cfg.pref_path = emuenv.default_path.string();
                 }
             }
         }

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -163,9 +163,9 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string &app_p
 
     if (!gui.live_area_contents.contains(app_path)) {
         auto default_contents = false;
-        const auto fw_path{ fs::path(emuenv.pref_path) / "vs0" };
+        const auto fw_path{ emuenv.pref_path / "vs0" };
         const auto default_fw_contents{ fw_path / "data/internal/livearea/default/sce_sys/livearea/contents/template.xml" };
-        const auto APP_PATH{ fs::path(emuenv.pref_path) / app_device._to_string() / "app" / app_path };
+        const auto APP_PATH{ emuenv.pref_path / app_device._to_string() / "app" / app_path };
         const auto live_area_path{ fs::path("sce_sys") / ((sku_flag[app_path] == 3) && fs::exists(APP_PATH / "sce_sys/retail/livearea") ? "retail/livearea" : "livearea") };
         auto template_xml{ APP_PATH / live_area_path / "contents/template.xml" };
 
@@ -253,11 +253,11 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string &app_p
                 }
 
                 if (default_contents)
-                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "data/internal/livearea/default/sce_sys/livearea/contents/" + contents.second);
+                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "data/internal/livearea/default/sce_sys/livearea/contents/" + contents.second);
                 else if (app_device == VitaIoDevice::vs0)
-                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "app/" + app_path + "/sce_sys/livearea/contents/" + contents.second);
+                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "app/" + app_path + "/sce_sys/livearea/contents/" + contents.second);
                 else
-                    vfs::read_app_file(buffer, emuenv.pref_path, app_path, live_area_path.string() + "/contents/" + contents.second);
+                    vfs::read_app_file(buffer, emuenv.pref_path.wstring(), app_path, live_area_path.string() + "/contents/" + contents.second);
 
                 if (buffer.empty()) {
                     if (is_ps_app || is_sys_app)
@@ -443,9 +443,9 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string &app_p
                             vfs::FileBuffer buffer;
 
                             if (app_device == VitaIoDevice::vs0)
-                                vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "app/" + app_path + "/sce_sys/livearea/contents/" + bg_name);
+                                vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "app/" + app_path + "/sce_sys/livearea/contents/" + bg_name);
                             else
-                                vfs::read_app_file(buffer, emuenv.pref_path, app_path, live_area_path.string() + "/contents/" + bg_name);
+                                vfs::read_app_file(buffer, emuenv.pref_path.wstring(), app_path, live_area_path.string() + "/contents/" + bg_name);
 
                             if (buffer.empty()) {
                                 if (is_ps_app || is_sys_app)
@@ -475,9 +475,9 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string &app_p
                             vfs::FileBuffer buffer;
 
                             if (app_device == VitaIoDevice::vs0)
-                                vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "app/" + app_path + "/sce_sys/livearea/contents/" + img_name);
+                                vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "app/" + app_path + "/sce_sys/livearea/contents/" + img_name);
                             else
-                                vfs::read_app_file(buffer, emuenv.pref_path, app_path, live_area_path.string() + "/contents/" + img_name);
+                                vfs::read_app_file(buffer, emuenv.pref_path.wstring(), app_path, live_area_path.string() + "/contents/" + img_name);
 
                             if (buffer.empty()) {
                                 if (is_ps_app || is_sys_app)
@@ -555,7 +555,7 @@ static const ImU32 ARROW_COLOR = 0xFFFFFFFF; // White
 static LiveAreaType live_area_type_selected = GATE;
 
 void browse_live_area_apps_list(GuiState &gui, EmuEnvState &emuenv, const uint32_t button) {
-    const auto manual_path{ fs::path(emuenv.pref_path) / "ux0/app" / gui.live_area_current_open_apps_list[gui.live_area_app_current_open] / "sce_sys/manual/" };
+    const auto manual_path{ emuenv.pref_path / "ux0/app" / gui.live_area_current_open_apps_list[gui.live_area_app_current_open] / "sce_sys/manual/" };
     const auto manual_found = fs::exists(manual_path) && !fs::is_empty(manual_path);
 
     if (!gui.is_nav_button) {
@@ -1084,7 +1084,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
 
     if (app_device == VitaIoDevice::ux0) {
         const auto widget_scal_size = ImVec2(80.0f * SCALE.x, 80.f * SCALE.y);
-        const auto manual_path{ fs::path(emuenv.pref_path) / "ux0/app" / app_path / "sce_sys/manual/" };
+        const auto manual_path{ emuenv.pref_path / "ux0/app" / app_path / "sce_sys/manual/" };
         const auto scal_widget_font_size = 23.0f / ImGui::GetFontSize();
 
         const auto manual_exist = fs::exists(manual_path) && !fs::is_empty(manual_path);

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -29,7 +29,7 @@ static void draw_file_menu(GuiState &gui, EmuEnvState &emuenv) {
     auto lang = gui.lang.main_menubar.file;
     if (ImGui::BeginMenu(lang["title"].c_str())) {
         if (ImGui::MenuItem(lang["open_pref_path"].c_str()))
-            open_path(string_utils::wide_to_utf(emuenv.pref_path));
+            open_path(emuenv.pref_path.string());
         ImGui::Separator();
         ImGui::MenuItem(lang["install_firmware"].c_str(), nullptr, &gui.file_menu.firmware_install_dialog);
         ImGui::MenuItem(lang["install_pkg"].c_str(), nullptr, &gui.file_menu.pkg_install_dialog);
@@ -110,7 +110,7 @@ static void draw_debug_menu(DebugMenuState &state) {
 
 static void draw_config_menu(GuiState &gui, EmuEnvState &emuenv) {
     auto lang = gui.lang.main_menubar.configuration;
-    const auto CUSTOM_CONFIG_PATH{ fs::path(emuenv.base_path) / "config" / fmt::format("config_{}.xml", emuenv.io.app_path) };
+    const auto CUSTOM_CONFIG_PATH{ emuenv.config_path / "config" / fmt::format("config_{}.xml", emuenv.io.app_path) };
     auto &settings_dialog = !emuenv.io.app_path.empty() && fs::exists(CUSTOM_CONFIG_PATH) ? gui.configuration_menu.custom_settings_dialog : gui.configuration_menu.settings_dialog;
     if (ImGui::BeginMenu(lang["title"].c_str())) {
         if (ImGui::MenuItem(gui.lang.settings_dialog["title"].c_str(), nullptr, &settings_dialog))

--- a/vita3k/gui/src/manual.cpp
+++ b/vita3k/gui/src/manual.cpp
@@ -82,7 +82,7 @@ bool init_manual(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
     height_manual_pages.clear();
 
     const auto APP_INDEX = get_app_index(gui, app_path);
-    const auto APP_PATH{ fs::path(emuenv.pref_path) / "ux0/app" / app_path };
+    const auto APP_PATH{ emuenv.pref_path / "ux0/app" / app_path };
     auto manual_path{ fs::path("sce_sys/manual/") };
 
     const auto lang = fmt::format("{:0>2d}", emuenv.cfg.sys_lang);
@@ -96,7 +96,7 @@ bool init_manual(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
                 const auto page_path = manual_path / manual.path().filename().string();
 
                 vfs::FileBuffer buffer;
-                vfs::read_app_file(buffer, emuenv.pref_path, app_path, page_path);
+                vfs::read_app_file(buffer, emuenv.pref_path.wstring(), app_path, page_path);
 
                 if (buffer.empty()) {
                     LOG_WARN("Manual not found for title: {} [{}].", app_path, APP_INDEX->title);

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -48,8 +48,8 @@ static std::vector<std::pair<std::string, time_t>> themes_list;
 static void get_themes_list(GuiState &gui, EmuEnvState &emuenv) {
     gui.themes_preview.clear(), themes_info.clear(), themes_list.clear();
 
-    const auto theme_path{ fs::path(emuenv.pref_path) / "ux0/theme" };
-    const auto fw_theme_path{ fs::path(emuenv.pref_path) / "vs0/data/internal/theme" };
+    const auto theme_path{ emuenv.pref_path / "ux0/theme" };
+    const auto fw_theme_path{ emuenv.pref_path / "vs0/data/internal/theme" };
     if ((!fs::exists(fw_theme_path) || fs::is_empty(fw_theme_path)) && (!fs::exists(theme_path) || fs::is_empty(theme_path))) {
         LOG_WARN("Theme path is empty");
         return;
@@ -157,9 +157,9 @@ static void get_themes_list(GuiState &gui, EmuEnvState &emuenv) {
                 vfs::FileBuffer buffer;
 
                 if (theme.first == "default")
-                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, name.second);
+                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), name.second);
                 else
-                    vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, fs::path("theme") / string_utils::utf_to_wide(theme.first) / name.second);
+                    vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), fs::path("theme") / string_utils::utf_to_wide(theme.first) / name.second);
 
                 if (buffer.empty()) {
                     LOG_WARN("Background, Name: '{}', Not found for title: {} [{}].", name.second, theme.first, theme.second.title);
@@ -462,7 +462,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                                 save_user(gui, emuenv, emuenv.io.user_id);
                                 init_theme_start_background(gui, emuenv, "default");
                             }
-                            fs::remove_all(fs::path{ emuenv.pref_path } / "ux0/theme" / string_utils::utf_to_wide(selected));
+                            fs::remove_all(emuenv.pref_path / "ux0/theme" / string_utils::utf_to_wide(selected));
                             if (emuenv.app_path == "NPXS10026")
                                 init_content_manager(gui, emuenv);
                             delete_theme = selected;
@@ -728,7 +728,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     if (ImGui::Selectable(emuenv.cfg.sys_date_format == date_format_value ? "V" : "##date_format", false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(TIME_SELECT_SIZE, SIZE_PUPUP_SELECT))) {
                         if (emuenv.cfg.sys_date_format != date_format_value) {
                             emuenv.cfg.sys_date_format = date_format_value;
-                            config::serialize_config(emuenv.cfg, emuenv.base_path);
+                            config::serialize_config(emuenv.cfg, emuenv.config_path);
                         }
                         menu.clear();
                     }
@@ -744,7 +744,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                 if (ImGui::Selectable(is_12_hour_format ? "V" : "##time_format", false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(TIME_SELECT_SIZE, SIZE_PUPUP_SELECT))) {
                     if (!is_12_hour_format) {
                         emuenv.cfg.sys_time_format = SCE_SYSTEM_PARAM_TIME_FORMAT_12HOUR;
-                        config::serialize_config(emuenv.cfg, emuenv.base_path);
+                        config::serialize_config(emuenv.cfg, emuenv.config_path);
                     }
                     menu.clear();
                 }
@@ -755,7 +755,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                 if (ImGui::Selectable(!is_12_hour_format ? "V" : "##time_format", false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(TIME_SELECT_SIZE, SIZE_PUPUP_SELECT))) {
                     if (is_12_hour_format) {
                         emuenv.cfg.sys_time_format = SCE_SYSTEM_PARAM_TIME_FORMAT_24HOUR;
-                        config::serialize_config(emuenv.cfg, emuenv.base_path);
+                        config::serialize_config(emuenv.cfg, emuenv.config_path);
                     }
                     menu.clear();
                 }
@@ -826,7 +826,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     if (ImGui::Selectable(is_current_lang ? "V" : "##lang", false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(SYS_LANG_SIZE, SIZE_PUPUP_SELECT))) {
                         if (!is_current_lang) {
                             emuenv.cfg.sys_lang = sys_lang.first;
-                            config::serialize_config(emuenv.cfg, emuenv.base_path);
+                            config::serialize_config(emuenv.cfg, emuenv.config_path);
                             lang::init_lang(gui.lang, emuenv);
                             if (sys_lang.first != gui.app_selector.apps_cache_lang) {
                                 std::thread init_app([&gui, &emuenv]() {
@@ -941,7 +941,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                                 emuenv.cfg.ime_langs = cfg_ime_langs_temp;
                             }
                         }
-                        config::serialize_config(emuenv.cfg, emuenv.base_path);
+                        config::serialize_config(emuenv.cfg, emuenv.config_path);
                     }
                     ImGui::NextColumn();
                     ImGui::Columns(1);

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -126,7 +126,7 @@ void init_theme_start_background(GuiState &gui, EmuEnvState &emuenv, const std::
 
     const auto content_id_wstr{ fs::path(string_utils::utf_to_wide(content_id)) };
     if (!content_id.empty() && (content_id != "default")) {
-        const auto THEME_PATH_XML{ fs::path(emuenv.pref_path) / "ux0/theme" / content_id_wstr / "theme.xml" };
+        const auto THEME_PATH_XML{ emuenv.pref_path / "ux0/theme" / content_id_wstr / "theme.xml" };
         pugi::xml_document doc;
         if (doc.load_file(THEME_PATH_XML.c_str())) {
             const auto theme = doc.child("theme");
@@ -166,14 +166,14 @@ void init_theme_start_background(GuiState &gui, EmuEnvState &emuenv, const std::
 
     if (theme_start_name.empty()) {
         const auto DEFAULT_START_PATH{ fs::path("data/internal/keylock/keylock.png") };
-        if (fs::exists(fs::path(emuenv.pref_path) / "vs0" / DEFAULT_START_PATH))
-            vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, DEFAULT_START_PATH);
+        if (fs::exists(emuenv.pref_path / "vs0" / DEFAULT_START_PATH))
+            vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), DEFAULT_START_PATH);
         else {
             LOG_WARN("Default start background not found, install firmware for fix this.");
             return;
         }
     } else
-        vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, fs::path("theme") / content_id_wstr / theme_start_name);
+        vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), fs::path("theme") / content_id_wstr / theme_start_name);
 
     if (buffer.empty()) {
         LOG_WARN("Background not found: '{}', for content id: {}.", theme_start_name, content_id);
@@ -241,7 +241,7 @@ bool init_theme(GuiState &gui, EmuEnvState &emuenv, const std::string &content_i
     const auto content_id_wstr = string_utils::utf_to_wide(content_id);
 
     if (content_id != "default") {
-        const auto THEME_XML_PATH{ fs::path(emuenv.pref_path) / "ux0/theme" / content_id_wstr / "theme.xml" };
+        const auto THEME_XML_PATH{ emuenv.pref_path / "ux0/theme" / content_id_wstr / "theme.xml" };
         pugi::xml_document doc;
 
         if (doc.load_file(THEME_XML_PATH.c_str())) {
@@ -301,7 +301,7 @@ bool init_theme(GuiState &gui, EmuEnvState &emuenv, const std::string &content_i
                     const auto type = notice.first;
                     const auto name = notice.second;
 
-                    vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, fs::path("theme") / content_id_wstr / name);
+                    vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), fs::path("theme") / content_id_wstr / name);
 
                     if (buffer.empty()) {
                         LOG_WARN("Notice icon, Name: '{}', Not found for content id: {}.", name, content_id);
@@ -327,7 +327,7 @@ bool init_theme(GuiState &gui, EmuEnvState &emuenv, const std::string &content_i
             "NPXS10098",
         };
         for (const auto &bg : app_id_bg_list) {
-            if (fs::exists(fs::path(emuenv.pref_path) / "vs0/app" / bg / "sce_sys/pic0.png"))
+            if (fs::exists(emuenv.pref_path / "vs0/app" / bg / "sce_sys/pic0.png"))
                 theme_bg_name.push_back(bg);
         }
     }
@@ -340,9 +340,9 @@ bool init_theme(GuiState &gui, EmuEnvState &emuenv, const std::string &content_i
         const auto title_id = icon.first;
         const auto name = icon.second;
         if (name.empty())
-            vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "app/" + title_id + "/sce_sys/icon0.png");
+            vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "app/" + title_id + "/sce_sys/icon0.png");
         else
-            vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, fs::path("theme") / content_id_wstr / name);
+            vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), fs::path("theme") / content_id_wstr / name);
 
         if (buffer.empty()) {
             buffer = init_default_icon(gui, emuenv);
@@ -368,9 +368,9 @@ bool init_theme(GuiState &gui, EmuEnvState &emuenv, const std::string &content_i
         vfs::FileBuffer buffer;
 
         if (content_id == "default")
-            vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "app/" + bg + "/sce_sys/pic0.png");
+            vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "app/" + bg + "/sce_sys/pic0.png");
         else
-            vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, fs::path("theme") / content_id_wstr / bg);
+            vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), fs::path("theme") / content_id_wstr / bg);
 
         if (buffer.empty()) {
             LOG_WARN("Background not found: '{}', for content id: {}.", bg, content_id);

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -125,7 +125,7 @@ static bool load_trophy_progress(IOState &io, const SceUID &progress_input_file,
 static std::string np_com_id_sort;
 
 void init_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
-    const auto TROPHY_PATH{ fs::path(emuenv.pref_path) / "ux0/user" / emuenv.io.user_id / "trophy" };
+    const auto TROPHY_PATH{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "trophy" };
     const auto TROPHY_CONF_PATH = TROPHY_PATH / "conf";
 
     gui.trophy_np_com_id_list_icons.clear(), np_com_id_info.clear(), np_com_id_list.clear();
@@ -151,7 +151,7 @@ void init_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
 
                 // Open trophy progress file
                 const auto trophy_progress_save_file = device::construct_normalized_path(VitaIoDevice::ux0, "user/" + emuenv.io.user_id + "/trophy/data/" + np_com_id + "/TROPUSR.DAT");
-                const auto progress_input_file = open_file(emuenv.io, trophy_progress_save_file.c_str(), SCE_O_RDONLY, emuenv.pref_path, "load_trophy_progress_file");
+                const auto progress_input_file = open_file(emuenv.io, trophy_progress_save_file.c_str(), SCE_O_RDONLY, emuenv.pref_path.wstring(), "load_trophy_progress_file");
 
                 if (!load_trophy_progress(emuenv.io, progress_input_file, np_com_id)) {
                     LOG_ERROR("Fail load trophy progress for Np Com ID: {}, clean trophy file.", np_com_id);
@@ -236,7 +236,7 @@ void init_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     int32_t height = 0;
                     vfs::FileBuffer buffer;
 
-                    vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, "user/" + emuenv.io.user_id + "/trophy/conf/" + np_com_id + "/" + group.second);
+                    vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), "user/" + emuenv.io.user_id + "/trophy/conf/" + np_com_id + "/" + group.second);
 
                     if (buffer.empty()) {
                         LOG_WARN("Icon: '{}', Not found for NPComId: {}.", group.second, np_com_id);
@@ -285,7 +285,7 @@ static std::vector<TrophySort> trophy_list;
 static std::string trophy_sort;
 
 static void get_trophy_list(GuiState &gui, EmuEnvState &emuenv, const std::string &np_com_id, const std::string &group_id) {
-    const auto trophy_conf_id_path{ fs::path(emuenv.pref_path) / "ux0/user" / emuenv.io.user_id / "trophy/conf" / np_com_id };
+    const auto trophy_conf_id_path{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "trophy/conf" / np_com_id };
     if (fs::is_empty(trophy_conf_id_path)) {
         LOG_WARN("Trophy conf path is empty");
         return;
@@ -318,7 +318,7 @@ static void get_trophy_list(GuiState &gui, EmuEnvState &emuenv, const std::strin
         const std::string trophy_id = trophy.first;
         const std::string icon_name = fmt::format("TROP{}.PNG", trophy_id);
 
-        vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, "user/" + emuenv.io.user_id + "/trophy/conf/" + np_com_id + "/" + icon_name);
+        vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), "user/" + emuenv.io.user_id + "/trophy/conf/" + np_com_id + "/" + icon_name);
         if (buffer.empty()) {
             LOG_WARN("Trophy icon, Name: '{}', Not found for trophy id: {}.", icon_name, trophy.first);
             continue;
@@ -407,7 +407,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
     const auto SIZE_INFO = ImVec2(820.f * SCALE.x, 484.f * SCALE.y);
     const auto POPUP_SIZE = ImVec2(756.0f * SCALE.x, 436.0f * SCALE.y);
 
-    const auto TROPHY_PATH{ fs::path(emuenv.pref_path) / "ux0/user" / emuenv.io.user_id / "trophy" };
+    const auto TROPHY_PATH{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "trophy" };
 
     const auto is_background = gui.apps_background.contains("NPXS10008");
     const auto is_12_hour_format = emuenv.cfg.sys_time_format == SCE_SYSTEM_PARAM_TIME_FORMAT_12HOUR;

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -53,7 +53,7 @@ struct AvatarInfo {
 
 static std::map<std::string, std::map<AvatarSize, AvatarInfo>> users_avatar_infos;
 static bool init_avatar(GuiState &gui, EmuEnvState &emuenv, const std::string &user_id, const std::string avatar_path) {
-    const auto avatar_path_wstr = avatar_path == "default" ? fs::path(emuenv.base_path) / "data/image/icon.png" : fs::path(string_utils::utf_to_wide(avatar_path));
+    const auto avatar_path_wstr = avatar_path == "default" ? emuenv.shared_path / "data/image/icon.png" : fs::path(string_utils::utf_to_wide(avatar_path));
 
     if (!fs::exists(avatar_path_wstr)) {
         LOG_WARN("Avatar image doesn't exist: {}.", avatar_path_wstr.string());
@@ -97,7 +97,7 @@ static bool init_avatar(GuiState &gui, EmuEnvState &emuenv, const std::string &u
 
 void get_users_list(GuiState &gui, EmuEnvState &emuenv) {
     gui.users.clear();
-    const auto user_path{ fs::path(emuenv.pref_path) / "ux0/user" };
+    const auto user_path{ emuenv.pref_path / "ux0/user" };
     if (fs::exists(user_path) && !fs::is_empty(user_path)) {
         for (const auto &path : fs::directory_iterator(user_path)) {
             pugi::xml_document user_xml;
@@ -154,7 +154,7 @@ void get_users_list(GuiState &gui, EmuEnvState &emuenv) {
 }
 
 void save_user(GuiState &gui, EmuEnvState &emuenv, const std::string &user_id) {
-    const auto user_path{ fs::path(emuenv.pref_path) / "ux0/user" / user_id };
+    const auto user_path{ emuenv.pref_path / "ux0/user" / user_id };
     if (!fs::exists(user_path))
         fs::create_directory(user_path);
 
@@ -318,7 +318,7 @@ static void select_and_open_user(GuiState &gui, EmuEnvState &emuenv, const std::
 }
 
 static void delete_user(GuiState &gui, EmuEnvState &emuenv) {
-    const auto user_path{ fs::path(emuenv.pref_path) / "ux0/user" };
+    const auto user_path{ emuenv.pref_path / "ux0/user" };
     fs::remove_all(user_path / user_id_selected);
     gui.users_avatar.erase(user_id_selected);
     gui.users.erase(get_users_index(gui, gui.users[user_id_selected].name));
@@ -493,7 +493,7 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
     else
         ImGui::GetBackgroundDrawList()->AddRectFilled(WINDOW_POS, WINDOW_POS_MAX, IM_COL32(10.f, 50.f, 140.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
 
-    const auto user_path{ fs::path(emuenv.pref_path) / "ux0/user" };
+    const auto user_path{ emuenv.pref_path / "ux0/user" };
 
     const auto SMALL_AVATAR_SIZE = get_avatar_size(SMALL, SCALE);
     const auto MED_AVATAR_SIZE = get_avatar_size(MEDIUM, SCALE);

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -395,7 +395,7 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
         if (ImGui::Button(state < UPDATE_VITA3K ? lang["next"].c_str() : lang["update"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
             state = (Vita3kUpdate)(state + 1);
             if (state == DOWNLOAD)
-                download_update(emuenv.base_path);
+                download_update(emuenv.base_path.string());
         }
         if (state == DOWNLOAD)
             ImGui::EndDisabled();

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -79,7 +79,7 @@ static void set_theme_name(EmuEnvState &emuenv, vfs::FileBuffer &buf) {
 }
 
 static bool is_nonpdrm(EmuEnvState &emuenv, const fs::path &output_path) {
-    const auto app_license_path{ fs::path(emuenv.pref_path) / "ux0/license" / emuenv.app_info.app_title_id / fmt::format("{}.rif", emuenv.app_info.app_content_id) };
+    const auto app_license_path{ emuenv.pref_path / "ux0/license" / emuenv.app_info.app_title_id / fmt::format("{}.rif", emuenv.app_info.app_content_id) };
     const auto is_patch_found_app_license = (emuenv.app_info.app_category == "gp") && fs::exists(app_license_path);
     if (fs::exists(output_path / "sce_sys/package/work.bin") || is_patch_found_app_license) {
         std::string licpath = is_patch_found_app_license ? app_license_path.string() : output_path.string() + "/sce_sys/package/work.bin";
@@ -129,7 +129,7 @@ bool install_archive_content(EmuEnvState &emuenv, GuiState *gui, const fs::path 
 
     const auto is_theme = mz_zip_reader_extract_file_to_callback(zip.get(), (fs::path(content_path) / theme_path).string().c_str(), &write_to_buffer, &theme, 0);
 
-    auto output_path{ fs::path(emuenv.pref_path) / "ux0" };
+    auto output_path{ emuenv.pref_path / "ux0" };
     if (mz_zip_reader_extract_file_to_callback(zip.get(), (fs::path(content_path) / sfo_path).string().c_str(), &write_to_buffer, &buffer, 0)) {
         sfo::get_param_info(emuenv.app_info, buffer, emuenv.cfg.sys_lang);
         if (!set_content_path(emuenv, is_theme, output_path))
@@ -226,7 +226,7 @@ bool install_archive_content(EmuEnvState &emuenv, GuiState *gui, const fs::path 
         else
             return false;
     }
-    if (!copy_path(output_path, emuenv.pref_path, emuenv.app_info.app_title_id, emuenv.app_info.app_category))
+    if (!copy_path(output_path, emuenv.pref_path.wstring(), emuenv.app_info.app_title_id, emuenv.app_info.app_category))
         return false;
 
     update_progress();
@@ -355,7 +355,7 @@ static bool install_content(EmuEnvState &emuenv, GuiState *gui, const fs::path &
     };
 
     const auto is_theme = fs::exists(content_path / "theme.xml");
-    auto dst_path{ fs::path(emuenv.pref_path) / "ux0" };
+    auto dst_path{ emuenv.pref_path / "ux0" };
     if (get_buffer(sfo_path)) {
         sfo::get_param_info(emuenv.app_info, buffer, emuenv.cfg.sys_lang);
         if (!set_content_path(emuenv, is_theme, dst_path))
@@ -380,7 +380,7 @@ static bool install_content(EmuEnvState &emuenv, GuiState *gui, const fs::path &
     if (fs::exists(dst_path / "sce_sys/package/") && !is_nonpdrm(emuenv, dst_path))
         return false;
 
-    if (!copy_path(dst_path, emuenv.pref_path, emuenv.app_info.app_title_id, emuenv.app_info.app_category))
+    if (!copy_path(dst_path, emuenv.pref_path.wstring(), emuenv.app_info.app_title_id, emuenv.app_info.app_category))
         return false;
 
     LOG_INFO("{} [{}] installed successfully!", emuenv.app_info.app_title, emuenv.app_info.app_title_id);
@@ -428,7 +428,7 @@ static ExitCode load_app_impl(SceUID &main_module_id, EmuEnvState &emuenv, const
     }
 
     if (emuenv.cfg.archive_log) {
-        const fs::path log_directory{ emuenv.base_path + "/logs" };
+        const fs::path log_directory{ emuenv.log_path / "logs" };
         fs::create_directory(log_directory);
         const auto log_path{ log_directory / string_utils::utf_to_wide(emuenv.io.title_id + " - [" + string_utils::remove_special_chars(emuenv.current_app_title) + "].log") };
         if (logging::add_sink(log_path) != Success)
@@ -491,7 +491,7 @@ static ExitCode load_app_impl(SceUID &main_module_id, EmuEnvState &emuenv, const
             process_preload_disabled = *preload_disabled_ptr.get(emuenv.mem);
         }
     }
-    const auto module_app_path{ fs::path(emuenv.pref_path) / "ux0/app" / emuenv.io.app_path / "sce_module" };
+    const auto module_app_path{ emuenv.pref_path / "ux0/app" / emuenv.io.app_path / "sce_module" };
     const auto is_app = fs::exists(module_app_path) && !fs::is_empty(module_app_path);
     std::vector<std::string> lib_load_list = {};
     // todo: check if module is imported

--- a/vita3k/io/include/io/functions.h
+++ b/vita3k/io/include/io/functions.h
@@ -35,7 +35,7 @@ inline SceUID invalid_fd = -1;
 
 void init_device_paths(IOState &io);
 bool init_savedata_app_path(IOState &io, const fs::path &pref_path);
-bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path, bool redirect_stdout);
+bool init(IOState &io, const fs::path &cache_path, const fs::path &log_path, const fs::path &pref_path, bool redirect_stdout);
 
 bool find_case_isens_path(IOState &io, VitaIoDevice &device, const fs::path &translated_path, const fs::path &system_path);
 fs::path find_in_cache(IOState &io, const std::string &system_path);

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -96,7 +96,7 @@ SpaceInfo get_space_info(const VitaIoDevice device, const std::string &vfs_path,
 // * End utility functions *
 // ****************************
 
-bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path, bool redirect_stdio) {
+bool init(IOState &io, const fs::path &cache_path, const fs::path &log_path, const fs::path &pref_path, bool redirect_stdio) {
     // Iterate through the entire list of devices and create the subdirectories if they do not exist
     for (auto i : VitaIoDevice::_names()) {
         if (!device::is_valid_output_path(i))
@@ -141,9 +141,9 @@ bool init(IOState &io, const fs::path &base_path, const fs::path &pref_path, boo
     if (!fs::exists(vd0_network))
         fs::create_directories(vd0_network);
 
-    fs::create_directories(base_path / "cache/shaders");
-    fs::create_directory(base_path / "shaderlog");
-    fs::create_directory(base_path / "texturelog");
+    fs::create_directories(cache_path / "shaders");
+    fs::create_directory(log_path / "shaderlog");
+    fs::create_directory(log_path / "texturelog");
 
     io.redirect_stdio = redirect_stdio;
 
@@ -683,7 +683,7 @@ SceUID open_dir(IOState &io, const char *path, const std::wstring &pref_path, co
     auto device_for_icase = device;
     const auto translated_path = translate_path(path, device, io.device_paths);
 
-    auto dir_path = device::construct_emulated_path(device, translated_path, pref_path, io.redirect_stdio) / "/";
+    auto dir_path = device::construct_emulated_path(device, translated_path, pref_path, io.redirect_stdio) / std::string{ fs::path::preferred_separator };
     if (!fs::exists(dir_path)) {
         if (io.case_isens_find_enabled) {
             // Attempt a case-insensitive file search.

--- a/vita3k/kernel/include/kernel/load_self.h
+++ b/vita3k/kernel/include/kernel/load_self.h
@@ -27,4 +27,4 @@ struct MemState;
 template <class T>
 class Ptr;
 
-SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &path);
+SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &self_path, const std::string &dump_path);

--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -381,7 +381,7 @@ static bool load_exports(SceKernelModuleInfo *kernel_module_info, const sce_modu
 /**
  * \return Negative on failure
  */
-SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &self_path) {
+SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &self_path, const std::string &dump_path) {
     // TODO: use raw I/O from path when io becomes less bad
     const uint8_t *const self_bytes = static_cast<const uint8_t *>(self);
     const SCE_header &self_header = *static_cast<const SCE_header *>(self);
@@ -583,12 +583,12 @@ SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std
             dump_segments[seg_index].p_vaddr = segment.addr;
             last_index = std::max(seg_index, last_index);
         }
-        constexpr auto DUMP_DIR = "elfdumps";
-        fs::create_directory(DUMP_DIR);
+        auto dump_dir = fs::path(dump_path) / "elfdumps";
+        fs::create_directory(dump_dir);
         const auto start = dump_segments[0].p_vaddr;
         const auto end = dump_segments[last_index].p_vaddr + dump_segments[last_index].p_filesz;
         const auto elf_name = fs::path(self_path).filename().stem().string();
-        const auto filename = fs::path(fmt::format("{}/{}-{}_{}.elf", DUMP_DIR, log_hex_full(start), log_hex_full(end), elf_name));
+        const auto filename = fs::path(fmt::format("{}/{}-{}_{}.elf", dump_dir.string(), log_hex_full(start), log_hex_full(end), elf_name));
         std::ofstream out(filename.string(), std::ios::out | std::ios::binary);
         out.write(reinterpret_cast<char *>(dump_elf.data()), dump_elf.size());
         out.close();

--- a/vita3k/lang/src/lang.cpp
+++ b/vita3k/lang/src/lang.cpp
@@ -68,7 +68,7 @@ void init_lang(LangState &lang, EmuEnvState &emuenv) {
     }
 
     pugi::xml_document lang_xml;
-    const auto lang_path{ fs::path(emuenv.base_path) / "lang" };
+    const auto lang_path{ emuenv.shared_path / "lang" };
     const auto lang_xml_path = (lang_path / (lang.user_lang[GUI] + ".xml")).string();
     if (fs::exists(lang_xml_path)) {
         if (lang_xml.load_file(lang_xml_path.c_str())) {

--- a/vita3k/modules/SceAppMgr/SceAppMgr.cpp
+++ b/vita3k/modules/SceAppMgr/SceAppMgr.cpp
@@ -399,7 +399,7 @@ EXPORT(SceInt32, _sceAppMgrLoadExec, const char *appPath, Ptr<char> const argv[]
 
     // Load exec executable
     vfs::FileBuffer exec_buffer;
-    if (vfs::read_app_file(exec_buffer, emuenv.pref_path, emuenv.io.app_path, exec_path)) {
+    if (vfs::read_app_file(exec_buffer, emuenv.pref_path.wstring(), emuenv.io.app_path, exec_path)) {
         if (argv && argv->get(emuenv.mem)) {
             size_t args = 0;
             emuenv.load_exec_argv = "\"";

--- a/vita3k/modules/SceAvPlayer/SceAvPlayer.cpp
+++ b/vita3k/modules/SceAvPlayer/SceAvPlayer.cpp
@@ -242,14 +242,13 @@ EXPORT(int32_t, sceAvPlayerAddSource, SceUID player_handle, Ptr<const char> path
 
     const auto thread = lock_and_find(thread_id, emuenv.kernel.threads, emuenv.kernel.mutex);
 
-    auto file_path = expand_path(emuenv.io, path.get(emuenv.mem), emuenv.pref_path);
+    auto file_path = expand_path(emuenv.io, path.get(emuenv.mem), emuenv.pref_path.wstring());
     if (!fs::exists(file_path) && player_info->file_manager.open_file && player_info->file_manager.close_file && player_info->file_manager.read_file && player_info->file_manager.file_size) {
-        const auto cache_path{ fs::path(emuenv.base_path) / "cache" };
-        if (!fs::exists(cache_path))
-            fs::create_directories(cache_path);
+        if (!fs::exists(emuenv.cache_path))
+            fs::create_directories(emuenv.cache_path);
 
         // Create temp media file
-        const auto temp_file_path = cache_path / "temp_vita_media.mp4";
+        const auto temp_file_path = emuenv.cache_path / "temp_vita_media.mp4";
         std::ofstream temp_file(temp_file_path.string(), std::ios::out | std::ios::binary);
 
         const Address buf = alloc(emuenv.mem, KiB(512), "AvPlayer buffer");

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -820,7 +820,7 @@ static void check_empty_param(EmuEnvState &emuenv, const SceAppUtilSaveDataSlotE
         if (iconPath) {
             auto device = device::get_device(empty_param->iconPath.get(emuenv.mem));
             auto thumbnail_path = translate_path(empty_param->iconPath.get(emuenv.mem), device, emuenv.io.device_paths);
-            vfs::read_file(VitaIoDevice::ux0, thumbnail_buffer, emuenv.pref_path, thumbnail_path);
+            vfs::read_file(VitaIoDevice::ux0, thumbnail_buffer, emuenv.pref_path.wstring(), thumbnail_path);
             emuenv.common_dialog.savedata.icon_buffer[idx] = thumbnail_buffer;
         } else if (iconBuf && iconBufSize != 0) {
             thumbnail_buffer.insert(thumbnail_buffer.end(), iconBuf, iconBuf + iconBufSize);
@@ -831,7 +831,7 @@ static void check_empty_param(EmuEnvState &emuenv, const SceAppUtilSaveDataSlotE
 }
 
 static void check_save_file(const uint32_t index, EmuEnvState &emuenv, const char *export_name) {
-    SceUID fd = open_file(emuenv.io, construct_slotparam_path(emuenv.common_dialog.savedata.slot_id[index]).c_str(), SCE_O_RDONLY, emuenv.pref_path, export_name);
+    SceUID fd = open_file(emuenv.io, construct_slotparam_path(emuenv.common_dialog.savedata.slot_id[index]).c_str(), SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
     if (fd < 0) {
         auto empty_param = emuenv.common_dialog.savedata.list_empty_param[index];
         check_empty_param(emuenv, empty_param, index);
@@ -848,7 +848,7 @@ static void check_save_file(const uint32_t index, EmuEnvState &emuenv, const cha
         emuenv.common_dialog.savedata.has_date[index] = true;
         auto device = device::get_device(slot_param.iconPath);
         auto thumbnail_path = translate_path(slot_param.iconPath, device, emuenv.io.device_paths);
-        vfs::read_file(device, thumbnail_buffer, emuenv.pref_path, thumbnail_path);
+        vfs::read_file(device, thumbnail_buffer, emuenv.pref_path.wstring(), thumbnail_path);
         emuenv.common_dialog.savedata.icon_buffer[index] = thumbnail_buffer;
         emuenv.common_dialog.savedata.icon_texture[index] = {};
     }

--- a/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
+++ b/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
@@ -557,9 +557,9 @@ EXPORT(int, sceAppMgrSaveDataDataRemove, Ptr<SceAppMgrSaveDataDataDelete> data) 
     for (int i = 0; i < data.get(emuenv.mem)->fileNum; i++) {
         const auto file = fs::path(construct_savedata0_path(data.get(emuenv.mem)->files.get(emuenv.mem)[i].dataPath.get(emuenv.mem)));
         if (fs::is_regular_file(file)) {
-            remove_file(emuenv.io, file.string().c_str(), emuenv.pref_path, export_name);
+            remove_file(emuenv.io, file.string().c_str(), emuenv.pref_path.wstring(), export_name);
         } else
-            remove_dir(emuenv.io, file.string().c_str(), emuenv.pref_path, export_name);
+            remove_dir(emuenv.io, file.string().c_str(), emuenv.pref_path.wstring(), export_name);
     }
 
     return 0;
@@ -580,22 +580,22 @@ EXPORT(int, sceAppMgrSaveDataDataSave, Ptr<SceAppMgrSaveDataData> data) {
         const auto file_path = construct_savedata0_path(files[i].dataPath.get(emuenv.mem));
         switch (files[i].mode) {
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_DIRECTORY:
-            create_dir(emuenv.io, file_path.c_str(), 0777, emuenv.pref_path, export_name);
+            create_dir(emuenv.io, file_path.c_str(), 0777, emuenv.pref_path.wstring(), export_name);
             break;
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_FILE_TRUNCATE:
             if (files[i].buf) {
-                fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
+                fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
                 seek_file(fd, static_cast<int>(files[i].offset), SCE_SEEK_SET, emuenv.io, export_name);
                 write_file(fd, files[i].buf.get(emuenv.mem), files[i].bufSize, emuenv.io, export_name);
                 close_file(emuenv.io, fd, export_name);
             }
-            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_APPEND | SCE_O_TRUNC, emuenv.pref_path, export_name);
+            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_APPEND | SCE_O_TRUNC, emuenv.pref_path.wstring(), export_name);
             truncate_file(fd, files[i].bufSize + files[i].offset, emuenv.io, export_name);
             close_file(emuenv.io, fd, export_name);
             break;
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_FILE:
         default:
-            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
+            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
             seek_file(fd, static_cast<int>(files[i].offset), SCE_SEEK_SET, emuenv.io, export_name);
             if (files[i].buf.get(emuenv.mem)) {
                 write_file(fd, files[i].buf.get(emuenv.mem), files[i].bufSize, emuenv.io, export_name);

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -38,6 +38,7 @@
 #include <util/bytes.h>
 #include <util/lock_and_find.h>
 #include <util/log.h>
+#include <util/string_utils.h>
 
 #include <util/tracy.h>
 TRACY_MODULE_NAME(SceGxm);
@@ -4355,7 +4356,7 @@ EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shade
     fp->is_maskupdate = false;
     fp->program = programId->program;
 
-    if (!renderer::create(fp->renderer_data, *emuenv.renderer, *programId->program.get(mem), blendInfo, emuenv.renderer->gxp_ptr_map, emuenv.base_path.c_str(), emuenv.io.title_id.c_str())) {
+    if (!renderer::create(fp->renderer_data, *emuenv.renderer, *programId->program.get(mem), blendInfo, emuenv.renderer->gxp_ptr_map, emuenv.cache_path.string().c_str(), emuenv.io.title_id.c_str())) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 
@@ -4382,7 +4383,7 @@ EXPORT(int, sceGxmShaderPatcherCreateMaskUpdateFragmentProgram, SceGxmShaderPatc
     fp->program = Ptr<const SceGxmProgram>(alloc_callbacked(emuenv, thread_id, shaderPatcher->params, size_mask_gxp));
     memcpy(const_cast<SceGxmProgram *>(fp->program.get(mem)), mask_gxp, size_mask_gxp);
 
-    if (!renderer::create(fp->renderer_data, *emuenv.renderer, *fp->program.get(mem), nullptr, emuenv.renderer->gxp_ptr_map, emuenv.base_path.c_str(), emuenv.io.title_id.c_str())) {
+    if (!renderer::create(fp->renderer_data, *emuenv.renderer, *fp->program.get(mem), nullptr, emuenv.renderer->gxp_ptr_map, emuenv.cache_path.string().c_str(), emuenv.io.title_id.c_str())) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 
@@ -4434,7 +4435,7 @@ EXPORT(int, sceGxmShaderPatcherCreateVertexProgram, SceGxmShaderPatcher *shaderP
         vp->attributes.insert(vp->attributes.end(), &attributes[0], &attributes[attributeCount]);
     }
 
-    if (!renderer::create(vp->renderer_data, *emuenv.renderer, *programId->program.get(mem), emuenv.renderer->gxp_ptr_map, emuenv.base_path.c_str(), emuenv.io.title_id.c_str())) {
+    if (!renderer::create(vp->renderer_data, *emuenv.renderer, *programId->program.get(mem), emuenv.renderer->gxp_ptr_map, emuenv.cache_path.string().c_str(), emuenv.io.title_id.c_str())) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 

--- a/vita3k/modules/SceIofilemgr/SceIofilemgr.cpp
+++ b/vita3k/modules/SceIofilemgr/SceIofilemgr.cpp
@@ -55,7 +55,7 @@ EXPORT(int, _sceIoDevctlAsync) {
 
 EXPORT(int, _sceIoDopen, const char *dir) {
     TRACY_FUNC(_sceIoDopen, dir);
-    return open_dir(emuenv.io, dir, emuenv.pref_path, export_name);
+    return open_dir(emuenv.io, dir, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, _sceIoDread, const SceUID fd, SceIoDirent *dir) {
@@ -63,12 +63,12 @@ EXPORT(int, _sceIoDread, const SceUID fd, SceIoDirent *dir) {
     if (dir == nullptr) {
         return RET_ERROR(SCE_KERNEL_ERROR_ILLEGAL_ADDR);
     }
-    return read_dir(emuenv.io, fd, dir, emuenv.pref_path, export_name);
+    return read_dir(emuenv.io, fd, dir, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, _sceIoGetstat, const char *file, SceIoStat *stat) {
     TRACY_FUNC(_sceIoGetstat, file, stat);
-    return stat_file(emuenv.io, file, stat, emuenv.pref_path, export_name);
+    return stat_file(emuenv.io, file, stat, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, _sceIoGetstatAsync) {
@@ -78,7 +78,7 @@ EXPORT(int, _sceIoGetstatAsync) {
 
 EXPORT(int, _sceIoGetstatByFd, const SceUID fd, SceIoStat *stat) {
     TRACY_FUNC(_sceIoGetstatByFd, fd, stat);
-    return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path, export_name);
+    return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, _sceIoIoctl) {
@@ -103,7 +103,7 @@ EXPORT(int, _sceIoLseekAsync) {
 
 EXPORT(int, _sceIoMkdir, const char *dir, const SceMode mode) {
     TRACY_FUNC(_sceIoMkdir, dir, mode);
-    return create_dir(emuenv.io, dir, mode, emuenv.pref_path, export_name);
+    return create_dir(emuenv.io, dir, mode, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, _sceIoMkdirAsync) {
@@ -117,7 +117,7 @@ EXPORT(int, _sceIoOpen, const char *file, const int flags, const SceMode mode) {
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
     }
     LOG_INFO("Opening file: {}", file);
-    return open_file(emuenv.io, file, flags, emuenv.pref_path, export_name);
+    return open_file(emuenv.io, file, flags, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, _sceIoOpenAsync) {

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -584,7 +584,7 @@ EXPORT(int, sceIoGetstatAsync) {
 
 EXPORT(int, sceIoGetstatByFd, const SceUID fd, SceIoStat *stat) {
     TRACY_FUNC(sceIoGetstatByFd, fd, stat);
-    return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path, export_name);
+    return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, sceIoIoctl, SceUID fd, int cmd, const void *argp, SceSize arglen, void *bufp, SceSize buflen) {
@@ -630,7 +630,7 @@ EXPORT(SceUID, sceIoOpen, const char *file, const int flags, const SceMode mode)
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
     }
     LOG_INFO("Opening file: {}", file);
-    return open_file(emuenv.io, file, flags, emuenv.pref_path, export_name);
+    return open_file(emuenv.io, file, flags, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, sceIoOpenAsync) {
@@ -682,7 +682,7 @@ EXPORT(int, sceIoRemove, const char *path) {
     if (path == nullptr) {
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
     }
-    return remove_file(emuenv.io, path, emuenv.pref_path, export_name);
+    return remove_file(emuenv.io, path, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, sceIoRemoveAsync) {
@@ -696,7 +696,7 @@ EXPORT(int, sceIoRename, const char *oldname, const char *newname) {
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
 
     LOG_INFO("Renaming: {} to {}", oldname, newname);
-    return rename(emuenv.io, oldname, newname, emuenv.pref_path, export_name);
+    return rename(emuenv.io, oldname, newname, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, sceIoRenameAsync) {
@@ -709,7 +709,7 @@ EXPORT(int, sceIoRmdir, const char *path) {
     if (path == nullptr) {
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
     }
-    return remove_dir(emuenv.io, path, emuenv.pref_path, export_name);
+    return remove_dir(emuenv.io, path, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, sceIoRmdirAsync) {

--- a/vita3k/modules/SceLibc/SceLibc.cpp
+++ b/vita3k/modules/SceLibc/SceLibc.cpp
@@ -432,7 +432,7 @@ EXPORT(int, fileno) {
 EXPORT(int, fopen, const char *filename, const char *mode) {
     TRACY_FUNC(fopen, filename, mode);
     LOG_WARN_IF(mode[0] != 'r', "fopen({}, {})", filename, *mode);
-    return open_file(emuenv.io, filename, SCE_O_RDONLY, emuenv.pref_path, export_name);
+    return open_file(emuenv.io, filename, SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, fopen_s) {

--- a/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
+++ b/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
@@ -153,7 +153,7 @@ EXPORT(int, sceNpTrophyCreateContext, np::trophy::ContextHandle *context, const 
     }
 
     np::NpTrophyError err = np::NpTrophyError::TROPHY_ERROR_NONE;
-    *context = create_trophy_context(emuenv.np, &emuenv.io, emuenv.pref_path, comm_id, static_cast<uint32_t>(emuenv.cfg.sys_lang),
+    *context = create_trophy_context(emuenv.np, &emuenv.io, emuenv.pref_path.wstring(), comm_id, static_cast<uint32_t>(emuenv.cfg.sys_lang),
         &err);
 
     if (*context == np::trophy::INVALID_CONTEXT_HANDLE) {

--- a/vita3k/modules/SceProcessmgr/SceProcessmgr.cpp
+++ b/vita3k/modules/SceProcessmgr/SceProcessmgr.cpp
@@ -157,17 +157,17 @@ EXPORT(int, sceKernelGetRemoteProcessTime) {
 
 EXPORT(int, sceKernelGetStderr) {
     TRACY_FUNC(sceKernelGetStderr);
-    return open_file(emuenv.io, "tty0:", SCE_O_WRONLY, emuenv.pref_path, export_name);
+    return open_file(emuenv.io, "tty0:", SCE_O_WRONLY, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, sceKernelGetStdin) {
     TRACY_FUNC(sceKernelGetStdin);
-    return open_file(emuenv.io, "tty0:", SCE_O_RDONLY, emuenv.pref_path, export_name);
+    return open_file(emuenv.io, "tty0:", SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, sceKernelGetStdout) {
     TRACY_FUNC(sceKernelGetStdout);
-    return open_file(emuenv.io, "tty0:", SCE_O_WRONLY, emuenv.pref_path, export_name);
+    return open_file(emuenv.io, "tty0:", SCE_O_WRONLY, emuenv.pref_path.wstring(), export_name);
 }
 
 EXPORT(int, sceKernelIsCDialogAvailable) {

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -33,6 +33,7 @@
 #include <util/find.h>
 #include <util/lock_and_find.h>
 #include <util/log.h>
+#include <util/string_utils.h>
 
 #include <unordered_set>
 
@@ -176,14 +177,14 @@ SceUID load_module(EmuEnvState &emuenv, const std::string &module_path) {
     VitaIoDevice device = device::get_device(module_path);
     auto translated_module_path = translate_path(module_path.c_str(), device, emuenv.io.device_paths);
     if (device == VitaIoDevice::app0)
-        res = vfs::read_app_file(module_buffer, emuenv.pref_path, emuenv.io.app_path, translated_module_path);
+        res = vfs::read_app_file(module_buffer, emuenv.pref_path.wstring(), emuenv.io.app_path, translated_module_path);
     else
-        res = vfs::read_file(device, module_buffer, emuenv.pref_path, translated_module_path);
+        res = vfs::read_file(device, module_buffer, emuenv.pref_path.wstring(), translated_module_path);
     if (!res) {
         LOG_ERROR("Failed to read module file {}", module_path);
         return SCE_ERROR_ERRNO_ENOENT;
     }
-    SceUID module_id = load_self(emuenv.kernel, emuenv.mem, module_buffer.data(), module_path);
+    SceUID module_id = load_self(emuenv.kernel, emuenv.mem, module_buffer.data(), module_path, emuenv.log_path.string());
     if (module_id >= 0) {
         const auto module = emuenv.kernel.loaded_modules[module_id];
         LOG_INFO("Module {} (at \"{}\") loaded", module->module_name, module_path);

--- a/vita3k/packages/src/license.cpp
+++ b/vita3k/packages/src/license.cpp
@@ -70,7 +70,7 @@ bool copy_license(EmuEnvState &emuenv, const fs::path &license_path) {
     if (open_license(emuenv, license_path)) {
         emuenv.license_content_id = license_buf.content_id;
         emuenv.license_title_id = emuenv.license_content_id.substr(7, 9);
-        const auto dst_path{ fs::path(emuenv.pref_path) / "ux0/license" / emuenv.license_title_id };
+        const auto dst_path{ emuenv.pref_path / "ux0/license" / emuenv.license_title_id };
         if (!fs::exists(dst_path))
             fs::create_directories(dst_path);
 
@@ -93,11 +93,11 @@ bool copy_license(EmuEnvState &emuenv, const fs::path &license_path) {
 int32_t get_license_sku_flag(EmuEnvState &emuenv, const std::string &content_id) {
     int32_t sku_flag;
     const auto title_id = content_id.substr(7, 9);
-    const auto license_path{ fs::path(emuenv.pref_path) / "ux0/license" / title_id / fmt::format("{}.rif", content_id) };
+    const auto license_path{ emuenv.pref_path / "ux0/license" / title_id / fmt::format("{}.rif", content_id) };
     if (open_license(emuenv, license_path)) {
         sku_flag = byte_swap(license_buf.sku_flag);
     } else {
-        const auto RETAIL_APP_PATH{ fs::path(emuenv.pref_path) / "ux0/app" / title_id / "sce_sys/retail/livearea" };
+        const auto RETAIL_APP_PATH{ emuenv.pref_path / "ux0/app" / title_id / "sce_sys/retail/livearea" };
         if (fs::exists(RETAIL_APP_PATH))
             sku_flag = 1;
         else
@@ -112,12 +112,11 @@ int32_t get_license_sku_flag(EmuEnvState &emuenv, const std::string &content_id)
 }
 
 bool create_license(EmuEnvState &emuenv, const std::string &zRIF) {
-    const auto cache_path = fs::path(emuenv.base_path) / "cache";
-    if (!fs::exists(cache_path))
-        fs::create_directories(cache_path);
+    if (!fs::exists(emuenv.cache_path))
+        fs::create_directories(emuenv.cache_path);
 
     // Create temp license file
-    const auto temp_license_path = cache_path / "temp_licence.rif";
+    const auto temp_license_path = emuenv.cache_path / "temp_licence.rif";
     std::ofstream temp_file(temp_license_path.string(), std::ios::out | std::ios::binary);
     zrif2rif(zRIF, temp_file);
 

--- a/vita3k/packages/src/pkg.cpp
+++ b/vita3k/packages/src/pkg.cpp
@@ -224,7 +224,7 @@ bool install_pkg(const std::string &pkg, EmuEnvState &emuenv, std::string &p_zRI
         type = PkgType::PKG_TYPE_VITA_PATCH;
     }
 
-    auto path{ fs::path(emuenv.pref_path) / "ux0" };
+    auto path{ emuenv.pref_path / "ux0" };
 
     switch (type) {
     case PkgType::PKG_TYPE_VITA_APP:
@@ -342,7 +342,7 @@ bool install_pkg(const std::string &pkg, EmuEnvState &emuenv, std::string &p_zRI
         break;
     }
 
-    if (!copy_path(title_id_src, emuenv.pref_path, emuenv.app_info.app_title_id, emuenv.app_info.app_category))
+    if (!copy_path(title_id_src, emuenv.pref_path.wstring(), emuenv.app_info.app_title_id, emuenv.app_info.app_category))
         return false;
 
     create_license(emuenv, zRIF);

--- a/vita3k/packages/src/sce_utils.cpp
+++ b/vita3k/packages/src/sce_utils.cpp
@@ -677,7 +677,7 @@ void extract_fat(const std::wstring &partition_path, const std::string &partitio
         });
 
     Fat16::Entry first;
-    traverse_directory(img, first, pref_path + string_utils::utf_to_wide(partition.substr(0, 3)));
+    traverse_directory(img, first, pref_path + std::wstring{ fs::path::preferred_separator } + string_utils::utf_to_wide(partition.substr(0, 3)));
 
     fclose(f);
 }

--- a/vita3k/renderer/include/renderer/driver_functions.h
+++ b/vita3k/renderer/include/renderer/driver_functions.h
@@ -30,11 +30,11 @@ struct CommandHelper;
 
 #define COMMAND(name)                                                                                \
     void cmd_##name(renderer::State &renderer, MemState &mem, Config &config, CommandHelper &helper, \
-        const FeatureState &features, Context *render_context, const char *base_path, const char *title_id, const char *self_name)
+        const FeatureState &features, Context *render_context, const char *cache_path, const char *title_id, const char *self_name)
 
 #define COMMAND_SET_STATE(name)                                                                                \
     void cmd_set_state_##name(renderer::State &renderer, MemState &mem, Config &config, CommandHelper &helper, \
-        Context *render_context, const char *base_path, const char *title_id)
+        Context *render_context, const char *cache_path, const char *title_id)
 
 COMMAND_SET_STATE(region_clip);
 COMMAND_SET_STATE(program);

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -31,8 +31,8 @@ struct RenderTarget;
 struct State;
 struct VertexProgram;
 
-bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
-bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id);
+bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *cache_path, const char *title_id);
+bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const char *cache_path, const char *title_id);
 void create(SceGxmSyncObject *sync, State &state);
 void destroy(SceGxmSyncObject *sync, State &state);
 void finish(State &state, Context *context);
@@ -57,7 +57,7 @@ void submit_command_list(State &state, renderer::Context *context, CommandList &
 bool is_cmd_ready(MemState &mem, CommandList &command_list);
 void process_batch(State &state, MemState &mem, Config &config, CommandList &command_list);
 void process_batches(State &state, const FeatureState &features, MemState &mem, Config &config);
-bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config, const char *base_path);
+bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config, const Root &root_paths);
 
 void set_depth_bias(State &state, Context *ctx, bool is_front, int factor, int units);
 void set_depth_func(State &state, Context *ctx, bool is_front, SceGxmDepthFunc depth_func);

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -36,13 +36,13 @@ struct FeatureState;
 namespace renderer::gl {
 
 // Compile program.
-SharedGLObject compile_program(GLState &renderer, GLContext &context, const GxmRecordState &state, const FeatureState &features, const MemState &mem, bool shader_cache, bool spirv, bool maskupdate, const char *base_path, const char *title_id, const char *self_name);
-void pre_compile_program(GLState &renderer, const char *base_path, const char *title_id, const char *self_name, const ShadersHash &hashs);
+SharedGLObject compile_program(GLState &renderer, GLContext &context, const GxmRecordState &state, const FeatureState &features, const MemState &mem, bool shader_cache, bool spirv, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name);
+void pre_compile_program(GLState &renderer, const char *cache_path, const char *title_id, const char *self_name, const ShadersHash &hashs);
 
 // Uniforms.
 bool set_uniform_buffer(GLContext &context, const ShaderProgram *program, const bool vertex_shader, const int block_num, const int size, const uint8_t *data);
 
-bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const char *base_path, const bool hashless_texture_cache);
+bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const Config &config);
 bool create(std::unique_ptr<Context> &context);
 bool create(GLState &state, std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &params, const FeatureState &features);
 bool create(std::unique_ptr<FragmentProgram> &fp, GLState &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend);
@@ -51,7 +51,7 @@ void set_context(GLState &state, GLContext &ctx, const MemState &mem, const GLRe
 void get_surface_data(GLState &renderer, GLContext &context, uint32_t *pixels, SceGxmColorSurface &surface);
 void lookup_and_get_surface_data(GLState &renderer, MemState &mem, SceGxmColorSurface &surface);
 void draw(GLState &renderer, GLContext &context, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format,
-    void *indices, size_t count, uint32_t instance_count, MemState &mem, const char *base_path, const char *title_id, const char *self_name, const Config &config);
+    void *indices, size_t count, uint32_t instance_count, MemState &mem, const char *cache_path, const char *title_id, const char *self_name, const Config &config);
 
 // State
 void sync_viewport_flat(const GLState &state, GLContext &context);
@@ -70,8 +70,7 @@ void sync_polygon_mode(const SceGxmPolygonMode mode, const bool front);
 void sync_point_line_width(const GLState &state, const std::uint32_t size, const bool front);
 void sync_depth_bias(const int factor, const int unit, const bool front);
 void sync_blending(const GxmRecordState &state, const MemState &mem);
-void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config,
-    const std::string &base_path, const std::string &title_id);
+void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config, const std::string &title_id);
 void sync_vertex_streams_and_attributes(GLContext &context, GxmRecordState &state, const MemState &mem);
 void bind_fundamental(GLContext &context);
 void clear_previous_uniform_storage(GLContext &context);
@@ -100,7 +99,7 @@ size_t bits_per_pixel(SceGxmTextureBaseFormat base_format);
 
 // Texture cache.
 bool init(GLTextureCacheState &cache, const bool hashless_texture_cache);
-void dump(const SceGxmTexture &gxm_texture, const MemState &mem, const std::string &name, const std::string &base_path, const std::string &title_id, Sha256Hash hash);
+void dump(const SceGxmTexture &gxm_texture, const MemState &mem, const std::string &name, const std::string &log_path, const std::string &title_id, Sha256Hash hash);
 
 } // namespace texture
 

--- a/vita3k/renderer/include/renderer/gl/screen_render.h
+++ b/vita3k/renderer/include/renderer/gl/screen_render.h
@@ -27,7 +27,7 @@ public:
     ScreenRenderer() = default;
     ~ScreenRenderer();
 
-    bool init(const std::string &base_path);
+    bool init(const char *shared_path);
     void render(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const float *uvs, const GLuint texture, const SceFVector2 texture_size);
 
     void destroy();

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -44,7 +44,7 @@ struct GLState : public renderer::State {
 
     ScreenRenderer screen_renderer;
 
-    bool init(const char *base_path, const bool hashless_texture_cache) override;
+    bool init(const char *shared_path, const bool hashless_texture_cache) override;
     void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem) override;
     void swap_window(SDL_Window *window) override;

--- a/vita3k/renderer/include/renderer/shaders.h
+++ b/vita3k/renderer/include/renderer/shaders.h
@@ -37,8 +37,8 @@ struct State;
 // Shaders.
 bool get_shaders_cache_hashs(State &renderer);
 void save_shaders_cache_hashs(State &renderer, std::vector<ShadersHash> &shaders_cache_hashs);
-std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
-std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const shader::Hints &hints, bool maskupdate, const char *base_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
-std::string pre_load_shader_glsl(const char *hash_text, const char *shader_type_str, const char *base_path, const char *title_id, const char *self_name);
-std::vector<uint32_t> pre_load_shader_spirv(const char *hash_text, const char *shader_type_str, const char *base_path, const char *title_id, const char *self_name);
+std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
+std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const shader::Hints &hints, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
+std::string pre_load_shader_glsl(const char *hash_text, const char *shader_type_str, const char *cache_path, const char *title_id, const char *self_name);
+std::vector<uint32_t> pre_load_shader_spirv(const char *hash_text, const char *shader_type_str, const char *cache_path, const char *title_id, const char *self_name);
 } // namespace renderer

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -42,7 +42,9 @@ enum struct Filter : int {
 };
 
 struct State {
-    const char *base_path;
+    std::string cache_path;
+    std::string log_path;
+    std::string shared_path;
     const char *title_id;
     const char *self_name;
 
@@ -74,7 +76,7 @@ struct State {
 
     bool need_page_table = false;
 
-    virtual bool init(const char *base_path, const bool hashless_texture_cache) = 0;
+    virtual bool init(const char *shared_path, const bool hashless_texture_cache) = 0;
     virtual void late_init(const Config &cfg){};
     virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem)

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -24,7 +24,7 @@ struct MemState;
 
 namespace renderer::vulkan {
 
-bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const char *base_path, const Config &config);
+bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const Config &config);
 
 bool create(VKState &state, std::unique_ptr<Context> &context, MemState &mem);
 bool create(VKState &state, std::unique_ptr<RenderTarget> &rt, const SceGxmRenderTargetParams &params, const FeatureState &features);
@@ -48,8 +48,7 @@ void sync_depth_bias(VKContext &context);
 void sync_depth_data(VKContext &context);
 void sync_stencil_data(VKContext &context, const MemState &mem);
 void sync_point_line_width(VKContext &context, const bool is_front);
-void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config,
-    const std::string &base_path, const std::string &title_id);
+void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config, const std::string &title_id);
 void sync_viewport_flat(VKContext &context);
 void sync_viewport_real(VKContext &context, const float xOffset, const float yOffset, const float zOffset,
     const float xScale, const float yScale, const float zScale);

--- a/vita3k/renderer/include/renderer/vulkan/screen_renderer.h
+++ b/vita3k/renderer/include/renderer/vulkan/screen_renderer.h
@@ -76,7 +76,7 @@ public:
 
     bool create(SDL_Window *window);
     // called after the logical device has been created
-    bool setup(const char *base_path);
+    bool setup(const char *shared_path);
     void cleanup();
 
     bool acquire_swapchain_image(bool start_render_pass = false);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -85,8 +85,8 @@ struct VKState : public renderer::State {
 
     VKState(int gpu_idx);
 
-    bool init(const char *base_path, const bool hashless_texture_cache) override;
-    bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const char *base_path, const Config &config);
+    bool init(const char *shared_path, const bool hashless_texture_cache) override;
+    bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const Config &config);
     void late_init(const Config &cfg) override;
     void cleanup();
     void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,

--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -104,7 +104,7 @@ void process_batch(renderer::State &state, const FeatureState &features, MemStat
             LOG_ERROR("Unimplemented command opcode {}", static_cast<int>(cmd->opcode));
         } else {
             CommandHelper helper(cmd);
-            handler->second(state, mem, config, helper, features, command_list.context, state.base_path, state.title_id, state.self_name);
+            handler->second(state, mem, config, helper, features, command_list.context, state.cache_path.c_str(), state.title_id, state.self_name);
         }
 
         Command *last_cmd = cmd;

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -178,7 +178,7 @@ COMMAND(handle_memory_unmap) {
 }
 
 // Client
-bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id) {
+bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *cache_path, const char *title_id) {
     switch (state.current_backend) {
     case Backend::OpenGL:
         gl::create(fp, dynamic_cast<gl::GLState &>(state), program, blend);
@@ -205,7 +205,7 @@ bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProg
     return true;
 }
 
-bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const char *base_path, const char *title_id) {
+bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const char *cache_path, const char *title_id) {
     switch (state.current_backend) {
     case Backend::OpenGL:
         gl::create(vp, dynamic_cast<gl::GLState &>(state), program);
@@ -251,18 +251,23 @@ void destroy(SceGxmSyncObject *sync, State &state) {
     // nothing to do right now
 }
 
-bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config, const char *base_path) {
+bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, const Config &config, const Root &root_paths) {
     switch (backend) {
     case Backend::OpenGL:
         state = std::make_unique<gl::GLState>();
-        if (!gl::create(window, state, base_path, config.hashless_texture_cache))
+        state->cache_path = root_paths.get_cache_path_string();
+        state->log_path = root_paths.get_log_path_string();
+        state->shared_path = root_paths.get_shared_path_string();
+        if (!gl::create(window, state, config))
             return false;
         break;
 
     case Backend::Vulkan:
         state = std::make_unique<vulkan::VKState>(config.gpu_idx);
-
-        if (!vulkan::create(window, state, base_path, config))
+        state->cache_path = root_paths.get_cache_path_string();
+        state->log_path = root_paths.get_log_path_string();
+        state->shared_path = root_paths.get_shared_path_string();
+        if (!vulkan::create(window, state, config))
             return false;
         break;
 

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -59,7 +59,7 @@ static GLenum translate_primitive(SceGxmPrimitiveType primType) {
 }
 
 void draw(GLState &renderer, GLContext &context, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format, void *indices, size_t count, uint32_t instance_count,
-    MemState &mem, const char *base_path, const char *title_id, const char *self_name, const Config &config) {
+    MemState &mem, const char *cache_path, const char *title_id, const char *self_name, const Config &config) {
     R_PROFILE(__func__);
 
     GLuint program_id = context.last_draw_program;
@@ -71,7 +71,7 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
     // If it's different, we need to switch. Else just stick to it.
     if (context.record.vertex_program.get(mem)->renderer_data->hash != context.last_draw_vertex_program_hash || context.record.fragment_program.get(mem)->renderer_data->hash != context.last_draw_fragment_program_hash) {
         // Need to recompile!
-        SharedGLObject program = gl::compile_program(renderer, context, context.record, features, mem, config.shader_cache, config.spirv_shader, gxm_fragment_program.is_maskupdate, base_path, title_id, self_name);
+        SharedGLObject program = gl::compile_program(renderer, context, context.record, features, mem, config.shader_cache, config.spirv_shader, gxm_fragment_program.is_maskupdate, cache_path, title_id, self_name);
 
         LOG_ERROR_IF(!program, "Fail to get program!");
 

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -173,8 +173,9 @@ static void debug_output_callback(GLenum source, GLenum type, GLuint id, GLenum 
 }
 #endif
 
-bool create(SDL_Window *window, std::unique_ptr<State> &state, const char *base_path, const bool hashless_texture_cache) {
+bool create(SDL_Window *window, std::unique_ptr<State> &state, const Config &config) {
     auto &gl_state = dynamic_cast<GLState &>(*state);
+    auto &hashless_texture_cache = config.hashless_texture_cache;
 
     // Recursively create GL version until one accepts
     // Major 4 is mandantory
@@ -256,16 +257,16 @@ bool create(SDL_Window *window, std::unique_ptr<State> &state, const char *base_
     // always enabled in the opengl renderer
     gl_state.features.use_mask_bit = true;
 
-    return gl_state.init(base_path, hashless_texture_cache);
+    return gl_state.init(gl_state.shared_path.c_str(), hashless_texture_cache);
 }
 
-bool GLState::init(const char *base_path, const bool hashless_texture_cache) {
+bool GLState::init(const char *shared_path, const bool hashless_texture_cache) {
     if (!texture_cache.init(hashless_texture_cache)) {
         LOG_ERROR("Failed to initialize texture cache!");
         return false;
     }
 
-    if (!screen_renderer.init(base_path)) {
+    if (!screen_renderer.init(shared_path)) {
         LOG_ERROR("Failed to initialize screen renderer");
         return false;
     }
@@ -733,7 +734,7 @@ void GLState::set_anisotropic_filtering(int anisotropic_filtering) {
 }
 
 void GLState::precompile_shader(const ShadersHash &hash) {
-    pre_compile_program(*this, base_path, title_id, self_name, hash);
+    pre_compile_program(*this, cache_path.c_str(), title_id, self_name, hash);
 }
 
 void GLState::preclose_action() {}

--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -23,10 +23,11 @@
 
 namespace renderer::gl {
 
-bool ScreenRenderer::init(const std::string &base_path) {
+bool ScreenRenderer::init(const char *shared_path) {
     glGenTextures(1, &m_screen_texture);
 
-    const auto builtin_shaders_path = base_path + "shaders-builtin/opengl/";
+    std::string builtin_shaders_path = shared_path;
+    builtin_shaders_path += "shaders-builtin/opengl/";
 
     m_render_shader_nofilter = ::gl::load_shaders(builtin_shaders_path + "render_main.vert", builtin_shaders_path + "render_main.frag");
     m_render_shader_fxaa = ::gl::load_shaders(builtin_shaders_path + "render_main.vert", builtin_shaders_path + "render_main_fxaa.frag");

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -268,7 +268,7 @@ void sync_depth_bias(const int factor, const int unit, const bool is_front) {
 }
 
 void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture,
-    const Config &config, const std::string &base_path, const std::string &title_id) {
+    const Config &config, const std::string &title_id) {
     Address data_addr = texture.data_addr << 2;
 
     if (!is_valid_addr(mem, data_addr)) {
@@ -415,7 +415,7 @@ void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t
                 break;
             }
         }
-        renderer::gl::texture::dump(texture, mem, parameter_name, base_path, title_id, program_hash);
+        renderer::gl::texture::dump(texture, mem, parameter_name, state.log_path, title_id, program_hash);
     }
 
     glActiveTexture(GL_TEXTURE0);

--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -185,7 +185,7 @@ void bind_texture_without_cache(GLTextureCache &cache, const SceGxmTexture &gxm_
 }
 
 // Dumps bound texture to a file
-void dump(const SceGxmTexture &gxm_texture, const MemState &mem, const std::string &parameter_name, const std::string &base_path, const std::string &title_id, Sha256Hash program_hash) {
+void dump(const SceGxmTexture &gxm_texture, const MemState &mem, const std::string &parameter_name, const std::string &log_path, const std::string &title_id, Sha256Hash program_hash) {
     static uint32_t g_tex_index = 0;
     static std::vector<uint8_t> g_pixels; // re-use the same vector instead of allocating one every time
     static std::map<uint64_t, uint64_t> g_dumped_hashes;
@@ -219,7 +219,7 @@ void dump(const SceGxmTexture &gxm_texture, const MemState &mem, const std::stri
 
     // TODO: Create the texturelog path elsewhere on init once and pass it here whole
     // TODO: Same for shaderlog path
-    const fs::path texturelog_path{ fs::path(base_path) / "texturelog" / title_id };
+    const fs::path texturelog_path{ fs::path(log_path) / "texturelog" / title_id };
     if (!fs::exists(texturelog_path))
         fs::create_directories(texturelog_path);
 

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -203,7 +203,7 @@ COMMAND(handle_mid_scene_flush) {
 
     if (!renderer.features.support_memory_mapping) {
         // handle it like a simple notification
-        cmd_handle_notification(renderer, mem, config, helper, features, render_context, base_path, title_id, self_name);
+        cmd_handle_notification(renderer, mem, config, helper, features, render_context, cache_path, title_id, self_name);
         return;
     }
 
@@ -224,7 +224,7 @@ COMMAND(handle_draw) {
     switch (renderer.current_backend) {
     case Backend::OpenGL:
         gl::draw(dynamic_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context),
-            features, type, format, indicies.cast<void>().get(mem), count, instance_count, mem, base_path, title_id, self_name, config);
+            features, type, format, indicies.cast<void>().get(mem), count, instance_count, mem, cache_path, title_id, self_name, config);
         break;
 
     case Backend::Vulkan:

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -429,12 +429,12 @@ COMMAND_SET_STATE(texture) {
     switch (renderer.current_backend) {
     case Backend::OpenGL:
         gl::sync_texture(dynamic_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context), mem, texture_index, texture,
-            config, base_path, title_id);
+            config, title_id);
         break;
 
     case Backend::Vulkan:
         vulkan::sync_texture(*reinterpret_cast<vulkan::VKContext *>(render_context), mem, texture_index, texture,
-            config, base_path, title_id);
+            config, title_id);
         break;
 
     default:
@@ -562,7 +562,7 @@ COMMAND(handle_set_state) {
 
     if (result != handlers.end()) {
         // LOG_TRACE("State set: {}", (int)gxm_state_to_set);
-        result->second(renderer, mem, config, helper, render_context, base_path, title_id);
+        result->second(renderer, mem, config, helper, render_context, cache_path, title_id);
     } else {
         LOG_ERROR("Unknown state set command {}", static_cast<uint16_t>(gxm_state_to_set));
     }

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -156,7 +156,7 @@ void PipelineCache::init() {
 }
 
 void PipelineCache::read_pipeline_cache() {
-    const auto shaders_path{ fs::path(state.base_path) / "cache/shaders" / state.title_id / state.self_name };
+    const auto shaders_path{ fs::path(state.cache_path) / "shaders" / state.title_id / state.self_name };
     const std::string pipeline_cache_name = fmt::format("pipeline-cache-vk{}.dat", shader::CURRENT_VERSION);
     const fs::path path = shaders_path / pipeline_cache_name;
 
@@ -190,7 +190,7 @@ void PipelineCache::save_pipeline_cache() {
         // No pipeline was created
         return;
 
-    const auto shaders_path{ fs::path(state.base_path) / "cache/shaders" / state.title_id / state.self_name };
+    const auto shaders_path{ fs::path(state.cache_path) / "shaders" / state.title_id / state.self_name };
     const std::string pipeline_cache_name = fmt::format("pipeline-cache-vk{}.dat", shader::CURRENT_VERSION);
     const fs::path path = shaders_path / pipeline_cache_name;
 
@@ -226,7 +226,6 @@ vk::PipelineShaderStageCreateInfo PipelineCache::retrieve_shader(const SceGxmPro
         return shader_stage_info;
     }
 
-    const char *base_path = state.base_path;
     const char *title_id = state.title_id;
     const char *self_name = state.self_name;
 
@@ -239,7 +238,7 @@ vk::PipelineShaderStageCreateInfo PipelineCache::retrieve_shader(const SceGxmPro
     current_context->shader_hints.color_format = current_context->record.color_surface.colorFormat;
     current_context->shader_hints.attributes = hint_attributes;
 
-    shader::usse::SpirvCode source = load_spirv_shader(*program, state.features, true, current_context->shader_hints, maskupdate, base_path, title_id, self_name, shader_version, true);
+    shader::usse::SpirvCode source = load_spirv_shader(*program, state.features, true, current_context->shader_hints, maskupdate, state.cache_path.c_str(), title_id, self_name, shader_version, true);
 
     vk::ShaderModuleCreateInfo shader_info{
         .codeSize = sizeof(uint32_t) * source.size(),
@@ -650,7 +649,7 @@ vk::Pipeline PipelineCache::retrieve_pipeline(VKContext &context, SceGxmPrimitiv
 }
 
 bool PipelineCache::precompile_shader(const Sha256Hash &hash) {
-    const auto shader_path{ fs::path(state.base_path) / "cache/shaders" / state.title_id / state.self_name };
+    const auto shader_path{ fs::path(state.cache_path) / "shaders" / state.title_id / state.self_name };
 
     if (shaders.contains(hash))
         return true;
@@ -662,7 +661,7 @@ bool PipelineCache::precompile_shader(const Sha256Hash &hash) {
     memcpy(shader_hash.data(), hash.data(), sizeof(Sha256Hash));
     const std::string hash_ver = fmt::format("vk{}-{}", shader::CURRENT_VERSION, hex_string(shader_hash));
 
-    const std::vector<uint32_t> source = renderer::pre_load_shader_spirv(hash_ver.c_str(), "spv", state.base_path, state.title_id, state.self_name);
+    const std::vector<uint32_t> source = renderer::pre_load_shader_spirv(hash_ver.c_str(), "spv", state.cache_path.c_str(), state.title_id, state.self_name);
 
     if (source.empty())
         return false;

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -162,10 +162,10 @@ std::string get_driver_version(uint32_t vendor_id, uint32_t version_raw) {
     return fmt::format("{}.{}.{}", (version_raw >> 22) & 0x3ff, (version_raw >> 12) & 0x3ff, (version_raw)&0xfff);
 }
 
-bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const char *base_path, const Config &config) {
+bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const Config &config) {
     auto &vk_state = dynamic_cast<VKState &>(*state);
 
-    return vk_state.create(window, state, base_path, config);
+    return vk_state.create(window, state, config);
 }
 
 VKState::VKState(int gpu_idx)
@@ -176,13 +176,12 @@ VKState::VKState(int gpu_idx)
     , screen_renderer(*this) {
 }
 
-bool VKState::init(const char *base_path, const bool hashless_texture_cache) {
+bool VKState::init(const char *shared_path, const bool hashless_texture_cache) {
     shader_version = fmt::format("v{}", shader::CURRENT_VERSION);
     return true;
 }
 
-bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const char *base_path, const Config &config) {
-    this->base_path = base_path;
+bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const Config &config) {
     // Create Instance
     {
         PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(SDL_Vulkan_GetVkGetInstanceProcAddr());
@@ -596,7 +595,7 @@ bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state
         default_image.sampler = device.createSampler(sampler_info);
     }
 
-    if (!screen_renderer.setup(base_path))
+    if (!screen_renderer.setup(shared_path.c_str()))
         return false;
 
     support_fsr &= static_cast<bool>(screen_renderer.surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eStorage);

--- a/vita3k/renderer/src/vulkan/screen_filters.cpp
+++ b/vita3k/renderer/src/vulkan/screen_filters.cpp
@@ -109,7 +109,7 @@ void SinglePassScreenFilter::create_layout_sync() {
 
 void SinglePassScreenFilter::create_graphics_pipeline() {
     // create shader modules
-    const auto builtin_shaders_path = std::string(screen.state.base_path) + "shaders-builtin/vulkan/";
+    const auto builtin_shaders_path = std::string(screen.state.shared_path) + "shaders-builtin/vulkan/";
     vertex_shader = vkutil::load_shader(screen.state.device, builtin_shaders_path + std::string(get_vertex_name()));
     fragment_shader = vkutil::load_shader(screen.state.device, builtin_shaders_path + std::string(get_fragment_name()));
     vk::PipelineShaderStageCreateInfo vert_info{
@@ -408,7 +408,7 @@ void FSRScreenFilter::init() {
     };
     sampler = device.createSampler(sampler_info);
 
-    const auto builtin_shaders_path = std::string(screen.state.base_path) + "shaders-builtin/vulkan/";
+    const auto builtin_shaders_path = std::string(screen.state.shared_path) + "shaders-builtin/vulkan/";
     easu_shader = vkutil::load_shader(screen.state.device, builtin_shaders_path + "fsr_filter_easu.comp.spv");
     rcas_shader = vkutil::load_shader(screen.state.device, builtin_shaders_path + "fsr_filter_rcas.comp.spv");
 

--- a/vita3k/renderer/src/vulkan/screen_renderer.cpp
+++ b/vita3k/renderer/src/vulkan/screen_renderer.cpp
@@ -43,7 +43,7 @@ bool ScreenRenderer::create(SDL_Window *window) {
     return true;
 }
 
-bool ScreenRenderer::setup(const char *base_path) {
+bool ScreenRenderer::setup(const char *cache_path) {
     const auto surface_formats = state.physical_device.getSurfaceFormatsKHR(surface);
     bool surface_format_found = false;
     for (const auto &format : surface_formats) {

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -55,8 +55,7 @@ static bool is_depth_stencil_compatible_format(SceGxmTextureBaseFormat format) {
 VKTextureCache::VKTextureCache(VKState &state)
     : state(state) {}
 
-void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config,
-    const std::string &base_path, const std::string &title_id) {
+void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config, const std::string &title_id) {
     // why are we doing this here?
     // well textures are synced right before the draw
     // in particular, we know that the scissor is the correct one for the upcoming draw

--- a/vita3k/util/include/util/fs.h
+++ b/vita3k/util/include/util/fs.h
@@ -25,6 +25,10 @@ namespace fs = boost::filesystem;
 class Root {
     fs::path base_path;
     fs::path pref_path;
+    fs::path log_path;
+    fs::path config_path;
+    fs::path shared_path;
+    fs::path cache_path;
 
 public:
     void set_base_path(const fs::path &p) {
@@ -49,6 +53,54 @@ public:
 
     std::string get_pref_path_string() const {
         return pref_path.generic_path().string();
+    }
+
+    void set_log_path(const fs::path &p) {
+        log_path = p;
+    }
+
+    fs::path get_log_path() const {
+        return log_path;
+    }
+
+    std::string get_log_path_string() const {
+        return log_path.generic_path().string();
+    }
+
+    void set_config_path(const fs::path &p) {
+        config_path = p;
+    }
+
+    fs::path get_config_path() const {
+        return config_path;
+    }
+
+    std::string get_config_path_string() const {
+        return config_path.generic_path().string();
+    }
+
+    void set_shared_path(const fs::path &p) {
+        shared_path = p;
+    }
+
+    fs::path get_shared_path() const {
+        return shared_path;
+    }
+
+    std::string get_shared_path_string() const {
+        return shared_path.generic_path().string();
+    }
+
+    void set_cache_path(const fs::path &p) {
+        cache_path = p;
+    }
+
+    fs::path get_cache_path() const {
+        return cache_path;
+    }
+
+    std::string get_cache_path_string() const {
+        return cache_path.generic_path().string();
     }
 }; // class root
 

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -72,7 +72,7 @@ ExitCode init(const Root &root_paths, bool use_stdout) {
     if (use_stdout)
         sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
 
-    if (add_sink(root_paths.get_base_path() / LOG_FILE_NAME) != Success)
+    if (add_sink(root_paths.get_log_path() / LOG_FILE_NAME) != Success)
         return InitConfigFailed;
 
     spdlog::set_error_handler([](const std::string &msg) {


### PR DESCRIPTION
Fixes #664.

With this PR, Vita3K gains proper support for XDG_DATA_DIRS, XDG_CACHE_HOME, and XDG_CONFIG_HOME. Default paths are constructed according to the XDG specification if those environment variables are not defined.

Everything should have been moved (logs, config, shader cache, static assets, etc.), so there should be no files created or read from the binary directory under Linux (by default) anymore.

I've tried to break up this PR as much as I could, but the biggest changes are for the renderer base class and the need to protect ImGui's IniFilename. Both of those are the last two commits in this PR.
