### PR TITLE
cmake: Static link stdc++

### DIFF
--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -152,6 +152,10 @@ if(USE_DISCORD_RICH_PRESENCE)
 	target_link_libraries(vita3k PRIVATE discord-rpc)
 endif()
 
+if(LINUX)
+	target_link_libraries(vita3k PRIVATE -static-libgcc -static-libstdc++)
+endif()
+
 set_target_properties(vita3k PROPERTIES OUTPUT_NAME Vita3K
 	ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
 	LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"


### PR DESCRIPTION
Static linking stdc++ allows the user to run a kernel that doesnt run the correct version of libc, which its pretty common because of distros not updating in time or simply the ci updates and very few people are on the updated kernel, should fix all errors of linux users not being able to run the emulator (SteamOS, debian, ubuntu, etc)