### PR TITLE
ci: Switch to clang15 for the linux build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -25,7 +25,7 @@ jobs:
           - os: ubuntu-latest
             cache_path: ~/.ccache
             extra_cmake_args:
-            cmake_preset: linux-ninja-clang14
+            cmake_preset: linux-ninja-clang15
           - os: windows-latest
             cache_path: |
                 C:\vcpkg\installed
@@ -58,7 +58,7 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:mhier/libboost-latest
           sudo apt update
-          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build lld-11
+          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build
         if: matrix.os == 'ubuntu-latest'
 
       - uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,14 +29,14 @@ jobs:
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
         os: [ubuntu-latest]
         config: [Release]
-        cmake_preset: [linux-ninja-clang14]
+        cmake_preset: [linux-ninja-clang15]
 
     steps:
       - name: Set up build environment (ubuntu-latest)
         run: |
           sudo add-apt-repository -y ppa:mhier/libboost-latest
           sudo apt update
-          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build lld-11
+          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build
 
       - uses: actions/cache@v3
         with:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,16 +93,16 @@
       }
     },
     {
-      "name": "linux-ninja-clang14",
+      "name": "linux-ninja-clang15",
       "inherits": "linux-ninja",
-      "displayName": "Linux with Ninja and Clang 14",
-      "description": "Linux native build using Ninja Multi-Config generator and Clang 14 compiler",
+      "displayName": "Linux with Ninja and Clang 15",
+      "description": "Linux native build using Ninja Multi-Config generator and Clang 15 compiler",
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-14",
-        "CMAKE_CXX_COMPILER": "clang++-14"
+        "CMAKE_C_COMPILER": "clang-15",
+        "CMAKE_CXX_COMPILER": "clang++-15"
       },
       "environment": {
-        "LDFLAGS": "-fuse-ld=lld-14"
+        "LDFLAGS": "-fuse-ld=lld-15"
       }
     },
     {
@@ -248,25 +248,25 @@
       "configurePreset": "linux-ninja-clang"
     },
     {
-      "name": "linux-ninja-clang14-debug",
+      "name": "linux-ninja-clang15-debug",
       "displayName": "Debug",
       "description": "Build with debugging information and no compiler optimizations",
       "configuration": "Debug",
-      "configurePreset": "linux-ninja-clang14"
+      "configurePreset": "linux-ninja-clang15"
     },
     {
-      "name": "linux-ninja-clang14-relwithdebinfo",
+      "name": "linux-ninja-clang15-relwithdebinfo",
       "displayName": "Release with debugging information",
       "description": "Build with compiler optimizations enabled and limited debugging information",
       "configuration": "RelWithDebInfo",
-      "configurePreset": "linux-ninja-clang14"
+      "configurePreset": "linux-ninja-clang15"
     },
     {
-      "name": "linux-ninja-clang14-release",
+      "name": "linux-ninja-clang15-release",
       "displayName": "Release",
       "description": "Build with compiler optimizations enabled and no debugging information",
       "configuration": "Release",
-      "configurePreset": "linux-ninja-clang14"
+      "configurePreset": "linux-ninja-clang15"
     },
     {
       "name": "linux-ninja-gnu-debug",


### PR DESCRIPTION
The linux CI started failing randomly because of some constexpr/consteval bug.
Hopefully updating to clang15 should fix it (and anyway it's still a good thing to do).