### PR TITLE
modules/SceThreadmgr: Return 1 as the process id

### DIFF
--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -1168,8 +1168,8 @@ EXPORT(int, sceKernelGetMsgPipeCreatorId) {
 
 EXPORT(int, sceKernelGetProcessId) {
     TRACY_FUNC(sceKernelGetProcessId);
-    STUBBED("pid: 0");
-    return 0;
+    STUBBED("pid: 1");
+    return 1;
 }
 
 EXPORT(uint64_t, sceKernelGetSystemTimeWide) {


### PR DESCRIPTION
Returning 0 as the process id sounds like a very bad idea. I'm not sure if this fixes anything but I'd better change it now than spend hours debugging a game to figure out this is the cause.