### PR TITLE
cmake: Enable XXH_X86DISPATCH_ALLOW_AVX by default

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -325,8 +325,12 @@ target_include_directories(libatrac9 PUBLIC LibAtrac9/C/src)
 
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
 option(XXHASH_BUILD_XXHSUM "Build the xxhsum binary" OFF)
+option(XXH_X86DISPATCH_ALLOW_AVX "Allow building XXH3 with AVX even if it crashes on SSE2-Only CPUs" OFF)
 set(DISPATCH 1)
 add_subdirectory(xxHash/cmake_unofficial EXCLUDE_FROM_ALL)
+if(XXH_X86DISPATCH_ALLOW_AVX)
+	target_compile_definitions(xxhash PRIVATE XXH_X86DISPATCH_ALLOW_AVX)
+endif()
 
 # Tracy
 option(TRACY_ENABLE_ON_CORE_COMPONENTS


### PR DESCRIPTION
Issue reported in [the AUR](https://aur.archlinux.org/packages/vita3k-git#comment-942974), This enables the option of compiling the AVX implementation of xxh3 even if it will crash on SSE2-Only CPUs, as this seems to only affect few users at the moment i decided to go with OFF as default, once merged the option will be set on the PKGBUILD as ON for the few users as the build generated by it is intended for usage in the same machine it was compiled on, not sharing