### PR TITLE
modules/SceGxm, display, renderer: Improve accuracy of sync objects and decrease video latency

### DIFF
--- a/vita3k/app/src/app.cpp
+++ b/vita3k/app/src/app.cpp
@@ -63,8 +63,8 @@ void calculate_fps(EmuEnvState &emuenv) {
 
 void set_window_title(EmuEnvState &emuenv) {
     const auto af = emuenv.cfg.current_config.anisotropic_filtering > 1 ? fmt ::format(" | AF {}x", emuenv.cfg.current_config.anisotropic_filtering) : "";
-    const auto x = emuenv.display.frame.image_size.x * emuenv.cfg.current_config.resolution_multiplier;
-    const auto y = emuenv.display.frame.image_size.y * emuenv.cfg.current_config.resolution_multiplier;
+    const auto x = emuenv.display.next_rendered_frame.image_size.x * emuenv.cfg.current_config.resolution_multiplier;
+    const auto y = emuenv.display.next_rendered_frame.image_size.y * emuenv.cfg.current_config.resolution_multiplier;
     const std::string title_to_set = fmt::format("{} | {} ({}) | {} | {} FPS ({} ms) | {}x{}{} | {}",
         window_title,
         emuenv.current_app_title, emuenv.io.title_id,

--- a/vita3k/display/include/display/functions.h
+++ b/vita3k/display/include/display/functions.h
@@ -18,12 +18,16 @@
 #pragma once
 
 #include <cstdint>
-#include <kernel/callback.h>
+#include <kernel/thread/thread_state.h>
 #include <util/types.h>
 
 struct DisplayState;
 struct KernelState;
 struct EmuEnvState;
+struct DisplayFrameInfo;
 
 void start_sync_thread(EmuEnvState &emuenv);
 void wait_vblank(DisplayState &display, KernelState &kernel, const ThreadStatePtr &wait_thread, const uint64_t target_vcount, const bool is_cb);
+// if the result is not nullptr, contain the predicted frame (pointer needs to be freed later)
+DisplayFrameInfo *predict_next_image(EmuEnvState &emuenv, Address sync_object);
+void update_prediction(EmuEnvState &emuenv, DisplayFrameInfo &frame);

--- a/vita3k/gxm/include/gxm/state.h
+++ b/vita3k/gxm/include/gxm/state.h
@@ -26,25 +26,20 @@
 
 struct SDL_Thread;
 
-typedef void SceGxmDisplayQueueCallback(Ptr<const void> callbackData);
-static constexpr std::uint64_t SCENE_TIME_UNDEF = 0xFFFFFFFFFFFFFFFF;
-static constexpr std::uint64_t GPU_SYNCING_DISABLE_SCENE_DELTA = 40;
-static constexpr std::uint64_t GPU_INSERT_FENCE_SCENE_DELTA = 30;
-
 struct SceGxmInitializeParams {
     uint32_t flags = 0;
     uint32_t displayQueueMaxPendingCount = 0;
-    Ptr<SceGxmDisplayQueueCallback> displayQueueCallback;
+    Ptr<void> displayQueueCallback;
     uint32_t displayQueueCallbackDataSize = 0;
     uint32_t parameterBufferSize = 0;
 };
 
 struct DisplayCallback {
-    Address pc;
     Address data;
     Ptr<SceGxmSyncObject> old_sync;
     Ptr<SceGxmSyncObject> new_sync;
     uint32_t new_sync_timestamp;
+    bool frame_predicted;
 };
 
 struct MemoryMapInfo {

--- a/vita3k/gxm/include/gxm/state.h
+++ b/vita3k/gxm/include/gxm/state.h
@@ -42,9 +42,9 @@ struct SceGxmInitializeParams {
 struct DisplayCallback {
     Address pc;
     Address data;
-    Ptr<SceGxmSyncObject> old_buffer;
-    Ptr<SceGxmSyncObject> new_buffer;
-    uint32_t new_buffer_timestamp;
+    Ptr<SceGxmSyncObject> old_sync;
+    Ptr<SceGxmSyncObject> new_sync;
+    uint32_t new_sync_timestamp;
 };
 
 struct MemoryMapInfo {
@@ -61,5 +61,4 @@ struct GxmState {
     SceUID display_queue_thread;
     std::map<Address, MemoryMapInfo> memory_mapped_regions;
     std::mutex callback_lock;
-    SDL_Thread *sdl_thread;
 };

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -403,12 +403,9 @@ int main(int argc, char *argv[]) {
         // Driver acto!
         renderer::process_batches(*emuenv.renderer.get(), emuenv.renderer->features, emuenv.mem, emuenv.cfg);
 
-        {
-            const std::lock_guard<std::mutex> guard(emuenv.display.display_info_mutex);
-            const SceFVector2 viewport_pos = { emuenv.viewport_pos.x, emuenv.viewport_pos.y };
-            const SceFVector2 viewport_size = { emuenv.viewport_size.x, emuenv.viewport_size.y };
-            emuenv.renderer->render_frame(viewport_pos, viewport_size, emuenv.display, emuenv.gxm, emuenv.mem);
-        }
+        const SceFVector2 viewport_pos = { emuenv.viewport_pos.x, emuenv.viewport_pos.y };
+        const SceFVector2 viewport_size = { emuenv.viewport_size.x, emuenv.viewport_size.y };
+        emuenv.renderer->render_frame(viewport_pos, viewport_size, emuenv.display, emuenv.gxm, emuenv.mem);
 
         gui::draw_begin(gui, emuenv);
         gui::draw_common_dialog(gui, emuenv);
@@ -424,13 +421,9 @@ int main(int argc, char *argv[]) {
         // Driver acto!
         renderer::process_batches(*emuenv.renderer.get(), emuenv.renderer->features, emuenv.mem, emuenv.cfg);
 
-        {
-            const std::lock_guard<std::mutex> guard(emuenv.display.display_info_mutex);
-            const SceFVector2 viewport_pos = { emuenv.viewport_pos.x, emuenv.viewport_pos.y };
-            const SceFVector2 viewport_size = { emuenv.viewport_size.x, emuenv.viewport_size.y };
-            emuenv.renderer->render_frame(viewport_pos, viewport_size, emuenv.display, emuenv.gxm, emuenv.mem);
-        }
-
+        const SceFVector2 viewport_pos = { emuenv.viewport_pos.x, emuenv.viewport_pos.y };
+        const SceFVector2 viewport_size = { emuenv.viewport_size.x, emuenv.viewport_size.y };
+        emuenv.renderer->render_frame(viewport_pos, viewport_size, emuenv.display, emuenv.gxm, emuenv.mem);
         // Calculate FPS
         app::calculate_fps(emuenv);
 

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -51,7 +51,7 @@ struct GLState : public renderer::State {
         return &texture_cache;
     }
 
-    void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
+    void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, DisplayState &display,
         const GxmState &gxm, MemState &mem) override;
     void swap_window(SDL_Window *window) override;
     int get_supported_filters() override;

--- a/vita3k/renderer/include/renderer/gxm_types.h
+++ b/vita3k/renderer/include/renderer/gxm_types.h
@@ -172,12 +172,10 @@ struct SceGxmSyncObject {
     std::atomic<uint32_t> timestamp_ahead;
 
     // timestamp for the last time the object was displayed
-    std::uint32_t last_display;
+    std::atomic<uint32_t> last_display;
 
     std::mutex lock;
     std::condition_variable cond;
-    // some extra space for additional data, on the Vulkan renderer this points to a RenderTarget* a,d a vector of fences
-    void *extra;
 };
 
 struct GxmContextState {

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -85,7 +85,7 @@ struct State {
 
     virtual TextureCache *get_texture_cache() = 0;
 
-    virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
+    virtual void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, DisplayState &display,
         const GxmState &gxm, MemState &mem)
         = 0;
     virtual void swap_window(SDL_Window *window) = 0;

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -37,6 +37,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
 
 void mid_scene_flush(VKContext &context, const SceGxmNotification notification);
 void new_frame(VKContext &context);
+void signal_sync_object(VKState &state, SceGxmSyncObject *sync_object, uint32_t timestamp);
 
 void set_context(VKContext &context, MemState &mem, VKRenderTarget *rt, const FeatureState &features);
 void set_uniform_buffer(VKContext &context, const MemState &mem, const ShaderProgram *program, const bool vertex_shader, const int block_num, const int size, Ptr<uint8_t> data);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -97,7 +97,7 @@ struct VKState : public renderer::State {
         return &texture_cache;
     }
 
-    void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, const DisplayState &display,
+    void render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &viewport_size, DisplayState &display,
         const GxmState &gxm, MemState &mem) override;
     void swap_window(SDL_Window *window) override;
     uint32_t get_features_mask() override;

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -76,6 +76,9 @@ struct VKState : public renderer::State {
     // only used when memory mapping is enabled
     std::map<Address, MappedMemory, std::greater<Address>> mapped_memories;
 
+    // queue where we put requests that need to wait for the GPU
+    Queue<WaitThreadRequest> request_queue;
+
     vkutil::Image default_image;
     vkutil::Buffer default_buffer;
 

--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -136,6 +136,11 @@ struct FrameDoneRequest {
     uint64_t frame_timestamp;
 };
 
+struct SyncSignalRequest {
+    SceGxmSyncObject *sync;
+    uint32_t timestamp;
+};
+
 struct PostSurfaceSyncRequest {
     ColorSurfaceCacheInfo *cache_info;
 };
@@ -143,7 +148,13 @@ struct PostSurfaceSyncRequest {
 // A parallel thread is handling these request and telling other waiting threads
 // when they are done
 // only used if memory mapping is enabled
-typedef std::variant<FenceWaitRequest, NotificationRequest, FrameDoneRequest, PostSurfaceSyncRequest> WaitThreadRequest;
+typedef std::variant<
+    FenceWaitRequest,
+    NotificationRequest,
+    FrameDoneRequest,
+    PostSurfaceSyncRequest,
+    SyncSignalRequest>
+    WaitThreadRequest;
 
 struct VKContext : public renderer::Context {
     // GXM Context Info
@@ -247,8 +258,6 @@ struct VKContext : public renderer::Context {
     // only used if memory mapping is enabled
     std::mutex new_frame_mutex;
     std::condition_variable new_frame_condv;
-    // queue were new notification and frame done request are added
-    Queue<WaitThreadRequest> request_queue;
     std::thread gpu_request_wait_thread;
     uint64_t last_frame_waited = 0;
 

--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -62,7 +62,7 @@ bool wait_cmd(MemState &mem, CommandList &command_list) {
     SceGxmSyncObject *sync = reinterpret_cast<Ptr<SceGxmSyncObject> *>(&command_list.first->data[0])->get(mem);
     const uint32_t timestamp = *reinterpret_cast<uint32_t *>(&command_list.first->data[sizeof(uint32_t) + 2 * sizeof(void *)]);
 
-    // wait 500 micro secibds and then return in case should_display is set to true
+    // wait 500 micro seconds and then return in case should_display is set to true
     return renderer::wishlist(sync, timestamp, 500);
 }
 

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -244,7 +244,6 @@ void create(SceGxmSyncObject *sync, State &state) {
     sync->last_display = 0;
     sync->timestamp_current = 0;
     sync->timestamp_ahead = 0;
-    sync->extra = 0;
 }
 
 void destroy(SceGxmSyncObject *sync, State &state) {

--- a/vita3k/renderer/src/sync.cpp
+++ b/vita3k/renderer/src/sync.cpp
@@ -43,7 +43,12 @@ COMMAND(handle_signal_sync_object) {
     SceGxmSyncObject *sync = helper.pop<Ptr<SceGxmSyncObject>>().get(mem);
     const uint32_t timestamp = helper.pop<uint32_t>();
 
-    renderer::subject_done(sync, timestamp);
+    if (features.support_memory_mapping) {
+        assert(renderer.current_backend == renderer::Backend::Vulkan);
+        vulkan::signal_sync_object(dynamic_cast<vulkan::VKState &>(renderer), sync, timestamp);
+    } else {
+        renderer::subject_done(sync, timestamp);
+    }
 }
 
 COMMAND(handle_wait_sync_object) {


### PR DESCRIPTION
First part: There was some flickering in some games (persona 4 dancing, Catherine) when using memory mapping. This was caused by the game using the display callback in order to know when the rendering was done (which is fine without memory mapping because everything is copied, but with the game was corrupting some uniforms / vertex buffers). Making the sync object be signaled after the GPU rendering is done (like what they are supposed to do) fixes this issue but...

Second part: This causes an increase of video latency (the frame needs to be rendered, then the request thread notified, then the display thread notified, then the callback executed, which calls setDisplay, then the main thread finishes its queue, record the render command and swapchain swaps and submit them...). To prevent this and even decrease the video latency on all renderers, I implemented a frame prediction: If Vita3K detects that the swapchain images form a cycle of length at most 6 at least 3 times in a row, then as soon as a display entry is added, the main thread will render the predicted image, bypassing everything above. This should decrease the video latency by around 1 (or even 2) frames (which at 30FPS is a lot) on all renderers.