### PR TITLE
renderer: Multiple improvements for texture replacement

### DIFF
--- a/external/ddspp/ddspp.h
+++ b/external/ddspp/ddspp.h
@@ -1018,19 +1018,33 @@ namespace ddspp
 		else
 		{
 			unsigned long long mipChainSize = 0;
+			unsigned int width = desc.width;
+			unsigned int height = desc.height;
 
 			for (unsigned int m = 0; m < desc.numMips; ++m)
 			{
-				unsigned long long mipSize = mip0Size >> 2 * m; // Divide by 2 in width and height
-				mipChainSize += mipSize > desc.bitsPerPixelOrBlock ? mipSize : desc.bitsPerPixelOrBlock;
+				unsigned long long blocksX = (width + desc.blockWidth - 1) / desc.blockWidth;
+				unsigned long long blocksY = (height + desc.blockHeight - 1) / desc.blockHeight;
+				unsigned long long mipSize = blocksX * blocksY * desc.bitsPerPixelOrBlock;
+				mipChainSize += mipSize;
+
+				width >>= 1;
+				height >>= 1;
 			}
 
 			offset += mipChainSize * slice;
 
+			width = desc.width;
+			height = desc.height;
 			for (unsigned int m = 0; m < mip; ++m)
 			{
-				unsigned long long mipSize = mip0Size >> 2 * m; // Divide by 2 in width and height
+				unsigned long long blocksX = (width + desc.blockWidth - 1) / desc.blockWidth;
+				unsigned long long blocksY = (height + desc.blockHeight - 1) / desc.blockHeight;
+				unsigned long long mipSize = blocksX * blocksY * desc.bitsPerPixelOrBlock;
 				offset += mipSize > desc.bitsPerPixelOrBlock ? mipSize : desc.bitsPerPixelOrBlock;
+
+				width >>= 1;
+				height >>= 1;
 			}
 		}
 

--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -400,7 +400,14 @@ enum SceGxmTextureBaseFormat : uint32_t {
     SCE_GXM_TEXTURE_BASE_FORMAT_P8 = 0x95000000,
     SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8 = 0x98000000,
     SCE_GXM_TEXTURE_BASE_FORMAT_S8S8S8 = 0x99000000,
-    SCE_GXM_TEXTURE_BASE_FORMAT_U2F10F10F10 = 0x9A000000
+    SCE_GXM_TEXTURE_BASE_FORMAT_U2F10F10F10 = 0x9A000000,
+
+    // Fake formats, these format are not defined nor supported on a real PS Vita
+    // They are defined and used here for texture replacement: a replaced texture
+    // can use the following formats
+    SCE_GXM_TEXTURE_BASE_FORMAT_UBC6H = 0xFF000001,
+    SCE_GXM_TEXTURE_BASE_FORMAT_SBC6H = 0xFF000002,
+    SCE_GXM_TEXTURE_BASE_FORMAT_UBC7 = 0xFF000003,
 };
 
 template <typename T>

--- a/vita3k/gxm/src/textures.cpp
+++ b/vita3k/gxm/src/textures.cpp
@@ -106,6 +106,9 @@ uint32_t get_num_components(SceGxmTextureBaseFormat fmt) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4:
     case SCE_GXM_TEXTURE_BASE_FORMAT_U1U5U5U5:
         return 4;
+
+    default:
+        return 0;
     }
 }
 
