### PR TITLE
modules/SceGxm: Improve softlock prevention for sync object

### DIFF
--- a/vita3k/gxm/include/gxm/state.h
+++ b/vita3k/gxm/include/gxm/state.h
@@ -50,10 +50,18 @@ struct MemoryMapInfo {
 
 struct GxmState {
     SceGxmInitializeParams params;
+
     Queue<DisplayCallback> display_queue;
-    Ptr<SceGxmSyncObject> last_fbo_sync_object;
-    Ptr<uint32_t> notification_region;
     SceUID display_queue_thread;
+
+    Ptr<SceGxmSyncObject> last_fbo_sync_object;
+    // global timestamp used by sync objects
+    std::atomic<uint32_t> global_timestamp{ 1 };
+    // last display operation, as given by the global timestamp
+    uint32_t last_display_global = 0;
+
+    Ptr<uint32_t> notification_region;
+
     std::map<Address, MemoryMapInfo> memory_mapped_regions;
     std::mutex callback_lock;
 };

--- a/vita3k/renderer/include/renderer/gxm_types.h
+++ b/vita3k/renderer/include/renderer/gxm_types.h
@@ -174,6 +174,9 @@ struct SceGxmSyncObject {
     // timestamp for the last time the object was displayed
     std::atomic<uint32_t> last_display;
 
+    // last signal operation done, given using the global timestamp
+    uint32_t last_operation_global = 0;
+
     std::mutex lock;
     std::condition_variable cond;
 };


### PR DESCRIPTION
This improves and supersedes PR #3140 as it was causing issues (messing the sync objects) in some cases when the timeout was triggered but a softlock was not expected to happen.
This does not handle all cases (it won't work if scenes using the old and new sync objects are interleaved) but it is good enough to still allow Unit 13 to go ingame and will only trigger to prevent a softlock.

This should fix #3157.