### PR TITLE
renderer: Use accurate sync object synchronisation only with high accuracy

### DIFF
--- a/vita3k/renderer/src/sync.cpp
+++ b/vita3k/renderer/src/sync.cpp
@@ -45,7 +45,7 @@ COMMAND(handle_signal_sync_object) {
     SceGxmSyncObject *sync = helper.pop<Ptr<SceGxmSyncObject>>().get(mem);
     const uint32_t timestamp = helper.pop<uint32_t>();
 
-    if (features.support_memory_mapping) {
+    if (features.support_memory_mapping && config.current_config.high_accuracy) {
         assert(renderer.current_backend == renderer::Backend::Vulkan);
         vulkan::signal_sync_object(dynamic_cast<vulkan::VKState &>(renderer), sync, timestamp);
     } else {


### PR DESCRIPTION
Only signaling sync objects after the whole render has been done is more accurate and needed by a few games (like Persona 4).
However, it has a really big performance cost for many games (30-40% performance decrease), so this PR only enables it with high accuracy enabled.