### PR TITLE
renderer, shader: FX10 and regformat improvements

### DIFF
--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -234,7 +234,7 @@ bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgra
         // Insert some symbols here
         if (program.primary_reg_count != 0) {
             for (size_t i = 0; i < attributes.size(); i++) {
-                vp->attribute_infos.emplace(attributes[i].regIndex, shader::usse::AttributeInformation(static_cast<uint16_t>(i), SCE_GXM_PARAMETER_TYPE_F32, false, false, false));
+                vp->attribute_infos.emplace(attributes[i].regIndex, shader::usse::AttributeInformation(static_cast<uint16_t>(i), SCE_GXM_PARAMETER_TYPE_F32, 1, false, false, false));
             }
         }
     }

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -29,8 +29,8 @@ vk::Format translate_attribute_format(SceGxmAttributeFormat format, unsigned int
     static constexpr vk::Format formats_integer[][4] = {
         /*SCE_GXM_ATTRIBUTE_FORMAT_U8*/ { vk::Format::eR8Uint, vk::Format::eR8G8Uint, vk::Format::eR8G8B8Uint, vk::Format::eR8G8B8A8Uint },
         /*SCE_GXM_ATTRIBUTE_FORMAT_S8*/ { vk::Format::eR8Sint, vk::Format::eR8G8Sint, vk::Format::eR8G8B8Sint, vk::Format::eR8G8B8A8Sint },
-        /*SCE_GXM_ATTRIBUTE_FORMAT_U16*/ { vk::Format::eR16Uint, vk::Format::eR16G16Uint, vk::Format::eR16G16B16Uint, vk::Format::eR8G8B8A8Uint },
-        /*SCE_GXM_ATTRIBUTE_FORMAT_S16*/ { vk::Format::eR16Sint, vk::Format::eR16G16Sint, vk::Format::eR16G16B16Sint, vk::Format::eR8G8B8A8Sint },
+        /*SCE_GXM_ATTRIBUTE_FORMAT_U16*/ { vk::Format::eR16Uint, vk::Format::eR16G16Uint, vk::Format::eR16G16B16Uint, vk::Format::eR16G16B16A16Uint },
+        /*SCE_GXM_ATTRIBUTE_FORMAT_S16*/ { vk::Format::eR16Sint, vk::Format::eR16G16Sint, vk::Format::eR16G16B16Sint, vk::Format::eR16G16B16A16Sint },
     };
 
     static constexpr vk::Format formats_integer_as_float[][4] = {

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -37,7 +37,7 @@ namespace shader {
 static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
-static constexpr uint32_t CURRENT_VERSION = 12;
+static constexpr uint32_t CURRENT_VERSION = 13;
 
 enum struct Target {
     GLSLOpenGL,

--- a/vita3k/shader/include/shader/usse_program_analyzer.h
+++ b/vita3k/shader/include/shader/usse_program_analyzer.h
@@ -31,6 +31,7 @@ using UniformBufferSizes = std::array<std::uint32_t, 15>;
 
 struct SceGxmProgramParameter;
 struct SceGxmProgram;
+enum SceGxmParameterType : uint8_t;
 
 namespace shader::usse {
 /**
@@ -197,7 +198,9 @@ public:
 };
 
 struct AttributeInformation {
-    std::uint32_t info;
+    uint16_t location;
+    SceGxmParameterType gxm_type;
+    uint8_t component_count;
     // this is needed for Vulkan as it doesn't implicitly convert between integers and floats and between signed and unsigned
     bool is_integer;
     // only meaningful is is_integer is true
@@ -205,29 +208,25 @@ struct AttributeInformation {
     bool regformat;
 
     explicit AttributeInformation()
-        : info(0)
+        : location(0)
+        , gxm_type(static_cast<SceGxmParameterType>(0))
+        , component_count(0)
         , is_integer(false)
         , is_signed(false)
         , regformat(false) {
     }
 
-    explicit AttributeInformation(const std::uint16_t loc, const std::uint16_t gxm_type, const bool is_integer, const bool is_signed, const bool regformat)
-        : info(loc | (static_cast<std::uint32_t>(gxm_type) << 16))
+    explicit AttributeInformation(uint16_t loc, SceGxmParameterType type, uint8_t count, bool is_integer, bool is_signed, bool regformat)
+        : location(loc)
+        , gxm_type(type)
+        , component_count(count)
         , is_integer(is_integer)
         , is_signed(is_signed)
         , regformat(regformat) {
     }
-
-    std::uint16_t location() const {
-        return static_cast<std::uint16_t>(info);
-    }
-
-    std::uint16_t gxm_type() const {
-        return static_cast<std::uint16_t>(info >> 16);
-    }
 };
 
-using USSEOffset = std::uint32_t;
+using USSEOffset = uint32_t;
 
 using UniformBufferMap = std::map<int, UniformBuffer>;
 using AttributeInformationMap = std::map<int, AttributeInformation>;

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -33,8 +33,7 @@ struct SpirvUtilFunctions {
     std::map<DataType, spv::Function *> unpack_funcs;
     std::map<DataType, spv::Function *> pack_funcs;
     spv::Function *fetch_memory{ nullptr };
-    spv::Function *pack_fx8{ nullptr };
-    spv::Function *unpack_fx8{ nullptr };
+    spv::Function *unpack_fx10{ nullptr };
 
     // buffer_addres_vec[i][1] contains the buffer pointer with an array of vec_i and stride 16 bytes
     // 0 in the last index is for the read buffer, 1 is for the write buffer

--- a/vita3k/shader/src/gxp_parser.cpp
+++ b/vita3k/shader/src/gxp_parser.cpp
@@ -40,36 +40,32 @@ GenericType translate_generic_type(const gxp::GenericParameterType &type) {
 
 std::tuple<DataType, std::string> get_parameter_type_store_and_name(const SceGxmParameterType &type) {
     switch (type) {
-    case SCE_GXM_PARAMETER_TYPE_F32: {
+    case SCE_GXM_PARAMETER_TYPE_F32:
         return std::make_tuple(DataType::F32, "float");
-    }
 
-    case SCE_GXM_PARAMETER_TYPE_F16: {
+    case SCE_GXM_PARAMETER_TYPE_F16:
         return std::make_tuple(DataType::F16, "half");
-    }
 
-    case SCE_GXM_PARAMETER_TYPE_U16: {
+    case SCE_GXM_PARAMETER_TYPE_U16:
         return std::make_tuple(DataType::UINT16, "ushort");
-    }
 
-    case SCE_GXM_PARAMETER_TYPE_S16: {
+    case SCE_GXM_PARAMETER_TYPE_S16:
         return std::make_tuple(DataType::INT16, "ishort");
-    }
 
-    case SCE_GXM_PARAMETER_TYPE_U8: {
+    case SCE_GXM_PARAMETER_TYPE_U8:
         return std::make_tuple(DataType::UINT8, "uchar");
-    }
 
-    case SCE_GXM_PARAMETER_TYPE_S8: {
+    case SCE_GXM_PARAMETER_TYPE_S8:
         return std::make_tuple(DataType::INT8, "ichar");
-    }
 
-    case SCE_GXM_PARAMETER_TYPE_U32: {
+    case SCE_GXM_PARAMETER_TYPE_C10:
+        return std::make_tuple(DataType::C10, "fixed");
+
+    case SCE_GXM_PARAMETER_TYPE_U32:
         return std::make_tuple(DataType::UINT32, "uint");
-    }
-    case SCE_GXM_PARAMETER_TYPE_S32: {
+
+    case SCE_GXM_PARAMETER_TYPE_S32:
         return std::make_tuple(DataType::INT32, "int");
-    }
 
     default:
         return std::make_tuple(DataType::UNK, "unk");

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -170,7 +170,7 @@ static spv::Id get_type_basic(spv::Builder &b, const Input &input) {
 
     // clang-format on
     default: {
-        LOG_ERROR("Unsupported parameter type {} used in shader.", log_hex(input.type));
+        LOG_ERROR("Unsupported parameter type {} used in shader.", log_hex(fmt::underlying(input.type)));
         return get_type_fallback(b);
     }
     }
@@ -1088,7 +1088,6 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
     }
 
     const auto add_var_to_reg = [&](const Input &input, const std::string &name, std::uint16_t semantic, bool pa, bool regformat, std::int32_t location) {
-        const spv::Id param_type = get_param_type(b, input);
         const int type_size = get_data_type_size(input.type);
         spv::Id var;
         if (regformat) {
@@ -1111,6 +1110,7 @@ static SpirvShaderParameters create_parameters(spv::Builder &b, const SceGxmProg
             var_to_reg.dtype = DataType::INT32;
             translation_state.var_to_regs.push_back(var_to_reg);
         } else {
+            const spv::Id param_type = get_param_type(b, input);
             var = b.createVariable(spv::NoPrecision, spv::StorageClassInput, param_type, name.c_str());
 
             VarToReg var_to_reg = {};

--- a/vita3k/shader/src/usse_program_analyzer.cpp
+++ b/vita3k/shader/src/usse_program_analyzer.cpp
@@ -226,8 +226,7 @@ void get_attribute_informations(const SceGxmProgram &program, AttributeInformati
             }
 
             bool regformat = (vertex_varyings_ptr->untyped_pa_regs & ((uint64_t)1 << parameter.resource_index)) != 0;
-
-            locmap.emplace(parameter.resource_index, AttributeInformation(fcount_allocated / 4, parameter.type, is_integer, is_signed, regformat));
+            locmap.emplace(parameter.resource_index, AttributeInformation(fcount_allocated / 4, parameter.type, parameter.component_count, is_integer, is_signed, regformat));
             fcount_allocated += ((parameter.array_size * parameter.component_count + 3) / 4) * 4;
         }
     }


### PR DESCRIPTION
Implement the FX10 unpack instruction on the shader. From my (limited) understanding and reverse engineering, the C10 type is actually a signed fixed-point floating point.

Another issue that pops up is that we are always using 32-bit type for regformat vertex attributes, this can cause the data to be unaligned (fine for most gpu), but also the data to overlap itself (killzone uses a regformat char2 with a 2-bytes stride), which causes most GPU to crash.

Instead, rewrite the regformat attribute to use an underlying type of the same size (for half type, use a U16 type). The only exception being the above 10-byte floating points which are passed using a vector of char (minimal alignment requirement, safest way to do it).

This fixes a few issues with Killzone and allows it to go ingame using the Vulkan renderer (without memory mapping).