### PR TITLE
app: fix incorrect AppImage assets handling

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -160,7 +160,7 @@ void init_paths(Root &root_paths) {
             root_paths.set_static_assets_path(fs::path(XDG_DATA_HOME) / app_name / dir_sep);
     }
 
-    if (APPDIR != NULL) {
+    if (APPDIR != NULL && fs::exists(fs::path(APPDIR) / "usr/share/Vita3K")) {
         root_paths.set_static_assets_path(fs::path(APPDIR) / "usr/share/Vita3K");
     }
 


### PR DESCRIPTION
Fixes an issue where if Vita3K is called to run from an AppImage (not AS an AppImage) it will incorrectly believe that it is running AS an AppImage, and try to read its files from a place they do not exist