### PR TITLE
renderer/vulkan: Disable the fragment shader when it has no effect

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1323,6 +1323,7 @@ enum SceGxmFragmentProgramInputs : int {
 };
 
 enum SceGxmProgramFlags : uint32_t {
+    SCE_GXM_PROGRAM_FLAG_FRAGMENT = 1 << 0,
     SCE_GXM_PROGRAM_FLAG_PER_INSTANCE_MODE = 1 << 1,
     SCE_GXM_PROGRAM_FLAG_DISCARD_USED = 1 << 3,
     SCE_GXM_PROGRAM_FLAG_DEPTH_USED = 1 << 4,
@@ -1403,7 +1404,7 @@ struct SceGxmProgram {
     uint32_t sampler_query_info_offset; // Offset to array of uint16_t
 
     SceGxmProgramType get_type() const {
-        return static_cast<SceGxmProgramType>(program_flags & SceGxmProgramType::Fragment);
+        return static_cast<SceGxmProgramType>(program_flags & SCE_GXM_PROGRAM_FLAG_FRAGMENT);
     }
     bool is_vertex() const {
         return get_type() == SceGxmProgramType::Vertex;
@@ -1441,17 +1442,14 @@ struct SceGxmProgram {
     SceGxmParameterType get_fragment_output_type() const {
         return static_cast<const SceGxmParameterType>(vertex_varyings()->output_param_type);
     }
-    std::uint8_t get_fragment_output_component_count() const {
+    uint8_t get_fragment_output_component_count() const {
         return vertex_varyings()->output_comp_count;
     }
     bool is_secondary_program_available() const {
         return secondary_program_offset < secondary_program_offset_end + 4;
     }
-    bool is_empty() const {
-        // if the primary program is empty, it will still only contain a PHAS instruction
-        return !is_secondary_program_available()
-            && primary_program_instr_count <= 1
-            && parameter_count == 0;
+    bool has_no_effect() const {
+        return (program_flags & SCE_GXM_PROGRAM_FLAG_OUTPUT_UNDEFINED) && !is_discard_used() && !is_depth_replace_used();
     }
 };
 

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -596,7 +596,7 @@ vk::Pipeline PipelineCache::retrieve_pipeline(VKContext &context, SceGxmPrimitiv
     const vk::PipelineShaderStageCreateInfo fragment_shader = retrieve_shader(gxm_fragment_shader, fragment_program.hash, false, fragment_program_gxm.is_maskupdate, mem, nullptr);
     const vk::PipelineShaderStageCreateInfo shader_stages[] = { vertex_shader, fragment_shader };
     // disable the fragment shader if gxm asks us to
-    const bool is_fragment_disabled = record.front_side_fragment_program_mode == SCE_GXM_FRAGMENT_PROGRAM_DISABLED;
+    const bool is_fragment_disabled = record.front_side_fragment_program_mode == SCE_GXM_FRAGMENT_PROGRAM_DISABLED || gxm_fragment_shader->has_no_effect();
     const uint32_t shader_stage_count = is_fragment_disabled ? 1U : 2U;
 
     const vk::PipelineInputAssemblyStateCreateInfo input_assembly{


### PR DESCRIPTION
If the fragment shader outputs no color and has no effect, it must be disabled.

This fixes the rendering issues in Borderlands 2.