### PR TITLE
ci: Dont bundle OpenSSL libs anymore

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -116,14 +116,6 @@ jobs:
         run: echo "build_variable=$(git rev-list HEAD --count)" >> $GITHUB_ENV
         if: matrix.os == 'ubuntu-latest'
 
-      - name: Bundle OpenSSL shared objects
-        id: bundle_openssl
-        run: |
-            cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
-            cp /usr/lib/x86_64-linux-gnu/libssl.so.3 ./libssl.so.3
-            cp /usr/lib/x86_64-linux-gnu/libcrypto.so.3 ./libcrypto.so.3
-        if: matrix.os == 'ubuntu-latest'
-        
       - name: Create DMG (macos-latest)
         run: |
           cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}


### PR DESCRIPTION
Older version of OpenSSL (1.1.0/1.1.1 LTS) are not maintained anymore since 9/11 (i swear this is a coincidence). So it makes sense to not bundle them anymore as they are not needed since at this point (1 year later since the switch to 3.x of mostly all distros) should have already updated from it.
Gonna leave as draft to just to make sure there isnt any major distro which still hasnt updated (SteamOS, LTS version of some distro, etc)