### PR TITLE
renderer/texture: Build fix for Boost 1.74.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,91 +117,95 @@ option(VITA3K_FORCE_SYSTEM_BOOST "Force Vita3K build process to use the Boost ve
 set(BOOST_MODULES_TO_FIND filesystem system)
 
 # If build process isn't set to forcefully use system Boost
-if(NOT VITA3K_FORCE_SYSTEM_BOOST)
-    # find_package(Boost ...) setting
-    set(Boost_USE_STATIC_LIBS ON)
+macro(get_boost)
+	if(NOT VITA3K_FORCE_SYSTEM_BOOST)
+		  # find_package(Boost ...) setting
+		  set(Boost_USE_STATIC_LIBS ON)
 
-    set(Boost_NO_WARN_NEW_VERSIONS 1)
+		  set(Boost_NO_WARN_NEW_VERSIONS 1)
 
-    # First, try to find Boost without any hints (system Boost)
-    if(NOT VITA3K_FORCE_CUSTOM_BOOST)
-        find_package(Boost COMPONENTS ${BOOST_MODULES_TO_FIND} QUIET)
-    endif()
+		  # First, try to find Boost without any hints (system Boost)
+		  if(NOT VITA3K_FORCE_CUSTOM_BOOST)
+		      find_package(Boost COMPONENTS ${BOOST_MODULES_TO_FIND} QUIET)
+		  endif()
 
-    # If system Boost hasn't been found, then enable hints to find custom Boost
-    if (NOT Boost_FOUND)
-        message(STATUS "A Boost distribution that meets the requirements needed for the project hasn't been found in your system. Falling back to custom Boost distribution...")
-    
-        # Set path hints for Boost search inside the repository folder and assist in compilation if needed
-        set(BOOST_SOURCEDIR "${CMAKE_SOURCE_DIR}/external/boost")       # For internal use
-        set(BOOST_INSTALLDIR "${CMAKE_BINARY_DIR}/external/boost")      # For internal use
-        set(BOOST_ROOT "${BOOST_SOURCEDIR}")                            # find_package(Boost ...) hint
-        set(BOOST_INCLUDEDIR "${BOOST_SOURCEDIR}")                      # find_package(Boost ...) hint
-        set(BOOST_LIBRARYDIR "${BOOST_INSTALLDIR}/lib")                 # find_package(Boost ...) hint
+		  # If system Boost hasn't been found, then enable hints to find custom Boost
+		  if (NOT Boost_FOUND)
+		      message(STATUS "A Boost distribution that meets the requirements needed for the project hasn't been found in your system. Falling back to custom Boost distribution...")
 
-        # Find Boost again to check for a existing compilation of the custom distribution
-        find_package(Boost COMPONENTS ${BOOST_MODULES_TO_FIND} QUIET)
+		      # Set path hints for Boost search inside the repository folder and assist in compilation if needed
+		      set(BOOST_SOURCEDIR "${CMAKE_SOURCE_DIR}/external/boost")       # For internal use
+		      set(BOOST_INSTALLDIR "${CMAKE_BINARY_DIR}/external/boost")      # For internal use
+		      set(BOOST_ROOT "${BOOST_SOURCEDIR}")                            # find_package(Boost ...) hint
+		      set(BOOST_INCLUDEDIR "${BOOST_SOURCEDIR}")                      # find_package(Boost ...) hint
+		      set(BOOST_LIBRARYDIR "${BOOST_INSTALLDIR}/libs")                # find_package(Boost ...) hint
 
-        # If no build of the custom distribution is found, compile it
-        if(NOT Boost_FOUND)
-            message(STATUS "No existing custom distribution of Boost has been found in ${BOOST_INSTALLDIR}. Proceeding to compile Boost...")
+		      # Find Boost again to check for a existing compilation of the custom distribution
+		      find_package(Boost COMPONENTS ${BOOST_MODULES_TO_FIND} PATHS ${BOOST_INSTALLDIR} QUIET NO_DEFAULT_PATH)
 
-            # Set compilation toolset for b2 and Boost builds
-            if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-                if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-                    if(CMAKE_GENERATOR_TOOLSET STREQUAL "ClangCL")
-                        # Proper toolset should be "clang-win", but b2 has a bug that makes it spam Visual Studio instances if set
-                        # Since Clang for Windows is ABI-compatible with MSVC, using MSVC is fine
-                        set(BOOST_TOOLSET "msvc")
-                    else()
-                        message(WARNING "Boost compilation on Windows requires the use of a clang-cl compiler running inside a Visual Studio Developer CLI environment with a Windows C++ SDK available.")
-                        set(BOOST_TOOLSET "msvc")
-                    endif()
-                else()
-                    set(BOOST_TOOLSET "msvc")
-                endif()
-            elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-                if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-                    set(BOOST_TOOLSET "clang")
-                elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-                    set(BOOST_TOOLSET "gcc")
-                endif()
-            endif()
+		      # If no build of the custom distribution is found, compile it
+		      if(NOT Boost_FOUND)
+		          message(STATUS "No existing custom distribution of Boost has been found in ${BOOST_INSTALLDIR}. Proceeding to compile Boost...")
 
-            # Determine b2 executable name depending on host system
-            if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-                set(b2_EXECUTABLE_NAME "b2.exe")
-            else()
-                set(b2_EXECUTABLE_NAME "b2")
-            endif()
+		          # Set compilation toolset for b2 and Boost builds
+		          if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+		              if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+		                  if(CMAKE_GENERATOR_TOOLSET STREQUAL "ClangCL")
+		                      # Proper toolset should be "clang-win", but b2 has a bug that makes it spam Visual Studio instances if set
+		                      # Since Clang for Windows is ABI-compatible with MSVC, using MSVC is fine
+		                      set(BOOST_TOOLSET "msvc")
+		                  else()
+		                      message(WARNING "Boost compilation on Windows requires the use of a clang-cl compiler running inside a Visual Studio Developer CLI environment with a Windows C++ SDK available.")
+		                      set(BOOST_TOOLSET "msvc")
+		                  endif()
+		              else()
+		                  set(BOOST_TOOLSET "msvc")
+		              endif()
+		          elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+		              if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+		                  set(BOOST_TOOLSET "clang")
+		              elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		                  set(BOOST_TOOLSET "gcc")
+		              endif()
+		          endif()
 
-            # Find b2
-            find_program(b2 NAME ${b2_EXECUTABLE_NAME} PATHS ${BOOST_SOURCEDIR} NO_CACHE)
+		          # Determine b2 executable name depending on host system
+		          if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+		              set(b2_EXECUTABLE_NAME "b2.exe")
+		          else()
+		              set(b2_EXECUTABLE_NAME "b2")
+		          endif()
 
-            # Compile b2 if it isn't found
-            if(b2 STREQUAL "b2-NOTFOUND")
-                message(STATUS "The b2 buildsystem executable hasn't been found in your system. Compiling b2...")
-                b2_build()
+		          # Find b2
+		          find_program(b2 NAME ${b2_EXECUTABLE_NAME} PATHS ${BOOST_SOURCEDIR} NO_CACHE NO_DEFAULT_PATH)
 
-                # Find b2 again after compilation
-                find_program(b2 NAME ${b2_EXECUTABLE_NAME} PATHS ${BOOST_SOURCEDIR} NO_CACHE)
-            endif()
+		          # Compile b2 if it isn't found
+		          if(b2 STREQUAL "b2-NOTFOUND")
+		              message(STATUS "The b2 buildsystem executable hasn't been found in your system. Compiling b2...")
+		              b2_build()
 
-            # Compile Boost
-            message(STATUS "Compiling Boost...")
-            boost_compile()
+		              # Find b2 again after compilation
+		              find_program(b2 NAME ${b2_EXECUTABLE_NAME} PATHS ${BOOST_SOURCEDIR} NO_CACHE NO_DEFAULT_PATH REQUIRED)
+		          endif()
 
-            # Find Boost again
-            find_package(Boost COMPONENTS ${BOOST_MODULES_TO_FIND} QUIET)
-        else()
-            message(STATUS "Custom Boost distribution found in ${BOOST_INSTALLDIR}")
-        endif()
-    endif()
-else()
-    # Try to find Boost on the system and CMake's default paths
-    set(Boost_USE_STATIC_LIBS ON)
-    find_package(Boost COMPONENTS ${BOOST_MODULES_TO_FIND} QUIET)
-endif()
+		          # Compile Boost
+		          message(STATUS "Compiling Boost...")
+		          boost_compile()
+
+		          # Find Boost again
+		          find_package(Boost COMPONENTS ${BOOST_MODULES_TO_FIND} PATHS ${BOOST_INSTALLDIR} NO_DEFAULT_PATH REQUIRED)
+		      else()
+		          message(STATUS "Custom Boost distribution found in ${BOOST_INSTALLDIR}")
+		      endif()
+		  endif()
+	else()
+		  # Try to find Boost on the system and CMake's default paths
+		  set(Boost_USE_STATIC_LIBS ON)
+		  find_package(Boost COMPONENTS ${BOOST_MODULES_TO_FIND} REQUIRED)
+	endif()
+endmacro(get_boost)
+
+get_boost()
 
 if(WIN32)
 	add_definitions (/D "_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS" /D "_CRT_SECURE_NO_WARNINGS" /D "NOMINMAX")

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -75,23 +75,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	set(LINUX TRUE)
 endif()
 
-macro(configure_boost)
-	message("configuring boost")
+get_boost()
 
-	set(Boost_USE_STATIC_LIBS ON)
-	set(Boost_USE_MULTITHREADED ON)
-	set(BOOST_COMPONENTS filesystem system)
-
-	find_package(Boost COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
-
-	include_directories(${Boost_INCLUDE_DIRS})
-
-	message("Using Boost_VERSION: ${Boost_VERSION}")
-	message("Using Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
-	message("Using Boost_LIBRARY_DIRS: ${Boost_LIBRARY_DIRS}")
-endmacro(configure_boost)
-
-configure_boost()
+include_directories(${Boost_INCLUDE_DIRS})
 
 if (USE_DISCORD_RICH_PRESENCE)
 	add_definitions(-DUSE_DISCORD)

--- a/vita3k/renderer/src/texture/cache.cpp
+++ b/vita3k/renderer/src/texture/cache.cpp
@@ -315,8 +315,8 @@ bool TextureCache::init(const bool hashless_texture_cache, const fs::path &textu
         sampler_lookup.reserve(sampler_cache_size);
     }
 
-    export_folder = texture_folder / "export" / game_id;
-    import_folder = texture_folder / "import" / game_id;
+    export_folder = texture_folder / "export" / std::string(game_id);
+    import_folder = texture_folder / "import" / std::string(game_id);
 
     refresh_available_textures();
 

--- a/vita3k/renderer/src/texture/replacement.cpp
+++ b/vita3k/renderer/src/texture/replacement.cpp
@@ -87,7 +87,7 @@ void TextureCache::export_select(const SceGxmTexture &texture) {
     else if (!save_as_png && !allowed_dds_textures(format))
         return;
 
-    if (exported_textures_hash.contains(current_info->hash))
+    if (exported_textures_hash.find(current_info->hash) != exported_textures_hash.end())
         // texture was already exported
         return;
 
@@ -639,7 +639,7 @@ void TextureCache::refresh_available_textures() {
 
         look_through_folder(import_folder, [&](uint64_t hash, const fs::path &file, bool is_dds) {
             // prioritize dds files
-            if (is_dds || !available_textures_hash.contains(hash)) {
+            if (is_dds || available_textures_hash.find(hash) == available_textures_hash.end()) {
                 const fs::path parent = file.parent_path();
                 auto it = found_folders.find(parent);
 


### PR DESCRIPTION
Fixes Vita3K/#3069

First commit fixes the build issues with Boost 1.74 by replacing the Boost::unordered_set::contains() usage with a ::find() != ... ::end() check. [As mentioned by @Macdu.](https://github.com/Vita3K/Vita3K/issues/3069#issuecomment-1805704221) Also fixes a build bug involving a std::string_view.

Second commit fixes cmake so that enabling VITA3K_FORCE_CUSTOM_BOOST will _actually_ force the use / compilation of the Boost submodule over whatever the host provides.