### PR TITLE
shader: Increase repeat offset for GPI on mode both

### DIFF
--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -142,13 +142,13 @@ private:
     [[maybe_unused]] int src2_repeat_offset = get_repeat_offset(inst.opr.src2, current_repeat, repeat_mode, inst.opr.src2.bank);
 
     const int get_repeat_offset(Operand &op, const std::uint8_t repeat_index, RepeatMode repeat_mode, RegisterBank bank) {
-        if (repeat_mode == RepeatMode::INTERNAL) {
+        if (repeat_mode == RepeatMode::INTERNAL || repeat_mode == RepeatMode::BOTH) {
             if (bank == RegisterBank::FPINTERNAL) {
                 return repeat_index;
             }
         }
-        // GPI operand can only get repeat offset with INTERNAL repeat mode.
-        // Intentionally put this here so that INTERNAL is checked with every FPINTERNAL, even if not GPI.
+        // GPI operand can only get repeat offset with INTERNAL/BOTH repeat mode.
+        // Intentionally put this here so that INTERNAL/BOTH is checked with every FPINTERNAL, even if not GPI.
         if (op.flags & RegisterFlags::GPI) {
             return 0;
         }


### PR DESCRIPTION
The RepeatMode Both means that both internal and external register must be increased during each step.

This (partially) fixes graphics in Chaos Rings 2.