### PR TITLE
renderer/vulkan: Improvements for asynchronous pipeline compilation

### DIFF
--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -858,7 +858,8 @@ vk::Pipeline PipelineCache::retrieve_pipeline(VKContext &context, SceGxmPrimitiv
     context.shader_hints.color_format = record.color_surface.colorFormat;
     context.shader_hints.attributes = &vertex_program_gxm.attributes;
 
-    const bool compile_pipeline_async = !already_in_cache && consider_for_async && use_async_compilation && can_use_deferred_compilation;
+    // note: the flag can_use_deferred_compilation is not considered here because it causes way too many false positives
+    const bool compile_pipeline_async = !already_in_cache && consider_for_async && use_async_compilation;
 
     if (compile_pipeline_async) {
         // create the pipeline compile request
@@ -888,7 +889,8 @@ vk::Pipeline PipelineCache::retrieve_pipeline(VKContext &context, SceGxmPrimitiv
         const auto time_s = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         next_pipeline_cache_save = time_s + pipeline_cache_save_delay;
 
-        state.shaders_count_compiled++;
+        if (!already_in_cache)
+            state.shaders_count_compiled++;
 
         it->second = result;
 

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -373,7 +373,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
 
         // We don't want to defer cases where we draw a whole quad over the screen as these draws could be necessary
         // to be able to see anything
-        bool can_be_whole_quad = instance_count == 1 && (count == 4 || count == 6);
+        bool can_be_whole_quad = instance_count == 1 && count <= 6;
         vk::Pipeline new_pipeline = context.state.pipeline_cache.retrieve_pipeline(context, type, !can_be_whole_quad, mem);
 
         if (new_pipeline != context.current_pipeline) {


### PR DESCRIPTION
- Remove the use of the can_use_deferred_compilation flag as it causes way too many false positives (for the really few games for which this causes long-standing graphical issues, you can disable async pipeline compilation instead).
- Make sure to detect all the cases where a shader draws over all the surface (draw count = 3: can be a triangle covering everything, draw count = 4 or 6: can be a quad covering the surface).
- Fix an issue where the compiling pipeline message could show up for pipelines already cached.