### PR TITLE
mem: Improve accuracy of virtual memory

### DIFF
--- a/vita3k/mem/include/mem/functions.h
+++ b/vita3k/mem/include/mem/functions.h
@@ -24,6 +24,8 @@ struct MemState;
 
 typedef std::function<bool(uint8_t *addr, bool write)> AccessViolationHandler;
 
+constexpr Address user_main_memory_start = 0x80000000U;
+
 // Permission when protecting a memory range
 // Note: WriteOnly is actually not supported (ReadWrite used instead)
 enum struct MemPerm {
@@ -34,8 +36,8 @@ enum struct MemPerm {
 };
 
 bool init(MemState &state, const bool use_page_table);
-Address alloc(MemState &state, uint32_t size, const char *name);
-Address alloc(MemState &state, uint32_t size, const char *name, unsigned int alignment);
+Address alloc(MemState &state, uint32_t size, const char *name, Address start_addr = user_main_memory_start);
+Address alloc_aligned(MemState &state, uint32_t size, const char *name, unsigned int alignment, Address start_addr = user_main_memory_start);
 void protect_inner(MemState &state, Address addr, uint32_t size, const MemPerm perm);
 void unprotect_inner(MemState &state, Address addr, uint32_t size);
 bool add_protect(MemState &state, Address addr, const uint32_t size, const MemPerm perm, ProtectCallback callback);
@@ -47,7 +49,7 @@ bool is_protecting(MemState &state, Address addr, MemPerm *perm = nullptr);
 bool is_valid_addr(const MemState &state, Address addr);
 bool is_valid_addr_range(const MemState &state, Address start, Address end);
 bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcept;
-Block alloc_block(MemState &mem, uint32_t size, const char *name);
+Block alloc_block(MemState &mem, uint32_t size, const char *name, Address start_addr = user_main_memory_start);
 Address alloc_at(MemState &state, Address address, uint32_t size, const char *name);
 Address try_alloc_at(MemState &state, Address address, uint32_t size, const char *name);
 void free(MemState &state, Address address);

--- a/vita3k/modules/SceLibc/SceLibc.cpp
+++ b/vita3k/modules/SceLibc/SceLibc.cpp
@@ -837,10 +837,7 @@ EXPORT(int, mbtowc) {
 
 EXPORT(Ptr<void>, memalign, uint32_t alignment, uint32_t size) {
     TRACY_FUNC(memalign, alignment, size);
-    Address address = alloc(emuenv.mem, size, "memalign", alignment);
-
-    STUBBED("No actual alignment.");
-    LOG_WARN_IF(address % alignment != 0, "Address {} does not fit alignment of {}.", log_hex(address), alignment);
+    Address address = alloc_aligned(emuenv.mem, size, "memalign", alignment);
 
     return Ptr<void>(address);
 }


### PR DESCRIPTION
Improve how the virtual memory is handled to match better what is happening on a real PS Vita.
Right now, the memory is allocated starting from 0 whereas on the PS Vita, the user main memory is allocated starting from 0x81000000. This can have some impact as games can expect addresses to be negative. 
I'm starting the user address at 0x80000000 instead of 0x81000000 because it shouldn't make a difference and games compiled with old SDKs want the elf segment to be exactly as 0x81000000 so doing so makes sure this memory range is not allocated for whatever reason before.

This fixes a crash in Trails in the sky the 3rd.