### PR TITLE
util: Improve float_to_half code

### DIFF
--- a/vita3k/util/src/float_to_half.cpp
+++ b/vita3k/util/src/float_to_half.cpp
@@ -17,22 +17,36 @@
 
 /*
 float32 to float16 conversion
-we can have 3 cases
-1 program compiled with AVX2 or F16C flags  - use fast conversion
-2 program compiled without AVX2 or F16C flags:
-2a we can include and use F16C intrinsic without AVX2 or F16C flags - autodetect and use fast or basic conversion depends of runtime cpu
-2b we can't include and use F16C intrinsic - use basic conversion
-msvc allow to include any intrinsic independent of architecture flags, other compilers disallow this
+we can have 2 cases
+1 program compiled for aarch64: Use the native __fp16 type
+2 autodetect and use fast or basic conversion depends of runtime cpu
 */
 
 #include <util/log.h>
 
 #include <cstdint>
 
-#if (defined(__AVX__) && defined(__F16C__)) || defined(__AVX2__) || (defined(_MSC_VER) && !defined(__clang__))
-#include <algorithm>
+#if defined(__aarch64__)
+#include <arm_neon.h>
+void float_to_half(const float *src, uint16_t *dest, const int total) {
+    // use the native type __fp16
+    __fp16 *dest_fp = reinterpret_cast<__fp16 *>(dest);
+    for (int i = 0; i < total; i++) {
+        dest_fp[i] = static_cast<__fp16>(src[i]);
+    }
+}
+#else
+#if defined(__GNUC__) || defined(__clang__)
+#define TARGET_F16C __attribute__((__target__("f16c")))
 #include <immintrin.h>
-void float_to_half_AVX_F16C(const float *src, uint16_t *dest, const int total) {
+#elif defined(_MSC_VER)
+#define TARGET_F16C
+#include <intrin.h>
+#else
+#error "Compiler is not supported"
+#endif
+
+void TARGET_F16C float_to_half_AVX_F16C(const float *src, uint16_t *dest, const int total) {
     int left = total;
 
     while (left >= 8) {
@@ -54,45 +68,14 @@ void float_to_half_AVX_F16C(const float *src, uint16_t *dest, const int total) {
         std::copy_n(reinterpret_cast<uint16_t *>(data), left, dest);
     }
 }
-#endif
 
-#if (defined(__AVX__) && defined(__F16C__)) || defined(__AVX2__)
-// forced use AVX+F16C instruction set
-// AVX2 checked intentionally cause MSVC does not have __F16C__ macros
-// and checking AVX is not enough for some CPU architectures (Intel Sandy bridge)
-void float_to_half(const float *src, uint16_t *dest, const int total) {
-    float_to_half_AVX_F16C(src, dest, total);
-}
-#elif defined(__aarch64__)
-#include <arm_neon.h>
-void float_to_half(const float *src, uint16_t *dest, const int total) {
-    int left = total;
-    while (left >= 4) {
-        float32x4_t floatx4 = vld1q_f32(src);
-        float16x4_t halfx4 = vcvt_f16_f32(floatx4);
-        vst1_f16(reinterpret_cast<float16_t *>(dest), halfx4);
-        left -= 4;
-        src += 4;
-        dest += 4;
-    }
-
-    if (left > 0) {
-        float data[4] = { 0.0, 0.0, 0.0, 0.0 };
-        std::copy_n(src, left, data);
-        float32x4_t floatx4 = vld1q_f32(data);
-        float16x4_t halfx4 = vcvt_f16_f32(floatx4);
-        vst1_f16(reinterpret_cast<float16_t *>(data), halfx4);
-        std::copy_n(reinterpret_cast<uint16_t *>(data), left, dest);
-    }
-}
-#else
 #include <util/float_to_half.h>
 void float_to_half_basic(const float *src, uint16_t *dest, const int total) {
     for (int i = 0; i < total; i++) {
         dest[i] = util::encode_flt16(src[i]);
     }
 }
-#if (defined(_MSC_VER) && !defined(__clang__))
+
 // check and use AVX+F16C instruction set if possible
 
 // use function variable as imitation of self-modifying code.
@@ -116,9 +99,4 @@ void float_to_half_init(const float *src, uint16_t *dest, const int total) {
 void float_to_half(const float *src, uint16_t *dest, const int total) {
     (*float_to_half_var)(src, dest, total);
 }
-#else
-void float_to_half(const float *src, uint16_t *dest, const int total) {
-    float_to_half_basic(src, dest, total);
-}
-#endif
 #endif


### PR DESCRIPTION
Improve the float_to_half code such that native __fp16 types are used on aarch64 and on x86_64, the fast path can be used with any compiler (and not just MSVC).