### PR TITLE
renderer/vulkan: Rewrite surface cache

### DIFF
--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -27,6 +27,7 @@
 #include <mem/ptr.h>
 #include <mem/util.h>
 #include <rtc/rtc.h>
+#include <util/containers.h>
 #include <util/pool.h>
 
 #include <atomic>
@@ -38,8 +39,6 @@
 #include <shared_mutex>
 #include <unordered_map>
 #include <vector>
-
-#include <boost/version.hpp>
 
 struct ThreadState;
 
@@ -61,15 +60,7 @@ typedef std::shared_ptr<SDL_Thread> ThreadPtr;
 typedef std::map<SceUID, ThreadPtr> ThreadPtrs;
 typedef std::map<SceUID, SceKernelModuleInfoPtr> SceKernelModuleInfoPtrs;
 typedef std::map<SceUID, CallbackPtr> CallbackPtrs;
-
-#if BOOST_VERSION >= 108100
-#include <boost/unordered/unordered_flat_map.hpp>
-// use a boost unordered_flat_map as performance really matters for this field
-typedef boost::unordered::unordered_flat_map<uint32_t, Address> ExportNids;
-#else
-// fallback in case someone is using an old boost version
-typedef std::unordered_map<uint32_t, Address> ExportNids;
-#endif
+typedef unordered_map_fast<uint32_t, Address> ExportNids;
 
 typedef std::map<Address, uint32_t> NotFoundVars;
 typedef std::unique_ptr<CPUProtocol> CPUProtocolPtr;

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -1226,7 +1226,7 @@ static int init_texture_base(const char *export_name, SceGxmTexture *texture, Pt
     if (width > 4096 || height > 4096 || mipCount > 13) {
         return RET_ERROR(SCE_GXM_ERROR_INVALID_VALUE);
     }
-    // data can be empty to be filled out later.
+    memset(texture, 0, sizeof(SceGxmTexture));
 
     texture->mip_count = std::min<std::uint32_t>(15, mipCount - 1);
     texture->format0 = (tex_format & 0x80000000) >> 31;
@@ -4871,6 +4871,8 @@ EXPORT(int, sceGxmTextureInitLinearStrided, SceGxmTexture *texture, Ptr<const vo
     if ((byteStride < 4) || (byteStride > 131072)) {
         return RET_ERROR(SCE_GXM_ERROR_INVALID_VALUE);
     }
+
+    memset(texture, 0, sizeof(SceGxmTexture));
 
     const uint32_t stride_compressed = (byteStride >> 2) - 1;
     texture->mip_filter = stride_compressed & 1;

--- a/vita3k/renderer/include/renderer/gl/types.h
+++ b/vita3k/renderer/include/renderer/gl/types.h
@@ -57,7 +57,7 @@ class GLTextureCache : public TextureCache {
 public:
     GLObjectArray<TextureCacheSize> textures;
 
-    bool init(const bool hashless_texture_cache) override;
+    bool init(const bool hashless_texture_cache);
     void select(size_t index, const SceGxmTexture &texture) override;
     void configure_texture(const SceGxmTexture &texture) override;
     void upload_texture_impl(SceGxmTextureBaseFormat base_format, uint32_t width, uint32_t height, uint32_t mip_index, const void *pixels, int face, uint32_t pixels_per_stride) override;

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -58,8 +58,4 @@ void sync_visibility_index(VKContext &context, bool enable, uint32_t index, bool
 
 void refresh_pipeline(VKContext &context);
 
-namespace texture {
-vk::Sampler create_sampler(VKState &state, const SceGxmTexture &gxm_texture, const uint16_t mip_count = 1);
-} // namespace texture
-
 } // namespace renderer::vulkan

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -350,7 +350,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
     // we need to always load the depth-stencil after the first draw
     if (context.is_first_scene_draw && (context.state.features.support_shader_interlock || context.ignore_macroblock)) {
         // update the render pass to load and store the depth and stencil
-        context.current_render_pass = context.state.pipeline_cache.retrieve_render_pass(context.current_color_attachment->format, true, true);
+        context.current_render_pass = context.state.pipeline_cache.retrieve_render_pass(context.current_color_format, true, true);
         context.is_first_scene_draw = false;
     }
 
@@ -365,7 +365,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
             .newLayout = vk::ImageLayout::eGeneral,
             .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
             .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-            .image = context.current_color_attachment->image,
+            .image = context.current_color_base_image->image,
             .subresourceRange = vkutil::color_subresource_range
         };
         context.render_cmd.pipelineBarrier(vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eFragmentShader,

--- a/vita3k/util/include/util/containers.h
+++ b/vita3k/util/include/util/containers.h
@@ -1,0 +1,99 @@
+// Vita3K emulator project
+// Copyright (C) 2023 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <boost/version.hpp>
+
+#include <vector>
+
+#if BOOST_VERSION >= 108100
+#include <boost/unordered/unordered_flat_map.hpp>
+// use a boost unordered_flat_map as performance really matters for fields using this type
+template <typename T, typename S>
+using unordered_map_fast = boost::unordered::unordered_flat_map<T, S>;
+#else
+// fallback in case someone is using an old boost version
+#include <boost/unordered_map.hpp>
+template <typename T, typename S>
+using unordered_map_fast = boost::unordered_map<T, S>;
+#endif
+
+namespace lru {
+
+template <typename T>
+struct Item {
+    Item<T> *next;
+    Item<T> *prev;
+    T content;
+};
+
+// A container which supports getting the least recently used item and setting an item as the most recently used
+template <typename T>
+struct Queue {
+    std::vector<Item<T>> items;
+    Item<T> *head;
+
+    void init(const size_t size) {
+        // workaround in case T is not copy/move constructible
+        items = std::vector<Item<T>>(size);
+
+        // initialize the doubly linked list
+        // make it so that items are first considered in the order of the array
+        for (size_t i = 0; i < size; i++) {
+            items[i].prev = &items[(i + 1) % size];
+            items[i].next = &items[(i - 1 + size) % size];
+        }
+        head = &items[size - 1];
+    }
+
+    // get the least recently used element
+    T *get_lru() const {
+        // it is at the end of the list (so before the first one)
+        return &head->prev->content;
+    }
+
+    // set an element as the most recently used
+    void set_as_mru(T *ptr) {
+        // get the item from a pointer to its content
+        // removed the offsetof to avoid compilation warnings
+        Item<T> *item = reinterpret_cast<Item<T> *>(reinterpret_cast<char *>(ptr) - 2 * sizeof(void *) /* offsetof(Item<T>, content)*/);
+        if (item == head)
+            return;
+
+        // remove it from its position
+        item->prev->next = item->next;
+        item->next->prev = item->prev;
+
+        // update the item itself
+        item->prev = head->prev;
+        item->next = head;
+
+        // insert it as the head
+        item->prev->next = item;
+        item->next->prev = item;
+        head = item;
+    }
+
+    // set an element as the least recently used (useful if it is removed)
+    void set_as_lru(T *ptr) {
+        // just set as mru and change the head
+        set_as_mru(ptr);
+        head = head->next;
+    }
+};
+} // namespace lru


### PR DESCRIPTION
The current vulkan surface cache was basically a copy-paste of the opengl surface cache, swapping opengl functions with vulkan functions.
But it had many issues related to the fact it was really complex and to the way vulkan is a lot closer to the harware:
- create two different functions for retrieving surfaces either as a framebuffer or as a texture. Make the code much more readable and easy to modify.
- Refractor the result given when retrieving textures from the surface cache so that a whole new Image field does not have to be created when all we want is a different view
- The sampler state is different compared to the texture state in Vulkan. So create a separate sampler cache for it. This avoids duplication of textures if the only thing which changes is the filter or lod parameter. This will also be needed for my next PR.
- Rewrite the way removing the least recently used texture is done (using a vector is pretty bad for it, even if the cache is small).
- A few other fixes here and there I did while rewriting the cache.

This shouldn't do much on its own (maybe reduce memory usage as it avoids some texture duplication (and a lot of sampler duplication but that shouldn't matter) but is needed for future improvements.