### PR TITLE
build: Add support for building AppImages under linux

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,12 +21,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         config: [Release]
+        version: [zip, appimage]
         include:
           - os: ubuntu-latest
+            version: appimage
+            cache_path: ~/.ccache
+            extra_cmake_args: -DLINUXDEPLOY_COMMAND=/usr/local/bin/linuxdeploy-x86_64.AppImage
+            cmake_preset: linux-ninja-clang15-appimage
+          - os: ubuntu-latest
+            version: zip
             cache_path: ~/.ccache
             extra_cmake_args: 
             cmake_preset: linux-ninja-clang15
           - os: windows-latest
+            version: zip
             cache_path: |
                 C:\vcpkg\installed
                 C:\vcpkg\packages
@@ -34,9 +42,15 @@ jobs:
             extra_cmake_args: -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake 
             cmake_preset: windows-ninja
           - os: macos-latest
+            version: zip
             cache_path: ~/Library/Caches/ccache
             extra_cmake_args: 
             cmake_preset: macos-ninja
+        exclude:
+          - os: macos-latest
+            version: appimage
+          - os: windows-latest
+            version: appimage
 
     steps:
       - uses: actions/checkout@v3
@@ -58,8 +72,9 @@ jobs:
       - name: Set up build environment (ubuntu-latest)
         run: |
           sudo add-apt-repository -y ppa:mhier/libboost-latest
+          sudo add-apt-repository universe
           sudo apt update
-          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build
+          sudo apt -y install ccache libboost-filesystem1.81-dev libboost-program-options1.81-dev libboost-system1.81-dev libgtk-3-dev libsdl2-dev ninja-build libfuse2
         if: matrix.os == 'ubuntu-latest'
 
       - uses: ilammy/msvc-dev-cmd@v1
@@ -95,6 +110,15 @@ jobs:
           fi
           sudo make -C SDL2-${SDL2VER} install
         if: matrix.os == 'ubuntu-latest'
+
+      - name: Set up linuxdeploy (ubuntu-latest, appimage)
+        run: |
+          if [[ ! -e linuxdeploy-x86_64.AppImage ]]; then
+            curl -sLO https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-x86_64.AppImage
+          fi
+          sudo cp -f linuxdeploy-x86_64.AppImage /usr/local/bin/
+          sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
+        if: matrix.os == 'ubuntu-latest' && matrix.version == 'appimage'
 
       - name: Ccache setup
         run: ccache -z
@@ -143,9 +167,18 @@ jobs:
           rm -rf Vita3K.app
         if: matrix.os == 'macos-latest'
 