@@ -121,7 +124,10 @@ bool is_bcn_format(SceGxmTextureBaseFormat base_format) {
         || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC4
         || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_SBC4
         || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC5
-        || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_SBC5;
+        || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_SBC5
+        || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC6H
+        || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_SBC6H
+        || base_format == SCE_GXM_TEXTURE_BASE_FORMAT_UBC7;
 }
 
 bool is_pvrt_format(SceGxmTextureBaseFormat base_format) {
@@ -187,6 +193,9 @@ uint32_t bits_per_pixel(SceGxmTextureBaseFormat base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
     case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC6H:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC6H:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC7:
         return 8;
     case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P2:
     case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P3:
@@ -214,6 +223,9 @@ std::pair<uint32_t, uint32_t> get_block_size(SceGxmTextureBaseFormat base_format
     case SCE_GXM_TEXTURE_BASE_FORMAT_SBC4:
     case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
     case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC6H:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC6H:
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC7:
         return { 4, 4 };
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_PVRT2BPP:

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -165,7 +165,7 @@ const uint32_t *get_texture_palette(const SceGxmTexture &texture, const MemState
  *
  * \return Void.
  */
-void resolve_z_order_compressed_texture(SceGxmTextureBaseFormat fmt, void *dest, const void *data, const std::uint32_t width, const std::uint32_t height);
+void resolve_z_order_compressed_texture(SceGxmTextureBaseFormat fmt, void *dest, const void *data, const uint32_t width, const uint32_t height);
 
 /**
  * \brief Try to decompress texture to 32-bit RGBA.
@@ -189,9 +189,9 @@ uint32_t decompress_compressed_texture(SceGxmTextureBaseFormat fmt, void *dest, 
  * \param height            Texture height.
  * \param block_storage     Pointer to compressed blocks.
  * \param image             Pointer to the image where the decompressed pixels will be stored.
- * \param bc_type           Block compressed type. BC1 (DXT1), BC2 (DXT3), BC3 (DXT5), BC4U (RGTC1), BC4S (RGTC1), BC5U (RGTC2) or BC5S (RGTC2).
+ * \param format_id         Id of the compressed format, in order: BC1 (DXT1), BC2 (DXT3), BC3 (DXT5), BC4U (RGTC1), BC4S (RGTC1), BC5U (RGTC2) or BC5S (RGTC2).
  */
-void decompress_bc_image(uint32_t width, uint32_t height, const uint8_t *block_storage, uint32_t *image, const uint8_t bc_type);
+void decompress_bc_image(uint32_t width, uint32_t height, const uint8_t *block_storage, uint32_t *image, const uint8_t format_id);
 
 /**
  * \brief Try to decompress texture to 16-bit RGB floating point color.
@@ -211,13 +211,13 @@ void decompress_packed_float_e5m9m9m9(SceGxmTextureBaseFormat fmt, void *dest, c
  *
  * Output results is in format RGBA, with each channel being 8 bits.
  *
- * \param width     Texture width.
- * \param height    Texture height.
- * \param src       Pointer to compressed blocks.
- * \param dest      Pointer to the image where the decompressed pixels will be stored.
- * \param bc_type   Block compressed type. BC1 (DXT1), BC2 (DXT3), BC3 (DXT5), BC4U (RGTC1), BC4S (RGTC1), BC5U (RGTC2 or BC5S (RGTC2).
+ * \param width         Texture width.
+ * \param height        Texture height.
+ * \param src           Pointer to compressed blocks.
+ * \param dest          Pointer to the image where the decompressed pixels will be stored.
+ * \param block_size    The size of a compressed block in (8 bytes or 16 bytes)
  */
-void resolve_z_order_compressed_image(uint32_t width, uint32_t height, const uint8_t *src, uint8_t *dest, const uint8_t bc_type);
+void resolve_z_order_compressed_image(uint32_t width, uint32_t height, const uint8_t *src, uint8_t *dest, const uint32_t block_size);
 
 // Convert x8u24 (or u24x8) format to f32 (only keep the u24 part)
 // Do not use a depth-stencil format as x8d24 is not supported on all GPUs for Vulkan

--- a/vita3k/renderer/include/renderer/texture_cache.h
+++ b/vita3k/renderer/include/renderer/texture_cache.h
@@ -60,7 +60,10 @@ struct SamplerCacheInfo {
     int index = 0;
 };
 
-typedef std::array<TextureCacheInfo, TextureCacheSize> TextureCacheInfoes;
+struct AvailableTexture {
+    bool is_dds;
+    std::shared_ptr<fs::path> folder_path;
+};
 
 class TextureCache {
 protected:
@@ -76,8 +79,8 @@ protected:
     std::vector<uint8_t> imported_texture_raw_data;
     // pointer to the decoded content
     uint8_t *imported_texture_decoded = nullptr;
-    // if set to false, means we are loading a png
-    bool loading_dds = false;
+    // Info about the texture currently loading
+    AvailableTexture loading_texture;
     // contain the decrypted header when loading dds
     ddspp::Descriptor *dds_descriptor = nullptr;
     // file being written to when exporting dds
@@ -104,7 +107,7 @@ public:
     // folder where the replacement textures should be located
     fs::path import_folder;
     // key = hash, content = is the texture a dds (true) or a png (false)
-    unordered_map_fast<uint64_t, bool> available_textures_hash;
+    unordered_map_fast<uint64_t, AvailableTexture> available_textures_hash;
     bool import_textures = false;
     bool save_as_png = true;
 

--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -191,13 +191,13 @@ void GLTextureCache::import_configure_impl(SceGxmTextureBaseFormat base_format, 
     glTexParameteriv(texture_bind_type, GL_TEXTURE_SWIZZLE_RGBA, swizzle);
     apply_sampler_state(gxm_texture, texture_bind_type, anisotropic_filtering);
 
+    bool compressed = gxm::is_bcn_format(base_format);
     const GLenum internal_format = translate_internal_format(base_format);
     const GLenum format = translate_format(base_format);
-    const GLenum type = translate_type(base_format);
+    const GLenum type = compressed ? 0 : translate_type(base_format);
 
     // GXM's cube map index is same as OpenGL: right, left, top, bottom, front, back
     GLenum upload_type = GL_TEXTURE_2D;
-    bool compressed = gxm::is_bcn_format(base_format);
 
     const bool is_cube = current_info->texture.texture_type() == SCE_GXM_TEXTURE_CUBE || current_info->texture.texture_type() == SCE_GXM_TEXTURE_CUBE_ARBITRARY;
     if (is_cube)

--- a/vita3k/renderer/src/gl/texture_formats.cpp
+++ b/vita3k/renderer/src/gl/texture_formats.cpp
@@ -288,6 +288,16 @@ GLenum translate_internal_format(SceGxmTextureBaseFormat base_format) {
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
         return GL_COMPRESSED_SIGNED_RG_RGTC2;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC6H:
+        return GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC6H:
+        return GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC7:
+        return GL_COMPRESSED_RGBA_BPTC_UNORM;
+
     default:
         LOG_ERROR("Missing case texture base format {}, fallback to GL_RGBA", fmt::underlying(base_format));
         return GL_RGBA;
@@ -376,6 +386,16 @@ GLenum translate_format(SceGxmTextureBaseFormat base_format) {
 
     case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
         return GL_COMPRESSED_SIGNED_RG_RGTC2;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC6H:
+        return GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC6H:
+        return GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC7:
+        return GL_COMPRESSED_RGBA_BPTC_UNORM;
+
     default:
         LOG_ERROR("Missing case texture base format {}, fallback to GL_RGBA", fmt::underlying(base_format));
         return GL_RGBA;
@@ -455,20 +475,6 @@ GLenum translate_type(SceGxmTextureBaseFormat base_format) {
         return GL_BYTE;
     case SCE_GXM_TEXTURE_BASE_FORMAT_PVRTII4BPP:
         return GL_BYTE;
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC1:
-        return GL_UNSIGNED_BYTE;
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC2:
-        return GL_UNSIGNED_BYTE;
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC3:
-        return GL_UNSIGNED_BYTE;
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC4:
-        return GL_UNSIGNED_BYTE;
-    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC4:
-        return GL_BYTE;
-    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC5:
-        return GL_UNSIGNED_BYTE;
-    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
-        return GL_BYTE;
     case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P2:
         return GL_UNSIGNED_BYTE;
     case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P3:
@@ -486,10 +492,11 @@ GLenum translate_type(SceGxmTextureBaseFormat base_format) {
         return GL_BYTE;
     case SCE_GXM_TEXTURE_BASE_FORMAT_U2F10F10F10:
         return GL_UNSIGNED_INT_2_10_10_10_REV;
-    }
 
-    LOG_WARN("Unhandled base format {}", log_hex(base_format));
-    return GL_UNSIGNED_BYTE;
+    default:
+        LOG_WARN("Unhandled base format {}", log_hex(base_format));
+        return GL_UNSIGNED_BYTE;
+    }
 }
 
 const GLint *translate_swizzle(SceGxmTextureFormat fmt) {
@@ -566,10 +573,11 @@ const GLint *translate_swizzle(SceGxmTextureFormat fmt) {
     // YUV422.
     case SCE_GXM_TEXTURE_BASE_FORMAT_YUV422:
         return translate_swizzle(static_cast<SceGxmTextureSwizzleYUV422Mode>(swizzle));
-    }
 
-    LOG_WARN("Invalid base format {}", log_hex(base_format));
-    return swizzle_abgr;
+    default:
+        LOG_WARN("Invalid base format {}", log_hex(base_format));
+        return swizzle_abgr;
+    }
 }
 
 GLenum translate_wrap_mode(SceGxmTextureAddrMode src) {

--- a/vita3k/renderer/src/texture/cache.cpp
+++ b/vita3k/renderer/src/texture/cache.cpp
@@ -715,7 +715,7 @@ void TextureCache::cache_and_bind_texture(const SceGxmTexture &gxm_texture, MemS
         auto it = available_textures_hash.find(info->hash);
         if (it != available_textures_hash.end()) {
             importing_texture = true;
-            loading_dds = it->second;
+            loading_texture = it->second;
             // always configure for replacement texture (although it may have no effect)
             // the reason being that we may have two replacement textures for the same gxm identifier
             // with different dimensions, so we can't assume

--- a/vita3k/renderer/src/texture/replacement.cpp
+++ b/vita3k/renderer/src/texture/replacement.cpp
@@ -685,11 +685,20 @@ static SceGxmTextureBaseFormat dxgi_to_gxm(const ddspp::DXGIFormat format) {
     case BC3_UNORM_SRGB:
         return SCE_GXM_TEXTURE_BASE_FORMAT_UBC3;
     case BC4_UNORM:
-    case BC4_SNORM:
         return SCE_GXM_TEXTURE_BASE_FORMAT_UBC4;
+    case BC4_SNORM:
+        return SCE_GXM_TEXTURE_BASE_FORMAT_SBC4;
     case BC5_UNORM:
-    case BC5_SNORM:
         return SCE_GXM_TEXTURE_BASE_FORMAT_UBC5;
+    case BC5_SNORM:
+        return SCE_GXM_TEXTURE_BASE_FORMAT_SBC5;
+    case BC6H_UF16:
+        return SCE_GXM_TEXTURE_BASE_FORMAT_UBC6H;
+    case BC6H_SF16:
+        return SCE_GXM_TEXTURE_BASE_FORMAT_SBC6H;
+    case BC7_UNORM:
+    case BC7_UNORM_SRGB:
+        return SCE_GXM_TEXTURE_BASE_FORMAT_UBC7;
     case B5G6R5_UNORM:
         return SCE_GXM_TEXTURE_BASE_FORMAT_U5U6U5;
     case B5G5R5A1_UNORM:
@@ -801,6 +810,8 @@ static ddspp::DXGIFormat dxgi_apply_srgb(const ddspp::DXGIFormat format) {
         return BC1_UNORM_SRGB;
     case BC3_UNORM:
         return BC3_UNORM_SRGB;
+    case BC7_UNORM:
+        return BC7_UNORM_SRGB;
     default:
         return format;
     }

--- a/vita3k/renderer/src/texture/replacement.cpp
+++ b/vita3k/renderer/src/texture/replacement.cpp
@@ -88,7 +88,9 @@ void TextureCache::export_select(const SceGxmTexture &texture) {
         const uint32_t array_size = is_cube ? 6 : 1;
         ddspp::TextureType texture_type = is_cube ? ddspp::Cubemap : ddspp::Texture2D;
         ddspp::Header header;
+        memset(&header, 0, sizeof(header));
         ddspp::HeaderDXT10 dxt_header;
+        memset(&dxt_header, 0, sizeof(dxt_header));
         ddspp::encode_header(dxgi_format, width, height, 1, texture_type, mipcount, array_size, header, dxt_header);
 
         // we need to do this to get the descriptor anyway
@@ -404,12 +406,12 @@ void TextureCache::export_texture_impl(SceGxmTextureBaseFormat base_format, uint
 }
 
 void TextureCache::export_done() {
-    exporting_texture = false;
-
-    if (!save_as_png) {
+    if (exporting_texture && !save_as_png) {
         output_file.close();
         exported_textures_hash.insert(current_info->hash);
     }
+
+    exporting_texture = false;
 }
 
 bool TextureCache::import_configure_texture() {
@@ -856,6 +858,7 @@ static bool dds_swap_rb(const ddspp::DXGIFormat format) {
     case B8G8R8X8_UNORM_SRGB:
     case B4G4R4A4_UNORM:
     case B5G5R5A1_UNORM:
+    case B5G6R5_UNORM:
         return true;
     default:
         return false;

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -820,6 +820,15 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format) {
     case SCE_GXM_TEXTURE_BASE_FORMAT_SBC5:
         return vk::Format::eBc5SnormBlock;
 
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC6H:
+        return vk::Format::eBc6HUfloatBlock;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_SBC6H:
+        return vk::Format::eBc6HSfloatBlock;
+
+    case SCE_GXM_TEXTURE_BASE_FORMAT_UBC7:
+        return vk::Format::eBc7UnormBlock;
+
     default:
         LOG_ERROR("Unknown format {}", log_hex(base_format));
         return {};

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -280,6 +280,8 @@ static vk::Format linear_to_srgb(const vk::Format format) {
         return vk::Format::eBc2SrgbBlock;
     case vk::Format::eBc3UnormBlock:
         return vk::Format::eBc3SrgbBlock;
+    case vk::Format::eBc7UnormBlock:
+        return vk::Format::eBc7SrgbBlock;
     default: {
         LOG_WARN_ONCE("Trying to use gamma correction with non-compatible format {}", vk::to_string(format));
         return format;

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -595,14 +595,14 @@ void VKTextureCache::import_configure_impl(SceGxmTextureBaseFormat base_format, 
         swap_rb = !swap_rb;
     }
 
-    if (swap_rb)
-        std::swap(swizzle.r, swizzle.b);
-
     // this format is stored as abgr in vulkan
     if (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_U4U4U4U4) {
         std::swap(swizzle.r, swizzle.a);
         std::swap(swizzle.g, swizzle.b);
     }
+
+    if (swap_rb)
+        std::swap(swizzle.r, swizzle.b);
 
     vk::ImageViewCreateInfo view_info{
         .image = image.image,


### PR DESCRIPTION
- Fix DDS exporting where some dumped textures could be not recognized by some tools because of garbage in the header
- Fix the swizzle of some DDS textures being imported
- Add support for importing BC6/BC7 textures
- Allow imported textures to be placed in subfolders in the import folder
- Fix loading of mips for compressed textures (error in the DDS library)