### PR TITLE
shader: Fix loading of negative immediate and implement rotation

### DIFF
--- a/vita3k/shader/src/usse_disasm.cpp
+++ b/vita3k/shader/src/usse_disasm.cpp
@@ -177,20 +177,20 @@ std::string reg_to_str(RegisterBank bank, uint32_t reg_num) {
 std::string operand_to_str(const Operand &op, Imm4 write_mask, int32_t shift) {
     std::string opstr = reg_to_str(op.bank, op.num + shift);
 
-    if (op.bank == RegisterBank::IMMEDIATE) {
-        return opstr;
-    }
-
-    if (write_mask != 0) {
-        opstr += "." + swizzle_to_str<4>(op.swizzle, write_mask);
-    }
-
     if (op.flags & RegisterFlags::Negative) {
         opstr = "-" + opstr;
     }
 
     if (op.flags & RegisterFlags::Absolute) {
         opstr = "abs(" + opstr + ")";
+    }
+
+    if (op.bank == RegisterBank::IMMEDIATE) {
+        return opstr;
+    }
+
+    if (write_mask != 0) {
+        opstr += "." + swizzle_to_str<4>(op.swizzle, write_mask);
     }
 
     return opstr;

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -1002,7 +1002,7 @@ spv::Id load(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunc
             }
 
             if (dest_comp_count == 1) {
-                return constant;
+                return apply_modifiers(b, utils, op.flags, constant);
             }
 
             std::vector<spv::Id> ops(dest_comp_count, constant);


### PR DESCRIPTION
This fixes the graphics of the refined version of Odin's sphere.
Clearing the shader cache is required to see the improvement.
![image](https://github.com/Vita3K/Vita3K/assets/5671744/eff916ed-db4c-4cdf-a611-799c60193bf2)
