### PR TITLE
io/appimage: Correctly handle appdir for static and shared assets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -108,8 +108,18 @@
     {
       "name": "linux-ninja-clang15-appimage",
       "inherits": "linux-ninja-clang15",
-      "displayName": "Linux AppImage with Ninja and Clang",
+      "displayName": "Linux AppImage with Ninja and Clang 15",
       "description": "Linux AppImage build using Ninja Multi-Config generator and Clang 15 compiler",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "/usr",
+        "BUILD_APPIMAGE": true
+      }
+    },
+    {
+      "name": "linux-ninja-clang-appimage",
+      "inherits": "linux-ninja-clang",
+      "displayName": "Linux AppImage with Ninja and Clang",
+      "description": "Linux AppImage build using Ninja Multi-Config generator and Clang compiler",
       "cacheVariables": {
         "CMAKE_INSTALL_PREFIX": "/usr",
         "BUILD_APPIMAGE": true

--- a/appimage/apprun.sh
+++ b/appimage/apprun.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 if [ "${APPIMAGE}" != "" ]; then
-	XDG_DATA_DIRS="${APPDIR}/usr/share:${XDG_DATA_DIRS}" "${APPDIR}/usr/bin/Vita3K" $@
+	"${APPDIR}/usr/bin/Vita3K" $@
 fi

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -123,6 +123,7 @@ void init_paths(Root &root_paths) {
     auto XDG_DATA_HOME = getenv("XDG_DATA_HOME");
     auto XDG_CACHE_HOME = getenv("XDG_CACHE_HOME");
     auto XDG_CONFIG_HOME = getenv("XDG_CONFIG_HOME");
+    auto APPDIR = getenv("APPDIR"); // Used in AppImage
 
     if (XDG_DATA_HOME != NULL)
         root_paths.set_pref_path(fs::path(XDG_DATA_HOME) / app_name / app_name / dir_sep);
@@ -157,6 +158,10 @@ void init_paths(Root &root_paths) {
     } else if (XDG_DATA_HOME != NULL) {
         if (fs::exists(fs::path(XDG_DATA_HOME) / app_name / "data") && fs::exists(fs::path(XDG_DATA_HOME) / app_name / "lang") && fs::exists(fs::path(XDG_DATA_HOME) / app_name / "shaders-builtin"))
             root_paths.set_static_assets_path(fs::path(XDG_DATA_HOME) / app_name / dir_sep);
+    }
+
+    if (APPDIR != NULL) {
+        root_paths.set_static_assets_path(fs::path(APPDIR) / "usr/share/Vita3K");
     }
 
     // shared path


### PR DESCRIPTION
* Shared path is supposed to be ALWAYS read-write, with this we only set the static assets dir to the correct one inside appdir for the appimage

Before:
![image](https://github.com/Vita3K/Vita3K/assets/30161277/17cfcfeb-8939-4443-8ff8-46bfc25839f8)

After: 
![image](https://github.com/Vita3K/Vita3K/assets/30161277/68f19d9a-dd39-4426-a150-b74c46736b6b)
