### PR TITLE
renderer/vulkan, gui: Replace shaders compiled by pipelines compiled on Vulkan

### DIFF
--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -224,11 +224,6 @@ enum ThemePreviewType {
     LOCK,
 };
 
-enum ShadersCompiledDisplay {
-    Time,
-    Count
-};
-
 static constexpr auto MODULES_MODE_COUNT = 3;
 using ConfigModuleMode = std::array<std::vector<const char *>, MODULES_MODE_COUNT>;
 
@@ -359,7 +354,8 @@ struct GuiState {
 
     std::vector<ImGui_Texture> manuals;
 
-    std::map<ShadersCompiledDisplay, uint64_t> shaders_compiled_display;
+    uint64_t shaders_compiled_display_count = 0;
+    uint64_t shaders_compiled_display_time = 0;
 
     SceUID thread_watch_index = -1;
 

--- a/vita3k/gui/src/compile_shaders.cpp
+++ b/vita3k/gui/src/compile_shaders.cpp
@@ -74,14 +74,14 @@ void draw_pre_compiling_shaders_progress(GuiState &gui, EmuEnvState &emuenv, con
 
 void set_shaders_compiled_display(GuiState &gui, EmuEnvState &emuenv) {
     const uint64_t time = std::time(nullptr);
-    if (emuenv.renderer->shaders_count_compiled) {
-        gui.shaders_compiled_display[Count] = emuenv.renderer->shaders_count_compiled;
-        gui.shaders_compiled_display[Time] = time;
+    if (emuenv.renderer->shaders_count_compiled > 0) {
+        gui.shaders_compiled_display_count += emuenv.renderer->shaders_count_compiled;
+        gui.shaders_compiled_display_time = time;
         emuenv.renderer->shaders_count_compiled = 0;
-    } else if (!gui.shaders_compiled_display.empty()) {
+    } else if (gui.shaders_compiled_display_count > 0) {
         // Display shaders compliled count during 3 sec
-        if ((gui.shaders_compiled_display[Time] + 3) <= time)
-            gui.shaders_compiled_display.clear();
+        if ((gui.shaders_compiled_display_time + 3) <= time)
+            gui.shaders_compiled_display_count = 0;
     }
 }
 
@@ -89,7 +89,13 @@ void draw_shaders_count_compiled(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(emuenv.viewport_pos.x + (2.f * emuenv.dpi_scale), emuenv.viewport_pos.y + emuenv.viewport_size.y - (42.f * emuenv.dpi_scale)));
     ImGui::SetNextWindowBgAlpha(0.6f);
     ImGui::Begin("##shaders_compiled", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
-    const auto shaders_compiled_str = fmt::format(fmt::runtime(gui.lang.compile_shaders["shaders_compiled"].c_str()), gui.shaders_compiled_display[Count]);
+    const char *gpu_objects_compiled_msg;
+    if (emuenv.renderer->current_backend == renderer::Backend::Vulkan) {
+        gpu_objects_compiled_msg = gui.lang.compile_shaders["pipelines_compiled"].c_str();
+    } else {
+        gpu_objects_compiled_msg = gui.lang.compile_shaders["shaders_compiled"].c_str();
+    }
+    const auto shaders_compiled_str = fmt::format(fmt::runtime(gpu_objects_compiled_msg), gui.shaders_compiled_display_count);
     ImGui::Text("%s", shaders_compiled_str.c_str());
     ImGui::End();
 }

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -789,7 +789,7 @@ void draw_vita_area(GuiState &gui, EmuEnvState &emuenv) {
     if (gui.vita_area.user_management)
         draw_user_management(gui, emuenv);
 
-    if (emuenv.cfg.show_compile_shaders && !gui.shaders_compiled_display.empty())
+    if (emuenv.cfg.show_compile_shaders && gui.shaders_compiled_display_count > 0)
         draw_shaders_count_compiled(gui, emuenv);
 
     if (!gui.trophy_unlock_display_requests.empty())

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -70,6 +70,7 @@ struct State {
 
     int last_scene_id = 0;
 
+    // on Vulkan, this is actually the number of pipelines compiled
     uint32_t shaders_count_compiled = 0;
     uint32_t programs_count_pre_compiled = 0;
 

--- a/vita3k/renderer/include/renderer/types.h
+++ b/vita3k/renderer/include/renderer/types.h
@@ -135,6 +135,8 @@ struct GxmRecordState {
     bool is_maskupdate = false;
     bool is_gamma_corrected = false;
 
+    uint8_t _padding[6] = {};
+
     // Do not put any state not used for the Vulkan pipeline creation before vertex_streams
     std::array<GXMStreamInfo, SCE_GXM_MAX_VERTEX_STREAMS> vertex_streams;
 

--- a/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
@@ -21,8 +21,8 @@
 #include <limits>
 #include <map>
 #include <set>
-#include <unordered_map>
 
+#include <util/containers.h>
 #include <vkutil/objects.h>
 
 struct SceGxmProgram;
@@ -57,7 +57,7 @@ private:
     // render passes used along shader interlock
     std::map<vk::Format, vk::RenderPass> shader_interlock_pass;
     std::map<Sha256Hash, vk::ShaderModule> shaders;
-    std::unordered_map<uint64_t, vk::Pipeline> pipelines;
+    unordered_map_fast<uint64_t, vk::Pipeline> pipelines;
 
     // temp vars used to store the result computed by auxialiary functions before createPipeline is called
     std::vector<vk::VertexInputBindingDescription> binding_descr;


### PR DESCRIPTION
On Vulkan, what is causing stutter is not really the step to create the ShaderModule, but instead a new pipeline creation. These two often coincide but sometimes not (also a lot more pipelines are created compared to shader compiled).

This PR changes the message on Vulkan from "k shaders compiled" to "k pipelines compiled" to have a better understanding of if a pipeline compilation is causing the stutter.
I also changed the pipeline lookup from an unordered_map to a boost unordered_map_flat, as this structure is accessed a lot.