### PR TITLE
tracy: autoregister modules, faster check if module is profiling

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -306,6 +306,7 @@ option(TRACY_ENABLE_ON_CORE_COMPONENTS
 	"Enable and require Tracy to compile core components such as the renderer, shader recompiler and
 		HLE modules"
 	ON)
+option(TRACY_NO_FRAME_IMAGE, ON)
 add_library(tracy STATIC tracy/public/TracyClient.cpp)
 target_include_directories(tracy SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tracy/public>)
 target_link_libraries(tracy PUBLIC ${CMAKE_DL_LIBS})

--- a/vita3k/config/include/config/functions.h
+++ b/vita3k/config/include/config/functions.h
@@ -42,20 +42,4 @@ ExitCode serialize_config(Config &cfg, const fs::path &output_path);
  */
 ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths);
 
-#ifdef TRACY_ENABLE
-/**
- * @brief Detect the Tracy advanced profiling activation state for a given HLE module
- *
- * @param active_modules Vector meant to contain the names of every module with Tracy advanced profiling enabled
- * @param module Name of the module to check the activation state for
- * @param index Variable where to store the calculated index where the name of the module is stored in
- * `emuenv.cfg.tracy_advanced_profiling_modules`. Useful to save on `std::find()` calls. It is recommended to initialize
- * the variable with `-1` before passing it to this function.
- * @return true Advanced profiling using Tracy is enabled for the module
- * @return false Advanced profiling using Tracy is not enabled for the module or module isn't available
- * for advanced profiling.
- */
-bool is_tracy_advanced_profiling_active_for_module(std::vector<std::string> &active_modules, const std::string &module, int *index = nullptr);
-#endif // TRACY_ENABLE
-
 } // namespace config

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -21,6 +21,9 @@
 #include <config/yaml.h>
 
 #include <util/fs.h>
+#ifdef TRACY_ENABLE
+#include <util/tracy_module_utils.h>
+#endif
 #include <util/vector_utils.h>
 
 #include <optional>
@@ -52,6 +55,10 @@ private:
 
         CONFIG_LIST(UPDATE_MEMBERS)
 #undef UPDATE_MEMBERS
+#ifdef TRACY_ENABLE
+        tracy_module_utils::cleanup(tracy_advanced_profiling_modules);
+        tracy_module_utils::load_from(tracy_advanced_profiling_modules);
+#endif
     }
 
     // Perform comparisons with optional settings
@@ -100,68 +107,6 @@ public:
     bool fullscreen = false;
     bool console = false;
     bool load_app_list = false;
