### PR TITLE
display: Add FPS hack

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -140,6 +140,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "asia-font-support", false, asia_font_support)                                           \
     code(bool, "shader-cache", true, shader_cache)                                                      \
     code(bool, "spirv-shader", false, spirv_shader)                                                     \
+    code(bool, "fps-hack", false, fps_hack)                                                             \
     code(uint64_t, "current-ime-lang", 4, current_ime_lang)                                             \
     code(int, "psn-signed-in", false, psn_signed_in)                                                    \
     code(bool, "http-enable", true, http_enable)                                                        \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -130,6 +130,7 @@ public:
         bool import_textures = false;
         bool export_textures = false;
         bool export_as_png = false;
+        bool fps_hack = false;
         bool stretch_the_display_area = false;
         bool show_touchpad_cursor = true;
         bool psn_signed_in = false;

--- a/vita3k/display/include/display/state.h
+++ b/vita3k/display/include/display/state.h
@@ -69,6 +69,12 @@ struct DisplayState {
     std::atomic<uint64_t> last_setframe_vblank_count = 0;
     std::map<SceUID, CallbackPtr> vblank_callbacks{};
 
+    // if set to true, make sceDisplayWaitVblankStartMulti/sceDisplayWaitSetFrameBufMulti behave as sceDisplayWaitVblankStart/sceDisplayWaitSetFrameBuf
+    // this allows some game running at 30fps to run at 60fps without any issue
+    // however this is not always the case, some games may not be affected (if they look at the Vcount)
+    // or run twice as fast (if they only rely on these function calls for their timings)
+    bool fps_hack = false;
+
     // should contain the list of sync objects / swapchain images (in the order they appear in the cycle)
     std::vector<PredictedDisplayFrame> predicted_frames;
     // position in the predicted_frame cycle (the -1 is needed)

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -182,6 +182,7 @@ static bool get_custom_config(GuiState &gui, EmuEnvState &emuenv, const std::str
                 config.import_textures = gpu_child.attribute("import-textures").as_bool();
                 config.export_textures = gpu_child.attribute("export-textures").as_bool();
                 config.export_as_png = gpu_child.attribute("export-as-png").as_bool();
+                config.fps_hack = gpu_child.attribute("fps-hack").as_bool();
             }
 
             // Load System Config
@@ -245,6 +246,7 @@ void init_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
         config.import_textures = emuenv.cfg.import_textures;
         config.export_textures = emuenv.cfg.export_textures;
         config.export_as_png = emuenv.cfg.export_as_png;
+        config.fps_hack = emuenv.cfg.fps_hack;
         config.pstv_mode = emuenv.cfg.pstv_mode;
         config.ngs_enable = emuenv.cfg.ngs_enable;
         config.show_touchpad_cursor = emuenv.cfg.show_touchpad_cursor;
@@ -327,6 +329,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         gpu_child.append_attribute("import-textures") = config.import_textures;
         gpu_child.append_attribute("export-textures") = config.export_textures;
         gpu_child.append_attribute("export-as-png") = config.export_as_png;
+        gpu_child.append_attribute("fps-hack") = config.fps_hack;
 
         // System
         auto system_child = config_child.append_child("system");
@@ -360,6 +363,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         emuenv.cfg.import_textures = config.import_textures;
         emuenv.cfg.export_textures = config.export_textures;
         emuenv.cfg.export_as_png = config.export_as_png;
+        emuenv.cfg.fps_hack = config.fps_hack;
         emuenv.cfg.ngs_enable = config.ngs_enable;
         emuenv.cfg.show_touchpad_cursor = config.show_touchpad_cursor;
         emuenv.cfg.psn_signed_in = config.psn_signed_in;
@@ -423,6 +427,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.cfg.current_config.import_textures = emuenv.cfg.import_textures;
         emuenv.cfg.current_config.export_textures = emuenv.cfg.export_textures;
         emuenv.cfg.current_config.export_as_png = emuenv.cfg.export_as_png;
+        emuenv.cfg.current_config.fps_hack = emuenv.cfg.fps_hack;
         emuenv.cfg.current_config.ngs_enable = emuenv.cfg.ngs_enable;
         emuenv.cfg.current_config.show_touchpad_cursor = emuenv.cfg.show_touchpad_cursor;
         emuenv.cfg.current_config.psn_signed_in = emuenv.cfg.psn_signed_in;
@@ -449,6 +454,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
     emuenv.renderer->set_stretch_display(emuenv.cfg.stretch_the_display_area);
     emuenv.renderer->get_texture_cache()->set_replacement_state(emuenv.cfg.current_config.import_textures, emuenv.cfg.current_config.export_textures, emuenv.cfg.current_config.export_as_png);
     emuenv.renderer->set_async_compilation(emuenv.cfg.current_config.async_pipeline_compilation);
+    emuenv.display.fps_hack = emuenv.cfg.current_config.fps_hack;
 
     // No change it if app already running
     if (emuenv.io.title_id.empty()) {
@@ -775,6 +781,15 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 fs::remove_all(emuenv.cache_path / "shaderlog");
             }
         }
+
+        // FPS hack
+        ImGui::Checkbox("FPS hack", &config.fps_hack);
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Game hack which allows some games running at 30fps to run at 60fps on the emulator."
+                              "Note that this is a hack and will only work on some games."
+                              "On other games, it may have no effect or make them run twice as fast.");
+        }
+
         ImGui::EndTabItem();
     } else
         ImGui::PopStyleColor();

--- a/vita3k/modules/SceDisplay/SceDisplay.cpp
+++ b/vita3k/modules/SceDisplay/SceDisplay.cpp
@@ -31,6 +31,11 @@ TRACY_MODULE_NAME(SceDisplay);
 static int display_wait(EmuEnvState &emuenv, SceUID thread_id, int vcount, const bool is_since_setbuf, const bool is_cb) {
     const auto &thread = emuenv.kernel.get_thread(thread_id);
 
+    if (emuenv.display.fps_hack)
+        // a game can use a vcount of 2 to render as 30fps
+        // thus doing this can allow some games to run at 60fps
+        vcount = 1;
+
     uint64_t target_vcount;
     if (is_since_setbuf) {
         target_vcount = emuenv.display.last_setframe_vblank_count + vcount;


### PR DESCRIPTION
Add a FPS hack, similar to what most VitaGrafix patches are doing (but on the emulator side).
This hack allows some games running at 30 fps to run at 60 fps.
However it is only a hack, meaning it won't work on all games, in particular:
- Some games won't be affected at all
- Some games will run at twice the speed (but with the audio running at the correct speed)

I tested it on Ys 8, GoW and Uncharted where it works as intended.