### PR TITLE
renderer/vulkan: Improve support of MSAA without a color surface

### DIFF
--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -111,7 +111,7 @@ void set_context(VKContext &context, MemState &mem, VKRenderTarget *rt, const Fe
 
         // set back default values
         vk_format = vk::Format::eR8G8B8A8Unorm;
-        context.record.color_surface.downscale = false;
+        context.record.color_surface.downscale = static_cast<bool>(rt->multisample_mode);
         context.record.is_gamma_corrected = false;
         context.record.is_maskupdate = false;
         context.record.color_base_format = SCE_GXM_COLOR_BASE_FORMAT_U8U8U8U8;


### PR DESCRIPTION
First, indeed using MSAA without a color surface on the PS Vita is completely useless (the depth stencil is never downscaled). The only thing it changes is the scaling of the fragment coordinate in the fragment shader I guess.

FFX remaster uses it. This fixes the crash when launching it with the vulkan renderer.