### PR TITLE
kernel: Improve thread end callback

### DIFF
--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -194,18 +194,20 @@ bool ThreadState::run_loop() {
             return;
 
         ThreadToDo old_to_do = to_do;
-        to_do = ThreadToDo::run;
         int old_call_level = call_level;
+        uint32_t old_returned_value = returned_value;
+        to_do = ThreadToDo::run;
         call_level = 1;
 
         lock.unlock();
-        int ret = run_callback(kernel.thread_event_end.address(), { SCE_KERNEL_THREAD_EVENT_TYPE_START, static_cast<uint32_t>(id), 0, kernel.thread_event_end_arg });
+        int ret = run_callback(kernel.thread_event_end.address(), { SCE_KERNEL_THREAD_EVENT_TYPE_END, static_cast<uint32_t>(id), 0, kernel.thread_event_end_arg });
         if (ret != 0)
             LOG_WARN("Thread start event handler returned {}", log_hex(ret));
         lock.lock();
 
         to_do = old_to_do;
         call_level = old_call_level;
+        returned_value = old_returned_value;
     };
 
     while (true) {


### PR DESCRIPTION
- The value given to the thread end callback should obviously be SCE_KERNEL_THREAD_EVENT_TYPE_END and not SCE_KERNEL_THREAD_EVENT_TYPE_START (although it did not matter as this value is not used by libc's callback)
- We must make sure the returned value is not modified by the thread end callback, Tearaway was expecting a thread to return 1 and the callback was modifying it to 0, causing the game to loop in menu.

This allows Tearaway to go back again ingame.