+      - name: Clean appimage build (ubuntu-latest, appimage)
+        run: |
+          cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
+          cp -f *AppImage* ../
+          rm -rf ./*
+          cp -f ../*AppImage* ./
+          rm -f ../*AppImage*
+        if: matrix.os == 'ubuntu-latest' && matrix.version == 'appimage'
+
       - uses: actions/upload-artifact@v3
         with:
-          name: vita3k-${{ env.git_short_sha }}-${{ matrix.os }}
+          name: vita3k-${{ env.git_short_sha }}-${{ matrix.version }}-${{ matrix.os }}
           # path is set up to be <binary_dir>/bin/<config_type> since that's how multi-config
           # generators work on CMake
           path: build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
@@ -176,8 +209,20 @@ jobs:
             then
               cp $(basename $f)/$(basename $f).dmg artifacts/macos-latest.dmg
             else
-              echo "Compressing $f"
-              (cd $(basename $f) && zip -r ../artifacts/$(basename $f  | cut -d "-" -f 3)-latest.zip *)
+              if [[ $f == *ubuntu-latest ]]
+              then
+                if [[ $f == *AppImage* ]]
+                then
+                  cp $(basename $f)/$(basename $f).AppImage* ../artifacts/
+                else
+                  rm -f $(basename $f)/$(basename $f).AppImage*
+                  echo "Compressing $f"
+                  (cd $(basename $f) && zip -r ../artifacts/$(basename $f  | cut -d "-" -f 4)-latest.zip *)
+                fi
+              else
+                echo "Compressing $f"
+                (cd $(basename $f) && zip -r ../artifacts/$(basename $f  | cut -d "-" -f 4)-latest.zip *)
+              fi
             fi
           done
           ls -al artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ build
 .cache
 # CMake user presets
 CMakeUserPresets.json
+# AppImage builder
+appimage/linuxdeploy.AppImage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 12.0)
 
 option(USE_DISCORD_RICH_PRESENCE "Build Vita3K with Discord Rich Presence" ON)
 option(USE_VITA3K_UPDATE "Build Vita3K with updater." ON)
+option(BUILD_APPIMAGE "Build an AppImage." OFF)
 
 if("${CMAKE_CXX_COMPILER_LAUNCHER}" STREQUAL "")
     find_program(CCACHE_PROGRAM ccache)
@@ -226,6 +227,17 @@ if (MSVC AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (MSVC_VERSION GREATER_E
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /experimental:external")
 	endif()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /external:I${CMAKE_SOURCE_DIR}/external/ /external:W0 /external:templates-")
+endif()
+
+if (${BUILD_APPIMAGE})
+	if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+		set(LINUXDEPLOY_COMMAND "${CMAKE_SOURCE_DIR}/appimage/linuxdeploy.AppImage" CACHE INTERNAL "")
+		if (NOT EXISTS "${LINUXDEPLOY_COMMAND}")
+			message(FATAL_ERROR "Could not find linuxdeploy at ${LINUXDEPLOY_COMMAND}!")
+		endif()
+	else()
+		message(FATAL_ERROR "Cannot build an AppImage for a non-Linux host.")
+	endif()
 endif()
 
 add_subdirectory(external)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -106,6 +106,16 @@
       }
     },
     {
+      "name": "linux-ninja-clang15-appimage",
+      "inherits": "linux-ninja-clang15",
+      "displayName": "Linux AppImage with Ninja and Clang",
+      "description": "Linux AppImage build using Ninja Multi-Config generator and Clang 15 compiler",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "/usr",
+        "BUILD_APPIMAGE": true
+      }
+    },
+    {
       "name": "linux-ninja-gnu",
       "inherits": "linux-ninja",
       "displayName": "Linux with Ninja and GNU GCC",
@@ -246,6 +256,13 @@
       "description": "Build with compiler optimizations enabled and no debugging information",
       "configuration": "Release",
       "configurePreset": "linux-ninja-clang"
+    },
+    {
+      "name": "linux-ninja-clang15-appimage-release",
+      "displayName": "Release",
+      "description": "Build with compiler optimizations enabled and no debugging information as an AppImage",
+      "configuration": "Release",
+      "configurePreset": "linux-ninja-clang15-appimage"
     },
     {
       "name": "linux-ninja-clang15-debug",

--- a/appimage/apprun.sh
+++ b/appimage/apprun.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+if [ "${APPIMAGE}" != "" ]; then
+	XDG_DATA_DIRS="${APPDIR}/usr/share:${XDG_DATA_DIRS}" "${APPDIR}/usr/bin/Vita3K" $@
+fi

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Executing linuxdeploy with cmdline: LDAI_VERBOSE=1 $@"
+
+LDAI_VERBOSE=1 $@

--- a/appimage/build_updater.sh
+++ b/appimage/build_updater.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Note: The documentation at https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/blob/master/README.md for embedding update info is wrong.
+# The correct env-variable name to use is UPDATE_INFORMATION, and *not* LDAI_UPDATE_INFORMATION.
+
+echo "Executing linuxdeploy with cmdline: LDAI_VERBOSE=1 UPDATE_INFORMATION=\"gh-releases-zsync|Vita3K|Vita3K|latest|Vita3K-x86_64.AppImage.zsync\" $@"
+
+LDAI_VERBOSE=1 UPDATE_INFORMATION="gh-releases-zsync|Vita3K|Vita3K|latest|Vita3K-x86_64.AppImage.zsync" $@

--- a/appimage/vita3k.desktop
+++ b/appimage/vita3k.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Name=Vita3K
+Icon=vita3k
+Categories=Game;Emulator;X-None;

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -174,9 +174,9 @@ if(APPLE)
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/external/sdl/macos/SDL2.framework" "$<TARGET_FILE_DIR:vita3k>/../Frameworks/SDL2.framework")
 	if(USE_VITA3K_UPDATE)
 		add_custom_command(
-			TARGET vita3k
-			POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/script/update-macos.sh" "$<TARGET_FILE_DIR:vita3k>/../Resources/update-vita3k.sh")
+		TARGET vita3k
+		POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/script/update-macos.sh" "$<TARGET_FILE_DIR:vita3k>/../Resources/update-vita3k.sh")
 	endif()
 	if(USE_DISCORD_RICH_PRESENCE)
 		add_custom_command(
@@ -201,17 +201,46 @@ if(APPLE)
 	set_source_files_properties(${MOLTENVK_DYLIB} PROPERTIES MACOSX_PACKAGE_LOCATION Frameworks)
 elseif(LINUX)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath='$ORIGIN'")
-	add_custom_command(
+	if(BUILD_APPIMAGE)
+		set(APPDIR "${CMAKE_BINARY_DIR}/AppImage")
+		add_custom_command(
 		TARGET vita3k
 		POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../data" "$<TARGET_FILE_DIR:vita3k>/data"
-		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../lang" "$<TARGET_FILE_DIR:vita3k>/lang"
-		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "$<TARGET_FILE_DIR:vita3k>/shaders-builtin")
+		COMMAND ${CMAKE_COMMAND} -E make_directory "${APPDIR}/usr/share/Vita3K"
+		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../data" "${APPDIR}/usr/share/Vita3K/data"
+		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../lang" "${APPDIR}/usr/share/Vita3K/lang"
+		COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "${APPDIR}/usr/share/Vita3K/shaders-builtin")
+		if(USE_VITA3K_UPDATE)
+			set(LINUXDEPLOY_WRAPPER "${CMAKE_SOURCE_DIR}/appimage/build_updater.sh")
+		else()
+			set(LINUXDEPLOY_WRAPPER "${CMAKE_SOURCE_DIR}/appimage/build.sh")
+		endif()
+		if(USE_DISCORD_RICH_PRESENCE)
+			set(DISCORD_LIB_APPIMAGE "-l \"${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so\"")
+		else()
+			set(DISCORD_LIB_APPIMAGE "")
+		endif()
+		add_custom_command(
+		TARGET vita3k
+		POST_BUILD
+		COMMAND ${LINUXDEPLOY_WRAPPER} ${LINUXDEPLOY_COMMAND} --appdir="${APPDIR}"
+			-e "$<TARGET_FILE:vita3k>" --icon-filename="vita3k"
+			-i "${CMAKE_CURRENT_SOURCE_DIR}/../data/image/icon.png" -d "${CMAKE_CURRENT_SOURCE_DIR}/../appimage/vita3k.desktop"
+			--custom-apprun="${CMAKE_CURRENT_SOURCE_DIR}/../appimage/apprun.sh" --output=appimage ${DISCORD_LIB_APPIMAGE}
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/*.AppImage*" "$<TARGET_FILE_DIR:vita3k>/"
+		COMMAND ${CMAKE_COMMAND} -E rm "${CMAKE_CURRENT_BINARY_DIR}/*.AppImage*")
+	endif()
+	add_custom_command(
+	TARGET vita3k
+	POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../data" "$<TARGET_FILE_DIR:vita3k>/data"
+	COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/../lang" "$<TARGET_FILE_DIR:vita3k>/lang"
+	COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/shaders-builtin" "$<TARGET_FILE_DIR:vita3k>/shaders-builtin")
 	if(USE_VITA3K_UPDATE)
 		add_custom_command(
-			TARGET vita3k
-			POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/script/update-linux.sh" "$<TARGET_FILE_DIR:vita3k>/update-vita3k.sh")
+		TARGET vita3k
+		POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/script/update-linux.sh" "$<TARGET_FILE_DIR:vita3k>/update-vita3k.sh")
 	endif()
 	if(USE_DISCORD_RICH_PRESENCE)
 		add_custom_command(
@@ -232,9 +261,9 @@ elseif(WIN32)
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/external/sdl/windows/lib/x64/SDL2.dll" "$<TARGET_FILE_DIR:vita3k>")
 	if(USE_VITA3K_UPDATE)
 		add_custom_command(
-			TARGET vita3k
-			POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/script/update-windows.bat" "$<TARGET_FILE_DIR:vita3k>/update-vita3k.bat")
+		TARGET vita3k
+		POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/script/update-windows.bat" "$<TARGET_FILE_DIR:vita3k>/update-vita3k.bat")
 	endif()
 	if(USE_DISCORD_RICH_PRESENCE)
 		add_custom_command(


### PR DESCRIPTION
This is an attempt at packaging Vita3K as an AppImage.

It currently depends on [linuxdeploy](https://github.com/linuxdeploy/linuxdeploy) as it's final packager. (linuxdeploy itself is shipped as an AppImage.)

To build it, simply place the release from linuxdeploy in appimage/linuxdeploy.AppImage and use the linux-ninja-clang-appimage cmake preset.