### PR TITLE
modules/SceGxm: Decrease stubbed rendertarget size

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2634,11 +2634,11 @@ EXPORT(uint32_t, sceGxmGetPrecomputedVertexStateSize, const SceGxmVertexProgram 
 
 EXPORT(int, sceGxmGetRenderTargetMemSize, const SceGxmRenderTargetParams *params, uint32_t *hostMemSize) {
     TRACY_FUNC(sceGxmGetRenderTargetMemSize, params, hostMemSize);
-    if (!params) {
+    if (!params || !hostMemSize)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
-    }
-    *hostMemSize = uint32_t(MiB(2));
-    return STUBBED("2MiB emuenv mem");
+
+    *hostMemSize = static_cast<uint32_t>(KiB(64));
+    return STUBBED("64KiB emuenv mem");
 }
 
 EXPORT(int, sceGxmInitialize, const SceGxmInitializeParams *params) {


### PR DESCRIPTION
According to my testing, the rendertarget size goes from 80 KB (128x128, one scene per frame) to 5MB (4096x4096, 3 scenes per frame), and is for a usual target around 200KB. The current value of 2MB is way too much and can cause out of memory issues in some cases. It is way better to give a lower bound (we don't use this memory anyway), so I now set it to 64KB.

This allows Killzone to progress further ingame.