### PR TITLE
codec, renderer: Improve YUV format implementation

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -100,6 +100,9 @@ struct H264DecoderState : public DecoderState {
     uint64_t dts = ~0ull;
     uint64_t pts_out = ~0ull;
 
+    // true means the output format is yuv420p3, false means it is yuv420p2
+    bool output_yuvp3;
+
     bool is_stopped = true;
 
     static uint32_t buffer_size(DecoderSize size);
@@ -112,6 +115,7 @@ struct H264DecoderState : public DecoderState {
     void set_res(const uint32_t width, const uint32_t height);
     void get_res(uint32_t &width, uint32_t &height);
     void get_pts(uint32_t &upper, uint32_t &lower);
+    void set_output_format(bool is_yuv_p3);
 
     H264DecoderState(uint32_t width, uint32_t height);
     ~H264DecoderState() override;
@@ -261,5 +265,5 @@ struct PlayerState {
 void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, int32_t inPitch);
 void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t width, uint32_t height, const DecoderColorSpace color_space);
 int convert_yuv_to_jpeg(const uint8_t *yuv, uint8_t *jpeg, uint32_t width, uint32_t height, uint32_t max_size, const DecoderColorSpace color_space, int32_t compress_ratio);
-void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest, const uint32_t width, const uint32_t height);
+void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest, const uint32_t width, const uint32_t height, bool is_p3);
 std::string codec_error_name(int error);

--- a/vita3k/codec/src/player.cpp
+++ b/vita3k/codec/src/player.cpp
@@ -225,7 +225,7 @@ std::vector<uint8_t> PlayerState::receive_video() {
 
         data.resize(H264DecoderState::buffer_size(
             { { static_cast<uint32_t>(video_context->width), static_cast<uint32_t>(video_context->height) } }));
-        copy_yuv_data_from_frame(frame, data.data(), frame->width, frame->height);
+        copy_yuv_data_from_frame(frame, data.data(), frame->width, frame->height, false);
 
         break;
     }

