### PR TITLE
renderer/vulkan: Use empty mask if frag has no output

### DIFF
--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -639,7 +639,8 @@ vk::Pipeline PipelineCache::retrieve_pipeline(VKContext &context, SceGxmPrimitiv
     };
 
     vk::PipelineColorBlendStateCreateInfo color_blending{};
-    if (is_fragment_disabled || use_shader_interlock) {
+    const bool frag_has_no_output = static_cast<bool>(gxm_fragment_shader->program_flags & SCE_GXM_PROGRAM_FLAG_OUTPUT_UNDEFINED);
+    if (is_fragment_disabled || frag_has_no_output || use_shader_interlock) {
         // The write mask must be empty as the lack of a fragment shader results in undefined values
         static const vk::PipelineColorBlendAttachmentState blending = {
             .blendEnable = VK_FALSE,


### PR DESCRIPTION
If a fragment shader has no output, but has a side effect (depth replacement / discard), we can't disable it. However, we still want it not to affect the surface (by setting the write mask to 0).

This fixes the (small) remaining graphical issues during menu/character selection in project diva X.