### PR TITLE
vita3k: set fs::path type for string paths and refactoring

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -103,18 +103,19 @@ void update_viewport(EmuEnvState &state) {
 }
 
 void init_paths(Root &root_paths) {
-    const auto dir_sep = std::string{ fs::path::preferred_separator };
-    auto base_path = SDL_GetBasePath();
-    auto pref_path = SDL_GetPrefPath(org_name, app_name);
-    root_paths.set_base_path(string_utils::utf_to_wide(base_path));
-    root_paths.set_pref_path(string_utils::utf_to_wide(pref_path));
-    root_paths.set_log_path(string_utils::utf_to_wide(base_path));
-    root_paths.set_config_path(string_utils::utf_to_wide(base_path));
-    root_paths.set_static_assets_path(string_utils::utf_to_wide(base_path));
-    root_paths.set_shared_path(string_utils::utf_to_wide(base_path));
-    root_paths.set_cache_path(fs::path(string_utils::utf_to_wide(base_path)) / "cache" / dir_sep);
-    SDL_free(base_path);
-    SDL_free(pref_path);
+    auto sdl_base_path = SDL_GetBasePath();
+    auto sdl_pref_path = SDL_GetPrefPath(org_name, app_name);
+    auto base_path = fs_utils::utf8_to_path(sdl_base_path);
+    auto pref_path = fs_utils::utf8_to_path(sdl_pref_path);
+    SDL_free(sdl_base_path);
+    SDL_free(sdl_pref_path);
+    root_paths.set_base_path(base_path);
+    root_paths.set_pref_path(pref_path);
+    root_paths.set_log_path(base_path);
+    root_paths.set_config_path(base_path);
+    root_paths.set_static_assets_path(base_path);
+    root_paths.set_shared_path(base_path);
+    root_paths.set_cache_path(base_path / "cache" / "");
 
 #if defined(__linux__) && !defined(__ANDROID__) && !defined(__APPLE__)
     // XDG Data Dirs.
@@ -126,38 +127,38 @@ void init_paths(Root &root_paths) {
     auto APPDIR = getenv("APPDIR"); // Used in AppImage
 
     if (XDG_DATA_HOME != NULL)
-        root_paths.set_pref_path(fs::path(XDG_DATA_HOME) / app_name / app_name / dir_sep);
+        root_paths.set_pref_path(fs::path(XDG_DATA_HOME) / app_name / app_name / "");
 
     if (XDG_CONFIG_HOME != NULL)
-        root_paths.set_config_path(fs::path(XDG_CONFIG_HOME) / app_name / dir_sep);
+        root_paths.set_config_path(fs::path(XDG_CONFIG_HOME) / app_name / "");
     else if (env_home != NULL)
-        root_paths.set_config_path(fs::path(env_home) / ".config" / app_name / dir_sep);
+        root_paths.set_config_path(fs::path(env_home) / ".config" / app_name / "");
 
     if (XDG_CACHE_HOME != NULL) {
-        root_paths.set_cache_path(fs::path(XDG_CACHE_HOME) / app_name / dir_sep);
-        root_paths.set_log_path(fs::path(XDG_CACHE_HOME) / app_name / dir_sep);
+        root_paths.set_cache_path(fs::path(XDG_CACHE_HOME) / app_name / "");
+        root_paths.set_log_path(fs::path(XDG_CACHE_HOME) / app_name / "");
     } else if (env_home != NULL) {
-        root_paths.set_cache_path(fs::path(env_home) / ".cache" / app_name / dir_sep);
-        root_paths.set_log_path(fs::path(env_home) / ".cache" / app_name / dir_sep);
+        root_paths.set_cache_path(fs::path(env_home) / ".cache" / app_name / "");
+        root_paths.set_log_path(fs::path(env_home) / ".cache" / app_name / "");
     }
 
     // Don't assume that base_path is portable.
     if (fs::exists(root_paths.get_base_path() / "data") && fs::exists(root_paths.get_base_path() / "lang") && fs::exists(root_paths.get_base_path() / "shaders-builtin"))
         root_paths.set_static_assets_path(root_paths.get_base_path());
     else if (env_home != NULL)
-        root_paths.set_static_assets_path(fs::path(env_home) / ".local/share" / app_name / dir_sep);
+        root_paths.set_static_assets_path(fs::path(env_home) / ".local/share" / app_name / "");
 
     if (XDG_DATA_DIRS != NULL) {
         auto env_paths = string_utils::split_string(XDG_DATA_DIRS, ':');
         for (auto &i : env_paths) {
             if (fs::exists(fs::path(i) / app_name)) {
-                root_paths.set_static_assets_path(fs::path(i) / app_name / dir_sep);
+                root_paths.set_static_assets_path(fs::path(i) / app_name / "");
                 break;
             }
         }
     } else if (XDG_DATA_HOME != NULL) {
         if (fs::exists(fs::path(XDG_DATA_HOME) / app_name / "data") && fs::exists(fs::path(XDG_DATA_HOME) / app_name / "lang") && fs::exists(fs::path(XDG_DATA_HOME) / app_name / "shaders-builtin"))
-            root_paths.set_static_assets_path(fs::path(XDG_DATA_HOME) / app_name / dir_sep);
+            root_paths.set_static_assets_path(fs::path(XDG_DATA_HOME) / app_name / "");
     }
 
     if (APPDIR != NULL && fs::exists(fs::path(APPDIR) / "usr/share/Vita3K")) {
@@ -166,64 +167,58 @@ void init_paths(Root &root_paths) {
 
     // shared path
     if (env_home != NULL)
-        root_paths.set_shared_path(fs::path(env_home) / ".local/share" / app_name / dir_sep);
+        root_paths.set_shared_path(fs::path(env_home) / ".local/share" / app_name / "");
 
     if (XDG_DATA_DIRS != NULL) {
         auto env_paths = string_utils::split_string(XDG_DATA_DIRS, ':');
         for (auto &i : env_paths) {
             if (fs::exists(fs::path(i) / app_name)) {
-                root_paths.set_shared_path(fs::path(i) / app_name / dir_sep);
+                root_paths.set_shared_path(fs::path(i) / app_name / "");
                 break;
             }
         }
     } else if (XDG_DATA_HOME != NULL) {
-        root_paths.set_shared_path(fs::path(XDG_DATA_HOME) / app_name / dir_sep);
+        root_paths.set_shared_path(fs::path(XDG_DATA_HOME) / app_name / "");
     }
 #endif
 
     // Create default preference and cache path for safety
-    if (!fs::exists(root_paths.get_config_path()))
-        fs::create_directories(root_paths.get_config_path());
-
-    if (!fs::exists(root_paths.get_cache_path()))
-        fs::create_directories(root_paths.get_cache_path());
-
-    if (!fs::exists(fs::path(root_paths.get_log_path()) / "shaderlog"))
-        fs::create_directories(fs::path(root_paths.get_log_path()) / "shaderlog");
-
-    if (!fs::exists(fs::path(root_paths.get_log_path()) / "texturelog"))
-        fs::create_directories(fs::path(root_paths.get_log_path()) / "texturelog");
+    fs::create_directories(root_paths.get_config_path());
+    fs::create_directories(root_paths.get_cache_path());
+    fs::create_directories(root_paths.get_log_path() / "shaderlog");
+    fs::create_directories(root_paths.get_log_path() / "texturelog");
 }
 
 bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
     state.cfg = std::move(cfg);
 
-    state.base_path = root_paths.get_base_path_string();
-    state.default_path = root_paths.get_pref_path_string();
-    state.log_path = string_utils::utf_to_wide(root_paths.get_log_path_string());
-    state.config_path = string_utils::utf_to_wide(root_paths.get_config_path_string());
-    state.cache_path = string_utils::utf_to_wide(root_paths.get_cache_path_string());
-    state.shared_path = root_paths.get_shared_path_string();
+    state.base_path = root_paths.get_base_path();
+    state.default_path = root_paths.get_pref_path();
+    state.log_path = root_paths.get_log_path();
+    state.config_path = root_paths.get_config_path();
+    state.cache_path = root_paths.get_cache_path();
+    state.shared_path = root_paths.get_shared_path();
     state.static_assets_path = root_paths.get_static_assets_path();
 
     // If configuration does not provide a preference path, use SDL's default
     if (state.cfg.pref_path == root_paths.get_pref_path() || state.cfg.pref_path.empty())
-        state.pref_path = string_utils::utf_to_wide(root_paths.get_pref_path_string());
+        state.pref_path = root_paths.get_pref_path();
     else {
-        if (state.cfg.pref_path.back() != '/')
-            state.cfg.pref_path += '/';
-        state.pref_path = string_utils::utf_to_wide(state.cfg.pref_path);
+        auto last_char = state.cfg.pref_path.back();
+        if (last_char != fs::path::preferred_separator && last_char != '/')
+            state.cfg.pref_path += fs::path::preferred_separator;
+        state.pref_path = state.cfg.get_pref_path();
     }
 
-    LOG_INFO("Base path: {}", state.base_path.string());
+    LOG_INFO("Base path: {}", state.base_path);
 #if defined(__linux__) && !defined(__ANDROID__) && !defined(__APPLE__)
-    LOG_INFO("Static assets path: {}", state.static_assets_path.string());
-    LOG_INFO("Shared path: {}", state.shared_path.string());
-    LOG_INFO("Log path: {}", state.log_path.string());
-    LOG_INFO("User config path: {}", state.config_path.string());
-    LOG_INFO("User cache path: {}", state.cache_path.string());
+    LOG_INFO("Static assets path: {}", state.static_assets_path);
+    LOG_INFO("Shared path: {}", state.shared_path);
+    LOG_INFO("Log path: {}", state.log_path);
+    LOG_INFO("User config path: {}", state.config_path);
+    LOG_INFO("User cache path: {}", state.cache_path);
 #endif
-    LOG_INFO("User pref path: {}", state.pref_path.string());
+    LOG_INFO("User pref path: {}", state.pref_path);
 
     if (ImGui::GetCurrentContext() == NULL) {
         ImGui::CreateContext();

--- a/vita3k/compat/src/compat.cpp
+++ b/vita3k/compat/src/compat.cpp
@@ -45,7 +45,7 @@ static const uint32_t db_version = 1;
 bool load_app_compat_db(GuiState &gui, EmuEnvState &emuenv) {
     const auto app_compat_db_path = emuenv.cache_path / "app_compat_db.xml";
     if (!fs::exists(app_compat_db_path)) {
-        LOG_WARN("Compatibility database not found at {}.", app_compat_db_path.string());
+        LOG_WARN("Compatibility database not found at {}.", app_compat_db_path);
         return false;
     }
 
@@ -53,7 +53,7 @@ bool load_app_compat_db(GuiState &gui, EmuEnvState &emuenv) {
     pugi::xml_document doc;
     pugi::xml_parse_result result = doc.load_file(app_compat_db_path.c_str());
     if (!result) {
-        LOG_ERROR("Compatibility database {} could not be loaded: {}", app_compat_db_path.string(), result.description());
+        LOG_ERROR("Compatibility database {} could not be loaded: {}", app_compat_db_path, result.description());
         return false;
     }
 

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -108,6 +108,14 @@ public:
     bool console = false;
     bool load_app_list = false;
 
+    fs::path get_pref_path() const {
+        return fs_utils::utf8_to_path(pref_path);
+    }
+
+    void set_pref_path(const fs::path &new_pref_path) {
+        pref_path = fs_utils::path_to_utf8(new_pref_path);
+    }
+
     /**
      * @brief Config struct for per-app configurable settings
      *
@@ -252,7 +260,8 @@ public:
 
     // Load a function to the node network, and then update the members
     void load_new_config(const fs::path &path) override {
-        yaml_node = YAML::LoadFile(path.generic_path().string());
+        fs::ifstream fin(path);
+        yaml_node = YAML::Load(fin);
         update_members();
     }
 

--- a/vita3k/glutil/include/glutil/shader.h
+++ b/vita3k/glutil/include/glutil/shader.h
@@ -18,8 +18,8 @@
 #pragma once
 
 #include <glutil/object.h>
-#include <string>
+#include <util/fs.h>
 
 namespace gl {
-UniqueGLObject load_shaders(const std::string &vertex_file_path, const std::string &fragment_file_path);
+UniqueGLObject load_shaders(const fs::path &vertex_file_path, const fs::path &fragment_file_path);
 }

--- a/vita3k/glutil/src/shader.cpp
+++ b/vita3k/glutil/src/shader.cpp
@@ -21,7 +21,6 @@
 #include <glutil/object.h>
 
 #include <util/log.h>
-#include <util/string_utils.h>
 
 #include <fstream>
 #include <sstream>
@@ -34,7 +33,7 @@
  * \param fragment_file_path File path of the fragment shader
  * \return SharedGLObject that holds the resulting program id. Empty if loading was unsuccessful
  */
-UniqueGLObject gl::load_shaders(const std::string &vertex_file_path, const std::string &fragment_file_path) {
+UniqueGLObject gl::load_shaders(const fs::path &vertex_file_path, const fs::path &fragment_file_path) {
     GLuint vs = glCreateShader(GL_VERTEX_SHADER);
     GLuint fs = glCreateShader(GL_FRAGMENT_SHADER);
 

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -44,7 +44,7 @@ static bool get_update_history(GuiState &gui, EmuEnvState &emuenv, const std::st
     std::string fname = fs::exists(change_info_path / fmt::format("changeinfo_{:0>2d}.xml", emuenv.cfg.sys_lang)) ? fmt::format("changeinfo_{:0>2d}.xml", emuenv.cfg.sys_lang) : "changeinfo.xml";
 
     pugi::xml_document doc;
-    pugi::xml_parse_result result = doc.load_file((change_info_path.string() + fname).c_str());
+    pugi::xml_parse_result result = doc.load_file((change_info_path / fname).c_str());
 
     for (const auto &info : doc.child("changeinfo"))
         update_history_infos[info.attribute("app_ver").as_double()] = info.text().as_string();
@@ -155,7 +155,7 @@ void get_time_apps(GuiState &gui, EmuEnvState &emuenv) {
                 }
             }
         } else {
-            LOG_ERROR("Time XML found is corrupted on path: {}", time_path.string());
+            LOG_ERROR("Time XML found is corrupted on path: {}", time_path);
             fs::remove(time_path);
         }
     }
@@ -240,6 +240,9 @@ void delete_app(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         const auto SHADER_LOG_PATH{ emuenv.cache_path / "shaderlog" / title_id };
         if (fs::exists(SHADER_LOG_PATH))
             fs::remove_all(SHADER_LOG_PATH);
+        const auto SHADER_LOG_PATH_2{ emuenv.log_path / "shaderlog" / title_id };
+        if (fs::exists(SHADER_LOG_PATH_2))
+            fs::remove_all(SHADER_LOG_PATH_2);
         const auto EXPORT_TEXTURES_PATH{ emuenv.shared_path / "textures/export" / title_id };
         if (fs::exists(EXPORT_TEXTURES_PATH))
             fs::remove_all(EXPORT_TEXTURES_PATH);

--- a/vita3k/gui/src/archive_install_dialog.cpp
+++ b/vita3k/gui/src/archive_install_dialog.cpp
@@ -139,7 +139,7 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                     } else
                         invalid_archives.push_back(archive_path);
                 };
-                const auto contents_path = fs::path(archive_path.wstring());
+                const auto contents_path = fs::path(archive_path.native());
                 if (type == "directory") {
                     const auto archives_path = get_path_of_archives(contents_path);
                     archives_count = float(archives_path.size());
@@ -193,7 +193,7 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.f);
             ImGui::BeginChild("##content_installed_list", ImVec2(WINDOW_SIZE.x - (10.f * SCALE.x), WINDOW_SIZE.y - (BUTTON_SIZE.y * 2.f) - (25 * SCALE.y)), false, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings);
             if (!contents_archives.empty()) {
-                const auto count_content_state = [&](const fs::path path, const bool state) {
+                const auto count_content_state = [&](const fs::path &path, const bool state) {
                     return std::count_if(contents_archives[path].begin(), contents_archives[path].end(), [&](const ContentInfo &c) {
                         return c.state == state;
                     });
@@ -204,7 +204,7 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::Spacing();
                 ImGui::Separator();
                 for (const auto &archive : contents_archives) {
-                    ImGui::TextWrapped("%s", string_utils::wide_to_utf(archive.first.filename().wstring()).c_str());
+                    ImGui::TextWrapped("%s", fs_utils::path_to_utf8(archive.first.filename()).c_str());
                     ImGui::Spacing();
                     const auto count_contents_successed = count_content_state(archive.first, true);
                     if (count_contents_successed) {
@@ -240,7 +240,7 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", not_compatible_content_str.c_str());
                 ImGui::Spacing();
                 for (const auto &archive : invalid_archives)
-                    ImGui::TextWrapped("%s", archive.filename().string().c_str());
+                    ImGui::TextWrapped("%s", fs_utils::path_to_utf8(archive.filename()).c_str());
             }
             ImGui::EndChild();
             ImGui::PopStyleVar();

--- a/vita3k/gui/src/content_manager.cpp
+++ b/vita3k/gui/src/content_manager.cpp
@@ -212,7 +212,7 @@ static void get_content_info(GuiState &gui, EmuEnvState &emuenv) {
 
             const auto content_path{ fs::path("addcont") / app_selected / content_id };
             vfs::FileBuffer params;
-            if (vfs::read_file(VitaIoDevice::ux0, params, emuenv.pref_path.wstring(), content_path.string() + "/sce_sys/param.sfo")) {
+            if (vfs::read_file(VitaIoDevice::ux0, params, emuenv.pref_path, content_path / "sce_sys/param.sfo")) {
                 SfoFile sfo_handle;
                 sfo::load(sfo_handle, params);
                 if (!sfo::get_data_by_key(addcont_info[content_id].name, sfo_handle, fmt::format("TITLE_{:0>2d}", emuenv.cfg.sys_lang)))

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -74,7 +74,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
 
         if (result == host::dialog::filesystem::Result::SUCCESS) {
             std::thread installation([&emuenv]() {
-                install_pup(emuenv.pref_path.wstring(), pup_path.string(), progress_callback);
+                install_pup(emuenv.pref_path, fs::path(pup_path.native()), progress_callback);
                 std::lock_guard<std::mutex> lock(install_mutex);
                 finished_installing = true;
                 get_firmware_version(emuenv);
@@ -143,7 +143,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - (20.f * SCALE.y)));
             if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
                 if (delete_pup_file) {
-                    fs::remove(fs::path(pup_path.wstring()));
+                    fs::remove(fs::path(pup_path.native()));
                     delete_pup_file = false;
                 }
                 get_modules_list(gui, emuenv);

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -67,12 +67,12 @@ static bool init_notice_icon(GuiState &gui, EmuEnvState &emuenv, const fs::path 
     int32_t height = 0;
     vfs::FileBuffer buffer;
 
-    if (!vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), content_path)) {
+    if (!vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, content_path)) {
         if (info.type == "trophy") {
             LOG_WARN("Icon no found for trophy id: {} on NpComId: {}", info.content_id, info.id);
             return false;
         } else {
-            if (!vfs::read_app_file(buffer, emuenv.pref_path.wstring(), info.id, "sce_sys/icon0.png")) {
+            if (!vfs::read_app_file(buffer, emuenv.pref_path, info.id, "sce_sys/icon0.png")) {
                 buffer = init_default_icon(gui, emuenv);
                 if (buffer.empty()) {
                     LOG_WARN("Not found default icon for this notice content: {}", info.content_id);
@@ -83,7 +83,7 @@ static bool init_notice_icon(GuiState &gui, EmuEnvState &emuenv, const fs::path 
     }
     stbi_uc *data = stbi_load_from_memory(&buffer[0], static_cast<int>(buffer.size()), &width, &height, nullptr, STBI_rgb_alpha);
     if (!data) {
-        LOG_ERROR("Invalid icon for notice id: {} in path {}.", info.id, content_path.string());
+        LOG_ERROR("Invalid icon for notice id: {} in path {}.", info.id, content_path);
         return false;
     }
     gui.notice_info_icon[info.time].init(gui.imgui_state.get(), data, width, height);
@@ -111,13 +111,13 @@ static bool set_notice_info(GuiState &gui, EmuEnvState &emuenv, const NoticeList
             msg = lang["install_complete"];
         }
         vfs::FileBuffer params;
-        if (vfs::read_file(VitaIoDevice::ux0, params, emuenv.pref_path.wstring(), content_path / "sce_sys/param.sfo")) {
+        if (vfs::read_file(VitaIoDevice::ux0, params, emuenv.pref_path, content_path / "sce_sys/param.sfo")) {
             SfoFile sfo_handle;
             sfo::load(sfo_handle, params);
             if (!sfo::get_data_by_key(name, sfo_handle, fmt::format("TITLE_{:0>2d}", emuenv.cfg.sys_lang)))
                 sfo::get_data_by_key(name, sfo_handle, "TITLE");
         } else {
-            LOG_WARN("Content not found for id: {}, in path: {}", info.content_id, content_path.string());
+            LOG_WARN("Content not found for id: {}, in path: {}", info.content_id, content_path);
             return false;
         }
         init_notice_icon(gui, emuenv, content_path / "sce_sys/icon0.png", info);
@@ -229,7 +229,7 @@ void get_notice_list(EmuEnvState &emuenv) {
                 }
             }
         } else {
-            LOG_ERROR("Notice XML found is corrupted on path: {}", notice_path.string());
+            LOG_ERROR("Notice XML found is corrupted on path: {}", notice_path);
             fs::remove(notice_path);
         }
     }

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -168,9 +168,9 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
             std::filesystem::path emulator_path = "";
             host::dialog::filesystem::Result result = host::dialog::filesystem::pick_folder(emulator_path);
 
-            if ((result == host::dialog::filesystem::Result::SUCCESS) && (emulator_path.wstring() != emuenv.pref_path)) {
-                emuenv.pref_path = emulator_path.wstring() + L'/';
-                emuenv.cfg.pref_path = emulator_path.string();
+            if ((result == host::dialog::filesystem::Result::SUCCESS) && (emulator_path.native() != emuenv.pref_path.native())) {
+                emuenv.pref_path = fs::path(emulator_path.native()) / "";
+                emuenv.cfg.set_pref_path(emuenv.pref_path);
             } else if (result == host::dialog::filesystem::Result::ERROR) {
                 LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
             }
@@ -180,7 +180,7 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
             if (ImGui::Button(lang["reset_emu_path"].c_str(), BIG_BUTTON_SIZE)) {
                 if (emuenv.default_path != emuenv.pref_path) {
                     emuenv.pref_path = emuenv.default_path;
-                    emuenv.cfg.pref_path = emuenv.default_path.string();
+                    emuenv.cfg.set_pref_path(emuenv.default_path);
                 }
             }
         }

--- a/vita3k/gui/src/license_install_dialog.cpp
+++ b/vita3k/gui/src/license_install_dialog.cpp
@@ -70,7 +70,7 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         host::dialog::filesystem::Result result = host::dialog::filesystem::Result::CANCEL;
         result = host::dialog::filesystem::open_file(license_path, { { "PlayStation Vita software license file", { "bin", "rif" } } });
         if (result == host::dialog::filesystem::Result::SUCCESS) {
-            if (copy_license(emuenv, fs::path(license_path.wstring())))
+            if (copy_license(emuenv, fs::path(license_path.native())))
                 state = "success";
             else
                 state = "fail";
@@ -114,7 +114,7 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - (20.f * SCALE.y)));
         if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
             if (delete_license_file) {
-                fs::remove(fs::path(license_path.wstring()));
+                fs::remove(fs::path(license_path.native()));
                 delete_license_file = false;
             }
             license_path = nullptr;

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -173,7 +173,7 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string &app_p
 
         if (!doc.load_file(template_xml.c_str())) {
             if (is_ps_app || is_sys_app)
-                LOG_WARN("Live Area Contents is corrupted or missing for title: {} '{}' in path: {}.", APP_INDEX->title_id, APP_INDEX->title, template_xml.string());
+                LOG_WARN("Live Area Contents is corrupted or missing for title: {} '{}' in path: {}.", APP_INDEX->title_id, APP_INDEX->title, template_xml);
             if (doc.load_file(default_fw_contents.c_str())) {
                 template_xml = default_fw_contents;
                 default_contents = true;
@@ -253,11 +253,11 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string &app_p
                 }
 
                 if (default_contents)
-                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "data/internal/livearea/default/sce_sys/livearea/contents/" + contents.second);
+                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "data/internal/livearea/default/sce_sys/livearea/contents/" + contents.second);
                 else if (app_device == VitaIoDevice::vs0)
-                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "app/" + app_path + "/sce_sys/livearea/contents/" + contents.second);
+                    vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "app/" + app_path + "/sce_sys/livearea/contents/" + contents.second);
                 else
-                    vfs::read_app_file(buffer, emuenv.pref_path.wstring(), app_path, live_area_path.string() + "/contents/" + contents.second);
+                    vfs::read_app_file(buffer, emuenv.pref_path, app_path, live_area_path / "contents" / contents.second);
 
                 if (buffer.empty()) {
                     if (is_ps_app || is_sys_app)
@@ -443,9 +443,9 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string &app_p
                             vfs::FileBuffer buffer;
 
                             if (app_device == VitaIoDevice::vs0)
-                                vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "app/" + app_path + "/sce_sys/livearea/contents/" + bg_name);
+                                vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "app/" + app_path + "/sce_sys/livearea/contents/" + bg_name);
                             else
-                                vfs::read_app_file(buffer, emuenv.pref_path.wstring(), app_path, live_area_path.string() + "/contents/" + bg_name);
+                                vfs::read_app_file(buffer, emuenv.pref_path, app_path, live_area_path / "contents" / bg_name);
 
                             if (buffer.empty()) {
                                 if (is_ps_app || is_sys_app)
@@ -475,9 +475,9 @@ void init_live_area(GuiState &gui, EmuEnvState &emuenv, const std::string &app_p
                             vfs::FileBuffer buffer;
 
                             if (app_device == VitaIoDevice::vs0)
-                                vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path.wstring(), "app/" + app_path + "/sce_sys/livearea/contents/" + img_name);
+                                vfs::read_file(VitaIoDevice::vs0, buffer, emuenv.pref_path, "app/" + app_path + "/sce_sys/livearea/contents/" + img_name);
                             else
-                                vfs::read_app_file(buffer, emuenv.pref_path.wstring(), app_path, live_area_path.string() + "/contents/" + img_name);
+                                vfs::read_app_file(buffer, emuenv.pref_path, app_path, live_area_path / "contents" / img_name);
 
                             if (buffer.empty()) {
                                 if (is_ps_app || is_sys_app)

--- a/vita3k/gui/src/manual.cpp
+++ b/vita3k/gui/src/manual.cpp
@@ -93,10 +93,10 @@ bool init_manual(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
         int32_t width, height;
         for (const auto &manual : fs::directory_iterator(APP_PATH / manual_path)) {
             if (manual.path().extension() == ".png") {
-                const auto page_path = manual_path / manual.path().filename().string();
+                const auto page_path = manual_path / manual.path().filename();
 
                 vfs::FileBuffer buffer;
-                vfs::read_app_file(buffer, emuenv.pref_path.wstring(), app_path, page_path);
+                vfs::read_app_file(buffer, emuenv.pref_path, app_path, page_path);
 
                 if (buffer.empty()) {
                     LOG_WARN("Manual not found for title: {} [{}].", app_path, APP_INDEX->title);
@@ -106,7 +106,7 @@ bool init_manual(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
                 // Load image data from memory buffer and check if it's valid
                 stbi_uc *data = stbi_load_from_memory(buffer.data(), static_cast<int>(buffer.size()), &width, &height, nullptr, STBI_rgb_alpha);
                 if (!data) {
-                    LOG_ERROR("Invalid manual image for title: {} [{}] in path: {}.", app_path, APP_INDEX->title, page_path.string());
+                    LOG_ERROR("Invalid manual image for title: {} [{}] in path: {}.", app_path, APP_INDEX->title, page_path);
                     return false;
                 }
 

--- a/vita3k/gui/src/pkg_install_dialog.cpp
+++ b/vita3k/gui/src/pkg_install_dialog.cpp
@@ -100,7 +100,7 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         } else if (state == "license") {
             result = host::dialog::filesystem::open_file(license_path, { { "PlayStation Vita software license file", { "bin", "rif" } } });
             if (result == host::dialog::filesystem::Result::SUCCESS) {
-                fs::ifstream binfile(license_path.wstring(), std::ios::in | std::ios::binary | std::ios::ate);
+                fs::ifstream binfile(license_path.native(), std::ios::in | std::ios::binary | std::ios::ate);
                 zRIF = rif2zrif(binfile);
                 state = "install";
             } else {
@@ -128,7 +128,7 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 state = "install";
         } else if (state == "install") {
             std::thread installation([&emuenv]() {
-                if (install_pkg(pkg_path.string(), emuenv, zRIF, progress_callback)) {
+                if (install_pkg(pkg_path.native(), emuenv, zRIF, progress_callback)) {
                     std::lock_guard<std::mutex> lock(install_mutex);
                     state = "success";
                 } else {
@@ -153,11 +153,11 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - (20.f * SCALE.y)));
             if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
                 if (delete_pkg_file) {
-                    fs::remove(fs::path(pkg_path.wstring()));
+                    fs::remove(fs::path(pkg_path.native()));
                     delete_pkg_file = false;
                 }
                 if (delete_license_file) {
-                    fs::remove(fs::path(license_path.wstring()));
+                    fs::remove(fs::path(license_path.native()));
                     delete_license_file = false;
                 }
                 if ((emuenv.app_info.app_category.find("gd") != std::string::npos) || (emuenv.app_info.app_category.find("gp") != std::string::npos)) {

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -151,7 +151,7 @@ void init_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
 
                 // Open trophy progress file
                 const auto trophy_progress_save_file = device::construct_normalized_path(VitaIoDevice::ux0, "user/" + emuenv.io.user_id + "/trophy/data/" + np_com_id + "/TROPUSR.DAT");
-                const auto progress_input_file = open_file(emuenv.io, trophy_progress_save_file.c_str(), SCE_O_RDONLY, emuenv.pref_path.wstring(), "load_trophy_progress_file");
+                const auto progress_input_file = open_file(emuenv.io, trophy_progress_save_file.c_str(), SCE_O_RDONLY, emuenv.pref_path, "load_trophy_progress_file");
 
                 if (!load_trophy_progress(emuenv.io, progress_input_file, np_com_id)) {
                     LOG_ERROR("Fail load trophy progress for Np Com ID: {}, clean trophy file.", np_com_id);
@@ -236,7 +236,7 @@ void init_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     int32_t height = 0;
                     vfs::FileBuffer buffer;
 
-                    vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), "user/" + emuenv.io.user_id + "/trophy/conf/" + np_com_id + "/" + group.second);
+                    vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, "user/" + emuenv.io.user_id + "/trophy/conf/" + np_com_id + "/" + group.second);
 
                     if (buffer.empty()) {
                         LOG_WARN("Icon: '{}', Not found for NPComId: {}.", group.second, np_com_id);
@@ -318,7 +318,7 @@ static void get_trophy_list(GuiState &gui, EmuEnvState &emuenv, const std::strin
         const std::string trophy_id = trophy.first;
         const std::string icon_name = fmt::format("TROP{}.PNG", trophy_id);
 
-        vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path.wstring(), "user/" + emuenv.io.user_id + "/trophy/conf/" + np_com_id + "/" + icon_name);
+        vfs::read_file(VitaIoDevice::ux0, buffer, emuenv.pref_path, "user/" + emuenv.io.user_id + "/trophy/conf/" + np_com_id + "/" + icon_name);
         if (buffer.empty()) {
             LOG_WARN("Trophy icon, Name: '{}', Not found for trophy id: {}.", icon_name, trophy.first);
             continue;

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -54,28 +54,23 @@ struct AvatarInfo {
 };
 
 static std::map<std::string, std::map<AvatarSize, AvatarInfo>> users_avatar_infos;
-static bool init_avatar(GuiState &gui, EmuEnvState &emuenv, const std::string &user_id, const std::string avatar_path) {
-    const auto avatar_path_wstr = avatar_path == "default" ? emuenv.static_assets_path / "data/image/icon.png"
-                                                           : fs::path(string_utils::utf_to_wide(avatar_path));
+static bool init_avatar(GuiState &gui, EmuEnvState &emuenv, const std::string &user_id, const std::string &avatar_path) {
+    const auto avatar_path_path = avatar_path == "default" ? emuenv.static_assets_path / "data/image/icon.png" : fs_utils::utf8_to_path(avatar_path);
 
-    if (!fs::exists(avatar_path_wstr)) {
-        LOG_WARN("Avatar image doesn't exist: {}.", avatar_path_wstr.string());
+    if (!fs::exists(avatar_path_path)) {
+        LOG_WARN("Avatar image doesn't exist: {}.", avatar_path_path);
         return false;
     }
 
     int32_t width = 0;
     int32_t height = 0;
 
-#ifdef _WIN32
-    FILE *f = _wfopen(avatar_path_wstr.c_str(), L"rb");
-#else
-    FILE *f = fopen(avatar_path_wstr.c_str(), "rb");
-#endif
+    FILE *f = FOPEN(avatar_path_path.c_str(), "rb");
 
     stbi_uc *data = stbi_load_from_file(f, &width, &height, nullptr, STBI_rgb_alpha);
 
     if (!data) {
-        LOG_ERROR("Invalid or corrupted image: {}.", avatar_path_wstr.string());
+        LOG_ERROR("Invalid or corrupted image: {}.", avatar_path_path);
         return false;
     }
 
@@ -158,8 +153,7 @@ void get_users_list(GuiState &gui, EmuEnvState &emuenv) {
 
 void save_user(GuiState &gui, EmuEnvState &emuenv, const std::string &user_id) {
     const auto user_path{ emuenv.pref_path / "ux0/user" / user_id };
-    if (!fs::exists(user_path))
-        fs::create_directory(user_path);
+    fs::create_directories(user_path);
 
     const auto &user = gui.users[user_id];
 
@@ -196,7 +190,7 @@ void save_user(GuiState &gui, EmuEnvState &emuenv, const std::string &user_id) {
 
     const auto save_xml = user_xml.save_file((user_path / "user.xml").c_str());
     if (!save_xml)
-        LOG_ERROR("Fail save xml for user id: {}, name: {}, in path: {}", user.id, user.name, user_path.string());
+        LOG_ERROR("Fail save xml for user id: {}, name: {}, in path: {}", user.id, user.name, user_path);
 }
 
 enum UserMenu {

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -148,7 +148,7 @@ static std::atomic<float> progress(0);
 static std::atomic<uint64_t> remaining(0);
 static net_utils::ProgressState progress_state{};
 
-static void download_update(const std::string &base_path) {
+static void download_update(const fs::path &base_path) {
     progress_state.download = true;
     progress_state.pause = false;
     std::thread download([base_path]() {
@@ -167,7 +167,7 @@ static void download_update(const std::string &base_path) {
         const std::string archive_ext = ".zip";
 #endif
 
-        const auto vita3k_latest_path = base_path + "vita3k-latest" + archive_ext;
+        const auto vita3k_latest_path = base_path / ("vita3k-latest" + archive_ext);
 
         const std::string version = std::to_string(git_version);
 
@@ -180,7 +180,7 @@ static void download_update(const std::string &base_path) {
             return &progress_state;
         };
 
-        if (net_utils::download_file(download_continuous_link, vita3k_latest_path, progress_callback)) {
+        if (net_utils::download_file(download_continuous_link, fs_utils::path_to_utf8(vita3k_latest_path), progress_callback)) {
             SDL_Event event;
             event.type = SDL_QUIT;
             SDL_PushEvent(&event);

--- a/vita3k/interface.h
+++ b/vita3k/interface.h
@@ -57,5 +57,5 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui);
 std::vector<ContentInfo> install_archive(EmuEnvState &emuenv, GuiState *gui, const fs::path &archive_path, const std::function<void(ArchiveContents)> &progress_callback = nullptr);
 uint32_t install_contents(EmuEnvState &emuenv, GuiState *gui, const fs::path &path);
 
-ExitCode load_app(int32_t &main_module_id, EmuEnvState &emuenv, const std::wstring &path);
+ExitCode load_app(int32_t &main_module_id, EmuEnvState &emuenv);
 ExitCode run_app(EmuEnvState &emuenv, int32_t main_module_id);

--- a/vita3k/io/include/io/device.h
+++ b/vita3k/io/include/io/device.h
@@ -123,7 +123,7 @@ inline std::string remove_duplicate_device(const std::string &path, VitaIoDevice
  * \param ext The extension of the file (optional).
  * \return A complete Boost.Filesystem path normalized.
  */
-inline fs::path construct_emulated_path(const VitaIoDevice dev, const fs::path &path, const std::wstring &base_path, const bool redirect_pwd = false, const std::string &ext = "") {
+inline fs::path construct_emulated_path(const VitaIoDevice dev, const fs::path &path, const fs::path &base_path, const bool redirect_pwd = false, const std::string &ext = "") {
     if (redirect_pwd && dev == +VitaIoDevice::host0) {
         return fs::current_path() / path;
     }

--- a/vita3k/io/include/io/functions.h
+++ b/vita3k/io/include/io/functions.h
@@ -40,7 +40,7 @@ bool init(IOState &io, const fs::path &cache_path, const fs::path &log_path, con
 bool find_case_isens_path(IOState &io, VitaIoDevice &device, const fs::path &translated_path, const fs::path &system_path);
 fs::path find_in_cache(IOState &io, const std::string &system_path);
 
-std::string expand_path(IOState &io, const char *path, const std::wstring &pref_path);
+fs::path expand_path(IOState &io, const char *path, const fs::path &pref_path);
 std::string translate_path(const char *path, VitaIoDevice &device, const IOState::DevicePaths &device_paths);
 
 /**
@@ -64,25 +64,25 @@ bool copy_directories(const fs::path &src_path, const fs::path &dst_path);
  * @return true Success
  * @return false Error
  */
-bool copy_path(const fs::path &src_path, const std::wstring &pref_path, const std::string &app_title_id, const std::string &app_category);
+bool copy_path(const fs::path &src_path, const fs::path &pref_path, const std::string &app_title_id, const std::string &app_category);
 
-SceUID open_file(IOState &io, const char *path, const int flags, const std::wstring &pref_path, const char *export_name);
+SceUID open_file(IOState &io, const char *path, const int flags, const fs::path &pref_path, const char *export_name);
 int read_file(void *data, IOState &io, SceUID fd, SceSize size, const char *export_name);
 int write_file(SceUID fd, const void *data, SceSize size, const IOState &io, const char *export_name);
 int truncate_file(SceUID fd, unsigned long long length, const IOState &io, const char *export_name);
 SceOff seek_file(SceUID fd, SceOff offset, SceIoSeekMode whence, IOState &io, const char *export_name);
 SceOff tell_file(IOState &io, const SceUID fd, const char *export_name);
-int stat_file(IOState &io, const char *file, SceIoStat *statp, const std::wstring &pref_path, const char *export_name, SceUID fd = invalid_fd);
-int stat_file_by_fd(IOState &io, const SceUID fd, SceIoStat *statp, const std::wstring &pref_path, const char *export_name);
+int stat_file(IOState &io, const char *file, SceIoStat *statp, const fs::path &pref_path, const char *export_name, SceUID fd = invalid_fd);
+int stat_file_by_fd(IOState &io, const SceUID fd, SceIoStat *statp, const fs::path &pref_path, const char *export_name);
 int close_file(IOState &io, SceUID fd, const char *export_name);
-int remove_file(IOState &io, const char *file, const std::wstring &pref_path, const char *export_name);
-int rename(IOState &io, const char *old_name, const char *new_name, const std::wstring &pref_path, const char *export_name);
+int remove_file(IOState &io, const char *file, const fs::path &pref_path, const char *export_name);
+int rename(IOState &io, const char *old_name, const char *new_name, const fs::path &pref_path, const char *export_name);
 
-SceUID open_dir(IOState &io, const char *path, const std::wstring &pref_path, const char *export_name);
-SceUID read_dir(IOState &io, SceUID fd, SceIoDirent *dent, const std::wstring &pref_path, const char *export_name);
-int create_dir(IOState &io, const char *dir, int mode, const std::wstring &pref_path, const char *export_name, const bool recursive = false);
+SceUID open_dir(IOState &io, const char *path, const fs::path &pref_path, const char *export_name);
+SceUID read_dir(IOState &io, SceUID fd, SceIoDirent *dent, const fs::path &pref_path, const char *export_name);
+int create_dir(IOState &io, const char *dir, int mode, const fs::path &pref_path, const char *export_name, const bool recursive = false);
 int close_dir(IOState &io, SceUID fd, const char *export_name);
-int remove_dir(IOState &io, const char *dir, const std::wstring &pref_path, const char *export_name);
+int remove_dir(IOState &io, const char *dir, const fs::path &pref_path, const char *export_name);
 
 // SceFios functions
 SceUID create_overlay(IOState &io, SceFiosProcessOverlay *fios_overlay);

--- a/vita3k/io/include/io/util.h
+++ b/vita3k/io/include/io/util.h
@@ -95,16 +95,10 @@ public:
         return file_info.access_mode;
     }
 
-// Overloaded functions for separate systems
-#ifdef WIN32
-    const wchar_t *get_char_path() const {
-        return file_info.sys_loc.generic_path().wstring().c_str();
+    // Returning type depends of system
+    auto get_char_path() const {
+        return file_info.sys_loc.generic_path().native().c_str();
     }
-#else
-    const char *get_char_path() const {
-        return file_info.sys_loc.generic_path().string().c_str();
-    }
-#endif
 
     // Modify IO parameters
     void create_io_perms(const int flags) {

--- a/vita3k/io/include/io/vfs.h
+++ b/vita3k/io/include/io/vfs.h
@@ -32,7 +32,7 @@ struct SpaceInfo {
 
 using FileBuffer = std::vector<SceUInt8>;
 
-bool read_file(VitaIoDevice device, FileBuffer &buf, const std::wstring &pref_path, const fs::path &vfs_file_path);
-bool read_app_file(FileBuffer &buf, const std::wstring &pref_path, const std::string &app_path, const fs::path &vfs_file_path);
-SpaceInfo get_space_info(const VitaIoDevice device, const std::string &vfs_path, const std::wstring &pref_path);
+bool read_file(VitaIoDevice device, FileBuffer &buf, const fs::path &pref_path, const fs::path &vfs_file_path);
+bool read_app_file(FileBuffer &buf, const fs::path &pref_path, const std::string &app_path, const fs::path &vfs_file_path);
+SpaceInfo get_space_info(const VitaIoDevice device, const std::string &vfs_path, const fs::path &pref_path);
 } // namespace vfs

--- a/vita3k/kernel/include/kernel/load_self.h
+++ b/vita3k/kernel/include/kernel/load_self.h
@@ -20,6 +20,7 @@
 #include <util/types.h>
 
 #include <string>
+#include <util/fs.h>
 
 struct Config;
 struct KernelState;
@@ -27,4 +28,4 @@ struct MemState;
 template <class T>
 class Ptr;
 
-SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &self_path, const std::string &dump_path);
+SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &self_path, const fs::path &log_path);

--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -381,7 +381,7 @@ static bool load_exports(SceKernelModuleInfo *kernel_module_info, const sce_modu
 /**
  * \return Negative on failure
  */
-SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &self_path, const std::string &dump_path) {
+SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &self_path, const fs::path &log_path) {
     // TODO: use raw I/O from path when io becomes less bad
     const uint8_t *const self_bytes = static_cast<const uint8_t *>(self);
     const SCE_header &self_header = *static_cast<const SCE_header *>(self);
@@ -583,13 +583,13 @@ SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std
             dump_segments[seg_index].p_vaddr = segment.addr;
             last_index = std::max(seg_index, last_index);
         }
-        auto dump_dir = fs::path(dump_path) / "elfdumps";
-        fs::create_directory(dump_dir);
+        fs::path dump_dir = log_path / "elfdumps";
+        fs::create_directories(dump_dir);
         const auto start = dump_segments[0].p_vaddr;
         const auto end = dump_segments[last_index].p_vaddr + dump_segments[last_index].p_filesz;
         const auto elf_name = fs::path(self_path).filename().stem().string();
-        const auto filename = fs::path(fmt::format("{}/{}-{}_{}.elf", dump_dir.string(), log_hex_full(start), log_hex_full(end), elf_name));
-        std::ofstream out(filename.string(), std::ios::out | std::ios::binary);
+        const auto filename = dump_dir / fmt::format("{}-{}_{}.elf", log_hex_full(start), log_hex_full(end), elf_name);
+        fs::ofstream out(filename, std::ios::out | std::ios::binary);
         out.write(reinterpret_cast<char *>(dump_elf.data()), dump_elf.size());
         out.close();
     }

--- a/vita3k/modules/SceAppMgr/SceAppMgr.cpp
+++ b/vita3k/modules/SceAppMgr/SceAppMgr.cpp
@@ -399,7 +399,7 @@ EXPORT(SceInt32, _sceAppMgrLoadExec, const char *appPath, Ptr<char> const argv[]
 
     // Load exec executable
     vfs::FileBuffer exec_buffer;
-    if (vfs::read_app_file(exec_buffer, emuenv.pref_path.wstring(), emuenv.io.app_path, exec_path)) {
+    if (vfs::read_app_file(exec_buffer, emuenv.pref_path, emuenv.io.app_path, exec_path)) {
         if (argv && argv->get(emuenv.mem)) {
             size_t args = 0;
             emuenv.load_exec_argv = "\"";

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -246,13 +246,13 @@ EXPORT(int, sceAppUtilSaveDataDataRemove, SceAppUtilSaveDataFileSlot *slot, SceA
     for (unsigned int i = 0; i < fileNum; i++) {
         const auto file = fs::path(construct_savedata0_path(files[i].dataPath.get(emuenv.mem)));
         if (fs::is_regular_file(file)) {
-            remove_file(emuenv.io, file.string().c_str(), emuenv.pref_path.wstring(), export_name);
+            remove_file(emuenv.io, file.string().c_str(), emuenv.pref_path, export_name);
         } else
-            remove_dir(emuenv.io, file.string().c_str(), emuenv.pref_path.wstring(), export_name);
+            remove_dir(emuenv.io, file.string().c_str(), emuenv.pref_path, export_name);
     }
 
     if (slot && files[0].mode == SCE_APPUTIL_SAVEDATA_DATA_REMOVE_MODE_DEFAULT) {
-        remove_file(emuenv.io, construct_slotparam_path(slot->id).c_str(), emuenv.pref_path.wstring(), export_name);
+        remove_file(emuenv.io, construct_slotparam_path(slot->id).c_str(), emuenv.pref_path, export_name);
     }
 
     return 0;
@@ -270,22 +270,22 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
         const auto file_path = construct_savedata0_path(files[i].dataPath.get(emuenv.mem));
         switch (files[i].mode) {
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_DIRECTORY:
-            create_dir(emuenv.io, file_path.c_str(), 0777, emuenv.pref_path.wstring(), export_name);
+            create_dir(emuenv.io, file_path.c_str(), 0777, emuenv.pref_path, export_name);
             break;
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_FILE_TRUNCATE:
             if (files[i].buf) {
-                fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
+                fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
                 seek_file(fd, static_cast<int>(files[i].offset), SCE_SEEK_SET, emuenv.io, export_name);
                 write_file(fd, files[i].buf.get(emuenv.mem), files[i].bufSize, emuenv.io, export_name);
                 close_file(emuenv.io, fd, export_name);
             }
-            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_APPEND | SCE_O_TRUNC, emuenv.pref_path.wstring(), export_name);
+            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_APPEND | SCE_O_TRUNC, emuenv.pref_path, export_name);
             truncate_file(fd, files[i].bufSize + files[i].offset, emuenv.io, export_name);
             close_file(emuenv.io, fd, export_name);
             break;
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_FILE:
         default:
-            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
+            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
             seek_file(fd, static_cast<int>(files[i].offset), SCE_SEEK_SET, emuenv.io, export_name);
             write_file(fd, files[i].buf.get(emuenv.mem), files[i].bufSize, emuenv.io, export_name);
             close_file(emuenv.io, fd, export_name);
@@ -306,7 +306,7 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
         modified_time.minute = local.tm_min;
         modified_time.second = local.tm_sec;
         slot->slotParam.get(emuenv.mem)->modifiedTime = modified_time;
-        fd = open_file(emuenv.io, construct_slotparam_path(slot->id).c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
+        fd = open_file(emuenv.io, construct_slotparam_path(slot->id).c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
         write_file(fd, slot->slotParam.get(emuenv.mem), sizeof(SceAppUtilSaveDataSlotParam), emuenv.io, export_name);
         close_file(emuenv.io, fd, export_name);
     }
@@ -316,8 +316,8 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
 
 EXPORT(int, sceAppUtilSaveDataGetQuota, SceSize *quotaSizeKiB, SceSize *usedSizeKiB, const SceAppUtilMountPoint *mountPoint) {
     TRACY_FUNC(sceAppUtilSaveDataGetQuota, quotaSizeKiB, usedSizeKiB, mountPoint);
-    *quotaSizeKiB = vfs::get_space_info(VitaIoDevice::ux0, emuenv.io.device_paths.savedata0, emuenv.pref_path.wstring()).max_capacity / KiB(1);
-    *usedSizeKiB = vfs::get_space_info(VitaIoDevice::ux0, emuenv.io.device_paths.savedata0, emuenv.pref_path.wstring()).used / KiB(1);
+    *quotaSizeKiB = vfs::get_space_info(VitaIoDevice::ux0, emuenv.io.device_paths.savedata0, emuenv.pref_path).max_capacity / KiB(1);
+    *usedSizeKiB = vfs::get_space_info(VitaIoDevice::ux0, emuenv.io.device_paths.savedata0, emuenv.pref_path).used / KiB(1);
     return 0;
 }
 
@@ -328,7 +328,7 @@ EXPORT(int, sceAppUtilSaveDataMount) {
 
 EXPORT(int, sceAppUtilSaveDataSlotCreate, unsigned int slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilMountPoint *mountPoint) {
     TRACY_FUNC(sceAppUtilSaveDataSlotCreate, slotId, param, mountPoint);
-    const auto fd = open_file(emuenv.io, construct_slotparam_path(slotId).c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
+    const auto fd = open_file(emuenv.io, construct_slotparam_path(slotId).c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
     write_file(fd, param, sizeof(SceAppUtilSaveDataSlotParam), emuenv.io, export_name);
     close_file(emuenv.io, fd, export_name);
     return 0;
@@ -336,13 +336,13 @@ EXPORT(int, sceAppUtilSaveDataSlotCreate, unsigned int slotId, SceAppUtilSaveDat
 
 EXPORT(int, sceAppUtilSaveDataSlotDelete, unsigned int slotId, SceAppUtilMountPoint *mountPoint) {
     TRACY_FUNC(sceAppUtilSaveDataSlotDelete, slotId, mountPoint);
-    remove_file(emuenv.io, construct_slotparam_path(slotId).c_str(), emuenv.pref_path.wstring(), export_name);
+    remove_file(emuenv.io, construct_slotparam_path(slotId).c_str(), emuenv.pref_path, export_name);
     return 0;
 }
 
 EXPORT(int, sceAppUtilSaveDataSlotGetParam, unsigned int slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilMountPoint *mountPoint) {
     TRACY_FUNC(sceAppUtilSaveDataSlotGetParam, slotId, param, mountPoint);
-    const auto fd = open_file(emuenv.io, construct_slotparam_path(slotId).c_str(), SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
+    const auto fd = open_file(emuenv.io, construct_slotparam_path(slotId).c_str(), SCE_O_RDONLY, emuenv.pref_path, export_name);
     if (fd < 0)
         return RET_ERROR(SCE_APPUTIL_ERROR_SAVEDATA_SLOT_NOT_FOUND);
     read_file(param, emuenv.io, fd, sizeof(SceAppUtilSaveDataSlotParam), export_name);
@@ -372,7 +372,7 @@ EXPORT(SceInt32, sceAppUtilSaveDataSlotSearch, SceAppUtilWorkBuffer *workBuf, co
             slotList[i].emptyParam = Ptr<SceAppUtilSaveDataSlotEmptyParam>(0);
         }
 
-        const auto fd = open_file(emuenv.io, construct_slotparam_path(i).c_str(), SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
+        const auto fd = open_file(emuenv.io, construct_slotparam_path(i).c_str(), SCE_O_RDONLY, emuenv.pref_path, export_name);
         switch (cond->type) {
         case SCE_APPUTIL_SAVEDATA_SLOT_SEARCH_TYPE_EXIST_SLOT:
             if (fd > 0) {
@@ -406,7 +406,7 @@ EXPORT(SceInt32, sceAppUtilSaveDataSlotSearch, SceAppUtilWorkBuffer *workBuf, co
 
 EXPORT(SceInt32, sceAppUtilSaveDataSlotSetParam, SceAppUtilSaveDataSlotId slotId, SceAppUtilSaveDataSlotParam *param, SceAppUtilMountPoint *mountPoint) {
     TRACY_FUNC(sceAppUtilSaveDataSlotSetParam, slotId, param, mountPoint);
-    const auto fd = open_file(emuenv.io, construct_slotparam_path(slotId).c_str(), SCE_O_WRONLY, emuenv.pref_path.wstring(), export_name);
+    const auto fd = open_file(emuenv.io, construct_slotparam_path(slotId).c_str(), SCE_O_WRONLY, emuenv.pref_path, export_name);
     if (fd < 0)
         return RET_ERROR(SCE_APPUTIL_ERROR_SAVEDATA_SLOT_NOT_FOUND);
     write_file(fd, param, sizeof(SceAppUtilSaveDataSlotParam), emuenv.io, export_name);
@@ -425,7 +425,7 @@ static SceInt32 SafeMemory(EmuEnvState &emuenv, void *buf, SceSize bufSize, SceO
     SceInt32 res = 0;
 
     // Open file when it exist
-    const auto fd = open_file(emuenv.io, safe_mem_path.c_str(), SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
+    const auto fd = open_file(emuenv.io, safe_mem_path.c_str(), SCE_O_RDONLY, emuenv.pref_path, export_name);
     if (fd > 0) {
         // Read file for set data inside safe mem when it exist
         res = read_file(safe_mem.data(), emuenv.io, fd, SCE_APPUTIL_SAFEMEMORY_MEMORY_SIZE, export_name);
@@ -434,7 +434,7 @@ static SceInt32 SafeMemory(EmuEnvState &emuenv, void *buf, SceSize bufSize, SceO
 
     if ((fd < 0) || save) {
         // When safe mem no exist or in save mode, write it with set buffer inside data
-        const auto fd = open_file(emuenv.io, safe_mem_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
+        const auto fd = open_file(emuenv.io, safe_mem_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
         memcpy(&safe_mem[offset], buf, bufSize);
         write_file(fd, safe_mem.data(), SCE_APPUTIL_SAFEMEMORY_MEMORY_SIZE, emuenv.io, export_name);
         close_file(emuenv.io, fd, export_name);

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -825,7 +825,7 @@ static void check_empty_param(EmuEnvState &emuenv, const SceAppUtilSaveDataSlotE
         if (iconPath) {
             auto device = device::get_device(empty_param->iconPath.get(emuenv.mem));
             auto thumbnail_path = translate_path(empty_param->iconPath.get(emuenv.mem), device, emuenv.io.device_paths);
-            vfs::read_file(VitaIoDevice::ux0, thumbnail_buffer, emuenv.pref_path.wstring(), thumbnail_path);
+            vfs::read_file(VitaIoDevice::ux0, thumbnail_buffer, emuenv.pref_path, thumbnail_path);
             emuenv.common_dialog.savedata.icon_buffer[idx] = thumbnail_buffer;
         } else if (iconBuf && iconBufSize != 0) {
             thumbnail_buffer.insert(thumbnail_buffer.end(), iconBuf, iconBuf + iconBufSize);
@@ -836,7 +836,7 @@ static void check_empty_param(EmuEnvState &emuenv, const SceAppUtilSaveDataSlotE
 }
 
 static void check_save_file(const uint32_t index, EmuEnvState &emuenv, const char *export_name) {
-    SceUID fd = open_file(emuenv.io, construct_slotparam_path(emuenv.common_dialog.savedata.slot_id[index]).c_str(), SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
+    SceUID fd = open_file(emuenv.io, construct_slotparam_path(emuenv.common_dialog.savedata.slot_id[index]).c_str(), SCE_O_RDONLY, emuenv.pref_path, export_name);
     if (fd < 0) {
         auto empty_param = emuenv.common_dialog.savedata.list_empty_param[index];
         check_empty_param(emuenv, empty_param, index);
@@ -853,7 +853,7 @@ static void check_save_file(const uint32_t index, EmuEnvState &emuenv, const cha
         emuenv.common_dialog.savedata.has_date[index] = true;
         auto device = device::get_device(slot_param.iconPath);
         auto thumbnail_path = translate_path(slot_param.iconPath, device, emuenv.io.device_paths);
-        vfs::read_file(device, thumbnail_buffer, emuenv.pref_path.wstring(), thumbnail_path);
+        vfs::read_file(device, thumbnail_buffer, emuenv.pref_path, thumbnail_path);
         emuenv.common_dialog.savedata.icon_buffer[index] = thumbnail_buffer;
         emuenv.common_dialog.savedata.icon_texture[index] = {};
     }

--- a/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
+++ b/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
@@ -557,9 +557,9 @@ EXPORT(int, sceAppMgrSaveDataDataRemove, Ptr<SceAppMgrSaveDataDataDelete> data) 
     for (int i = 0; i < data.get(emuenv.mem)->fileNum; i++) {
         const auto file = fs::path(construct_savedata0_path(data.get(emuenv.mem)->files.get(emuenv.mem)[i].dataPath.get(emuenv.mem)));
         if (fs::is_regular_file(file)) {
-            remove_file(emuenv.io, file.string().c_str(), emuenv.pref_path.wstring(), export_name);
+            remove_file(emuenv.io, file.string().c_str(), emuenv.pref_path, export_name);
         } else
-            remove_dir(emuenv.io, file.string().c_str(), emuenv.pref_path.wstring(), export_name);
+            remove_dir(emuenv.io, file.string().c_str(), emuenv.pref_path, export_name);
     }
 
     return 0;
@@ -580,22 +580,22 @@ EXPORT(int, sceAppMgrSaveDataDataSave, Ptr<SceAppMgrSaveDataData> data) {
         const auto file_path = construct_savedata0_path(files[i].dataPath.get(emuenv.mem));
         switch (files[i].mode) {
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_DIRECTORY:
-            create_dir(emuenv.io, file_path.c_str(), 0777, emuenv.pref_path.wstring(), export_name);
+            create_dir(emuenv.io, file_path.c_str(), 0777, emuenv.pref_path, export_name);
             break;
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_FILE_TRUNCATE:
             if (files[i].buf) {
-                fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
+                fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
                 seek_file(fd, static_cast<int>(files[i].offset), SCE_SEEK_SET, emuenv.io, export_name);
                 write_file(fd, files[i].buf.get(emuenv.mem), files[i].bufSize, emuenv.io, export_name);
                 close_file(emuenv.io, fd, export_name);
             }
-            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_APPEND | SCE_O_TRUNC, emuenv.pref_path.wstring(), export_name);
+            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_APPEND | SCE_O_TRUNC, emuenv.pref_path, export_name);
             truncate_file(fd, files[i].bufSize + files[i].offset, emuenv.io, export_name);
             close_file(emuenv.io, fd, export_name);
             break;
         case SCE_APPUTIL_SAVEDATA_DATA_SAVE_MODE_FILE:
         default:
-            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path.wstring(), export_name);
+            fd = open_file(emuenv.io, file_path.c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
             seek_file(fd, static_cast<int>(files[i].offset), SCE_SEEK_SET, emuenv.io, export_name);
             if (files[i].buf.get(emuenv.mem)) {
                 write_file(fd, files[i].buf.get(emuenv.mem), files[i].bufSize, emuenv.io, export_name);

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -4367,7 +4367,7 @@ EXPORT(int, sceGxmShaderPatcherCreateFragmentProgram, SceGxmShaderPatcher *shade
     fp->is_maskupdate = false;
     fp->program = programId->program;
 
-    if (!renderer::create(fp->renderer_data, *emuenv.renderer, *programId->program.get(mem), blendInfo, emuenv.renderer->gxp_ptr_map, emuenv.cache_path.string().c_str(), emuenv.io.title_id.c_str())) {
+    if (!renderer::create(fp->renderer_data, *emuenv.renderer, *programId->program.get(mem), blendInfo, emuenv.renderer->gxp_ptr_map)) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 
@@ -4394,7 +4394,7 @@ EXPORT(int, sceGxmShaderPatcherCreateMaskUpdateFragmentProgram, SceGxmShaderPatc
     fp->program = Ptr<const SceGxmProgram>(alloc_callbacked(emuenv, thread_id, shaderPatcher->params, size_mask_gxp));
     memcpy(const_cast<SceGxmProgram *>(fp->program.get(mem)), mask_gxp, size_mask_gxp);
 
-    if (!renderer::create(fp->renderer_data, *emuenv.renderer, *fp->program.get(mem), nullptr, emuenv.renderer->gxp_ptr_map, emuenv.cache_path.string().c_str(), emuenv.io.title_id.c_str())) {
+    if (!renderer::create(fp->renderer_data, *emuenv.renderer, *fp->program.get(mem), nullptr, emuenv.renderer->gxp_ptr_map)) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 
@@ -4446,7 +4446,7 @@ EXPORT(int, sceGxmShaderPatcherCreateVertexProgram, SceGxmShaderPatcher *shaderP
         vp->attributes.insert(vp->attributes.end(), &attributes[0], &attributes[attributeCount]);
     }
 
-    if (!renderer::create(vp->renderer_data, *emuenv.renderer, *programId->program.get(mem), emuenv.renderer->gxp_ptr_map, vp->attributes, emuenv.cache_path.string().c_str(), emuenv.io.title_id.c_str())) {
+    if (!renderer::create(vp->renderer_data, *emuenv.renderer, *programId->program.get(mem), emuenv.renderer->gxp_ptr_map, vp->attributes)) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);
     }
 

--- a/vita3k/modules/SceIofilemgr/SceIofilemgr.cpp
+++ b/vita3k/modules/SceIofilemgr/SceIofilemgr.cpp
@@ -55,7 +55,7 @@ EXPORT(int, _sceIoDevctlAsync) {
 
 EXPORT(int, _sceIoDopen, const char *dir) {
     TRACY_FUNC(_sceIoDopen, dir);
-    return open_dir(emuenv.io, dir, emuenv.pref_path.wstring(), export_name);
+    return open_dir(emuenv.io, dir, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, _sceIoDread, const SceUID fd, SceIoDirent *dir) {
@@ -63,12 +63,12 @@ EXPORT(int, _sceIoDread, const SceUID fd, SceIoDirent *dir) {
     if (dir == nullptr) {
         return RET_ERROR(SCE_KERNEL_ERROR_ILLEGAL_ADDR);
     }
-    return read_dir(emuenv.io, fd, dir, emuenv.pref_path.wstring(), export_name);
+    return read_dir(emuenv.io, fd, dir, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, _sceIoGetstat, const char *file, SceIoStat *stat) {
     TRACY_FUNC(_sceIoGetstat, file, stat);
-    return stat_file(emuenv.io, file, stat, emuenv.pref_path.wstring(), export_name);
+    return stat_file(emuenv.io, file, stat, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, _sceIoGetstatAsync) {
@@ -78,7 +78,7 @@ EXPORT(int, _sceIoGetstatAsync) {
 
 EXPORT(int, _sceIoGetstatByFd, const SceUID fd, SceIoStat *stat) {
     TRACY_FUNC(_sceIoGetstatByFd, fd, stat);
-    return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path.wstring(), export_name);
+    return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, _sceIoIoctl) {
@@ -103,7 +103,7 @@ EXPORT(int, _sceIoLseekAsync) {
 
 EXPORT(int, _sceIoMkdir, const char *dir, const SceMode mode) {
     TRACY_FUNC(_sceIoMkdir, dir, mode);
-    return create_dir(emuenv.io, dir, mode, emuenv.pref_path.wstring(), export_name);
+    return create_dir(emuenv.io, dir, mode, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, _sceIoMkdirAsync) {
@@ -117,7 +117,7 @@ EXPORT(int, _sceIoOpen, const char *file, const int flags, const SceMode mode) {
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
     }
     LOG_INFO("Opening file: {}", file);
-    return open_file(emuenv.io, file, flags, emuenv.pref_path.wstring(), export_name);
+    return open_file(emuenv.io, file, flags, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, _sceIoOpenAsync) {

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -584,7 +584,7 @@ EXPORT(int, sceIoGetstatAsync) {
 
 EXPORT(int, sceIoGetstatByFd, const SceUID fd, SceIoStat *stat) {
     TRACY_FUNC(sceIoGetstatByFd, fd, stat);
-    return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path.wstring(), export_name);
+    return stat_file_by_fd(emuenv.io, fd, stat, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, sceIoIoctl, SceUID fd, int cmd, const void *argp, SceSize arglen, void *bufp, SceSize buflen) {
@@ -630,7 +630,7 @@ EXPORT(SceUID, sceIoOpen, const char *file, const int flags, const SceMode mode)
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
     }
     LOG_INFO("Opening file: {}", file);
-    return open_file(emuenv.io, file, flags, emuenv.pref_path.wstring(), export_name);
+    return open_file(emuenv.io, file, flags, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, sceIoOpenAsync) {
@@ -682,7 +682,7 @@ EXPORT(int, sceIoRemove, const char *path) {
     if (path == nullptr) {
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
     }
-    return remove_file(emuenv.io, path, emuenv.pref_path.wstring(), export_name);
+    return remove_file(emuenv.io, path, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, sceIoRemoveAsync) {
@@ -696,7 +696,7 @@ EXPORT(int, sceIoRename, const char *oldname, const char *newname) {
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
 
     LOG_INFO("Renaming: {} to {}", oldname, newname);
-    return rename(emuenv.io, oldname, newname, emuenv.pref_path.wstring(), export_name);
+    return rename(emuenv.io, oldname, newname, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, sceIoRenameAsync) {
@@ -709,7 +709,7 @@ EXPORT(int, sceIoRmdir, const char *path) {
     if (path == nullptr) {
         return RET_ERROR(SCE_ERROR_ERRNO_EINVAL);
     }
-    return remove_dir(emuenv.io, path, emuenv.pref_path.wstring(), export_name);
+    return remove_dir(emuenv.io, path, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, sceIoRmdirAsync) {

--- a/vita3k/modules/SceLibc/SceLibc.cpp
+++ b/vita3k/modules/SceLibc/SceLibc.cpp
@@ -432,7 +432,7 @@ EXPORT(int, fileno) {
 EXPORT(int, fopen, const char *filename, const char *mode) {
     TRACY_FUNC(fopen, filename, mode);
     LOG_WARN_IF(mode[0] != 'r', "fopen({}, {})", filename, *mode);
-    return open_file(emuenv.io, filename, SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
+    return open_file(emuenv.io, filename, SCE_O_RDONLY, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, fopen_s) {

--- a/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
+++ b/vita3k/modules/SceNpTrophy/SceNpTrophy.cpp
@@ -153,7 +153,7 @@ EXPORT(int, sceNpTrophyCreateContext, np::trophy::ContextHandle *context, const 
     }
 
     np::NpTrophyError err = np::NpTrophyError::TROPHY_ERROR_NONE;
-    *context = create_trophy_context(emuenv.np, &emuenv.io, emuenv.pref_path.wstring(), comm_id, static_cast<uint32_t>(emuenv.cfg.sys_lang),
+    *context = create_trophy_context(emuenv.np, &emuenv.io, emuenv.pref_path, comm_id, static_cast<uint32_t>(emuenv.cfg.sys_lang),
         &err);
 
     if (*context == np::trophy::INVALID_CONTEXT_HANDLE) {

--- a/vita3k/modules/SceProcessmgr/SceProcessmgr.cpp
+++ b/vita3k/modules/SceProcessmgr/SceProcessmgr.cpp
@@ -157,17 +157,17 @@ EXPORT(int, sceKernelGetRemoteProcessTime) {
 
 EXPORT(int, sceKernelGetStderr) {
     TRACY_FUNC(sceKernelGetStderr);
-    return open_file(emuenv.io, "tty0:", SCE_O_WRONLY, emuenv.pref_path.wstring(), export_name);
+    return open_file(emuenv.io, "tty0:", SCE_O_WRONLY, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, sceKernelGetStdin) {
     TRACY_FUNC(sceKernelGetStdin);
-    return open_file(emuenv.io, "tty0:", SCE_O_RDONLY, emuenv.pref_path.wstring(), export_name);
+    return open_file(emuenv.io, "tty0:", SCE_O_RDONLY, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, sceKernelGetStdout) {
     TRACY_FUNC(sceKernelGetStdout);
-    return open_file(emuenv.io, "tty0:", SCE_O_WRONLY, emuenv.pref_path.wstring(), export_name);
+    return open_file(emuenv.io, "tty0:", SCE_O_WRONLY, emuenv.pref_path, export_name);
 }
 
 EXPORT(int, sceKernelIsCDialogAvailable) {

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -177,14 +177,14 @@ SceUID load_module(EmuEnvState &emuenv, const std::string &module_path) {
     VitaIoDevice device = device::get_device(module_path);
     auto translated_module_path = translate_path(module_path.c_str(), device, emuenv.io.device_paths);
     if (device == VitaIoDevice::app0)
-        res = vfs::read_app_file(module_buffer, emuenv.pref_path.wstring(), emuenv.io.app_path, translated_module_path);
+        res = vfs::read_app_file(module_buffer, emuenv.pref_path, emuenv.io.app_path, translated_module_path);
     else
-        res = vfs::read_file(device, module_buffer, emuenv.pref_path.wstring(), translated_module_path);
+        res = vfs::read_file(device, module_buffer, emuenv.pref_path, translated_module_path);
     if (!res) {
         LOG_ERROR("Failed to read module file {}", module_path);
         return SCE_ERROR_ERRNO_ENOENT;
     }
-    SceUID module_id = load_self(emuenv.kernel, emuenv.mem, module_buffer.data(), module_path, emuenv.log_path.string());
+    SceUID module_id = load_self(emuenv.kernel, emuenv.mem, module_buffer.data(), module_path, emuenv.log_path);
     if (module_id >= 0) {
         const auto module = emuenv.kernel.loaded_modules[module_id];
         LOG_INFO("Module {} (at \"{}\") loaded", module->module_name, module_path);

--- a/vita3k/np/include/np/functions.h
+++ b/vita3k/np/include/np/functions.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <np/common.h>
 #include <string>
+#include <util/fs.h>
 
 namespace np {
 struct CommunicationID;
@@ -51,7 +52,7 @@ bool deinit(NpTrophyState &state);
  *
  * \returns uint32_t(-1) on failure, else the handle to the context.
  */
-np::trophy::ContextHandle create_trophy_context(NpState &np, IOState *io, const std::wstring &pref_path,
+np::trophy::ContextHandle create_trophy_context(NpState &np, IOState *io, const fs::path &pref_path,
     const np::CommunicationID *custom_comm, const std::uint32_t lang, np::NpTrophyError *error);
 
 np::trophy::Context *get_trophy_context(NpTrophyState &state, const np::trophy::ContextHandle handle);

--- a/vita3k/np/include/np/trophy/context.h
+++ b/vita3k/np/include/np/trophy/context.h
@@ -19,6 +19,7 @@
 
 #include <np/common.h>
 #include <np/trophy/trp_parser.h>
+#include <util/fs.h>
 #include <util/types.h>
 
 #include <array>
@@ -71,13 +72,13 @@ struct Context {
     uint32_t lang{ 1 };
 
     IOState *io;
-    std::wstring pref_path;
+    fs::path pref_path;
 
     void save_trophy_progress_file();
     bool load_trophy_progress_file(const SceUID &progress_input_file);
 
     int copy_file_data_from_trophy_file(const char *filename, void *buffer, SceSize *size);
-    int install_trophy_conf(IOState *io, const std::wstring &pref_path, const std::string &np_com_id);
+    int install_trophy_conf(IOState *io, const fs::path &pref_path, const std::string &np_com_id);
     bool init_info_from_trp();
     bool unlock_trophy(int32_t id, np::NpTrophyError *err, const bool force_unlock = false);
 

--- a/vita3k/np/src/trophy/context.cpp
+++ b/vita3k/np/src/trophy/context.cpp
@@ -356,7 +356,7 @@ bool Context::get_trophy_set(std::string &name, std::string &detail) {
     return !name.empty() && !detail.empty();
 }
 
-int Context::install_trophy_conf(IOState *io, const std::wstring &pref_path, const std::string &np_com_id) {
+int Context::install_trophy_conf(IOState *io, const fs::path &pref_path, const std::string &np_com_id) {
     auto trophy_conf_path = device::construct_normalized_path(VitaIoDevice::ux0, "user/" + io->user_id + "/trophy/conf/" + np_com_id);
 
     create_dir(*io, trophy_conf_path.c_str(), 0, pref_path, "create_trophy_context", true);
@@ -382,7 +382,7 @@ int Context::install_trophy_conf(IOState *io, const std::wstring &pref_path, con
 
 } // namespace np::trophy
 
-np::trophy::ContextHandle create_trophy_context(NpState &np, IOState *io, const std::wstring &pref_path,
+np::trophy::ContextHandle create_trophy_context(NpState &np, IOState *io, const fs::path &pref_path,
     const np::CommunicationID *custom_comm, const std::uint32_t lang, np::NpTrophyError *error) {
     if (!custom_comm) {
         custom_comm = &np.comm_id;

--- a/vita3k/packages/include/packages/functions.h
+++ b/vita3k/packages/include/packages/functions.h
@@ -33,7 +33,7 @@
 
 struct SfoFile;
 
-void install_pup(const std::wstring &pref_path, const std::string &pup_path, const std::function<void(uint32_t)> &progress_callback = nullptr);
+void install_pup(const fs::path &pref_path, const fs::path &pup_path, const std::function<void(uint32_t)> &progress_callback = nullptr);
 
 bool create_license(EmuEnvState &emuenv, const std::string &zRIF);
 bool copy_license(EmuEnvState &emuenv, const fs::path &license_path);

--- a/vita3k/packages/include/packages/pkg.h
+++ b/vita3k/packages/include/packages/pkg.h
@@ -81,6 +81,6 @@ struct PkgEntry {
     uint32_t padding;
 };
 
-bool install_pkg(const std::string &pkg, EmuEnvState &emuenv, std::string &p_zRIF, const std::function<void(float)> &progress_callback = nullptr);
+bool install_pkg(const fs::path &pkg_path, EmuEnvState &emuenv, std::string &p_zRIF, const std::function<void(float)> &progress_callback = nullptr);
 
-bool decrypt_install_nonpdrm(EmuEnvState &emuenv, std::string &drmlicpath, const std::string &title_path);
+bool decrypt_install_nonpdrm(EmuEnvState &emuenv, const fs::path &drmlicpath, const fs::path &title_path);

--- a/vita3k/packages/include/packages/sce_types.h
+++ b/vita3k/packages/include/packages/sce_types.h
@@ -654,10 +654,8 @@ public:
 };
 
 void register_keys(KeyStore &SCE_KEYS, int type);
-void extract_fat(const std::wstring &partition_path, const std::string &partition, const std::wstring &pref_path);
+void extract_fat(const fs::path &partition_path, const std::string &partition, const fs::path &pref_path);
 std::string decompress_segments(const std::vector<uint8_t> &decrypted_data, const uint64_t &size);
-void self2elf(const fs::path &infile, const fs::path &outfile, KeyStore &SCE_KEYS, unsigned char *klictxt, uint64_t *authid);
-void make_fself(const fs::path &input_file, const fs::path &output_file, uint64_t authid);
 std::tuple<uint64_t, SelfType> get_key_type(std::ifstream &file, const SceHeader &sce_hdr);
 std::vector<SceSegment> get_segments(std::ifstream &file, const SceHeader &sce_hdr, KeyStore &SCE_KEYS, uint64_t sysver = -1, SelfType self_type = static_cast<SelfType>(0), int keytype = 0, unsigned char *klictxt = 0);
 void decrypt_fself(const fs::path &file_path, KeyStore &SCE_KEYS, unsigned char *klictxt);

--- a/vita3k/packages/src/license.cpp
+++ b/vita3k/packages/src/license.cpp
@@ -71,21 +71,20 @@ bool copy_license(EmuEnvState &emuenv, const fs::path &license_path) {
         emuenv.license_content_id = license_buf.content_id;
         emuenv.license_title_id = emuenv.license_content_id.substr(7, 9);
         const auto dst_path{ emuenv.pref_path / "ux0/license" / emuenv.license_title_id };
-        if (!fs::exists(dst_path))
-            fs::create_directories(dst_path);
+        fs::create_directories(dst_path);
 
         const auto license_dst_path{ dst_path / fmt::format("{}.rif", emuenv.license_content_id) };
         if (license_path != license_dst_path) {
             fs::copy_file(license_path, license_dst_path, fs::copy_options::overwrite_existing);
             if (fs::exists(license_dst_path)) {
-                LOG_INFO("Success copy license file to: {}", license_dst_path.string());
+                LOG_INFO("Success copy license file to: {}", license_dst_path);
                 return true;
             } else
-                LOG_ERROR("Fail copy license file to: {}", license_dst_path.string());
+                LOG_ERROR("Fail copy license file to: {}", license_dst_path);
         } else
-            LOG_ERROR("Source and destination license is same at: {}", license_path.string());
+            LOG_ERROR("Source and destination license is same at: {}", license_path);
     } else
-        LOG_ERROR("License file is corrupted at: {}", license_path.string());
+        LOG_ERROR("License file is corrupted at: {}", license_path);
 
     return false;
 }
@@ -104,7 +103,7 @@ int32_t get_license_sku_flag(EmuEnvState &emuenv, const std::string &content_id)
             sku_flag = 0;
         if (fs::exists(license_path)) {
             fs::remove(license_path);
-            LOG_WARN("License file is corrupted at: {}, using default value.", license_path.string());
+            LOG_WARN("License file is corrupted at: {}, using default value.", license_path);
         }
     }
 
@@ -112,13 +111,13 @@ int32_t get_license_sku_flag(EmuEnvState &emuenv, const std::string &content_id)
 }
 
 bool create_license(EmuEnvState &emuenv, const std::string &zRIF) {
-    if (!fs::exists(emuenv.cache_path))
-        fs::create_directories(emuenv.cache_path);
+    fs::create_directories(emuenv.cache_path);
 
     // Create temp license file
     const auto temp_license_path = emuenv.cache_path / "temp_licence.rif";
-    std::ofstream temp_file(temp_license_path.string(), std::ios::out | std::ios::binary);
+    fs::ofstream temp_file(temp_license_path, std::ios::out | std::ios::binary);
     zrif2rif(zRIF, temp_file);
-
-    return copy_license(emuenv, temp_license_path);
+    auto res = copy_license(emuenv, temp_license_path);
+    fs::remove(temp_license_path);
+    return res;
 }

--- a/vita3k/regmgr/include/regmgr/functions.h
+++ b/vita3k/regmgr/include/regmgr/functions.h
@@ -24,7 +24,7 @@
 
 namespace regmgr {
 
-void init_regmgr(RegMgrState &regmgr, const std::wstring &pref_path);
+void init_regmgr(RegMgrState &regmgr, const fs::path &pref_path);
 
 // Getters and setters for binary values
 void get_bin_value(RegMgrState &regmgr, const std::string &category, const std::string &name, void *buf, uint32_t bufSize);

--- a/vita3k/regmgr/include/regmgr/state.h
+++ b/vita3k/regmgr/include/regmgr/state.h
@@ -20,11 +20,12 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <util/fs.h>
 #include <vector>
 
 struct RegMgrState {
     std::mutex mutex;
-    std::wstring system_dreg_path;
+    fs::path system_dreg_path;
 
     std::map<std::string, std::map<std::string, std::vector<char>>> system_dreg;
 };

--- a/vita3k/regmgr/src/regmgr.cpp
+++ b/vita3k/regmgr/src/regmgr.cpp
@@ -26,10 +26,10 @@ namespace regmgr {
 
 constexpr std::array<unsigned char, 16> xorKey = { 0x89, 0xFA, 0x95, 0x48, 0xCB, 0x6D, 0x77, 0x9D, 0xA2, 0x25, 0x34, 0xFD, 0xA9, 0x35, 0x59, 0x6E };
 
-static std::string decryptRegistryFile(const fs::path reg_path) {
-    std::ifstream file(reg_path.string(), std::ios::binary);
+static std::string decryptRegistryFile(const fs::path &reg_path) {
+    fs::ifstream file(reg_path, std::ios::binary);
     if (!file.is_open()) {
-        LOG_WARN("Error while opening file: {}, install firmware for solve this!", reg_path.string());
+        LOG_WARN("Error while opening file: {}, install firmware for solve this!", reg_path);
         return {};
     }
 
@@ -38,7 +38,7 @@ static std::string decryptRegistryFile(const fs::path reg_path) {
 
     // Check if file is empty
     if (encryptedData.empty()) {
-        LOG_DEBUG("File is empty: {}", reg_path.string());
+        LOG_DEBUG("File is empty: {}", reg_path);
         return {};
     }
 
@@ -406,9 +406,9 @@ void set_str_value(RegMgrState &regmgr, const std::string &category, const std::
     save_system_dreg(regmgr);
 }
 
-void init_regmgr(RegMgrState &regmgr, const std::wstring &pref_path) {
+void init_regmgr(RegMgrState &regmgr, const fs::path &pref_path) {
     // Load the registry template
-    const auto reg = decryptRegistryFile(fs::path(pref_path) / "os0/kd/registry.db0");
+    const auto reg = decryptRegistryFile(pref_path / "os0/kd/registry.db0");
     if (reg.empty()) {
         return;
     }
@@ -417,7 +417,7 @@ void init_regmgr(RegMgrState &regmgr, const std::wstring &pref_path) {
     init_reg_template(regmgr, reg);
 
     // Initialize the system.dreg
-    regmgr.system_dreg_path = pref_path + L"vd0/registry/system.dreg";
+    regmgr.system_dreg_path = pref_path / "vd0/registry/system.dreg";
     regmgr.system_dreg.clear();
     if (!load_system_dreg(regmgr)) {
         LOG_WARN("Failed to load system.dreg, attempting to create it");

--- a/vita3k/renderer/include/renderer/driver_functions.h
+++ b/vita3k/renderer/include/renderer/driver_functions.h
@@ -30,11 +30,11 @@ struct CommandHelper;
 
 #define COMMAND(name)                                                                                \
     void cmd_##name(renderer::State &renderer, MemState &mem, Config &config, CommandHelper &helper, \
-        const FeatureState &features, Context *render_context, const char *cache_path, const char *title_id, const char *self_name)
+        const FeatureState &features, Context *render_context)
 
 #define COMMAND_SET_STATE(name)                                                                                \
     void cmd_set_state_##name(renderer::State &renderer, MemState &mem, Config &config, CommandHelper &helper, \
-        Context *render_context, const char *cache_path, const char *title_id)
+        Context *render_context)
 
 COMMAND_SET_STATE(region_clip);
 COMMAND_SET_STATE(program);

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -31,8 +31,8 @@ struct RenderTarget;
 struct State;
 struct VertexProgram;
 
-bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *cache_path, const char *title_id);
-bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const std::vector<SceGxmVertexAttribute> &attributes, const char *cache_path, const char *title_id);
+bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map);
+bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const std::vector<SceGxmVertexAttribute> &attributes);
 void create(SceGxmSyncObject *sync, State &state);
 void destroy(SceGxmSyncObject *sync, State &state);
 void finish(State &state, Context *context);

--- a/vita3k/renderer/include/renderer/gl/functions.h
+++ b/vita3k/renderer/include/renderer/gl/functions.h
@@ -36,8 +36,8 @@ struct FeatureState;
 namespace renderer::gl {
 
 // Compile program.
-SharedGLObject compile_program(GLState &renderer, GLContext &context, const GxmRecordState &state, const FeatureState &features, const MemState &mem, bool shader_cache, bool spirv, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name);
-void pre_compile_program(GLState &renderer, const char *cache_path, const char *title_id, const char *self_name, const ShadersHash &hashs);
+SharedGLObject compile_program(GLState &renderer, GLContext &context, const GxmRecordState &state, const FeatureState &features, const MemState &mem, bool shader_cache, bool spirv, bool maskupdate);
+void pre_compile_program(GLState &renderer, const ShadersHash &hashs);
 
 // Uniforms.
 bool set_uniform_buffer(GLContext &context, const ShaderProgram *program, const bool vertex_shader, const int block_num, const int size, const uint8_t *data);
@@ -51,7 +51,7 @@ void set_context(GLState &state, GLContext &ctx, const MemState &mem, const GLRe
 void get_surface_data(GLState &renderer, GLContext &context, uint32_t *pixels, SceGxmColorSurface &surface);
 void lookup_and_get_surface_data(GLState &renderer, MemState &mem, SceGxmColorSurface &surface);
 void draw(GLState &renderer, GLContext &context, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format,
-    void *indices, size_t count, uint32_t instance_count, MemState &mem, const char *cache_path, const char *title_id, const char *self_name, const Config &config);
+    void *indices, size_t count, uint32_t instance_count, MemState &mem, const Config &config);
 
 // State
 void sync_viewport_flat(const GLState &state, GLContext &context);
@@ -70,7 +70,7 @@ void sync_polygon_mode(const SceGxmPolygonMode mode, const bool front);
 void sync_point_line_width(const GLState &state, const std::uint32_t size, const bool front);
 void sync_depth_bias(const int factor, const int unit, const bool front);
 void sync_blending(const GxmRecordState &state, const MemState &mem);
-void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config, const std::string &title_id);
+void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config);
 void sync_vertex_streams_and_attributes(GLContext &context, GxmRecordState &state, const MemState &mem);
 void bind_fundamental(GLContext &context);
 void clear_previous_uniform_storage(GLContext &context);

--- a/vita3k/renderer/include/renderer/gl/state.h
+++ b/vita3k/renderer/include/renderer/gl/state.h
@@ -44,7 +44,7 @@ struct GLState : public renderer::State {
 
     ScreenRenderer screen_renderer;
 
-    bool init(const fs::path &static_assets, const bool hashless_texture_cache) override;
+    bool init() override;
     void late_init(const Config &cfg, const std::string_view game_id, MemState &mem) override;
 
     TextureCache *get_texture_cache() override {

--- a/vita3k/renderer/include/renderer/shaders.h
+++ b/vita3k/renderer/include/renderer/shaders.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <string>
+#include <util/fs.h>
 #include <vector>
 
 namespace shader {
@@ -37,8 +38,9 @@ struct State;
 // Shaders.
 bool get_shaders_cache_hashs(State &renderer);
 void save_shaders_cache_hashs(State &renderer, std::vector<ShadersHash> &shaders_cache_hashs);
-std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
-std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const shader::Hints &hints, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache);
-std::string pre_load_shader_glsl(const char *hash_text, const char *shader_type_str, const char *cache_path, const char *title_id, const char *self_name);
-std::vector<uint32_t> pre_load_shader_spirv(const char *hash_text, const char *shader_type_str, const char *cache_path, const char *title_id, const char *self_name);
+std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const fs::path &shader_cache_path, const fs::path &shader_log_path, const std::string &shader_version, bool shader_cache);
+std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const shader::Hints &hints, bool maskupdate, const fs::path &shader_cache_path, const fs::path &shader_log_path, const std::string &shader_version, bool shader_cache);
+std::string pre_load_shader_glsl(const fs::path &shader_path);
+std::vector<uint32_t> pre_load_shader_spirv(const fs::path &shader_path);
+
 } // namespace renderer

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -45,12 +45,12 @@ enum struct Filter : int {
 };
 
 struct State {
-    std::string cache_path;
-    std::string log_path;
-    std::string shared_path;
+    fs::path cache_path;
+    fs::path log_path;
+    fs::path shared_path;
     fs::path static_assets;
-    const char *title_id;
-    const char *self_name;
+    fs::path shaders_path;
+    fs::path shaders_log_path;
 
     Backend current_backend;
     FeatureState features;
@@ -81,7 +81,7 @@ struct State {
 
     bool need_page_table = false;
 
-    virtual bool init(const fs::path &static_assets, const bool hashless_texture_cache) = 0;
+    virtual bool init() = 0;
     virtual void late_init(const Config &cfg, const std::string_view game_id, MemState &mem) = 0;
 
     virtual TextureCache *get_texture_cache() = 0;
@@ -118,5 +118,21 @@ struct State {
     virtual void preclose_action() = 0;
 
     virtual ~State() = default;
+
+    fs::path texture_folder() const {
+        return shared_path / "textures";
+    }
+
+    void init_paths(const Root &root_paths) {
+        cache_path = root_paths.get_cache_path();
+        log_path = root_paths.get_log_path();
+        shared_path = root_paths.get_shared_path();
+        static_assets = root_paths.get_static_assets_path();
+    }
+
+    void set_app(const char *title_id, const char *self_name) {
+        shaders_path = cache_path / "shaders" / title_id / self_name;
+        shaders_log_path = log_path / "shaderlog" / title_id / self_name;
+    }
 };
 } // namespace renderer

--- a/vita3k/renderer/include/renderer/vulkan/functions.h
+++ b/vita3k/renderer/include/renderer/vulkan/functions.h
@@ -48,7 +48,7 @@ void sync_depth_bias(VKContext &context);
 void sync_depth_data(VKContext &context);
 void sync_stencil_data(VKContext &context, const MemState &mem);
 void sync_point_line_width(VKContext &context, const bool is_front);
-void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config, const std::string &title_id);
+void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config);
 void sync_viewport_flat(VKContext &context);
 void sync_viewport_real(VKContext &context, const float xOffset, const float yOffset, const float zOffset,
     const float xScale, const float yScale, const float zScale);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -99,7 +99,7 @@ struct VKState : public renderer::State {
 
     VKState(int gpu_idx);
 
-    bool init(const fs::path &static_assets, const bool hashless_texture_cache) override;
+    bool init() override;
     bool create(SDL_Window *window, std::unique_ptr<renderer::State> &state, const Config &config);
     void late_init(const Config &cfg, const std::string_view game_id, MemState &mem) override;
     void cleanup();

--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -104,7 +104,7 @@ void process_batch(renderer::State &state, const FeatureState &features, MemStat
             LOG_ERROR("Unimplemented command opcode {}", static_cast<int>(cmd->opcode));
         } else {
             CommandHelper helper(cmd);
-            handler->second(state, mem, config, helper, features, command_list.context, state.cache_path.c_str(), state.title_id, state.self_name);
+            handler->second(state, mem, config, helper, features, command_list.context);
         }
 
         Command *last_cmd = cmd;

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -178,7 +178,7 @@ COMMAND(handle_memory_unmap) {
 }
 
 // Client
-bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map, const char *cache_path, const char *title_id) {
+bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProgram &program, const SceGxmBlendInfo *blend, GXPPtrMap &gxp_ptr_map) {
     switch (state.current_backend) {
     case Backend::OpenGL:
         gl::create(fp, dynamic_cast<gl::GLState &>(state), program, blend);
@@ -205,7 +205,7 @@ bool create(std::unique_ptr<FragmentProgram> &fp, State &state, const SceGxmProg
     return true;
 }
 
-bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const std::vector<SceGxmVertexAttribute> &attributes, const char *cache_path, const char *title_id) {
+bool create(std::unique_ptr<VertexProgram> &vp, State &state, const SceGxmProgram &program, GXPPtrMap &gxp_ptr_map, const std::vector<SceGxmVertexAttribute> &attributes) {
     switch (state.current_backend) {
     case Backend::OpenGL:
         gl::create(vp, dynamic_cast<gl::GLState &>(state), program);
@@ -257,20 +257,14 @@ bool init(SDL_Window *window, std::unique_ptr<State> &state, Backend backend, co
     switch (backend) {
     case Backend::OpenGL:
         state = std::make_unique<gl::GLState>();
-        state->cache_path = root_paths.get_cache_path_string();
-        state->log_path = root_paths.get_log_path_string();
-        state->shared_path = root_paths.get_shared_path_string();
-        state->static_assets = root_paths.get_static_assets_path();
+        state->init_paths(root_paths);
         if (!gl::create(window, state, config))
             return false;
         break;
 
     case Backend::Vulkan:
         state = std::make_unique<vulkan::VKState>(config.gpu_idx);
-        state->cache_path = root_paths.get_cache_path_string();
-        state->log_path = root_paths.get_log_path_string();
-        state->shared_path = root_paths.get_shared_path_string();
-        state->static_assets = root_paths.get_static_assets_path();
+        state->init_paths(root_paths);
         if (!vulkan::create(window, state, config))
             return false;
         break;

--- a/vita3k/renderer/src/gl/compile_program.cpp
+++ b/vita3k/renderer/src/gl/compile_program.cpp
@@ -153,13 +153,13 @@ static SharedGLObject compile_program(ProgramCache &program_cache, const SharedG
     return program;
 }
 
-static SharedGLObject compile_shader(const char *cache_path, const char *title_id, const char *self_name, const std::string &shader_version, const std::string &hash_hex,
+static SharedGLObject compile_shader(const fs::path &shader_cache_path, const std::string &shader_version, const std::string &hash_hex,
     const char *type_str, const GLenum type, ShaderCache &cache, const Sha256Hash &hash) {
     // Set Shader version with hash
-    const std::string hash_hex_ver = shader_version + "-" + hash_hex;
 
     // Load Shader
-    const std::string shader = pre_load_shader_glsl(hash_hex_ver.c_str(), type_str, cache_path, title_id, self_name);
+    const auto shader_name = shader_cache_path / fmt::format("{}-{}.{}", shader_version, hash_hex, type_str);
+    const std::string shader = pre_load_shader_glsl(shader_name);
     if (shader.empty()) {
         LOG_WARN("{} shader is empty or not found:\n{}", type_str, hash_hex);
         return SharedGLObject();
@@ -187,12 +187,11 @@ static std::vector<ShadersHash>::iterator get_shaders_hash_index(std::vector<Sha
     return shader_hash_index;
 }
 
-void pre_compile_program(GLState &renderer, const char *cache_path, const char *title_id, const char *self_name, const ShadersHash &hash) {
-    const auto shader_path{ fs::path(cache_path) / "shaders" / title_id / self_name };
-    if (fs::exists(shader_path) && !fs::is_empty(shader_path)) {
+void pre_compile_program(GLState &renderer, const ShadersHash &hash) {
+    if (fs::exists(renderer.shaders_path) && !fs::is_empty(renderer.shaders_path)) {
         // Compile Fragment Shader
         const auto frag_hash_hex = convert_hash_to_hex(hash.frag);
-        const SharedGLObject frag_shader = compile_shader(cache_path, title_id, self_name, renderer.shader_version,
+        const SharedGLObject frag_shader = compile_shader(renderer.shaders_path, renderer.shader_version,
             frag_hash_hex, "frag", GL_FRAGMENT_SHADER, renderer.fragment_shader_cache, hash.frag);
         if (!frag_shader) {
             return;
@@ -200,7 +199,7 @@ void pre_compile_program(GLState &renderer, const char *cache_path, const char *
 
         // Compile Vertex Shader
         const auto vert_hash_hex = convert_hash_to_hex(hash.vert);
-        const SharedGLObject vert_shader = compile_shader(cache_path, title_id, self_name, renderer.shader_version,
+        const SharedGLObject vert_shader = compile_shader(renderer.shaders_path, renderer.shader_version,
             vert_hash_hex, "vert", GL_VERTEX_SHADER, renderer.vertex_shader_cache, hash.vert);
         if (!vert_shader) {
             return;
@@ -215,16 +214,16 @@ void pre_compile_program(GLState &renderer, const char *cache_path, const char *
 }
 
 static SharedGLObject get_or_compile_shader(const SceGxmProgram *program, const FeatureState &features, const Sha256Hash &hash,
-    ShaderCache &cache, const GLenum type, const shader::Hints &hints, bool shader_cache, bool spirv, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name, const std::string &shader_version, uint32_t &shaders_count_compiled) {
+    ShaderCache &cache, const GLenum type, const shader::Hints &hints, bool shader_cache, bool spirv, bool maskupdate, const fs::path &shader_cache_path, const fs::path &shader_log_path, const std::string &shader_version, uint32_t &shaders_count_compiled) {
     const auto cached = cache.find(hash);
     if (cached == cache.end()) {
         SharedGLObject obj = nullptr;
 
         // Need to compile new one and add it to cache
         if (features.spirv_shader && spirv) {
-            obj = compile_spirv(type, load_spirv_shader(*program, features, false, hints, maskupdate, cache_path, title_id, self_name, shader_version + "spv", shader_cache));
+            obj = compile_spirv(type, load_spirv_shader(*program, features, false, hints, maskupdate, shader_cache_path, shader_log_path, shader_version + "spv", shader_cache));
         } else {
-            obj = compile_glsl(type, load_glsl_shader(*program, features, hints, maskupdate, cache_path, title_id, self_name, shader_version, shader_cache));
+            obj = compile_glsl(type, load_glsl_shader(*program, features, hints, maskupdate, shader_cache_path, shader_log_path, shader_version, shader_cache));
         }
 
         cache.emplace(hash, obj);
@@ -238,7 +237,7 @@ static SharedGLObject get_or_compile_shader(const SceGxmProgram *program, const 
 }
 
 SharedGLObject compile_program(GLState &renderer, GLContext &context, const GxmRecordState &state, const FeatureState &features, const MemState &mem,
-    bool shader_cache, bool spirv, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name) {
+    bool shader_cache, bool spirv, bool maskupdate) {
     R_PROFILE(__func__);
 
     assert(state.fragment_program);
@@ -269,7 +268,7 @@ SharedGLObject compile_program(GLState &renderer, GLContext &context, const GxmR
     context.shader_hints.attributes = &vertex_program_gxm.attributes;
 
     const SharedGLObject fragment_shader = get_or_compile_shader(fragment_program_gxm.program.get(mem), features, fragment_program.hash, renderer.fragment_shader_cache,
-        GL_FRAGMENT_SHADER, context.shader_hints, shader_cache, spirv, maskupdate, cache_path, title_id, self_name, renderer.shader_version, renderer.shaders_count_compiled);
+        GL_FRAGMENT_SHADER, context.shader_hints, shader_cache, spirv, maskupdate, renderer.shaders_path, renderer.shaders_log_path, renderer.shader_version, renderer.shaders_count_compiled);
 
     if (!fragment_shader) {
         LOG_CRITICAL("Error in get/compile fragment vertex shader:\n{}", hex_string(fragment_program.hash));
@@ -277,7 +276,7 @@ SharedGLObject compile_program(GLState &renderer, GLContext &context, const GxmR
     }
 
     const SharedGLObject vertex_shader = get_or_compile_shader(vertex_program_gxm.program.get(mem), features, vertex_program.hash, renderer.vertex_shader_cache,
-        GL_VERTEX_SHADER, context.shader_hints, shader_cache, spirv, maskupdate, cache_path, title_id, self_name, renderer.shader_version, renderer.shaders_count_compiled);
+        GL_VERTEX_SHADER, context.shader_hints, shader_cache, spirv, maskupdate, renderer.shaders_path, renderer.shaders_log_path, renderer.shader_version, renderer.shaders_count_compiled);
 
     if (!vertex_shader) {
         LOG_CRITICAL("Error in get/compiled vertex shader:\n{}", hex_string(vertex_program.hash));

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -59,7 +59,7 @@ static GLenum translate_primitive(SceGxmPrimitiveType primType) {
 }
 
 void draw(GLState &renderer, GLContext &context, const FeatureState &features, SceGxmPrimitiveType type, SceGxmIndexFormat format, void *indices, size_t count, uint32_t instance_count,
-    MemState &mem, const char *cache_path, const char *title_id, const char *self_name, const Config &config) {
+    MemState &mem, const Config &config) {
     R_PROFILE(__func__);
 
     GLuint program_id = context.last_draw_program;
@@ -71,7 +71,7 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
     // If it's different, we need to switch. Else just stick to it.
     if (context.record.vertex_program.get(mem)->renderer_data->hash != context.last_draw_vertex_program_hash || context.record.fragment_program.get(mem)->renderer_data->hash != context.last_draw_fragment_program_hash) {
         // Need to recompile!
-        SharedGLObject program = gl::compile_program(renderer, context, context.record, features, mem, config.shader_cache, config.spirv_shader, gxm_fragment_program.is_maskupdate, cache_path, title_id, self_name);
+        SharedGLObject program = gl::compile_program(renderer, context, context.record, features, mem, config.shader_cache, config.spirv_shader, gxm_fragment_program.is_maskupdate);
 
         LOG_ERROR_IF(!program, "Fail to get program!");
 

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -257,10 +257,10 @@ bool create(SDL_Window *window, std::unique_ptr<State> &state, const Config &con
     // always enabled in the opengl renderer
     gl_state.features.use_mask_bit = true;
 
-    return gl_state.init(gl_state.static_assets, hashless_texture_cache);
+    return gl_state.init();
 }
 
-bool GLState::init(const fs::path &static_assets, const bool hashless_texture_cache) {
+bool GLState::init() {
     if (!screen_renderer.init(static_assets)) {
         LOG_ERROR("Failed to initialize screen renderer");
         return false;
@@ -272,8 +272,7 @@ bool GLState::init(const fs::path &static_assets, const bool hashless_texture_ca
 }
 
 void GLState::late_init(const Config &cfg, const std::string_view game_id, MemState &mem) {
-    const fs::path texture_folder = fs::path(shared_path) / "textures";
-    texture_cache.init(cfg.hashless_texture_cache, texture_folder, game_id);
+    texture_cache.init(cfg.hashless_texture_cache, texture_folder(), game_id);
 }
 
 bool create(std::unique_ptr<Context> &context) {
@@ -739,7 +738,7 @@ void GLState::set_anisotropic_filtering(int anisotropic_filtering) {
 }
 
 void GLState::precompile_shader(const ShadersHash &hash) {
-    pre_compile_program(*this, cache_path.c_str(), title_id, self_name, hash);
+    pre_compile_program(*this, hash);
 }
 
 void GLState::preclose_action() {}

--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -32,8 +32,8 @@ bool ScreenRenderer::init(const fs::path &static_assets) {
     const auto render_main_path_frag = builtin_shaders_path / "render_main.frag";
     const auto render_main_path_fxaa_frag = builtin_shaders_path / "render_main_fxaa.frag";
 
-    m_render_shader_nofilter = ::gl::load_shaders(render_main_path_vert.string(), render_main_path_frag.string());
-    m_render_shader_fxaa = ::gl::load_shaders(render_main_path_vert.string(), render_main_path_fxaa_frag.string());
+    m_render_shader_nofilter = ::gl::load_shaders(render_main_path_vert, render_main_path_frag);
+    m_render_shader_fxaa = ::gl::load_shaders(render_main_path_vert, render_main_path_fxaa_frag);
     if (!m_render_shader_nofilter || !m_render_shader_fxaa) {
         LOG_CRITICAL("Couldn't compile essential shaders for rendering. Exiting");
         return false;

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -268,7 +268,7 @@ void sync_depth_bias(const int factor, const int unit, const bool is_front) {
 }
 
 void sync_texture(GLState &state, GLContext &context, MemState &mem, std::size_t index, SceGxmTexture texture,
-    const Config &config, const std::string &title_id) {
+    const Config &config) {
     Address data_addr = texture.data_addr << 2;
 
     if (!is_valid_addr(mem, data_addr)) {

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -203,7 +203,7 @@ COMMAND(handle_mid_scene_flush) {
 
     if (!renderer.features.support_memory_mapping) {
         // handle it like a simple notification
-        cmd_handle_notification(renderer, mem, config, helper, features, render_context, cache_path, title_id, self_name);
+        cmd_handle_notification(renderer, mem, config, helper, features, render_context);
         return;
     }
 
@@ -224,7 +224,7 @@ COMMAND(handle_draw) {
     switch (renderer.current_backend) {
     case Backend::OpenGL:
         gl::draw(dynamic_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context),
-            features, type, format, indicies.cast<void>().get(mem), count, instance_count, mem, cache_path, title_id, self_name, config);
+            features, type, format, indicies.cast<void>().get(mem), count, instance_count, mem, config);
         break;
 
     case Backend::Vulkan:

--- a/vita3k/renderer/src/shaders.cpp
+++ b/vita3k/renderer/src/shaders.cpp
@@ -33,10 +33,9 @@
 namespace renderer {
 
 bool get_shaders_cache_hashs(State &renderer) {
-    const auto shaders_path{ fs::path(renderer.cache_path) / "shaders" / renderer.title_id / renderer.self_name };
     const std::string hash_file_name = fmt::format("hashs-{}.dat", (renderer.current_backend == Backend::OpenGL) ? "gl" : "vk");
 
-    fs::ifstream shaders_hashs(shaders_path / hash_file_name, std::ios::in | std::ios::binary);
+    fs::ifstream shaders_hashs(renderer.shaders_path / hash_file_name, std::ios::in | std::ios::binary);
     if (!shaders_hashs.is_open())
         return false;
 
@@ -52,8 +51,8 @@ bool get_shaders_cache_hashs(State &renderer) {
     shaders_hashs.read((char *)&features_mask, sizeof(uint32_t));
     if (versionInFile != shader::CURRENT_VERSION || features_mask != renderer.get_features_mask()) {
         shaders_hashs.close();
-        fs::remove_all(shaders_path);
-        fs::remove_all(fs::path(renderer.log_path) / "shaderlog" / renderer.title_id / renderer.self_name);
+        fs::remove_all(renderer.shaders_path);
+        fs::remove_all(renderer.shaders_log_path);
         if (versionInFile != shader::CURRENT_VERSION)
             LOG_WARN("Current version of cache: {}, is outdated, recreate it.", versionInFile);
         else
@@ -89,11 +88,9 @@ bool get_shaders_cache_hashs(State &renderer) {
 }
 
 void save_shaders_cache_hashs(State &renderer, std::vector<ShadersHash> &shaders_cache_hashs) {
-    const auto shaders_path{ fs::path(renderer.cache_path) / "shaders" / renderer.title_id / renderer.self_name };
-    if (!fs::exists(shaders_path))
-        fs::create_directories(shaders_path);
+    fs::create_directories(renderer.shaders_path);
     std::string hash_file_name = fmt::format("hashs-{}.dat", (renderer.current_backend == Backend::OpenGL) ? "gl" : "vk");
-    fs::ofstream shaders_hashs(shaders_path / hash_file_name, std::ios::out | std::ios::binary);
+    fs::ofstream shaders_hashs(renderer.shaders_path / hash_file_name, std::ios::out | std::ios::binary);
 
     if (shaders_hashs.is_open()) {
         // Write Size of shaders cache hashes list
@@ -119,9 +116,8 @@ void save_shaders_cache_hashs(State &renderer, std::vector<ShadersHash> &shaders
     }
 }
 
-static bool load_shader(const char *hash, const char *extension, const char *cache_path, const char *title_id, const char *self_name, char **destination, std::size_t &size_read) {
-    const auto shader_path = fs_utils::construct_file_name(cache_path, (fs::path("shaders") / title_id / self_name).string().c_str(), hash, extension);
-    fs::ifstream is(shader_path, fs::ifstream::binary);
+static bool load_shader(const fs::path &shader_name, char **destination, std::size_t &size_read) {
+    fs::ifstream is(shader_name, fs::ifstream::binary);
     if (!is) {
         return false;
     }
@@ -148,99 +144,81 @@ static const Sha256Hash get_shader_hash(const SceGxmProgram &program) {
 }
 
 template <typename R>
-R load_shader_generic(const char *hash_text, const char *cache_path, const char *title_id, const char *self_name, const char *shader_type_str) {
+R load_shader_generic(const fs::path &shader_path) {
     std::size_t read_size = 0;
     R source;
 
-    if (load_shader(hash_text, shader_type_str, cache_path, title_id, self_name, nullptr, read_size)) {
+    if (load_shader(shader_path, nullptr, read_size)) {
         source.resize((read_size + sizeof(typename R::value_type) - 1) / sizeof(typename R::value_type));
 
         char *dest_pointer = reinterpret_cast<char *>(source.data());
-        load_shader(hash_text, shader_type_str, cache_path, title_id, self_name, &dest_pointer, read_size);
+        load_shader(shader_path, &dest_pointer, read_size);
     }
 
     return source;
 }
 
-shader::GeneratedShader load_shader_generic(shader::Target target, const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name, const char *shader_type_str, const std::string &shader_version, bool shader_cache) {
+shader::GeneratedShader load_shader_generic(shader::Target target, const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const fs::path &shader_cache_path, const fs::path &shaderlog_path, const char *shader_type_str, const std::string &shader_version, bool shader_cache) {
     // TODO: no need to recompute the hash here
     const std::string hash_text = hex_string(get_shader_hash(program));
     // Set Shader Hash with Version
-    const std::string hash_hex_ver = shader_version + "-" + static_cast<std::string>(hash_text.data());
+    const std::string hash_hex_ver = fmt::format("{}-{}", shader_version, hash_text);
+    const auto get_shader_path = [&](const char *ext) {
+        return shader_cache_path / fmt::format("{}.{}", hash_hex_ver, ext);
+    };
+    const auto get_shaderlog_path = [&](const char *ext) {
+        return shaderlog_path / fmt::format("{}.{}", hash_hex_ver, ext);
+    };
 
+    const auto shader_path = get_shader_path(shader_type_str);
     if (shader_cache) {
         if (target == shader::Target::GLSLOpenGL) {
-            std::string source = load_shader_generic<std::string>(hash_hex_ver.c_str(), cache_path, title_id, self_name, shader_type_str);
+            std::string source = load_shader_generic<std::string>(shader_path);
             if (!source.empty()) {
                 return { source, std::vector<uint32_t>() };
             }
         } else {
-            std::vector<uint32_t> source = load_shader_generic<std::vector<uint32_t>>(hash_hex_ver.c_str(), cache_path, title_id, self_name, shader_type_str);
+            std::vector<uint32_t> source = load_shader_generic<std::vector<uint32_t>>(get_shader_path("spv"));
             if (!source.empty())
                 return { "", source };
         }
     }
 
-    LOG_INFO("Generating {} shader {}", shader_type_str, hash_text.data());
+    LOG_INFO("Generating {} shader {}", shader_type_str, hash_text);
 
-    std::string spirv_dump;
-    std::string disasm_dump;
+    fs::create_directories(shaderlog_path);
 
-    const fs::path shader_base_dir{ fs::path("shaderlog") / title_id / self_name };
-    if (!fs::exists(cache_path / shader_base_dir))
-        fs::create_directories(cache_path / shader_base_dir);
-
-    auto shader_cache_path = fs_utils::construct_file_name(cache_path, shader_base_dir, hash_hex_ver.c_str(), ".gxp");
+    auto shader_log_path = get_shaderlog_path("gxp");
 
     // Dump gxp binary
-    fs::ofstream of{ shader_cache_path, fs::ofstream::binary };
-    if (!of.fail()) {
-        of.write(reinterpret_cast<const char *>(&program), program.size);
-        of.close();
-    }
-
+    fs_utils::dump_data(shader_log_path, &program, program.size);
     const auto write_data_with_ext = [&](const std::string &ext, const std::string &data) {
-        fs::path out_path{ shader_cache_path };
-        out_path.replace_extension(ext);
-        fs::ofstream of{ out_path };
-        if (!of.fail()) {
-            of << data;
-            of.close();
+        fs::path out_path;
+        if (ext == shader_type_str) {
+            out_path = shader_path;
+        } else {
+            out_path = shader_log_path;
+            out_path.replace_extension(ext);
         }
+        fs_utils::dump_data(out_path, data.c_str(), data.size());
         return true;
     };
 
-    shader::GeneratedShader source = shader::convert_gxp(program, hash_text.data(), features, target, hints, maskupdate, false, write_data_with_ext);
+    shader::GeneratedShader source = shader::convert_gxp(program, hash_text, features, target, hints, maskupdate, false, write_data_with_ext);
 
     // Copy shader generate to shaders cache
-    const auto shaders_cache_path = fs::path("shaders") / title_id / self_name;
-    if (!fs::exists(cache_path / shaders_cache_path))
-        fs::create_directories(cache_path / shaders_cache_path);
+    const auto shaders_cache_path = fs::path(shader_cache_path);
+    fs::create_directories(shaders_cache_path);
 
-    if (target == shader::Target::GLSLOpenGL) {
-        shader_cache_path.replace_extension(shader_type_str);
-        if (fs::exists(shader_cache_path)) {
-            try {
-                const auto shader_dst_path = fs_utils::construct_file_name(cache_path, shaders_cache_path, hash_hex_ver.c_str(), shader_type_str);
-                fs::copy_file(shader_cache_path, shader_dst_path, fs::copy_options::overwrite_existing);
-                fs::remove(shader_cache_path);
-            } catch (std::exception &e) {
-                LOG_ERROR("Failed to moved shaders file: \n{}", e.what());
-            }
-        }
-    } else {
-        const auto shader_dst_path = fs_utils::construct_file_name(cache_path, shaders_cache_path, hash_hex_ver.c_str(), "spv");
-        fs::ofstream of{ shader_dst_path, fs::ofstream::binary };
-        if (!of.fail()) {
-            of.write(reinterpret_cast<const char *>(source.spirv.data()), sizeof(uint32_t) * source.spirv.size());
-            of.close();
-        }
+    if (target != shader::Target::GLSLOpenGL) {
+        const auto shader_dst_path = get_shader_path("spv");
+        fs_utils::dump_data(shader_dst_path, source.spirv.data(), sizeof(uint32_t) * source.spirv.size());
     }
 
     return source;
 }
 
-std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache) {
+std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &features, const shader::Hints &hints, bool maskupdate, const fs::path &shader_cache_path, const fs::path &shader_log_path, const std::string &shader_version, bool shader_cache) {
     SceGxmProgramType program_type = program.get_type();
 
     auto shader_type_to_str = [](SceGxmProgramType type) {
@@ -248,25 +226,26 @@ std::string load_glsl_shader(const SceGxmProgram &program, const FeatureState &f
     };
 
     const char *shader_type_str = shader_type_to_str(program_type);
-    return load_shader_generic(shader::Target::GLSLOpenGL, program, features, hints, maskupdate, cache_path, title_id, self_name, shader_type_str, shader_version, shader_cache).glsl;
+
+    return load_shader_generic(shader::Target::GLSLOpenGL, program, features, hints, maskupdate, shader_cache_path, shader_log_path, shader_type_str, shader_version, shader_cache).glsl;
 }
 
-std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const shader::Hints &hints, bool maskupdate, const char *cache_path, const char *title_id, const char *self_name, const std::string &shader_version, bool shader_cache) {
+std::vector<uint32_t> load_spirv_shader(const SceGxmProgram &program, const FeatureState &features, bool is_vulkan, const shader::Hints &hints, bool maskupdate, const fs::path &shader_cache_path, const fs::path &shader_log_path, const std::string &shader_version, bool shader_cache) {
     const shader::Target target = is_vulkan ? shader::Target::SpirVVulkan : shader::Target::SpirVOpenGL;
     auto shader_type_to_str = [](SceGxmProgramType type) {
         return (type == SceGxmProgramType::Vertex) ? "vert.spv.txt" : ((type == SceGxmProgramType::Fragment) ? "frag.spv.txt" : "unknown.spv.txt");
     };
     const char *shader_type_str = shader_type_to_str(program.get_type());
 
-    return load_shader_generic(target, program, features, hints, maskupdate, cache_path, title_id, self_name, shader_type_str, shader_version, shader_cache).spirv;
+    return load_shader_generic(target, program, features, hints, maskupdate, shader_cache_path, shader_log_path, shader_type_str, shader_version, shader_cache).spirv;
 }
 
-std::string pre_load_shader_glsl(const char *hash_text, const char *shader_type_str, const char *cache_path, const char *title_id, const char *self_name) {
-    return load_shader_generic<std::string>(hash_text, cache_path, title_id, self_name, shader_type_str);
+std::string pre_load_shader_glsl(const fs::path &shader_path) {
+    return load_shader_generic<std::string>(shader_path);
 }
 
-std::vector<uint32_t> pre_load_shader_spirv(const char *hash_text, const char *shader_type_str, const char *cache_path, const char *title_id, const char *self_name) {
-    return load_shader_generic<std::vector<uint32_t>>(hash_text, cache_path, title_id, self_name, shader_type_str);
+std::vector<uint32_t> pre_load_shader_spirv(const fs::path &shader_path) {
+    return load_shader_generic<std::vector<uint32_t>>(shader_path);
 }
 
 } // namespace renderer

--- a/vita3k/renderer/src/state_set.cpp
+++ b/vita3k/renderer/src/state_set.cpp
@@ -429,12 +429,12 @@ COMMAND_SET_STATE(texture) {
     switch (renderer.current_backend) {
     case Backend::OpenGL:
         gl::sync_texture(dynamic_cast<gl::GLState &>(renderer), *reinterpret_cast<gl::GLContext *>(render_context), mem, texture_index, texture,
-            config, title_id);
+            config);
         break;
 
     case Backend::Vulkan:
         vulkan::sync_texture(*reinterpret_cast<vulkan::VKContext *>(render_context), mem, texture_index, texture,
-            config, title_id);
+            config);
         break;
 
     default:
@@ -562,7 +562,7 @@ COMMAND(handle_set_state) {
 
     if (result != handlers.end()) {
         // LOG_TRACE("State set: {}", (int)gxm_state_to_set);
-        result->second(renderer, mem, config, helper, render_context, cache_path, title_id);
+        result->second(renderer, mem, config, helper, render_context);
     } else {
         LOG_ERROR("Unknown state set command {}", static_cast<uint16_t>(gxm_state_to_set));
     }

--- a/vita3k/renderer/src/texture/replacement.cpp
+++ b/vita3k/renderer/src/texture/replacement.cpp
@@ -595,8 +595,7 @@ void TextureCache::refresh_available_textures() {
         return;
 
     auto look_through_folder = [&]<typename F>(const fs::path &folder, F on_texture_found) {
-        if (!fs::exists(folder))
-            fs::create_directories(folder);
+        fs::create_directories(folder);
 
         // iterate through all the files, and list the png/dds inside
         for (const auto &file_entry : fs::recursive_directory_iterator(folder)) {

--- a/vita3k/renderer/src/transfer.cpp
+++ b/vita3k/renderer/src/transfer.cpp
@@ -22,9 +22,10 @@
 #include <renderer/functions.h>
 #include <renderer/state.h>
 #include <renderer/types.h>
-#include <util/keywords.h>
 #include <util/log.h>
 #include <util/tracy.h>
+// keywords.h must be after tracy.h for msvc compiler
+#include <util/keywords.h>
 
 namespace renderer {
 

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -176,7 +176,7 @@ VKState::VKState(int gpu_idx)
     , screen_renderer(*this) {
 }
 
-bool VKState::init(const fs::path &static_assets, const bool hashless_texture_cache) {
+bool VKState::init() {
     shader_version = fmt::format("v{}", shader::CURRENT_VERSION);
     return true;
 }
@@ -649,8 +649,7 @@ void VKState::late_init(const Config &cfg, const std::string_view game_id, MemSt
 
     pipeline_cache.init();
 
-    const fs::path texture_folder = fs::path(shared_path) / "textures";
-    texture_cache.init(false, texture_folder, game_id);
+    texture_cache.init(false, texture_folder(), game_id);
 }
 
 void VKState::cleanup() {
@@ -959,7 +958,7 @@ void VKState::precompile_shader(const ShadersHash &hash) {
 
 void VKState::preclose_action() {
     // make sure we are in a game
-    if (!title_id[0])
+    if (shaders_path.empty())
         return;
 
     pipeline_cache.save_pipeline_cache();

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -55,7 +55,7 @@ static bool is_depth_stencil_compatible_format(SceGxmTextureBaseFormat format) {
 VKTextureCache::VKTextureCache(VKState &state)
     : state(state) {}
 
-void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config, const std::string &title_id) {
+void sync_texture(VKContext &context, MemState &mem, std::size_t index, SceGxmTexture texture, const Config &config) {
     // why are we doing this here?
     // well textures are synced right before the draw
     // in particular, we know that the scissor is the correct one for the upcoming draw

--- a/vita3k/util/CMakeLists.txt
+++ b/vita3k/util/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(
 	src/arm.cpp
 	src/byte.cpp
 	src/float_to_half.cpp
+	src/fs_utils.cpp
 	src/hash.cpp
 	src/instrset_detect.cpp
 	src/logging.cpp

--- a/vita3k/util/include/util/fs.h
+++ b/vita3k/util/include/util/fs.h
@@ -19,8 +19,146 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <fmt/format.h>
+#include <fmt/std.h>
 
 namespace fs = boost::filesystem;
+
+#ifdef _WIN32
+#define FOPEN(filename, params) _wfopen(filename, L##params)
+#else
+#define FOPEN(filename, params) fopen(filename, params)
+#endif
+
+namespace fs_utils {
+
+/**
+ * \brief  Construct a file name (optionally with an extension) to be placed in a Vita3K directory.
+ * \param  base_path   The main output path for the file.
+ * \param  folder_path The sub-directory/sub-directories to output to.
+ * \param  file_name   The name of the file.
+ * \param  extension   The extension of the file (optional)
+ * \return A complete Boost.Filesystem file path normalized.
+ */
+fs::path construct_file_name(const fs::path &base_path, const fs::path &folder_path, const fs::path &file_name, const fs::path &extension = "");
+
+/**
+ * \brief Convert a Boost.Filesystem path to a UTF-8 string.
+ * \param path path to convert
+ * \return UTF-8 string
+ */
+std::string path_to_utf8(const fs::path &path);
+
+/**
+ * \brief Convert a UTF-8 string to a Boost.Filesystem path.
+ * \param str UTF-8 string to convert
+ * \return Boost.Filesystem path
+ */
+fs::path utf8_to_path(const std::string &str);
+
+/**
+ * \brief Concatenate two Boost.Filesystem paths. Usable to add extension to path.
+ * \param path1 First path
+ * \param path2 Second path
+ * \return First path + second path
+ */
+fs::path path_concat(const fs::path &path1, const fs::path &path2);
+
+/**
+ * \brief Store data buffer into file.
+ * \param path full file name to store data
+ * \param data pointer to data buffer
+ * \param size size of data buffer in bytes
+ */
+void dump_data(const fs::path &path, const void *data, const std::streamsize size);
+
+} // namespace fs_utils
+
+FMT_BEGIN_NAMESPACE
+namespace detail {
+
+template <typename Char, typename PathChar>
+auto get_path_string(const fs::path &p,
+    const std::basic_string<PathChar> &native) {
+    if constexpr (std::is_same_v<Char, char> && std::is_same_v<PathChar, wchar_t>)
+        return to_utf8<wchar_t>(native, to_utf8_error_policy::replace);
+    else
+        return native;
+}
+
+template <typename Char, typename PathChar>
+void write_escaped_path(basic_memory_buffer<Char> &quoted,
+    const fs::path &p,
+    const std::basic_string<PathChar> &native) {
+    if constexpr (std::is_same_v<Char, char> && std::is_same_v<PathChar, wchar_t>) {
+        auto buf = basic_memory_buffer<wchar_t>();
+        write_escaped_string<wchar_t>(std::back_inserter(buf), native);
+        bool valid = to_utf8<wchar_t>::convert(quoted, { buf.data(), buf.size() });
+        FMT_ASSERT(valid, "invalid utf16");
+    } else if constexpr (std::is_same_v<Char, PathChar>) {
+        write_escaped_string<fs::path::value_type>(
+            std::back_inserter(quoted), native);
+    } else {
+        write_escaped_string<Char>(std::back_inserter(quoted), p.string<Char>());
+    }
+}
+
+} // namespace detail
+
+template <typename Char>
+struct formatter<fs::path, Char> {
+private:
+    format_specs<Char> specs_;
+    detail::arg_ref<Char> width_ref_;
+    bool debug_ = false;
+    char path_type_ = 'n';
+
+public:
+    constexpr void set_debug_format(bool set = true) { debug_ = set; }
+
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) {
+        auto it = ctx.begin(), end = ctx.end();
+        if (it == end)
+            return it;
+
+        it = detail::parse_align(it, end, specs_);
+        if (it == end)
+            return it;
+
+        it = detail::parse_dynamic_spec(it, end, specs_.width, width_ref_, ctx);
+        if (it != end && *it == '?') {
+            debug_ = true;
+            ++it;
+        }
+        if (it != end && (*it == 'g' || *it == 'n'))
+            path_type_ = *it++;
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const fs::path &p, FormatContext &ctx) const {
+        auto specs = specs_;
+#ifdef _WIN32
+        auto path_string = path_type_ == 'n' ? p.native() : p.generic_wstring();
+#else
+        auto path_string = path_type_ == 'n' ? p.native() : p.generic_string();
+#endif
+
+        detail::handle_dynamic_spec<detail::width_checker>(specs.width, width_ref_,
+            ctx);
+        if (!debug_) {
+            auto s = detail::get_path_string<Char>(p, path_string);
+            return detail::write(ctx.out(), basic_string_view<Char>(s), specs);
+        }
+        auto quoted = basic_memory_buffer<Char>();
+        detail::write_escaped_path(quoted, p, path_string);
+        return detail::write(ctx.out(),
+            basic_string_view<Char>(quoted.data(), quoted.size()),
+            specs);
+    }
+};
+FMT_END_NAMESPACE
 
 class Root {
     fs::path base_path;
@@ -35,105 +173,48 @@ public:
     void set_base_path(const fs::path &p) {
         base_path = p;
     }
-
     fs::path get_base_path() const {
         return base_path;
-    }
-
-    std::string get_base_path_string() const {
-        return base_path.generic_path().string();
     }
 
     void set_pref_path(const fs::path &p) {
         pref_path = p;
     }
-
     fs::path get_pref_path() const {
         return pref_path;
-    }
-
-    std::string get_pref_path_string() const {
-        return pref_path.generic_path().string();
     }
 
     void set_log_path(const fs::path &p) {
         log_path = p;
     }
-
     fs::path get_log_path() const {
         return log_path;
-    }
-
-    std::string get_log_path_string() const {
-        return log_path.generic_path().string();
     }
 
     void set_config_path(const fs::path &p) {
         config_path = p;
     }
-
     fs::path get_config_path() const {
         return config_path;
-    }
-
-    std::string get_config_path_string() const {
-        return config_path.generic_path().string();
     }
 
     void set_shared_path(const fs::path &p) {
         shared_path = p;
     }
-
     fs::path get_shared_path() const {
         return shared_path;
-    }
-
-    std::string get_shared_path_string() const {
-        return shared_path.generic_path().string();
     }
 
     void set_cache_path(const fs::path &p) {
         cache_path = p;
     }
-
     fs::path get_cache_path() const {
         return cache_path;
     }
-
-    std::string get_cache_path_string() const {
-        return cache_path.generic_path().string();
-    }
-
     void set_static_assets_path(const fs::path &p) {
         static_assets_path = p;
     }
-
     fs::path get_static_assets_path() const {
         return static_assets_path;
     }
-
-    std::string get_static_assets_path_string() const {
-        return static_assets_path.generic_path().string();
-    }
-
 }; // class root
-
-namespace fs_utils {
-
-/**
- * \brief  Construct a file name (optionally with an extension) to be placed in a Vita3K directory.
- * \param  base_path   The main output path for the file.
- * \param  folder_path The sub-directory/sub-directories to output to.
- * \param  file_name   The name of the file.
- * \param  extension   The extension of the file (optional)
- * \return A complete Boost.Filesystem file path normalized.
- */
-inline fs::path construct_file_name(const fs::path &base_path, const fs::path &folder_path, const fs::path &file_name, const fs::path &extension = "") {
-    fs::path full_file_path{ base_path / folder_path / file_name };
-    if (!extension.empty())
-        full_file_path.replace_extension(extension);
-
-    return full_file_path.generic_path();
-}
-
-} // namespace fs_utils

--- a/vita3k/util/include/util/hash.h
+++ b/vita3k/util/include/util/hash.h
@@ -30,7 +30,7 @@ void hex_buf(const std::uint8_t *hash, char *dst, const std::size_t source_size)
 
 template <size_t N>
 const std::string hex_string(const std::array<uint8_t, N> &hash) {
-    std::string dst(2 * N + 1, 0);
+    std::string dst(2 * N, 0);
     hex_buf(hash.data(), dst.data(), N);
 
     return dst;

--- a/vita3k/util/src/fs_utils.cpp
+++ b/vita3k/util/src/fs_utils.cpp
@@ -1,0 +1,59 @@
+// Vita3K emulator project
+// Copyright (C) 2023 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <util/fs.h>
+#include <util/string_utils.h>
+
+namespace fs_utils {
+
+fs::path construct_file_name(const fs::path &base_path, const fs::path &folder_path, const fs::path &file_name, const fs::path &extension) {
+    fs::path full_file_path{ base_path / folder_path / file_name };
+    if (!extension.empty())
+        full_file_path.replace_extension(extension);
+
+    return full_file_path.generic_path();
+}
+
+std::string path_to_utf8(const fs::path &path) {
+    if constexpr (sizeof(fs::path::value_type) == sizeof(wchar_t)) {
+        return string_utils::wide_to_utf(path.wstring());
+    } else {
+        return path.string();
+    }
+}
+
+fs::path utf8_to_path(const std::string &str) {
+    if constexpr (sizeof(fs::path::value_type) == sizeof(wchar_t)) {
+        return fs::path{ string_utils::utf_to_wide(str) };
+    } else {
+        return fs::path{ str };
+    }
+}
+
+fs::path path_concat(const fs::path &path1, const fs::path &path2) {
+    return fs::path{ path1.native() + path2.native() };
+}
+
+void dump_data(const fs::path &path, const void *data, const std::streamsize size) {
+    fs::ofstream of{ path, fs::ofstream::binary };
+    if (!of.fail()) {
+        of.write(static_cast<const char *>(data), size);
+        of.close();
+    }
+}
+
+} // namespace fs_utils

--- a/vita3k/util/src/hash.cpp
+++ b/vita3k/util/src/hash.cpp
@@ -21,7 +21,7 @@
 
 Sha256Hash sha256(const void *data, size_t size) {
     Sha256Hash hash;
-    
+
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
     EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr);
     EVP_DigestUpdate(ctx, data, size);

--- a/vita3k/util/src/logging.cpp
+++ b/vita3k/util/src/logging.cpp
@@ -80,11 +80,7 @@ void set_level(spdlog::level::level_enum log_level) {
 
 ExitCode add_sink(const fs::path &log_path) {
     try {
-#ifdef WIN32
-        sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.generic_path().wstring(), true));
-#else
-        sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.generic_path().string(), true));
-#endif
+        sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path.generic_path().native(), true));
     } catch (const spdlog::spdlog_ex &ex) {
         std::cerr << "File log initialization failed: " << ex.what() << std::endl;
         return InitConfigFailed;


### PR DESCRIPTION
avoid not need conversion string->wstring->string for linux and macos 
native logging of fs::path
more correct conversion from std path to boost path 
refactor pathes for shaders compiler, shorten parameters lists 
crypto::hex_string: remove not needed null character as last character in string