### PR TITLE
Fix sceAudioOutSetConfig implementation

### DIFF
--- a/vita3k/modules/SceAudio/SceAudio.cpp
+++ b/vita3k/modules/SceAudio/SceAudio.cpp
@@ -252,7 +252,7 @@ EXPORT(int, sceAudioOutSetCompress) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceAudioOutSetConfig, int port, SceSize len, int freq, SceAudioOutMode mode) {
+EXPORT(int, sceAudioOutSetConfig, int port, int len, int freq, SceAudioOutMode mode) {
     TRACY_FUNC(sceAudioOutSetConfig, port, len, freq, mode);
     if (len == 0)
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_SIZE);
@@ -267,7 +267,7 @@ EXPORT(int, sceAudioOutSetConfig, int port, SceSize len, int freq, SceAudioOutMo
     if ((freq >= 0) && (prt->type == SCE_AUDIO_OUT_PORT_TYPE_MAIN) && (freq != 48000))
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_SAMPLE_FREQ);
 
-    const auto set_len = len > 0 ? len : prt->len;
+    const auto set_len = len > 0 ? static_cast<SceSize>(len) : prt->len;
     const auto set_freq = freq >= 0 ? freq : prt->freq;
     const auto set_mode = mode >= 0 ? mode : prt->mode;
 


### PR DESCRIPTION
If (-1) is specified for any argument (excepted for port), current configuration is used instead.
Fixes crashes in some VNs (and maybe in other games which use this).

Thanks nishinji who found the commit when the regression appeared.