### PR TITLE
external: Use dispatch version of xxhash

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -302,6 +302,7 @@ target_include_directories(libatrac9 PUBLIC LibAtrac9/C/src)
 
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
 option(XXHASH_BUILD_XXHSUM "Build the xxhsum binary" OFF)
+set(DISPATCH 1)
 add_subdirectory(xxHash/cmake_unofficial EXCLUDE_FROM_ALL)
 
 # Tracy

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -20,7 +20,12 @@
 #include <modules/module_parent.h>
 
 #include <span>
-#include <xxh3.h>
+#ifdef __x86_64__
+#include <xxh_x86dispatch.h>
+#else
+#define XXH_INLINE_ALL
+#include <xxhash.h>
+#endif
 
 #include <gxm/functions.h>
 #include <gxm/state.h>
@@ -1190,7 +1195,7 @@ static const uint8_t mask_gxp[] = {
 static constexpr std::uint32_t DEFAULT_RING_SIZE = 4096;
 
 static VertexCacheHash hash_data(const void *data, size_t size) {
-    auto hash = XXH_INLINE_XXH3_64bits(data, size);
+    auto hash = XXH3_64bits(data, size);
     return VertexCacheHash(hash);
 }
 

--- a/vita3k/renderer/src/texture/cache.cpp
+++ b/vita3k/renderer/src/texture/cache.cpp
@@ -29,7 +29,12 @@
 #include <algorithm>
 #include <cstring>
 #include <numeric>
-#include <xxh3.h>
+#ifdef __x86_64__
+#include <xxh_x86dispatch.h>
+#else
+#define XXH_INLINE_ALL
+#include <xxhash.h>
+#endif
 #ifdef WIN32
 #include <execution>
 #endif
@@ -38,7 +43,7 @@ namespace renderer {
 namespace texture {
 
 static uint64_t hash_data(const void *data, size_t size) {
-    return XXH_INLINE_XXH3_64bits(data, size);
+    return XXH3_64bits(data, size);
 }
 
 static uint64_t hash_palette_data(const SceGxmTexture &texture, size_t count, const MemState &mem) {

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -17,8 +17,6 @@
 
 #include <renderer/vulkan/pipeline_cache.h>
 
-#include <xxh3.h>
-
 #include <renderer/vulkan/gxm_to_vulkan.h>
 #include <renderer/vulkan/state.h>
 #include <renderer/vulkan/types.h>
@@ -31,6 +29,11 @@
 #include <util/align.h>
 #include <util/fs.h>
 #include <util/log.h>
+
+// don't use the dispatch version, because we always hash a small amount
+// with a known size
+#define XXH_INLINE_ALL
+#include <xxhash.h>
 
 namespace renderer::vulkan {
 PipelineCache::PipelineCache(VKState &state)
@@ -562,7 +565,7 @@ vk::Pipeline PipelineCache::retrieve_pipeline(VKContext &context, SceGxmPrimitiv
     const GxmRecordState &record = context.record;
     // get the hash of the current context
     constexpr size_t record_pipeline_len = offsetof(GxmRecordState, vertex_streams);
-    uint64_t key = XXH_INLINE_XXH3_64bits(&record, record_pipeline_len);
+    uint64_t key = XXH3_64bits(&record, record_pipeline_len);
 
     // add the hash of the blending
     const SceGxmFragmentProgram &fragment_program_gxm = *record.fragment_program.get(mem);


### PR DESCRIPTION
Vita3K is currently compiled with only SSE support. This is annoying as xxhash has AVX2 (and even AVX512) paths that are 2 times faster than the SSE2 paths and that the main bottleneck for the render thread on PC is texture hashing.

Enable the dispatch version which allows the fastest path always to be taken when hashing. This should decrease a lot the CPU load (which is not high, but anyway) when the CPU supports AVX2.

I do not use the dispatch version for the pipeline cache hash as the size is known (and small) so the inline version should be as fast.