### PR TITLE
Correct typo in settings_dialog.cpp

### DIFF
--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -620,7 +620,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         }
 
         if (is_vulkan) {
-            ImGui::Checkbox("Aynchronous pipeline compilation", &config.async_pipeline_compilation);
+            ImGui::Checkbox("Asynchronous pipeline compilation", &config.async_pipeline_compilation);
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("Allow pipelines to be compiler concurrently on multiple concurrent threads.\n This decreases pipeline compilation stutter at the cost of temporary graphical glitches");
         }


### PR DESCRIPTION
Asynchronous incorrectly spelled as "Aynchronous".