### PR TITLE
io: Fix export/import textures path being same place as exec in linux

### DIFF
--- a/vita3k/emuenv/include/emuenv/state.h
+++ b/vita3k/emuenv/include/emuenv/state.h
@@ -118,6 +118,7 @@ public:
     fs::path log_path{};
     fs::path cache_path{};
     fs::path pref_path{};
+    fs::path static_assets_path{};
     fs::path shared_path{};
     bool load_exec{};
     std::string load_app_path{};

--- a/vita3k/gui/include/gui/imgui_impl_sdl.h
+++ b/vita3k/gui/include/gui/imgui_impl_sdl.h
@@ -28,7 +28,7 @@ union SDL_Event;
 struct SDL_Window;
 struct SDL_Cursor;
 
-IMGUI_API ImGui_State *ImGui_ImplSdl_Init(renderer::State *renderer, SDL_Window *window, const std::string &base_path);
+IMGUI_API ImGui_State *ImGui_ImplSdl_Init(renderer::State *renderer, SDL_Window *window);
 IMGUI_API void ImGui_ImplSdl_Shutdown(ImGui_State *state);
 IMGUI_API void ImGui_ImplSdl_NewFrame(ImGui_State *state);
 IMGUI_API void ImGui_ImplSdl_RenderDrawData(ImGui_State *state);

--- a/vita3k/gui/include/gui/imgui_impl_sdl_vulkan.h
+++ b/vita3k/gui/include/gui/imgui_impl_sdl_vulkan.h
@@ -90,7 +90,7 @@ struct ImGui_VulkanState : public ImGui_State {
     ImGui_ImplVulkanH_WindowRenderBuffers MainWindowRenderBuffers;
 };
 
-IMGUI_API ImGui_VulkanState *ImGui_ImplSdlVulkan_Init(renderer::State *renderer, SDL_Window *window, const std::string &base_path);
+IMGUI_API ImGui_VulkanState *ImGui_ImplSdlVulkan_Init(renderer::State *renderer, SDL_Window *window);
 IMGUI_API void ImGui_ImplSdlVulkan_Shutdown(ImGui_VulkanState &state);
 IMGUI_API void ImGui_ImplSdlVulkan_RenderDrawData(ImGui_VulkanState &state);
 

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -245,7 +245,8 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
         font_config.SizePixels = 22.f;
 
         // Set up default font path
