### PR TITLE
packages: Copy self authid when decrypting

### DIFF
--- a/vita3k/packages/include/packages/sce_types.h
+++ b/vita3k/packages/include/packages/sce_types.h
@@ -251,14 +251,12 @@ public:
     };
 };
 
-class AppInfoHeader {
-private:
+struct AppInfoHeader {
     uint64_t auth_id;
     uint32_t vendor_id;
     uint32_t _self_type;
     uint64_t field_18;
 
-public:
     static const int Size = 32;
     uint64_t sys_version;
     SelfType self_type;
@@ -658,8 +656,8 @@ public:
 void register_keys(KeyStore &SCE_KEYS, int type);
 void extract_fat(const std::wstring &partition_path, const std::string &partition, const std::wstring &pref_path);
 std::string decompress_segments(const std::vector<uint8_t> &decrypted_data, const uint64_t &size);
-void self2elf(const fs::path &infile, const fs::path &outfile, KeyStore &SCE_KEYS, unsigned char *klictxt);
-void make_fself(const fs::path &input_file, const fs::path &output_file);
+void self2elf(const fs::path &infile, const fs::path &outfile, KeyStore &SCE_KEYS, unsigned char *klictxt, uint64_t *authid);
+void make_fself(const fs::path &input_file, const fs::path &output_file, uint64_t authid);
 std::tuple<uint64_t, SelfType> get_key_type(std::ifstream &file, const SceHeader &sce_hdr);
 std::vector<SceSegment> get_segments(std::ifstream &file, const SceHeader &sce_hdr, KeyStore &SCE_KEYS, uint64_t sysver = -1, SelfType self_type = static_cast<SelfType>(0), int keytype = 0, unsigned char *klictxt = 0);
 void decrypt_fself(const fs::path &file_path, KeyStore &SCE_KEYS, unsigned char *klictxt);

--- a/vita3k/packages/src/pkg.cpp
+++ b/vita3k/packages/src/pkg.cpp
@@ -98,9 +98,10 @@ bool decrypt_install_nonpdrm(EmuEnvState &emuenv, std::string &drmlicpath, const
 
     for (const auto &file : fs::recursive_directory_iterator(title_id_src)) {
         if ((file.path().extension() == ".suprx") || (file.path().extension() == ".self") || (file.path().filename() == "eboot.bin")) {
-            self2elf(file.path().string(), file.path().string() + "elf", SCE_KEYS, temp_klicensee.data());
+            uint64_t authid = 0x2F00000000000001ULL;
+            self2elf(file.path().string(), file.path().string() + "elf", SCE_KEYS, temp_klicensee.data(), &authid);
             fs::rename(file.path().string() + "elf", file.path().string());
-            make_fself(file.path().string(), file.path().string() + "fself");
+            make_fself(file.path().string(), file.path().string() + "fself", authid);
             fs::rename(file.path().string() + "fself", file.path().string());
             LOG_INFO("Decrypted {} with klicensee {}", file.path().string(), byte_array_to_string(temp_klicensee.data(), 16));
         }


### PR DESCRIPTION
This allows self files generated by Vita3K to match exactly self files decrypted using third-party tools.
This is useful when patching file with a hash check (right now it is not possible to patch the eboot file of Tales of Innocence decrypted with Vita3K with the english patch).