### PR TITLE
renderer/vulkan: Fix issue with surface cache typeless copies

### DIFF
--- a/vita3k/renderer/src/vulkan/surface_cache.cpp
+++ b/vita3k/renderer/src/vulkan/surface_cache.cpp
@@ -560,7 +560,7 @@ std::optional<TextureLookupResult> VKSurfaceCache::retrieve_color_surface_as_tex
             const uint32_t dst_pixel_stride = (stride_bytes / bytes_per_pixel_requested) * state.res_multiplier;
             copy_image_buffer
                 .setBufferOffset(start_x * bytes_per_pixel_requested)
-                .setBufferRowLength(width)
+                .setBufferRowLength(dst_pixel_stride)
                 .setImageOffset({ 0, 0, 0 })
                 .setImageExtent({ width, height, 1 });
             cmd_buffer.copyBufferToImage(casted->transition_buffer.buffer, casted->texture.image, vk::ImageLayout::eTransferDstOptimal, copy_image_buffer);


### PR DESCRIPTION
Fix a small mistake from my PR #3160 