### PR TITLE
gui: Add log of NFD Error in ever case it can happen

### DIFF
--- a/vita3k/gui/src/archive_install_dialog.cpp
+++ b/vita3k/gui/src/archive_install_dialog.cpp
@@ -120,8 +120,11 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             }
             if (result == host::dialog::filesystem::Result::SUCCESS) {
                 state = "install";
-            } else
+            } else {
+                if (result == host::dialog::filesystem::Result::ERROR)
+                    LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
                 type.clear();
+            }
         } else if (state == "install") {
             std::thread installation([&emuenv, &gui]() {
                 global_progress = 1.f;

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -171,6 +171,8 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
             if ((result == host::dialog::filesystem::Result::SUCCESS) && (emulator_path.wstring() != emuenv.pref_path)) {
                 emuenv.pref_path = emulator_path.wstring() + L'/';
                 emuenv.cfg.pref_path = emulator_path.string();
+            } else if (result == host::dialog::filesystem::Result::ERROR) {
+                LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
             }
         }
         if (!is_default_path) {

--- a/vita3k/gui/src/license_install_dialog.cpp
+++ b/vita3k/gui/src/license_install_dialog.cpp
@@ -74,8 +74,12 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 state = "success";
             else
                 state = "fail";
-        } else
+        } else {
+            if (result == host::dialog::filesystem::Result::ERROR)
+                LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
+
             state.clear();
+        }
     } else if (state == "zrif") {
         title = license["enter_zrif_key"];
         ImGui::PushItemWidth(640.f * SCALE.x);

--- a/vita3k/gui/src/pkg_install_dialog.cpp
+++ b/vita3k/gui/src/pkg_install_dialog.cpp
@@ -103,8 +103,11 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 fs::ifstream binfile(license_path.wstring(), std::ios::in | std::ios::binary | std::ios::ate);
                 zRIF = rif2zrif(binfile);
                 state = "install";
-            } else
+            } else {
+                if (result == host::dialog::filesystem::Result::ERROR)
+                    LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
                 state.clear();
+            }
         } else if (state == "zrif") {
             title = lang["enter_zrif_key"];
             ImGui::PushItemWidth(640.f * SCALE.x);

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -32,6 +32,8 @@
 #include <pugixml.hpp>
 #include <stb_image.h>
 
+#undef ERROR
+
 namespace gui {
 
 struct Theme {
@@ -606,6 +608,9 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                             gui.users[emuenv.io.user_id].start_type = "image";
                             save_user(gui, emuenv, emuenv.io.user_id);
                         }
+                        if (result == host::dialog::filesystem::Result::ERROR) {
+                            LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
+                        }
                         sub_menu.clear();
                     } else if (sub_menu == "default") {
                         title = theme_background.main["default"];
@@ -668,6 +673,9 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                             gui.users[emuenv.io.user_id].use_theme_bg = false;
                             save_user(gui, emuenv, emuenv.io.user_id);
                         }
+                    }
+                    if (result == host::dialog::filesystem::Result::ERROR) {
+                        LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
                     }
                 }
                 ImGui::PopStyleVar();

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -48,6 +48,8 @@
 #include <pugixml.hpp>
 #include <sstream>
 
+#undef ERROR
+
 namespace gui {
 
 /**
@@ -117,6 +119,10 @@ static void change_emulator_path(GuiState &gui, EmuEnvState &emuenv) {
         // TODO: Move app old to new path
         reset_emulator(gui, emuenv);
         LOG_INFO("Successfully moved Vita3K path to: {}", emuenv.pref_path.string());
+    }
+
+    if (result == host::dialog::filesystem::Result::ERROR) {
+        LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
     }
 }
 

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -34,6 +34,8 @@
 #include <pugixml.hpp>
 #include <stb_image.h>
 
+#undef ERROR
+
 namespace gui {
 
 enum AvatarSize {
@@ -677,6 +679,9 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
 
             if ((result == host::dialog::filesystem::Result::SUCCESS) && init_avatar(gui, emuenv, "temp", avatar_path.string()))
                 temp.avatar = avatar_path.string();
+
+            if (result == host::dialog::filesystem::Result::ERROR)
+                LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
         }
         ImGui::SetWindowFontScale(0.8f);
         const auto INPUT_NAME_SIZE = 330.f * SCALE.x;


### PR DESCRIPTION
There were many cases where (especially in initial setup) where the native file dialog would fail to open either due to bad system config or something else, now instead of just doing nothing it will actually log why it failed to open the file dialog in case it happens.
Especially useful for experienced users which can debug and fix it if the error is bad configuration on system side