### PR TITLE
renderer, gui: Add keyboard shortcut to toggle texture replacement

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -131,6 +131,7 @@ enum PerfomanceOverleyPosition {
     code(int, "keyboard-gui-toggle-gui", 10, keyboard_gui_toggle_gui)                                   \
     code(int, "keyboard-gui-fullscreen", 68, keyboard_gui_fullscreen)                                   \
     code(int, "keyboard-gui-toggle-touch", 23, keyboard_gui_toggle_touch)                               \
+    code(int, "keyboard-toggle-texture-replacement", 0, keyboard_toggle_texture_replacement)            \
     code(std::string, "user-id", std::string{}, user_id)                                                \
     code(bool, "user-auto-connect", false, auto_user_login)                                             \
     code(bool, "display-info-message", true, display_info_message)                                      \

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -187,6 +187,17 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
         remapper_button(gui, emuenv, &emuenv.cfg.keyboard_gui_toggle_gui, lang["toggle_gui_visibility"].c_str(), lang["toggle_gui_visibility_description"].c_str());
         ImGui::EndTable();
     }
+
+    ImGui::Separator();
+    ImGui::Spacing();
+    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", "Miscellaneous");
+    if (ImGui::BeginTable("misc", 2)) {
+        ImGui::TableSetupColumn("button");
+        ImGui::TableSetupColumn("mapped_button");
+        remapper_button(gui, emuenv, &emuenv.cfg.keyboard_toggle_texture_replacement, "Toggle texture replacement");
+        ImGui::EndTable();
+    }
+
     if (need_open_error_duplicate_key_popup) {
         ImGui::OpenPopup(gui.lang.controls["error"].c_str());
         need_open_error_duplicate_key_popup = false;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -27,6 +27,7 @@
 #include <io/state.h>
 #include <kernel/state.h>
 #include <renderer/state.h>
+#include <renderer/texture_cache.h>
 
 #include <gui/functions.h>
 #include <gui/state.h>
@@ -422,7 +423,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
     emuenv.renderer->res_multiplier = emuenv.cfg.current_config.resolution_multiplier;
     emuenv.renderer->set_anisotropic_filtering(emuenv.cfg.current_config.anisotropic_filtering);
     emuenv.renderer->set_stretch_display(emuenv.cfg.stretch_the_display_area);
-    emuenv.renderer->set_texture_state(emuenv.cfg.current_config.import_textures, emuenv.cfg.current_config.export_textures, emuenv.cfg.current_config.export_as_png);
+    emuenv.renderer->get_texture_cache()->set_replacement_state(emuenv.cfg.current_config.import_textures, emuenv.cfg.current_config.export_textures, emuenv.cfg.current_config.export_as_png);
 
     // No change it if app already running
     if (emuenv.io.title_id.empty()) {

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -34,6 +34,8 @@
 #include <packages/functions.h>
 #include <packages/pkg.h>
 #include <packages/sfo.h>
+#include <renderer/state.h>
+#include <renderer/texture_cache.h>
 
 #include <modules/module_parent.h>
 #include <string>
@@ -545,6 +547,11 @@ static void switch_full_screen(EmuEnvState &emuenv) {
     app::update_viewport(emuenv);
 }
 
+static void toggle_texture_replacement(EmuEnvState &emuenv) {
+    emuenv.cfg.current_config.import_textures = !emuenv.cfg.current_config.import_textures;
+    emuenv.renderer->get_texture_cache()->set_replacement_state(emuenv.cfg.current_config.import_textures, emuenv.cfg.current_config.export_textures, emuenv.cfg.current_config.export_as_png);
+}
+
 bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
     refresh_controllers(emuenv.ctrl, emuenv);
     const auto allow_switch_state = !emuenv.io.title_id.empty() && !gui.vita_area.app_close && !gui.vita_area.home_screen && !gui.vita_area.user_management && !gui.configuration_menu.custom_settings_dialog && !gui.configuration_menu.settings_dialog && !gui.controls_menu.controls_dialog && gui::get_sys_apps_state(gui);
@@ -694,6 +701,8 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
                 toggle_touchscreen();
             if (event.key.keysym.scancode == emuenv.cfg.keyboard_gui_fullscreen && !gui.is_key_capture_dropped)
                 switch_full_screen(emuenv);
+            if (event.key.keysym.scancode == emuenv.cfg.keyboard_toggle_texture_replacement && !gui.is_key_capture_dropped)
+                toggle_texture_replacement(emuenv);
 
             if (sce_ctrl_btn != 0)
                 ui_navigation(sce_ctrl_btn);

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -46,6 +46,11 @@ struct GLState : public renderer::State {
 
     bool init(const char *shared_path, const bool hashless_texture_cache) override;
     void late_init(const Config &cfg, const std::string_view game_id) override;
+
+    TextureCache *get_texture_cache() override {
+        return &texture_cache;
+    }
+
     void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem) override;
     void swap_window(SDL_Window *window) override;
@@ -53,7 +58,6 @@ struct GLState : public renderer::State {
     void set_screen_filter(const std::string_view &filter) override;
     int get_max_anisotropic_filtering() override;
     void set_anisotropic_filtering(int anisotropic_filtering) override;
-    void set_texture_state(bool import_textures, bool export_textures, bool export_as_png) override;
 
     void precompile_shader(const ShadersHash &hash) override;
     void preclose_action() override;

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -34,6 +34,8 @@ struct Config;
 
 namespace renderer {
 
+struct TextureCache;
+
 enum struct Filter : int {
     NEAREST = 1 << 0,
     BILINEAR = 1 << 1,
@@ -80,6 +82,9 @@ struct State {
 
     virtual bool init(const char *shared_path, const bool hashless_texture_cache) = 0;
     virtual void late_init(const Config &cfg, const std::string_view game_id) = 0;
+
+    virtual TextureCache *get_texture_cache() = 0;
+
     virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem)
         = 0;
@@ -93,7 +98,6 @@ struct State {
     virtual void set_screen_filter(const std::string_view &filter) = 0;
     virtual int get_max_anisotropic_filtering() = 0;
     virtual void set_anisotropic_filtering(int anisotropic_filtering) = 0;
-    virtual void set_texture_state(bool import_textures, bool export_textures, bool export_as_png) = 0;
     void set_surface_sync_state(bool disable) {
         disable_surface_sync = disable;
     }

--- a/vita3k/renderer/include/renderer/texture_cache.h
+++ b/vita3k/renderer/include/renderer/texture_cache.h
@@ -88,6 +88,11 @@ protected:
     // used when exporting dds
     bool export_dds_swap_rb = false;
 
+    bool import_textures = false;
+    // if set to false, save textures as dds
+    bool save_as_png = true;
+    bool export_textures = false;
+
 public:
     Backend backend;
     bool use_protect = false;
@@ -108,16 +113,15 @@ public:
     fs::path import_folder;
     // key = hash, content = is the texture a dds (true) or a png (false)
     unordered_map_fast<uint64_t, AvailableTexture> available_textures_hash;
-    bool import_textures = false;
-    bool save_as_png = true;
 
     // folder where the exported textures will be saved
     fs::path export_folder;
     // hash of the textures that have already been exported
     unordered_set_fast<uint64_t> exported_textures_hash;
-    bool export_textures = false;
 
     bool init(const bool hashless_texture_cache, const fs::path &texture_folder, const std::string_view game_id, const size_t sampler_cache_size = 0);
+    void set_replacement_state(bool import_textures, bool export_textures, bool export_as_png);
+
     virtual void select(size_t index, const SceGxmTexture &texture) = 0;
     virtual void configure_texture(const SceGxmTexture &texture) = 0;
     virtual void upload_texture_impl(SceGxmTextureBaseFormat base_format, uint32_t width, uint32_t height, uint32_t mip_index, const void *pixels, int face, uint32_t pixels_per_stride) = 0;

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -89,6 +89,11 @@ struct VKState : public renderer::State {
     bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const Config &config);
     void late_init(const Config &cfg, const std::string_view game_id) override;
     void cleanup();
+
+    TextureCache *get_texture_cache() override {
+        return &texture_cache;
+    }
+
     void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
         const GxmState &gxm, MemState &mem) override;
     void swap_window(SDL_Window *window) override;
@@ -97,7 +102,6 @@ struct VKState : public renderer::State {
     void set_screen_filter(const std::string_view &filter) override;
     int get_max_anisotropic_filtering() override;
     void set_anisotropic_filtering(int anisotropic_filtering) override;
-    void set_texture_state(bool import_textures, bool export_textures, bool export_as_png) override;
 
     bool map_memory(MemState &mem, Ptr<void> address, uint32_t size) override;
     void unmap_memory(MemState &mem, Ptr<void> address) override;

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -732,13 +732,6 @@ void GLState::set_anisotropic_filtering(int anisotropic_filtering) {
     texture_cache.anisotropic_filtering = anisotropic_filtering;
 }
 
-void GLState::set_texture_state(bool import_textures, bool export_textures, bool export_as_png) {
-    texture_cache.import_textures = import_textures;
-    texture_cache.export_textures = export_textures;
-    texture_cache.save_as_png = export_as_png;
-    texture_cache.refresh_available_textures();
-}
-
 void GLState::precompile_shader(const ShadersHash &hash) {
     pre_compile_program(*this, cache_path.c_str(), title_id, self_name, hash);
 }

--- a/vita3k/renderer/src/texture/replacement.cpp
+++ b/vita3k/renderer/src/texture/replacement.cpp
@@ -54,6 +54,25 @@ static void reverse_comp3_order(const void *src, void *dst, uint32_t nb_pixels);
 // some dds format are encoded in a bgra way, in this case the swizzle must be changed
 static bool dds_swap_rb(const ddspp::DXGIFormat format);
 
+void TextureCache::set_replacement_state(bool import_textures, bool export_textures, bool export_as_png) {
+    if (this->import_textures == import_textures
+        && this->exporting_texture == export_textures
+        && this->save_as_png == export_as_png)
+        return;
+
+    this->import_textures = import_textures;
+    this->exporting_texture = export_textures;
+    this->save_as_png = export_as_png;
+
+    // invalidate all the current textures, will force all of them to be re-uploaded next frame
+    for (int i = 0; i < TextureCacheSize; i++) {
+        texture_queue.items[i].content.hash = 0;
+        texture_queue.items[i].content.dirty = true;
+    }
+
+    refresh_available_textures();
+}
+
 void TextureCache::export_select(const SceGxmTexture &texture) {
     const SceGxmTextureBaseFormat format = gxm::get_base_format(gxm::get_format(texture));
     const bool is_cube = texture.texture_type() == SCE_GXM_TEXTURE_CUBE || texture.texture_type() == SCE_GXM_TEXTURE_CUBE_ARBITRARY;

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -902,13 +902,6 @@ void VKState::set_anisotropic_filtering(int anisotropic_filtering) {
     texture_cache.anisotropic_filtering = anisotropic_filtering;
 }
 
-void VKState::set_texture_state(bool import_textures, bool export_textures, bool export_as_png) {
-    texture_cache.import_textures = import_textures;
-    texture_cache.export_textures = export_textures;
-    texture_cache.save_as_png = export_as_png;
-    texture_cache.refresh_available_textures();
-}
-
 std::vector<std::string> VKState::get_gpu_list() {
     const std::vector<vk::PhysicalDevice> gpus = instance.enumeratePhysicalDevices();
 


### PR DESCRIPTION
At the request of a third-party group, add a keyboard shortcut to toggle texture replacement (enable/disable texture importation). 
Also contains some code cleanup for accessing the texture cache.