### PR TITLE
shader: Test and conditional moves improvements

### DIFF
--- a/tools/usse-decoder-gen/grammar.yaml
+++ b/tools/usse-decoder-gen/grammar.yaml
@@ -1447,6 +1447,33 @@ SMLSI:
         - src2_inc:
             offset: 0
             size: 8
+SMBO:
+    description: SMBO control instruction
+    members:
+        - op1: '11111'
+        - op2:
+            size: 3
+            offset: 56
+            match: '011'
+        - opcat: 
+            match: '01'
+            size: 2
+            offset: 52
+        - nosched:
+            offset: 50
+            size: 1
+        - dest_offset:
+            offset: 36
+            size: 12
+        - src0_offset:
+            offset: 24
+            size: 12
+        - src1_offset:
+            offset: 12
+            size: 12
+        - src2_offset:
+            offset: 0
+            size: 12
 KILL:
     description: Kill program
     members:

--- a/vita3k/shader/include/shader/usse_translator.h
+++ b/vita3k/shader/include/shader/usse_translator.h
@@ -759,6 +759,12 @@ public:
         Imm8 src1_inc,
         Imm8 src2_inc);
 
+    bool smbo(Imm1 nosched,
+        Imm12 dest_offset,
+        Imm12 src0_offset,
+        Imm12 src1_offset,
+        Imm12 src2_offset);
+
     bool kill(ShortPredicate pred);
 
     bool limm(bool skipinv,

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -78,10 +78,14 @@ bool USSETranslatorVisitor::vmov(
     inst.opr.dest = decode_dest(inst.opr.dest, dest_n, dest_bank_sel, dest_bank_ext, is_double_regs, reg_bits, m_second_program);
     inst.opr.src1 = decode_src12(inst.opr.src1, src1_n, src1_bank_sel, src1_bank_ext, is_double_regs, reg_bits, m_second_program);
 
-    dest_mask = decode_write_mask(inst.opr.dest.bank, dest_mask, move_data_type == DataType::F16);
+    if (move_data_type == DataType::F16 || move_data_type == DataType::F32)
+        dest_mask = decode_write_mask(inst.opr.dest.bank, dest_mask, move_data_type == DataType::F16);
+    else if (!is_double_regs)
+        // only floating point moves are vectorized
+        dest_mask = 0b1;
 
     // Velocity uses a vec4 table, non-extended, so i assumes type=vec4, extended=false
-    inst.opr.src1.swizzle = decode_vec34_swizzle(src0_swiz, false, 2);
+    inst.opr.src1.swizzle = is_double_regs ? decode_vec34_swizzle(src0_swiz, false, 2) : (Swizzle4 SWIZZLE_CHANNEL_4_DEFAULT);
 
     inst.opr.src1.type = move_data_type;
     inst.opr.dest.type = move_data_type;

--- a/vita3k/shader/src/translator/special.cpp
+++ b/vita3k/shader/src/translator/special.cpp
@@ -148,6 +148,28 @@ bool USSETranslatorVisitor::smlsi(
     return true;
 }
 
+bool USSETranslatorVisitor::smbo(Imm1 nosched,
+    Imm12 dest_offset,
+    Imm12 src0_offset,
+    Imm12 src1_offset,
+    Imm12 src2_offset) {
+    LOG_DISASM("{:016x}: SMBO {}, {}, {}, {}", m_instr, dest_offset, src0_offset, src1_offset, src2_offset);
+
+    m_b.setLine(m_recompiler.cur_pc);
+
+    auto parse_offset = [&](const int idx, Imm12 offset) {
+        for (int i = 0; i < 17; i++) {
+            repeat_increase[idx][i] = i + offset;
+        }
+    };
+    parse_offset(3, dest_offset);
+    parse_offset(0, src0_offset);
+    parse_offset(1, src1_offset);
+    parse_offset(2, src2_offset);
+
+    return true;
+}
+
 bool USSETranslatorVisitor::kill(
     ShortPredicate pred) {
     LOG_DISASM("{:016x}: KILL {}", m_instr, disasm::s_predicate_str(pred));

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -35,7 +35,7 @@ using USSEMatcher = shader::decoder::Matcher<Visitor, uint64_t>;
 
 template <typename V>
 static std::optional<const USSEMatcher<V>> DecodeUSSE(uint64_t instruction) {
-    static const std::array<USSEMatcher<V>, 34> table = {
+    static const std::array<USSEMatcher<V>, 35> table = {
 #define INST(fn, name, bitstring) shader::decoder::detail::detail<USSEMatcher<V>>::GetMatcher(fn, name, bitstring)
         // clang-format off
         // Vector multiply-add (Normal version)
@@ -744,6 +744,21 @@ static std::optional<const USSEMatcher<V>> DecodeUSSE(uint64_t instruction) {
                                                                                              ffffffff = src2_inc (8 bits)
         */
         INST(&V::smlsi, "SMLSI ()", "11111010--01-n--ttttppppssssdrcieeeeeeeeaaaaaaaabbbbbbbbffffffff"),
+        // SMBO control instruction
+        /*
+                                   11111 = op1
+                                        011 = op2
+                                           -- = don't care
+                                             01 = opcat
+                                               - = don't care
+                                                n = nosched (1 bit)
+                                                 -- = don't care
+                                                   dddddddddddd = dest_offset (12 bits)
+                                                               ssssssssssss = src0_offset (12 bits)
+                                                                           rrrrrrrrrrrr = src1_offset (12 bits)
+                                                                                       cccccccccccc = src2_offset (12 bits)
+        */
+        INST(&V::smbo, "SMBO ()", "11111011--01-n--ddddddddddddssssssssssssrrrrrrrrrrrrcccccccccccc"),
         // Kill program
         /*
                                    11111 = op1


### PR DESCRIPTION
Multiple small shader fixes:
- Fix the mask of CMP(MSK) for multiple cases where it was wrong
- From my understanding, CMOV is vectorized only for floating points
- Implement the SMBO shader instruction

This allows Spiderman to go ingame using the Vulkan renderer