### PR TITLE
config, gui: Add option to disable checking for updates

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -135,6 +135,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "user-auto-connect", false, auto_user_login)                                             \
     code(bool, "display-info-message", true, display_info_message)                                      \
     code(bool, "show-welcome", true, show_welcome)                                                      \
+    code(bool, "check-for-updates", true, check_for_updates)                                            \
     code(bool, "asia-font-support", false, asia_font_support)                                           \
     code(bool, "shader-cache", true, shader_cache)                                                      \
     code(bool, "spirv-shader", false, spirv_shader)                                                     \

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -828,6 +828,10 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Checkbox("Log Compatibility Warnings", &emuenv.cfg.log_compat_warn);
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Check the box to log issues related to the app compatibility database.");
+        ImGui::Spacing();
+        ImGui::Checkbox("Check for updates", &emuenv.cfg.check_for_updates);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Automatically check for updates at startup.");
         ImGui::Separator();
         const auto perfomance_overley_size = ImGui::CalcTextSize("Performance overlay").x;
         ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (perfomance_overley_size / 2.f));

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -243,11 +243,13 @@ void open_user(GuiState &gui, EmuEnvState &emuenv) {
     gui.vita_area.start_screen = true;
 
 #ifdef USE_VITA3K_UPDATE
-    std::thread update_vita3k_thread([&gui]() {
-        if (init_vita3k_update(gui))
-            gui.help_menu.vita3k_update = true;
-    });
-    update_vita3k_thread.detach();
+    if (emuenv.cfg.check_for_updates) {
+        std::thread update_vita3k_thread([&gui]() {
+            if (init_vita3k_update(gui))
+                gui.help_menu.vita3k_update = true;
+        });
+        update_vita3k_thread.detach();
+    }
 #endif
 }
 


### PR DESCRIPTION
At the request of retrodeck's developper, add an option to disable checking for updates during startup.