### PR TITLE
modules/SceGxm: Workaround to prevent softlock when swapping images

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -913,7 +913,11 @@ static void display_entry_thread(EmuEnvState &emuenv) {
         SceGxmSyncObject *new_sync = display_callback->new_sync.get(emuenv.mem);
 
         // Wait for fragment on the new buffer to finish
-        renderer::wishlist(new_sync, display_callback->new_sync_timestamp);
+        // set a (big) time limit to make sure we don't softlock
+        constexpr int one_second = 1'000'000;
+        if (!renderer::wishlist(new_sync, display_callback->new_sync_timestamp, one_second))
+            LOG_ERROR_ONCE("Failed to wait for the new frame to be ready");
+
         // now we can remove the thread from the display queue
         display_queue.pop();
 


### PR DESCRIPTION
Unit 13 has a situation where:
- Frame A is being presented
- The game asks for frame B to be presented instead of frame A, causing the display entry thread to wait for frame B to be ready before swapping it
- The game renders to frame A then to frame B, causing the render thread to wait for frame A to be available (not being displayed anymore) before doing anything

To be honest, I'm not sure how to react in this situation, but it looks like softlocking is not the correct way. Instead, as a better workaround, if the display thread waits for (way) too much, just do the swap.

This allows Unit 13 to go ingame.