### PR TITLE
appimage: Fix desktop integration

### DIFF
--- a/appimage/apprun.sh
+++ b/appimage/apprun.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 if [ "${APPIMAGE}" != "" ]; then
+	export PATH="$APPDIR/usr/bin:$PATH"
 	"${APPDIR}/usr/bin/Vita3K" $@
 fi

--- a/appimage/vita3k.desktop
+++ b/appimage/vita3k.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Type=Application
 Name=Vita3K
+Exec=Vita3K
 Icon=vita3k
 Categories=Game;Emulator;X-None;


### PR DESCRIPTION
Running the appimage once worked fine, but clicking the option to integrate it into the desktop wasnt working because the desktop entry was wrong, it was missing the `Exec` line.