### PR TITLE
vita3k: Improve path support for Linux and macOS.

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -104,83 +104,125 @@ void update_viewport(EmuEnvState &state) {
 
 void init_paths(Root &root_paths) {
     auto sdl_base_path = SDL_GetBasePath();
-    auto sdl_pref_path = SDL_GetPrefPath(org_name, app_name);
     auto base_path = fs_utils::utf8_to_path(sdl_base_path);
-    auto pref_path = fs_utils::utf8_to_path(sdl_pref_path);
     SDL_free(sdl_base_path);
-    SDL_free(sdl_pref_path);
+
     root_paths.set_base_path(base_path);
-    root_paths.set_pref_path(pref_path);
-    root_paths.set_log_path(base_path);
-    root_paths.set_config_path(base_path);
     root_paths.set_static_assets_path(base_path);
-    root_paths.set_shared_path(base_path);
-    root_paths.set_cache_path(base_path / "cache" / "");
+
+#if defined(__APPLE__)
+    // On Apple platforms, base_path is "Contents/Resources/" inside the app bundle.
+    // An extra parent_path is apparently needed because of the trailing slash.
+    auto portable_path = base_path.parent_path().parent_path().parent_path().parent_path() / "portable" / "";
+#else
+    auto portable_path = base_path / "portable" / "";
+#endif
+
+    if (fs::is_directory(portable_path)) {
+        // If a portable directory exists, use it for everything else.
+        // Note that pref_path should not be the same as the other paths.
+        root_paths.set_pref_path(portable_path / "fs" / "");
+        root_paths.set_log_path(portable_path);
+        root_paths.set_config_path(portable_path);
+        root_paths.set_shared_path(portable_path);
+        root_paths.set_cache_path(portable_path / "cache" / "");
+    } else {
+        // SDL_GetPrefPath is deferred as it creates the directory.
+        // When using a portable directory, it is not needed.
+        auto sdl_pref_path = SDL_GetPrefPath(org_name, app_name);
+        auto pref_path = fs_utils::utf8_to_path(sdl_pref_path);
+        SDL_free(sdl_pref_path);
+
+#if defined(__APPLE__)
+        // Store other data in the user-wide path. Otherwise we may end up dumping
+        // files into the "/Applications/" install directory or the app bundle.
+        // This will typically be "~/Library/Application Support/Vita3K/Vita3K/".
+        // Check for config.yml first, though, to maintain backwards compatibility,
+        // even though storing user data inside the app bundle is not a good idea.
+        auto existing_config = base_path / "config.yml";
+        if (!fs::exists(existing_config)) {
+            base_path = pref_path;
+        }
+
+        // pref_path should not be the same as the other paths.
+        // For backwards compatibility, though, check if ux0 exists first.
+        auto existing_ux0 = pref_path / "ux0";
+        if (!fs::is_directory(existing_ux0)) {
+            pref_path = pref_path / "fs" / "";
+        }
+#endif
+
+        root_paths.set_pref_path(pref_path);
+        root_paths.set_log_path(base_path);
+        root_paths.set_config_path(base_path);
+        root_paths.set_shared_path(base_path);
+        root_paths.set_cache_path(base_path / "cache" / "");
 
 #if defined(__linux__) && !defined(__ANDROID__) && !defined(__APPLE__)
-    // XDG Data Dirs.
-    auto env_home = getenv("HOME");
-    auto XDG_DATA_DIRS = getenv("XDG_DATA_DIRS");
-    auto XDG_DATA_HOME = getenv("XDG_DATA_HOME");
-    auto XDG_CACHE_HOME = getenv("XDG_CACHE_HOME");
-    auto XDG_CONFIG_HOME = getenv("XDG_CONFIG_HOME");
-    auto APPDIR = getenv("APPDIR"); // Used in AppImage
+        // XDG Data Dirs.
+        auto env_home = getenv("HOME");
+        auto XDG_DATA_DIRS = getenv("XDG_DATA_DIRS");
+        auto XDG_DATA_HOME = getenv("XDG_DATA_HOME");
+        auto XDG_CACHE_HOME = getenv("XDG_CACHE_HOME");
+        auto XDG_CONFIG_HOME = getenv("XDG_CONFIG_HOME");
+        auto APPDIR = getenv("APPDIR"); // Used in AppImage
 
-    if (XDG_DATA_HOME != NULL)
-        root_paths.set_pref_path(fs::path(XDG_DATA_HOME) / app_name / app_name / "");
+        if (XDG_DATA_HOME != NULL)
+            root_paths.set_pref_path(fs::path(XDG_DATA_HOME) / app_name / app_name / "");
 
-    if (XDG_CONFIG_HOME != NULL)
-        root_paths.set_config_path(fs::path(XDG_CONFIG_HOME) / app_name / "");
-    else if (env_home != NULL)
-        root_paths.set_config_path(fs::path(env_home) / ".config" / app_name / "");
+        if (XDG_CONFIG_HOME != NULL)
+            root_paths.set_config_path(fs::path(XDG_CONFIG_HOME) / app_name / "");
+        else if (env_home != NULL)
+            root_paths.set_config_path(fs::path(env_home) / ".config" / app_name / "");
 
-    if (XDG_CACHE_HOME != NULL) {
-        root_paths.set_cache_path(fs::path(XDG_CACHE_HOME) / app_name / "");
-        root_paths.set_log_path(fs::path(XDG_CACHE_HOME) / app_name / "");
-    } else if (env_home != NULL) {
-        root_paths.set_cache_path(fs::path(env_home) / ".cache" / app_name / "");
-        root_paths.set_log_path(fs::path(env_home) / ".cache" / app_name / "");
-    }
-
-    // Don't assume that base_path is portable.
-    if (fs::exists(root_paths.get_base_path() / "data") && fs::exists(root_paths.get_base_path() / "lang") && fs::exists(root_paths.get_base_path() / "shaders-builtin"))
-        root_paths.set_static_assets_path(root_paths.get_base_path());
-    else if (env_home != NULL)
-        root_paths.set_static_assets_path(fs::path(env_home) / ".local/share" / app_name / "");
-
-    if (XDG_DATA_DIRS != NULL) {
-        auto env_paths = string_utils::split_string(XDG_DATA_DIRS, ':');
-        for (auto &i : env_paths) {
-            if (fs::exists(fs::path(i) / app_name)) {
-                root_paths.set_static_assets_path(fs::path(i) / app_name / "");
-                break;
-            }
+        if (XDG_CACHE_HOME != NULL) {
+            root_paths.set_cache_path(fs::path(XDG_CACHE_HOME) / app_name / "");
+            root_paths.set_log_path(fs::path(XDG_CACHE_HOME) / app_name / "");
+        } else if (env_home != NULL) {
+            root_paths.set_cache_path(fs::path(env_home) / ".cache" / app_name / "");
+            root_paths.set_log_path(fs::path(env_home) / ".cache" / app_name / "");
         }
-    } else if (XDG_DATA_HOME != NULL) {
-        if (fs::exists(fs::path(XDG_DATA_HOME) / app_name / "data") && fs::exists(fs::path(XDG_DATA_HOME) / app_name / "lang") && fs::exists(fs::path(XDG_DATA_HOME) / app_name / "shaders-builtin"))
-            root_paths.set_static_assets_path(fs::path(XDG_DATA_HOME) / app_name / "");
-    }
 
-    if (APPDIR != NULL && fs::exists(fs::path(APPDIR) / "usr/share/Vita3K")) {
-        root_paths.set_static_assets_path(fs::path(APPDIR) / "usr/share/Vita3K");
-    }
+        // Don't assume that base_path is portable.
+        if (fs::exists(root_paths.get_base_path() / "data") && fs::exists(root_paths.get_base_path() / "lang") && fs::exists(root_paths.get_base_path() / "shaders-builtin"))
+            root_paths.set_static_assets_path(root_paths.get_base_path());
+        else if (env_home != NULL)
+            root_paths.set_static_assets_path(fs::path(env_home) / ".local/share" / app_name / "");
 
-    // shared path
-    if (env_home != NULL)
-        root_paths.set_shared_path(fs::path(env_home) / ".local/share" / app_name / "");
-
-    if (XDG_DATA_DIRS != NULL) {
-        auto env_paths = string_utils::split_string(XDG_DATA_DIRS, ':');
-        for (auto &i : env_paths) {
-            if (fs::exists(fs::path(i) / app_name)) {
-                root_paths.set_shared_path(fs::path(i) / app_name / "");
-                break;
+        if (XDG_DATA_DIRS != NULL) {
+            auto env_paths = string_utils::split_string(XDG_DATA_DIRS, ':');
+            for (auto &i : env_paths) {
+                if (fs::exists(fs::path(i) / app_name)) {
+                    root_paths.set_static_assets_path(fs::path(i) / app_name / "");
+                    break;
+                }
             }
+        } else if (XDG_DATA_HOME != NULL) {
+            if (fs::exists(fs::path(XDG_DATA_HOME) / app_name / "data") && fs::exists(fs::path(XDG_DATA_HOME) / app_name / "lang") && fs::exists(fs::path(XDG_DATA_HOME) / app_name / "shaders-builtin"))
+                root_paths.set_static_assets_path(fs::path(XDG_DATA_HOME) / app_name / "");
         }
-    } else if (XDG_DATA_HOME != NULL) {
-        root_paths.set_shared_path(fs::path(XDG_DATA_HOME) / app_name / "");
-    }
+
+        if (APPDIR != NULL && fs::exists(fs::path(APPDIR) / "usr/share/Vita3K")) {
+            root_paths.set_static_assets_path(fs::path(APPDIR) / "usr/share/Vita3K");
+        }
+
+        // shared path
+        if (env_home != NULL)
+            root_paths.set_shared_path(fs::path(env_home) / ".local/share" / app_name / "");
+
+        if (XDG_DATA_DIRS != NULL) {
+            auto env_paths = string_utils::split_string(XDG_DATA_DIRS, ':');
+            for (auto &i : env_paths) {
+                if (fs::exists(fs::path(i) / app_name)) {
+                    root_paths.set_shared_path(fs::path(i) / app_name / "");
+                    break;
+                }
+            }
+        } else if (XDG_DATA_HOME != NULL) {
+            root_paths.set_shared_path(fs::path(XDG_DATA_HOME) / app_name / "");
+        }
 #endif
+    }
 
     // Create default preference and cache path for safety
     fs::create_directories(root_paths.get_config_path());


### PR DESCRIPTION
Improves path support in the following ways:
* macOS:
  * Config and other files are currently placed inside the app bundle's `Resources` directory, as by default this is what `SDL_GetBasePath` returns. This can be inconvenient as if the app bundle is ever deleted/replaced, config files will be lost. Users will also likely not even realize the files are being stored here as generally app bundles are not used to store user data. Instead, use the `SDL_GetPrefPath` "~/Library/Application Support/Vita3K/Vita3K" by default.
    * We can't just use the path outside the app bundle as the user may install Vita3K to "/Applications/", which should not be used to store emulator data.
* macOS & Linux:
  * Since macOS now uses the user data path by default, and Linux already uses the XDG paths by default, introduce a new "portable" directory concept where, if the user creates a directory named "portable" next to the executable/app bundle, it will use that for all user data by default. This preserves the case where users want to keep all of their data together in a more portable location. Some other emulators like Citra, Yuzu, Ryujinx, Dolphin, etc have the same or similar concepts, so this will be familiar to users who want this.