### PR TITLE
kernel: Page-align the stack size

### DIFF
--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -52,6 +52,9 @@ bool ThreadSignal::send() {
 int ThreadState::init(const char *name, Ptr<const void> entry_point, int init_priority, SceInt32 affinity_mask, int stack_size, const SceKernelThreadOptParam *option = nullptr) {
     constexpr size_t KERNEL_TLS_SIZE = 0x800;
 
+    // the stack size should be page-aligned
+    stack_size = align(stack_size, KiB(4));
+
     this->name = name;
     this->entry_point = entry_point.address();
 


### PR DESCRIPTION
The kernel rounds up the stack size to the next page size.
Spiderman was allocating a stack of size 0x180c4 and expecting the stack pointer to be 8 byte aligned, which wasn't the case.
This allows Spiderman to go ingame---.