### PR TITLE
gui, np: Replace PSN status by signed in

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <np/state.h>
-
 #include <util/log.h>
 #include <util/system.h>
 
@@ -142,7 +140,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "shader-cache", true, shader_cache)                                                      \
     code(bool, "spirv-shader", false, spirv_shader)                                                     \
     code(uint64_t, "current-ime-lang", 4, current_ime_lang)                                             \
-    code(int, "psn-status", static_cast<int>(SCE_NP_SERVICE_STATE_UNKNOWN), psn_status)                 \
+    code(int, "psn-signed-in", false, psn_signed_in)                                                    \
     code(bool, "http-enable", true, http_enable)                                                        \
     code(int, "http-timeout-attempts", 50, http_timeout_attempts)                                       \
     code(int, "http-timeout-sleep-ms", 100, http_timeout_sleep_ms)                                      \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -131,7 +131,7 @@ public:
         bool export_as_png = false;
         bool stretch_the_display_area = false;
         bool show_touchpad_cursor = true;
-        int psn_status = SCE_NP_SERVICE_STATE_UNKNOWN;
+        bool psn_signed_in = false;
     };
 
     /**

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -198,7 +198,7 @@ static bool get_custom_config(GuiState &gui, EmuEnvState &emuenv, const std::str
             // Load Network Config
             if (!config_child.child("network").empty()) {
                 const auto network_child = config_child.child("network");
-                config.psn_status = network_child.attribute("psn-status").as_int();
+                config.psn_signed_in = network_child.attribute("psn-signed-in").as_bool();
             }
 
             return true;
@@ -246,7 +246,7 @@ void init_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
         config.pstv_mode = emuenv.cfg.pstv_mode;
         config.ngs_enable = emuenv.cfg.ngs_enable;
         config.show_touchpad_cursor = emuenv.cfg.show_touchpad_cursor;
-        config.psn_status = emuenv.cfg.psn_status;
+        config.psn_signed_in = emuenv.cfg.psn_signed_in;
     }
 
     list_user_lang.clear();
@@ -332,7 +332,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
 
         // Network
         auto network_child = config_child.append_child("network");
-        network_child.append_attribute("psn-status") = config.psn_status;
+        network_child.append_attribute("psn-signed-in") = config.psn_signed_in;
 
         const auto save_xml = custom_config_xml.save_file(CUSTOM_CONFIG_PATH.c_str());
         if (!save_xml)
@@ -354,7 +354,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         emuenv.cfg.export_as_png = config.export_as_png;
         emuenv.cfg.ngs_enable = config.ngs_enable;
         emuenv.cfg.show_touchpad_cursor = config.show_touchpad_cursor;
-        emuenv.cfg.psn_status = config.psn_status;
+        emuenv.cfg.psn_signed_in = config.psn_signed_in;
     }
 
     if (emuenv.cfg.stretch_the_display_area != config.stretch_the_display_area) {
@@ -416,7 +416,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.cfg.current_config.export_as_png = emuenv.cfg.export_as_png;
         emuenv.cfg.current_config.ngs_enable = emuenv.cfg.ngs_enable;
         emuenv.cfg.current_config.show_touchpad_cursor = emuenv.cfg.show_touchpad_cursor;
-        emuenv.cfg.current_config.psn_status = emuenv.cfg.psn_status;
+        emuenv.cfg.current_config.psn_signed_in = emuenv.cfg.psn_signed_in;
     }
 
     // If backend render or resolution multiplier is changed when app run, reboot emu and app
@@ -1057,9 +1057,9 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (psn / 2.f));
         ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "PlayStation Network");
         ImGui::Spacing();
-        ImGui::Combo(lang.network["psn_status"].c_str(), &config.psn_status, "Unknown\0Signed Out\0Signed In\0Online\0");
+        ImGui::Checkbox("Signed in PSN", &config.psn_signed_in);
         if (ImGui::IsItemHovered())
-            ImGui::SetTooltip("%s", lang.network["select_psn_state"].c_str());
+            ImGui::SetTooltip("%s", "If checked, games will consider the user is connected to the PSN network (but offline)");
 
         // HTTP
         ImGui::Spacing();

--- a/vita3k/modules/SceNpManager/SceNpManager.cpp
+++ b/vita3k/modules/SceNpManager/SceNpManager.cpp
@@ -64,14 +64,11 @@ EXPORT(int, sceNpAuthGetAuthorizationCode) {
 
 EXPORT(int, sceNpCheckCallback) {
     TRACY_FUNC(sceNpCheckCallback);
-    if (emuenv.np.state == 0)
-        return 0;
-
-    emuenv.np.state = emuenv.cfg.current_config.psn_status;
 
     const ThreadStatePtr thread = lock_and_find(thread_id, emuenv.kernel.threads, emuenv.kernel.mutex);
+    const SceNpServiceState state = emuenv.cfg.current_config.psn_signed_in ? SCE_NP_SERVICE_STATE_SIGNED_IN : SCE_NP_SERVICE_STATE_SIGNED_OUT;
     for (auto &callback : emuenv.np.cbs) {
-        thread->run_callback(callback.second.pc, { (uint32_t)emuenv.np.state, 0, callback.second.data });
+        thread->run_callback(callback.second.pc, { static_cast<uint32_t>(state), 0, callback.second.data });
     }
 
     return STUBBED("Stub");
@@ -79,7 +76,7 @@ EXPORT(int, sceNpCheckCallback) {
 
 EXPORT(int, sceNpGetServiceState, SceNpServiceState *state) {
     TRACY_FUNC(sceNpGetServiceState, state);
-    *state = static_cast<SceNpServiceState>(emuenv.cfg.current_config.psn_status);
+    *state = emuenv.cfg.current_config.psn_signed_in ? SCE_NP_SERVICE_STATE_SIGNED_IN : SCE_NP_SERVICE_STATE_SIGNED_OUT;
 
     return STUBBED("Stub");
 }

--- a/vita3k/np/include/np/state.h
+++ b/vita3k/np/include/np/state.h
@@ -52,18 +52,17 @@ struct NpTrophyState {
     NpTrophyUnlockCallback trophy_unlock_callback;
 };
 
-enum SceNpServiceState {
-    SCE_NP_SERVICE_STATE_UNKNOWN,
-    SCE_NP_SERVICE_STATE_SIGNED_OUT,
-    SCE_NP_SERVICE_STATE_SIGNED_IN,
-    SCE_NP_SERVICE_STATE_ONLINE
+enum SceNpServiceState : uint32_t {
+    SCE_NP_SERVICE_STATE_UNKNOWN = 0,
+    SCE_NP_SERVICE_STATE_SIGNED_OUT = 1,
+    SCE_NP_SERVICE_STATE_SIGNED_IN = 2,
+    SCE_NP_SERVICE_STATE_ONLINE = 3
 };
 
 struct NpState {
     bool inited = false;
     np_callbacks cbs;
     int state_cb_id;
-    int state = -1;
 
     NpTrophyState trophy_state;
     np::CommunicationID comm_id;


### PR DESCRIPTION
Remove the PSN status option as Vita3K supports no online capability and Unknown is basically never supposed to be returned.
Set the PSN status to signed out by default as this matches the best the current state of Vita3K (we don't want games calling too many PSN functions).

This allows Borderlands 2 and Bastion to boot without having to change settings.