### PR TITLE
ci: Fix copying AppImage build in create-release

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -211,11 +211,11 @@ jobs:
             else
               if [[ $f == *ubuntu-latest ]]
               then
-                if [[ $f == *AppImage* ]]
+                if [[ $f == *appimage* ]]
                 then
-                  cp $(basename $f)/$(basename $f).AppImage* ../artifacts/
+                  cp $(basename $f)/*.AppImage* artifacts/
                 else
-                  rm -f $(basename $f)/$(basename $f).AppImage*
+                  rm -f $(basename $f)/*.AppImage*
                   echo "Compressing $f"
                   (cd $(basename $f) && zip -r ../artifacts/$(basename $f  | cut -d "-" -f 4)-latest.zip *)
                 fi


### PR DESCRIPTION
The current ci doesn't copy the output *.AppImage files in create-release. As such it doesn't appear on the releases page.

That's due to me using invalid expansions in the if statement and cp command, and not having a valid directory to copy to. (Copy paste bug. The macos-build cd's into it's directory before the cp command is given, whereas the appimage build does not. As such the artifacts directory is in the PWD when cp is called.)

This PR should fix both of these errors.