-        const auto default_font_path{ emuenv.shared_path / "data/fonts/mplus-1mn-bold.ttf" };
+        fs::path default_font_path = emuenv.static_assets_path / "data/fonts/mplus-1mn-bold.ttf";
+
         // Check existence of default font file
         if (fs::exists(default_font_path)) {
             gui.vita_font = io.Fonts->AddFontFromFileTTF(default_font_path.string().c_str(), font_config.SizePixels, &font_config, latin_range);
@@ -273,7 +274,8 @@ vfs::FileBuffer init_default_icon(GuiState &gui, EmuEnvState &emuenv) {
     vfs::FileBuffer buffer;
 
     const auto default_fw_icon{ emuenv.pref_path / "vs0/data/internal/livearea/default/sce_sys/icon0.png" };
-    const auto default_icon{ emuenv.shared_path / "data/image/icon.png" };
+
+    fs::path default_icon = emuenv.static_assets_path / "data/image/icon.png";
 
     if (fs::exists(default_fw_icon) || fs::exists(default_icon)) {
         auto icon_path = fs::exists(default_fw_icon) ? default_fw_icon.string() : default_icon.string();
@@ -698,7 +700,7 @@ void pre_init(GuiState &gui, EmuEnvState &emuenv) {
     if (ImGui::GetCurrentContext() == NULL) {
         ImGui::CreateContext();
     }
-    gui.imgui_state.reset(ImGui_ImplSdl_Init(emuenv.renderer.get(), emuenv.window.get(), emuenv.base_path.string()));
+    gui.imgui_state.reset(ImGui_ImplSdl_Init(emuenv.renderer.get(), emuenv.window.get()));
 
     assert(gui.imgui_state);
 

--- a/vita3k/gui/src/imgui_impl_sdl.cpp
+++ b/vita3k/gui/src/imgui_impl_sdl.cpp
@@ -34,7 +34,7 @@ static void ImGui_ImplSdl_SetClipboardText(void *, const char *text) {
     SDL_SetClipboardText(text);
 }
 
-IMGUI_API ImGui_State *ImGui_ImplSdl_Init(renderer::State *renderer, SDL_Window *window, const std::string &base_path) {
+IMGUI_API ImGui_State *ImGui_ImplSdl_Init(renderer::State *renderer, SDL_Window *window) {
     ImGui_State *state;
 
     switch (renderer->current_backend) {
@@ -43,7 +43,7 @@ IMGUI_API ImGui_State *ImGui_ImplSdl_Init(renderer::State *renderer, SDL_Window 
         break;
 
     case renderer::Backend::Vulkan:
-        state = reinterpret_cast<ImGui_State *>(ImGui_ImplSdlVulkan_Init(renderer, window, base_path));
+        state = reinterpret_cast<ImGui_State *>(ImGui_ImplSdlVulkan_Init(renderer, window));
         break;
 
     default:

--- a/vita3k/gui/src/imgui_impl_sdl_vulkan.cpp
+++ b/vita3k/gui/src/imgui_impl_sdl_vulkan.cpp
@@ -279,7 +279,7 @@ static void ImGui_ImplVulkan_SetupRenderState(ImGui_VulkanState &state, ImDrawDa
 
 // constexpr vk::IndexType imgui_index_type = sizeof(ImDrawIdx) == 2 ? vk::IndexType::eUint16 : vk::IndexType::eUint32;
 
-IMGUI_API ImGui_VulkanState *ImGui_ImplSdlVulkan_Init(renderer::State *renderer, SDL_Window *window, const std::string &base_path) {
+IMGUI_API ImGui_VulkanState *ImGui_ImplSdlVulkan_Init(renderer::State *renderer, SDL_Window *window) {
     auto *state = new ImGui_VulkanState;
     state->renderer = renderer;
     state->window = window;

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -55,7 +55,8 @@ struct AvatarInfo {
 
 static std::map<std::string, std::map<AvatarSize, AvatarInfo>> users_avatar_infos;
 static bool init_avatar(GuiState &gui, EmuEnvState &emuenv, const std::string &user_id, const std::string avatar_path) {
-    const auto avatar_path_wstr = avatar_path == "default" ? emuenv.shared_path / "data/image/icon.png" : fs::path(string_utils::utf_to_wide(avatar_path));
+    const auto avatar_path_wstr = avatar_path == "default" ? emuenv.static_assets_path / "data/image/icon.png"
+                                                           : fs::path(string_utils::utf_to_wide(avatar_path));
 
     if (!fs::exists(avatar_path_wstr)) {
         LOG_WARN("Avatar image doesn't exist: {}.", avatar_path_wstr.string());

--- a/vita3k/lang/src/lang.cpp
+++ b/vita3k/lang/src/lang.cpp
@@ -68,7 +68,8 @@ void init_lang(LangState &lang, EmuEnvState &emuenv) {
     }
 
     pugi::xml_document lang_xml;
-    const auto lang_path{ emuenv.shared_path / "lang" };
+
+    fs::path lang_path = emuenv.static_assets_path / "lang";
     const auto lang_xml_path = (lang_path / (lang.user_lang[GUI] + ".xml")).string();
     if (fs::exists(lang_xml_path)) {
         if (lang_xml.load_file(lang_xml_path.c_str())) {

--- a/vita3k/renderer/include/renderer/gl/screen_render.h
+++ b/vita3k/renderer/include/renderer/gl/screen_render.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <glutil/shader.h>
+#include <util/fs.h>
 #include <util/types.h>
 
 namespace renderer::gl {
@@ -27,7 +28,7 @@ public:
     ScreenRenderer() = default;
     ~ScreenRenderer();
 
-    bool init(const char *shared_path);
+    bool init(const fs::path &static_assets);
     void render(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const float *uvs, const GLuint texture, const SceFVector2 texture_size);
 
     void destroy();

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -44,7 +44,7 @@ struct GLState : public renderer::State {
 
     ScreenRenderer screen_renderer;
 
-    bool init(const char *shared_path, const bool hashless_texture_cache) override;
+    bool init(const fs::path &static_assets, const bool hashless_texture_cache) override;
     void late_init(const Config &cfg, const std::string_view game_id) override;
 
     TextureCache *get_texture_cache() override {

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -48,6 +48,7 @@ struct State {
     std::string cache_path;
     std::string log_path;
     std::string shared_path;
+    fs::path static_assets;
     const char *title_id;
     const char *self_name;
 
@@ -80,7 +81,7 @@ struct State {
 
     bool need_page_table = false;
 
-    virtual bool init(const char *shared_path, const bool hashless_texture_cache) = 0;
+    virtual bool init(const fs::path &static_assets, const bool hashless_texture_cache) = 0;
     virtual void late_init(const Config &cfg, const std::string_view game_id) = 0;
 
     virtual TextureCache *get_texture_cache() = 0;

--- a/vita3k/renderer/include/renderer/vulkan/screen_renderer.h
+++ b/vita3k/renderer/include/renderer/vulkan/screen_renderer.h
@@ -76,7 +76,7 @@ public:
 
     bool create(SDL_Window *window);
     // called after the logical device has been created
-    bool setup(const char *shared_path);
+    bool setup();
     void cleanup();
 
     bool acquire_swapchain_image(bool start_render_pass = false);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -85,7 +85,7 @@ struct VKState : public renderer::State {
 
     VKState(int gpu_idx);
 
-    bool init(const char *shared_path, const bool hashless_texture_cache) override;
+    bool init(const fs::path &static_assets, const bool hashless_texture_cache) override;
     bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const Config &config);
     void late_init(const Config &cfg, const std::string_view game_id) override;
     void cleanup();

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -258,6 +258,7 @@ bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, co
         state->cache_path = root_paths.get_cache_path_string();
         state->log_path = root_paths.get_log_path_string();
         state->shared_path = root_paths.get_shared_path_string();
+        state->static_assets = root_paths.get_static_assets_path();
         if (!gl::create(window, state, config))
             return false;
         break;
@@ -267,6 +268,7 @@ bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, co
         state->cache_path = root_paths.get_cache_path_string();
         state->log_path = root_paths.get_log_path_string();
         state->shared_path = root_paths.get_shared_path_string();
+        state->static_assets = root_paths.get_static_assets_path();
         if (!vulkan::create(window, state, config))
             return false;
         break;

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -257,11 +257,11 @@ bool create(SDL_Window *window, std::unique_ptr<State> &state, const Config &con
     // always enabled in the opengl renderer
     gl_state.features.use_mask_bit = true;
 
-    return gl_state.init(gl_state.shared_path.c_str(), hashless_texture_cache);
+    return gl_state.init(gl_state.static_assets, hashless_texture_cache);
 }
 
-bool GLState::init(const char *shared_path, const bool hashless_texture_cache) {
-    if (!screen_renderer.init(shared_path)) {
+bool GLState::init(const fs::path &static_assets, const bool hashless_texture_cache) {
+    if (!screen_renderer.init(static_assets)) {
         LOG_ERROR("Failed to initialize screen renderer");
         return false;
     }

--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -23,14 +23,17 @@
 
 namespace renderer::gl {
 
-bool ScreenRenderer::init(const char *shared_path) {
+bool ScreenRenderer::init(const fs::path &static_assets) {
     glGenTextures(1, &m_screen_texture);
 
-    std::string builtin_shaders_path = shared_path;
-    builtin_shaders_path += "shaders-builtin/opengl/";
+    fs::path builtin_shaders_path = static_assets / "shaders-builtin/opengl";
 
-    m_render_shader_nofilter = ::gl::load_shaders(builtin_shaders_path + "render_main.vert", builtin_shaders_path + "render_main.frag");
-    m_render_shader_fxaa = ::gl::load_shaders(builtin_shaders_path + "render_main.vert", builtin_shaders_path + "render_main_fxaa.frag");
+    const auto render_main_path_vert = builtin_shaders_path / "render_main.vert";
+    const auto render_main_path_frag = builtin_shaders_path / "render_main.frag";
+    const auto render_main_path_fxaa_vert = builtin_shaders_path / "render_main_fxaa.vert";
+
+    m_render_shader_nofilter = ::gl::load_shaders(render_main_path_vert.string(), render_main_path_frag.string());
+    m_render_shader_fxaa = ::gl::load_shaders(render_main_path_vert.string(), render_main_path_fxaa_vert.string());
     if (!m_render_shader_nofilter || !m_render_shader_fxaa) {
         LOG_CRITICAL("Couldn't compile essential shaders for rendering. Exiting");
         return false;

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -176,7 +176,7 @@ VKState::VKState(int gpu_idx)
     , screen_renderer(*this) {
 }
 
-bool VKState::init(const char *shared_path, const bool hashless_texture_cache) {
+bool VKState::init(const fs::path &static_assets, const bool hashless_texture_cache) {
     shader_version = fmt::format("v{}", shader::CURRENT_VERSION);
     return true;
 }
@@ -596,7 +596,7 @@ bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state
         default_image.sampler = device.createSampler(sampler_info);
     }
 
-    if (!screen_renderer.setup(shared_path.c_str()))
+    if (!screen_renderer.setup())
         return false;
 
     support_fsr &= static_cast<bool>(screen_renderer.surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eStorage);

--- a/vita3k/renderer/src/vulkan/screen_filters.cpp
+++ b/vita3k/renderer/src/vulkan/screen_filters.cpp
@@ -109,9 +109,13 @@ void SinglePassScreenFilter::create_layout_sync() {
 
 void SinglePassScreenFilter::create_graphics_pipeline() {
     // create shader modules
-    const auto builtin_shaders_path = std::string(screen.state.shared_path) + "shaders-builtin/vulkan/";
-    vertex_shader = vkutil::load_shader(screen.state.device, builtin_shaders_path + std::string(get_vertex_name()));
-    fragment_shader = vkutil::load_shader(screen.state.device, builtin_shaders_path + std::string(get_fragment_name()));
+
+    fs::path builtin_shaders_path = screen.state.static_assets / "shaders-builtin/vulkan";
+    const auto vertex_shader_path = builtin_shaders_path / get_vertex_name();
+    const auto fragment_shader_path = builtin_shaders_path / get_fragment_name();
+
+    vertex_shader = vkutil::load_shader(screen.state.device, vertex_shader_path.string());
+    fragment_shader = vkutil::load_shader(screen.state.device, fragment_shader_path.string());
     vk::PipelineShaderStageCreateInfo vert_info{
         .stage = vk::ShaderStageFlagBits::eVertex,
         .module = vertex_shader,
@@ -408,9 +412,13 @@ void FSRScreenFilter::init() {
     };
     sampler = device.createSampler(sampler_info);
 
-    const auto builtin_shaders_path = std::string(screen.state.shared_path) + "shaders-builtin/vulkan/";
-    easu_shader = vkutil::load_shader(screen.state.device, builtin_shaders_path + "fsr_filter_easu.comp.spv");
-    rcas_shader = vkutil::load_shader(screen.state.device, builtin_shaders_path + "fsr_filter_rcas.comp.spv");
+    fs::path builtin_shaders_path = screen.state.static_assets / "shaders-builtin/vulkan";
+
+    const auto easu_shader_path = builtin_shaders_path / "fsr_filter_easu.comp.spv";
+    const auto frcas_shader_path = builtin_shaders_path / "fsr_filter_rcas.comp.spv";
+
+    easu_shader = vkutil::load_shader(screen.state.device, easu_shader_path.string());
+    rcas_shader = vkutil::load_shader(screen.state.device, frcas_shader_path.string());
 
     std::array<vk::DescriptorSetLayoutBinding, 3> layout_bindings = {
         // src img

--- a/vita3k/renderer/src/vulkan/screen_renderer.cpp
+++ b/vita3k/renderer/src/vulkan/screen_renderer.cpp
@@ -43,7 +43,7 @@ bool ScreenRenderer::create(SDL_Window *window) {
     return true;
 }
 
-bool ScreenRenderer::setup(const char *cache_path) {
+bool ScreenRenderer::setup() {
     const auto surface_formats = state.physical_device.getSurfaceFormatsKHR(surface);
     bool surface_format_found = false;
     for (const auto &format : surface_formats) {

--- a/vita3k/util/include/util/fs.h
+++ b/vita3k/util/include/util/fs.h
@@ -29,6 +29,7 @@ class Root {
     fs::path config_path;
     fs::path shared_path;
     fs::path cache_path;
+    fs::path static_assets_path;
 
 public:
     void set_base_path(const fs::path &p) {
@@ -102,6 +103,19 @@ public:
     std::string get_cache_path_string() const {
         return cache_path.generic_path().string();
     }
+
+    void set_static_assets_path(const fs::path &p) {
+        static_assets_path = p;
+    }
+
+    fs::path get_static_assets_path() const {
+        return static_assets_path;
+    }
+
+    std::string get_static_assets_path_string() const {
+        return static_assets_path.generic_path().string();
+    }
+
 }; // class root
 
 namespace fs_utils {


### PR DESCRIPTION
This fixed imported/exported textures being in the same path as the executable (in linux) by default, however, this come at the super small cost of not being able to change the base path from where gui font, lang and builtin shaders get loaded from, shouldnt be a problem since i really see no reason for someone to use it, now the textures folder is `.local/share/Vita3K/textures` by default, shared_path should never be used for stuff thats meant to be inside the executable folder, and base_path only for reading files, never writing