### PR TITLE
ci: Remove big-sur bottles for homebrew

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -46,10 +46,7 @@ jobs:
       - name: Set up build environment (macos-latest)
         run: |
           brew install ccache ninja create-dmg
-          brew fetch --force --bottle-tag=big_sur boost openssl@3 molten-vk
-          brew install $(brew --cache --bottle-tag=big_sur boost)
-          brew install $(brew --cache --bottle-tag=big_sur molten-vk)
-          brew reinstall $(brew --cache --bottle-tag=big_sur openssl@3)
+          brew install boost openssl@3 molten-vk
           echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
           ccache --set-config=compiler_check=content
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
The latest moltenVK release does not have a big sur bottle, so stop using it.
I believe this increases the MacOs version required to use Vita3K but that's still better than the CI not working. 
@KhoraLee if you want you can try to find a better solution after this PR is merged.