### PR TITLE
ci: Switch to builtin curl for linux

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:mhier/libboost-latest
           sudo apt update
-          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build libcurl4-gnutls-dev
+          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build
         if: matrix.os == 'ubuntu-latest'
 
       - uses: ilammy/msvc-dev-cmd@v1
@@ -117,13 +117,12 @@ jobs:
         run: echo "build_variable=$(git rev-list HEAD --count)" >> $GITHUB_ENV
         if: matrix.os == 'ubuntu-latest'
 
-      - name: Bundle shared objects
+      - name: Bundle Shared Objects
         id: bundle_shared_objects
         run: |
             cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
             cp /usr/lib/x86_64-linux-gnu/libssl.so.3 ./libssl.so.3
             cp /usr/lib/x86_64-linux-gnu/libcrypto.so.3 ./libcrypto.so.3
-            cp /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4 ./libcurl-gnutls.so.4
         if: matrix.os == 'ubuntu-latest'
 
       - name: Ccache statistics

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:mhier/libboost-latest
           sudo apt update
-          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build libcurl4-gnutls-dev
+          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
The libcurldev library in ubuntu implements all the protocols, so it has a lot of dependencies (most not supported by the steam deck....)
Use the builtin version (implementing only HTTP and HTTPS) to fix that for the time being.