-
-    /**
-     * @brief Available HLE modules for advanced profiling using Tracy
-     *
-     * Advanced profiling using Tracy allows for function calls to be logged with their arguments
-     * Please keep them in order.
-     */
-    const std::set<std::string> tracy_available_advanced_profiling_modules = {
-        "Renderer commands",
-        "SceAppMgr",
-        "SceAppMgrUser",
-        "SceAppUtil",
-        "SceAtrac",
-        "SceAudio",
-        "SceAudiodecUser",
-        "SceAudioIn",
-        "SceCodecEngineUser",
-        "SceCommonDialog",
-        "SceCtrl",
-        "SceDbg",
-        "SceDisplay",
-        "SceDisplayUser",
-        "SceFiber",
-        "SceFios2Kernel",
-        "SceFios2User",
-        "SceGxm",
-        "SceHttp",
-        "SceIme",
-        "SceIofilemgr",
-        "SceJpegEncUser",
-        "SceJpegUser",
-        "SceKernelForMono",
-        "SceKernelForVM",
-        "SceLibc",
-        "SceLibKernel",
-        "SceLibm",
-        "SceLibRng",
-        "SceLibstdcxx",
-        "SceModulemgr",
-        "SceMotion",
-        "SceNet",
-        "SceNetCtl",
-        "SceNetInternal",
-        "SceNgs",
-        "SceNpCommon",
-        "SceNpManager",
-        "SceNpTrophy",
-        "ScePafStdc",
-        "ScePower",
-        "SceProcessmgr",
-        "SceRegMgr",
-        "SceRtc",
-        "SceRtcUser",
-        "SceSblRng",
-        "SceSsl",
-        "SceSysmem",
-        "SceSysmodule",
-        "SceThreadmgr",
-        "SceThreadmgrCoredumpTime",
-        "SceTouch",
-        "SceVideodecUser"
-    };
 
     /**
      * @brief Config struct for per-app configurable settings

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -277,36 +277,4 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
     return Success;
 }
 
-#ifdef TRACY_ENABLE
-bool is_tracy_advanced_profiling_active_for_module(std::vector<std::string> &active_modules, const std::string &module, int *index) {
-    // If we dont care about the index that means that its getting executed from an export
-    // And because of that we know its sorted so we can use binary search so it
-    // doesn't hurt performance as a standard std::find, also we just care for the result
-    if (!index)
-        return std::binary_search(active_modules.begin(), active_modules.end(), module);
-
-    bool result = false;
-
-    // Retrieve index for module name in the list of enabled modules
-    auto iterator = std::find(active_modules.begin(), active_modules.end(), module);
-
-    // Check the index the iterator references to (`std::find()` returns `last` if no match was found)
-    if (iterator == active_modules.end()) {
-        // Return false if no match is found in the active modules vector
-        result = false;
-    } else {
-        // Return true if there was at least one match
-        result = true;
-    }
-
-    // If index is being requested and the module name was found
-    if (result) {
-        // Calculate the distance between the first element in the module and
-        *index = std::distance(active_modules.begin(), iterator);
-    }
-
-    return result;
-}
-#endif // TRACY_ENABLE
-
 } // namespace config

--- a/vita3k/module/include/module/bridge.h
+++ b/vita3k/module/include/module/bridge.h
@@ -52,8 +52,7 @@ ImportFn bridge(Ret (*export_fn)(EmuEnvState &, SceUID, const char *, Args...), 
 
     return [export_fn, export_name, args_layout](EmuEnvState &emuenv, CPUState &cpu, SceUID thread_id) {
 #ifdef TRACY_ENABLE
-        ZoneNamed(___tracy_scoped_zone, emuenv.cfg.tracy_primitive_impl); // Tracy - Track function scope
-        ZoneColorV(___tracy_scoped_zone, 0xFFF34C); // Tracy - Change color to yellow
+        ZoneNamedC(___tracy_scoped_zone, 0xFFF34C, emuenv.cfg.tracy_primitive_impl); // Tracy - Track function scope and set color to yellow
         ZoneNameV(___tracy_scoped_zone, export_name, strlen(export_name)); // Tracy - Edit scope name based on export_name
 #endif
 

--- a/vita3k/util/CMakeLists.txt
+++ b/vita3k/util/CMakeLists.txt
@@ -7,3 +7,5 @@ add_library(
 
 target_include_directories(util PUBLIC include)
 target_link_libraries(util PUBLIC ${Boost_LIBRARIES} config fmt spdlog http mem)
+target_compile_definitions(util PRIVATE $<$<CONFIG:Debug,RelWithDebInfo>:TRACY_ENABLE>)
+

--- a/vita3k/util/include/util/tracy_module_utils.h
+++ b/vita3k/util/include/util/tracy_module_utils.h
@@ -1,0 +1,39 @@
+// Vita3K emulator project
+// Copyright (C) 2023 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+namespace tracy_module_utils {
+
+// Helper struct to register module names on application startup. It is used in TRACY_MODULE_NAME macro
+struct tracy_module_helper {
+    int mod_id;
+    tracy_module_helper(const char *module_name);
+};
+
+// function for tracy macro to check if module is active
+bool is_tracy_active(tracy_module_helper module);
+
+// functions for settings dialog
+std::vector<std::string> get_available_module_names();
+bool is_tracy_active(const std::string &module);
+void set_tracy_active(const std::string &module, bool value);
+// function for config loading
+void load_from(const std::vector<std::string> &active_modules_str);
+// remove non-existent modules
+void cleanup(std::vector<std::string> &active_modules_str);
+} // namespace tracy_module_utils

--- a/vita3k/util/include/util/vector_utils.h
+++ b/vita3k/util/include/util/vector_utils.h
@@ -43,4 +43,16 @@ std::vector<T, A> merge_vectors(const std::vector<T, A> &cur, const std::vector<
     return new_vector;
 }
 
+template <typename T, typename A = std::allocator<T>>
+size_t find_index(const std::vector<T, A> &v, const T &value) {
+    auto it = std::find(v.begin(), v.end(), value);
+    if (it != v.end()) {
+        // The value was found, return its index
+        return std::distance(v.begin(), it);
+    } else {
+        // The value was not found, return -1
+        return -1;
+    }
+}
+
 } // namespace vector_utils

--- a/vita3k/util/src/util.cpp
+++ b/vita3k/util/src/util.cpp
@@ -21,6 +21,7 @@
 #include <util/log.h>
 #include <util/net_utils.h>
 #include <util/string_utils.h>
+#include <util/vector_utils.h>
 
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/msvc_sink.h>
@@ -42,12 +43,12 @@
 #endif
 
 #include <algorithm>
+#include <bitset>
 #include <codecvt> // std::codecvt_utf8
 #include <iostream>
 #include <locale> // std::wstring_convert
 #include <map>
 #include <memory>
-#include <regex>
 #include <set>
 #include <sstream>
 #include <string>
@@ -193,6 +194,67 @@ void register_log_exception_handler() {
 void register_log_exception_handler() {}
 #endif
 } // namespace logging
+
+#ifdef TRACY_ENABLE
+#include <util/tracy_module_utils.h>
+
+namespace tracy_module_utils {
+
+constexpr int max_modules = 64; // If not enough increase to 64*n
+typedef std::bitset<max_modules> tracy_module_flags;
+typedef std::vector<std::string> tracy_module_names;
+
+tracy_module_names tracy_available_advanced_profiling_modules{};
+tracy_module_flags tracy_advanced_profiling_modules{};
+
+tracy_module_helper::tracy_module_helper(const char *module_name) {
+    mod_id = tracy_available_advanced_profiling_modules.size();
+    tracy_available_advanced_profiling_modules.emplace_back(module_name);
+    if (mod_id >= max_modules) {
+        LOG_ERROR_ONCE("Too many tracy modules. Increase max_modules const");
+    }
+}
+
+bool is_tracy_active(tracy_module_helper module) {
+    return tracy_advanced_profiling_modules.test(module.mod_id);
+}
+
+bool is_tracy_active(const std::string &module) {
+    int module_index = vector_utils::find_index(tracy_available_advanced_profiling_modules, module);
+    if (module_index >= 0)
+        return tracy_advanced_profiling_modules.test(module_index);
+    else
+        return false;
+}
+
+void set_tracy_active(const std::string &module, bool value) {
+    int module_index = vector_utils::find_index(tracy_available_advanced_profiling_modules, module);
+    if (module_index >= 0) {
+        tracy_advanced_profiling_modules.set(module_index, value);
+    }
+}
+
+std::vector<std::string> get_available_module_names() {
+    std::vector<std::string> names = tracy_available_advanced_profiling_modules;
+    std::sort(names.begin(), names.end());
+    return names;
+}
+
+void load_from(const std::vector<std::string> &active_modules_str) {
+    tracy_advanced_profiling_modules.reset();
+    for (auto &module : active_modules_str)
+        set_tracy_active(module, true);
+}
+
+void cleanup(std::vector<std::string> &active_modules_str) {
+    // remove if not found in tracy_available_advanced_profiling_modules
+    std::erase_if(active_modules_str, [](const std::string &module) {
+        return std::find(tracy_available_advanced_profiling_modules.begin(), tracy_available_advanced_profiling_modules.end(), module) == tracy_available_advanced_profiling_modules.end();
+    });
+}
+
+} // namespace tracy_module_utils
+#endif
 
 namespace string_utils {
 


### PR DESCRIPTION
Main idea of this PR is optimization of tracy usage
* automatic collection of modules list for advanced profiling. Remove available modules list from config.
* faster check if module is active for advanced profiling
* rename some macro not used yet to correspond tracy naming convention
* disable unused tracy option to save screenshots on demand. This option create background thread to compress that images, so it's better to disable this if nobody use it.
* some minor code improvements

I use global variables because I'm lazy.