### PR TITLE
shader: Do not sample to PA in secondary program

### DIFF
--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -249,6 +249,9 @@ bool USSETranslatorVisitor::smp(
 
     // Decode dest
     inst.opr.dest.bank = (dest_use_pa) ? RegisterBank::PRIMATTR : RegisterBank::TEMP;
+    if (dest_use_pa && m_second_program)
+        // PA can't be used in the secondary program
+        inst.opr.dest.bank = RegisterBank::SECATTR;
     inst.opr.dest.num = dest_n;
     inst.opr.dest.type = tb_dest_fmt[fconv_type];
 


### PR DESCRIPTION
The PA registers can't be used in the secondary program, replace it by SA when it happens.

This fixes the character borders in Hyperdimension Neptunia games.