### PR TITLE
renderer/vulkan: Improve macroblock slow path workaround

### DIFF
--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -441,11 +441,13 @@ void VKContext::check_for_macroblock_change(bool is_draw) {
     if (!render_target->has_macroblock_sync)
         return;
 
-    if (scissor.extent.width == render_target->width && scissor.extent.height == render_target->height) {
+    if (!ignore_macroblock && (scissor.extent.width > render_target->macroblock_width || scissor.extent.height > render_target->macroblock_height)) {
         // flower does not specify a scissor adapted to the current macroblock
         // so fallback to the slow path (one scene per draw, can't really do better)
         // TODO: with the feedback loop extension we can do better
         ignore_macroblock = true;
+        // in this case we must load and store the depth stencil each time
+        current_render_pass = state.pipeline_cache.retrieve_render_pass(current_color_format, true, true);
     }
 
     // use the scissor to know in which macroblock we are


### PR DESCRIPTION
Hyperdimension neptunia also does not respect the macroblock constraints (but this time the scissor extent is not the rendertarget extent). Handle this case for the slow path.
Also replace the renderpass by one which loads and saves the stencil each time, as this is needed for the slow path.

This fixes half the screen being black in hyperdimension neptunia.