### PR TITLE
ngs: Duplicate info buffers

### DIFF
--- a/vita3k/ngs/include/ngs/modules/equalizer.h
+++ b/vita3k/ngs/include/ngs/modules/equalizer.h
@@ -44,11 +44,7 @@ public:
     uint32_t module_id() const override { return 0x5CEC; }
 
     static constexpr uint32_t get_max_parameter_size() {
-        constexpr uint32_t max_size = std::max(sizeof(SceNgsParamEqParams), sizeof(SceNgsParamEqParamsCoEff));
-        // World of Final Fantasy acts as if the parameter buffer is followed by another parameter buffer
-        // Probably assuming something about the layout in ngs memory or how lock/unlock params works
-        // right now, just multiply by 2 this buffer size
-        return 2 * max_size;
+        return std::max(sizeof(SceNgsParamEqParams), sizeof(SceNgsParamEqParamsCoEff));
     }
     uint32_t get_buffer_parameter_size() const override {
         return get_max_parameter_size();


### PR DESCRIPTION
The two duplicate info buffer (VoiceLock causes ngs to use one and returns the other) are adjacent in memory.
Replicate (kind of) this behavior in Vita3K.

This fixes Borderlands 2 crashing with ngs enabled.