### PR TITLE
Initialize cache_path when installing packages from the command line

### DIFF
--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -150,6 +150,7 @@ int main(int argc, char *argv[]) {
             }
             if (cfg.pkg_path.has_value() && cfg.pkg_zrif.has_value()) {
                 LOG_INFO("Installing pkg from {} ", *cfg.pkg_path);
+                emuenv.cache_path = string_utils::utf_to_wide(root_paths.get_cache_path_string());
                 emuenv.pref_path = string_utils::utf_to_wide(cfg.pref_path);
                 install_pkg(*cfg.pkg_path, emuenv, *cfg.pkg_zrif, [](float) {});
             }


### PR DESCRIPTION
When installing an app or a patch, Vita3k creates a license file based on the zRIF. This currently requires `emuenv.cache_path` to be initialized, as the temporary license is created there, and then moved into the proper location. This path is not currently initialized when installing packages via a command-line argument, as it is only ever initialized in `app::init`.

This patch initializes this path in the CLI pkg install code path in `main`, similar to `pref_path`.