--- a/vita3k/modules/SceVideodec/SceVideodecUser.cpp
+++ b/vita3k/modules/SceVideodec/SceVideodecUser.cpp
@@ -200,7 +200,14 @@ EXPORT(int, sceAvcdecDecode, SceAvcdecCtrl *decoder, const SceAvcdecAu *au, SceA
     SceAvcdecPicture *pPicture = picture->pPicture.get(emuenv.mem)[0].get(emuenv.mem);
     uint8_t *output = pPicture->frame.pPicture[0].cast<uint8_t>().get(emuenv.mem);
 
-    // TODO: decoding can be done async I think
+    if ((pPicture->frame.pixelType & (SCE_AVCDEC_PIXEL_YUV420_RASTER | SCE_AVCDEC_PIXEL_YUV420_PACKED_RASTER)) == 0) {
+        LOG_ERROR_ONCE("Avcdec rgba output is not implemented");
+        picture->numOfOutput++;
+        return 0;
+    }
+    bool is_yuvp3 = static_cast<bool>(pPicture->frame.pixelType & SCE_AVCDEC_PIXEL_YUV420_RASTER);
+    decoder_info->set_output_format(is_yuvp3);
+
     decoder_info->configure(&options);
     const auto send = decoder_info->send(reinterpret_cast<uint8_t *>(au->es.pBuf.get(emuenv.mem)), au->es.size);
     decoder_info->set_res(pPicture->frame.frameWidth, pPicture->frame.frameHeight);

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -151,7 +151,7 @@ namespace texture {
 // Paletted textures.
 void palette_texture_to_rgba_4(uint32_t *dst, const uint8_t *src, uint32_t width, uint32_t height, const uint32_t *palette);
 void palette_texture_to_rgba_8(uint32_t *dst, const uint8_t *src, uint32_t width, uint32_t height, const uint32_t *palette);
-void yuv420P3_texture_to_rgb(uint8_t *dst, const uint8_t *src, uint32_t width, uint32_t height, uint32_t layout_width, uint32_t layout_height);
+void yuv420_texture_to_rgb(uint8_t *dst, const uint8_t *src, uint32_t width, uint32_t height, uint32_t layout_width, uint32_t layout_height, bool is_p3);
 const uint32_t *get_texture_palette(const SceGxmTexture &texture, const MemState &mem);
 
 /**

--- a/vita3k/renderer/src/texture/cache.cpp
+++ b/vita3k/renderer/src/texture/cache.cpp
@@ -524,15 +524,12 @@ void TextureCache::upload_texture(const SceGxmTexture &gxm_texture, MemState &me
             pixels = texture_data_decompressed.data();
             upload_format = SCE_GXM_TEXTURE_BASE_FORMAT_F32;
             break;
-        // TODO: we are decoding YUV420P2 as YUV420P3, that's completely wrong...
-        // The reason I do not put an error message instead is because the video decoder
-        // is always outputting YUV420P2 frames (instead of what is asked by the user...)
-        // so this works in this case but that needs to be fixed
         case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P2:
         case SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P3:
             texture_data_decompressed.resize(pixels_per_stride * memory_height * 4);
-            yuv420P3_texture_to_rgb(texture_data_decompressed.data(),
-                reinterpret_cast<const uint8_t *>(pixels), pixels_per_stride, memory_height, layout_width, layout_height);
+            yuv420_texture_to_rgb(texture_data_decompressed.data(),
+                reinterpret_cast<const uint8_t *>(pixels), pixels_per_stride, memory_height, layout_width, layout_height,
+                base_format == SCE_GXM_TEXTURE_BASE_FORMAT_YUV420P3);
             pixels = texture_data_decompressed.data();
             bpp = 32;
             upload_format = SCE_GXM_TEXTURE_BASE_FORMAT_U8U8U8U8;

--- a/vita3k/renderer/src/texture/yuv.cpp
+++ b/vita3k/renderer/src/texture/yuv.cpp
@@ -29,12 +29,14 @@ namespace renderer::texture {
 
 static SwsContext *s_render_sws_context{};
 static size_t res[2] = { 0, 0 };
-SwsContext *get_sws_context(size_t width, size_t height) {
+static bool is_yuv_p3 = false;
+static SwsContext *get_sws_context(size_t width, size_t height, bool is_p3) {
     bool recreate = false;
-    if (res[0] != width || res[1] != height) {
+    if (res[0] != width || res[1] != height || is_yuv_p3 != is_p3) {
         recreate = true;
         res[0] = width;
         res[1] = height;
+        is_yuv_p3 = is_p3;
     } else if (s_render_sws_context == nullptr) {
         recreate = true;
     }
@@ -44,20 +46,21 @@ SwsContext *get_sws_context(size_t width, size_t height) {
             sws_freeContext(s_render_sws_context);
             s_render_sws_context = nullptr;
         }
-        s_render_sws_context = sws_getContext(width, height, AV_PIX_FMT_YUV420P, width, height, AV_PIX_FMT_RGB0,
+        const AVPixelFormat format = is_p3 ? AV_PIX_FMT_YUV420P : AV_PIX_FMT_NV12;
+        s_render_sws_context = sws_getContext(width, height, format, width, height, AV_PIX_FMT_RGB0,
             0, nullptr, nullptr, nullptr);
     }
     return s_render_sws_context;
 }
 
-void yuv420P3_texture_to_rgb(uint8_t *dst, const uint8_t *src, uint32_t width, uint32_t height, uint32_t layout_width, uint32_t layout_height) {
-    SwsContext *context = get_sws_context(width, height);
+void yuv420_texture_to_rgb(uint8_t *dst, const uint8_t *src, uint32_t width, uint32_t height, uint32_t layout_width, uint32_t layout_height, bool is_p3) {
+    SwsContext *context = get_sws_context(width, height, is_p3);
     assert(context);
 
     const uint8_t *slices[] = {
         src, // Y Slice
-        src + layout_width * layout_height, // U Slice
-        src + layout_width * layout_height + layout_width * layout_height / 4, // V Slice
+        src + layout_width * layout_height, // U(V for P2) Slice
+        src + layout_width * layout_height + layout_width * layout_height / 4, // V Slice (for P3)
     };
 
     int strides[] = {
@@ -65,6 +68,11 @@ void yuv420P3_texture_to_rgb(uint8_t *dst, const uint8_t *src, uint32_t width, u
         static_cast<int>(width / 2),
         static_cast<int>(width / 2),
     };
+    if (!is_p3) {
+        // src only have two slices
+        strides[1] = static_cast<int>(width);
+        strides[2] = 0;
+    }
 
     uint8_t *dst_slices[] = {
         dst,
@@ -77,4 +85,5 @@ void yuv420P3_texture_to_rgb(uint8_t *dst, const uint8_t *src, uint32_t width, u
     int error = sws_scale(context, slices, strides, 0, height, dst_slices, dst_strides);
     assert(error == height);
 }
+
 } // namespace renderer::texture


### PR DESCRIPTION
When using the video decoder, the game can ask whether to output YUV P3 (3 planes) or YUV P2(2planes, the U and V components are interleaved). Most games actually ask for a YUV P2 format.
However, before this PR, Vita3K was not looking at this and always outputting YUVP3 images. This was not causing issues for most of the games as YUVP2 textures are decoded as if they were YUVP3 (which is completely wrong, I noticed this while rewriting the texture cache and this was not documented...).

This PR properly decodes H264 as YUVP2 or YUVP3 depending on what has been asked and properly support the YUVP2 format in the renderer.

This fixes the FMVs in Ys Origin.