### PR TITLE
renderer/vulkan, vkutil: Refractoring of the Vulkan renderer

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -44,7 +44,6 @@ void set_uniform_buffer(VKContext &context, const MemState &mem, const ShaderPro
 
 void sync_clipping(VKContext &context);
 void sync_stencil_func(VKContext &context, const bool is_back);
-void sync_mask(VKContext &context, const MemState &mem);
 void sync_depth_bias(VKContext &context);
 void sync_depth_data(VKContext &context);
 void sync_stencil_data(VKContext &context, const MemState &mem);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -73,6 +73,15 @@ struct VKState : public renderer::State {
     // Transfer pool has transient bit set.
     vk::CommandPool transfer_command_pool;
 
+    // objects for which one copy is needed for every frame being rendered at the same time
+    std::array<FrameObject, MAX_FRAMES_RENDERING> frames;
+    // start at 1 because last_frame_waited is set to 0
+    int current_frame_idx = 1;
+
+    // vector of descriptor pools used for the frame descriptor, they are not really used anywhere
+    // but it's better to keep a reference to them somewhere
+    std::deque<vk::DescriptorPool> frame_descriptor_pools;
+
     // only used when memory mapping is enabled
     std::map<Address, MappedMemory, std::greater<Address>> mapped_memories;
 
@@ -116,5 +125,9 @@ struct VKState : public renderer::State {
 
     void precompile_shader(const ShadersHash &hash) override;
     void preclose_action() override;
+
+    inline FrameObject &frame() {
+        return frames[current_frame_idx];
+    }
 };
 } // namespace renderer::vulkan

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -112,6 +112,14 @@ void PipelineCache::init() {
 
     {
         // texture layout
+
+        // empty descriptor
+        {
+            vk::DescriptorSetLayoutCreateInfo empty_info{};
+            vertex_textures_layout[0] = state.device.createDescriptorSetLayout(empty_info);
+            fragment_textures_layout[0] = vertex_textures_layout[0];
+        }
+
         // first vertex
         std::array<vk::DescriptorSetLayoutBinding, 16> layout_bindings;
         for (uint32_t i = 0; i < 16; i++) {
@@ -122,7 +130,7 @@ void PipelineCache::init() {
                 .stageFlags = vk::ShaderStageFlagBits::eVertex
             };
         }
-        for (uint32_t i = 0; i < 17; i++) {
+        for (uint32_t i = 1; i <= 16; i++) {
             vk::DescriptorSetLayoutCreateInfo descriptor_info{
                 .bindingCount = i,
                 .pBindings = layout_bindings.data()
@@ -134,7 +142,7 @@ void PipelineCache::init() {
         for (uint32_t i = 0; i < 16; i++) {
             layout_bindings[i].stageFlags = vk::ShaderStageFlagBits::eFragment;
         }
-        for (uint32_t i = 0; i < 17; i++) {
+        for (uint32_t i = 1; i <= 16; i++) {
             vk::DescriptorSetLayoutCreateInfo descriptor_info{
                 .bindingCount = i,
                 .pBindings = layout_bindings.data()

--- a/vita3k/renderer/src/vulkan/screen_filters.cpp
+++ b/vita3k/renderer/src/vulkan/screen_filters.cpp
@@ -98,7 +98,6 @@ void SinglePassScreenFilter::create_layout_sync() {
     pipeline_layout = device.createPipelineLayout(layout_info);
 
     // create vao
-    vao.allocator = screen.state.allocator;
     vao.size = sizeof(screen_vertices_t) * screen.swapchain_size;
     vao.init_buffer(vk::BufferUsageFlagBits::eVertexBuffer | vk::BufferUsageFlagBits::eTransferDst);
 
@@ -505,10 +504,9 @@ void FSRScreenFilter::init() {
 
     // create intermediate images
     intermediate_images.resize(screen.swapchain_size);
-    for (auto &img : intermediate_images) {
-        img.allocator = screen.state.allocator;
+    for (auto &img : intermediate_images)
         img.format = vk::Format::eR8G8B8A8Unorm;
-    }
+
     on_resize();
 }
 

--- a/vita3k/renderer/src/vulkan/sync_state.cpp
+++ b/vita3k/renderer/src/vulkan/sync_state.cpp
@@ -99,19 +99,6 @@ void sync_stencil_func(VKContext &context, const bool is_back) {
     context.render_cmd.setStencilWriteMask(face, state->write_mask);
 }
 
-void sync_mask(VKContext &context, const MemState &mem) {
-    if (!context.state.features.use_mask_bit)
-        return;
-
-    float initial_val = context.record.depth_stencil_surface.mask ? 1.0f : 0.0f;
-
-    std::array<float, 4> clear_bytes = { initial_val, initial_val, initial_val, initial_val };
-    vk::ClearColorValue clear_color{ clear_bytes };
-    context.render_target->mask.transition_to_discard(context.render_cmd, vkutil::ImageLayout::TransferDst);
-    context.render_cmd.clearColorImage(context.render_target->mask.image, vk::ImageLayout::eTransferDstOptimal, clear_color, vkutil::color_subresource_range);
-    context.render_target->mask.transition_to(context.render_cmd, vkutil::ImageLayout::StorageImage);
-}
-
 void sync_depth_bias(VKContext &context) {
     if (!context.is_recording)
         return;

--- a/vita3k/util/include/util/bit_cast.h
+++ b/vita3k/util/include/util/bit_cast.h
@@ -18,18 +18,21 @@
 #pragma once
 
 #include <bit>
-#include <cstring> // memcpy
+#include <cstring>
+#include <type_traits>
 
 #ifndef __cpp_lib_bit_cast
 namespace std {
-template <typename T, typename U>
-T bit_cast(U &&u) {
-    static_assert(sizeof(T) == sizeof(U));
-    union {
-        T t;
-    }; // prevent construction
-    std::memcpy(&t, &u, sizeof(t));
-    return t;
+// https://en.cppreference.com/w/cpp/numeric/bit_cast
+template <class To, class From>
+std::enable_if_t<sizeof(To) == sizeof(From), To> bit_cast(const From &src) noexcept {
+    if constexpr (alignof(From) >= alignof(To)) {
+        return *reinterpret_cast<const To *>(&src);
+    } else {
+        alignas(alignof(To)) char dst[sizeof(To)];
+        std::memcpy(&dst, &src, sizeof(To));
+        return *reinterpret_cast<To *>(&dst);
+    }
 }
 } // namespace std
 #endif

--- a/vita3k/vkutil/include/vkutil/vkutil.h
+++ b/vita3k/vkutil/include/vkutil/vkutil.h
@@ -97,24 +97,6 @@ static constexpr vma::AllocationCreateInfo vma_host_visible = {
     .requiredFlags = vk::MemoryPropertyFlagBits::eHostVisible,
 };
 
-template <typename T>
-[[maybe_unused]] static std::enable_if_t<vk::isVulkanHandleType<T>::value, uint64_t> &to_u64(T &vk_object) {
-    return reinterpret_cast<uint64_t &>(vk_object);
-}
-
-[[maybe_unused]] static uint64_t &to_u64(vma::Allocation &vk_object) {
-    return reinterpret_cast<uint64_t &>(vk_object);
-}
-
-template <typename T>
-[[maybe_unused]] static std::enable_if_t<vk::isVulkanHandleType<T>::value, T> &from_u64(uint64_t &vk_object) {
-    return reinterpret_cast<T &>(vk_object);
-}
-
-[[maybe_unused]] static vma::Allocation &from_u64(uint64_t &vk_object) {
-    return reinterpret_cast<vma::Allocation &>(vk_object);
-}
-
 vk::CommandBuffer create_single_time_command(vk::Device device, vk::CommandPool cmd_pool);
 void end_single_time_command(vk::Device device, vk::Queue queue, vk::CommandPool cmd_pool, vk::CommandBuffer cmd_buffer);
 


### PR DESCRIPTION
A lot of small changes to the vulkan renderer:
- Remove the mask bit support, was not really supported (never enabled), and if I ever end up implementing it, I would do something completely different anyway
- Move a bunch of stuff from the context to the state. This is kind of necessary for some gxm commands to be called before the gxm context is created. This allows chaos ring to go ingame with the Vulkan renderer
- Make the vma allocator a static field in vkutil, instead of having to supply it to every object. Also remove the thread safety part of vma as it's not needed by Vita3K right now (all vma calls are in the same thread). And replace some of my custom functions by a call to std::bit_cast which does the same thing.
- Rewrite the descriptor set model, this allows the call to AllocateDescriptorSet to be completely removed (once enough descriptor set have been allocated). As this takes a pretty big amount of time on the CPU side, this should improve the performance (especially when using drivers with a bad memory allocator).