### PR TITLE
shader: Fix loading of indexed values

### DIFF
--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -165,7 +165,10 @@ private:
         if (repeat_mode == RepeatMode::SLMSI) {
             auto inc = repeat_increase[op.index][repeat_index];
 
-            if (((bank >= RegisterBank::TEMP) && (bank <= RegisterBank::SECATTR)) || bank == RegisterBank::PREDICATE)
+            if (((bank >= RegisterBank::TEMP) && (bank <= RegisterBank::SECATTR))
+                || bank == RegisterBank::PREDICATE
+                || bank == RegisterBank::INDEXED1
+                || bank == RegisterBank::INDEXED2)
                 inc *= repeat_multiplier[op.index];
 
             return inc;

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -43,7 +43,7 @@ struct SpirvUtilFunctions {
     spv::Id buffer_address_vec[5][2] = {};
 };
 
-spv::Id finalize(spv::Builder &b, spv::Id first, spv::Id second, const Swizzle4 swizz, const int offset, const Imm4 dest_mask);
+spv::Id finalize(spv::Builder &b, spv::Id first, spv::Id second, const Swizzle4 swizz, spv::Id offset, const Imm4 dest_mask);
 spv::Id load(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand op, const Imm4 dest_mask, int shift_offset);
 void store(spv::Builder &b, const SpirvShaderParameters &params, SpirvUtilFunctions &utils, const FeatureState &features, Operand dest, spv::Id source, std::uint8_t dest_mask, int off);
 

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -309,7 +309,7 @@ static spv::Id create_input_variable(spv::Builder &b, SpirvShaderParameters &par
         if (!b.isConstant(var)) {
             if (b.isPointer(var))
                 var = b.createLoad(var, spv::NoPrecision);
-            var = utils::finalize(b, var, var, SWIZZLE_CHANNEL_4_DEFAULT, 0, dest_mask);
+            var = utils::finalize(b, var, var, SWIZZLE_CHANNEL_4_DEFAULT, b.makeIntConstant(0), dest_mask);
 
             if (!features.support_rgb_attributes && !translation_state.is_fragment && dest_mask == 0b1111) {
                 // if the vertex input was rgb, the alpha component must be set to 1,

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -495,7 +495,7 @@ bool USSETranslatorVisitor::vpck(
         src2.swizzle = SWIZZLE_CHANNEL_4_DEFAULT;
         spv::Id source1 = load(src1, 0b11, src1_repeat_offset);
         spv::Id source2 = load(src2, 0b11, src2_repeat_offset);
-        source = utils::finalize(m_b, source1, source2, inst.opr.src1.swizzle, 0, dest_mask);
+        source = utils::finalize(m_b, source1, source2, inst.opr.src1.swizzle, m_b.makeIntConstant(0), dest_mask);
     }
 
     // source is int destination is float


### PR DESCRIPTION
Indexed values had a few issues:
- The shift offset wasn't considered
- The value position is not known at compile time, so the code has to be modified to do the vec4 offset computation in spirv instead of in c++ when it is not possible to do the latter. 

This fixes the screen transition in hyperdimension neptunia games.