### PR TITLE
config: Implement global volume percent setting.

### DIFF
--- a/lang/system/en-gb.xml
+++ b/lang/system/en-gb.xml
@@ -667,6 +667,8 @@ Some applications don't use this and get default confirmation button.</enter_but
 			<boot_apps_full_screen>Boot apps in full screen</boot_apps_full_screen>
 			<audio_backend>Audio Backend</audio_backend>
 			<select_audio_backend>Select your preferred audio backend.</select_audio_backend>
+			<audio_volume>Audio Volume</audio_volume>
+			<audio_volume_description>Adjusts the volume percentage of all audio outputs.</audio_volume_description>
 			<enable_ngs_support>Enable NGS support</enable_ngs_support>
 			<ngs_description>Uncheck the box to disable support for advanced audio library NGS.</ngs_description>
 			<trace>Trace</trace>

--- a/lang/system/en.xml
+++ b/lang/system/en.xml
@@ -667,6 +667,8 @@ Some applications don't use this and get default confirmation button.</enter_but
 			<boot_apps_full_screen>Boot apps in full screen</boot_apps_full_screen>
 			<audio_backend>Audio Backend</audio_backend>
 			<select_audio_backend>Select your preferred audio backend.</select_audio_backend>
+			<audio_volume>Audio Volume</audio_volume>
+			<audio_volume_description>Adjusts the volume percentage of all audio outputs.</audio_volume_description>
 			<enable_ngs_support>Enable NGS support</enable_ngs_support>
 			<ngs_description>Uncheck the box to disable support for advanced audio library NGS.</ngs_description>
 			<trace>Trace</trace>

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -348,7 +348,7 @@ bool late_init(EmuEnvState &state) {
             thread->update_status(ThreadStatus::run);
         }
     };
-    if (!state.audio.init(resume_thread, state.cfg.audio_backend)) {
+    if (!state.audio.init(resume_thread, state.cfg.audio_backend, state.cfg.current_config.audio_volume)) {
         LOG_WARN("Failed to initialize audio! Audio will not work.");
     }
 

--- a/vita3k/audio/include/audio/state.h
+++ b/vita3k/audio/include/audio/state.h
@@ -114,11 +114,13 @@ struct AudioState {
     AudioInPort in_port;
     ResumeAudioThread resume_thread;
     std::string audio_backend;
+    float global_volume;
 
-    bool init(const ResumeAudioThread &resume_thread, const std::string &adapter_name);
+    bool init(const ResumeAudioThread &resume_thread, const std::string &adapter_name, float global_volume);
     void set_backend(const std::string &adapter_name);
     AudioOutPortPtr open_port(int nb_channels, int freq, int nb_sample);
     void audio_output(ThreadState &thread, AudioOutPort &out_port, const void *buffer);
     void set_volume(AudioOutPort &out_port, float volume);
+    void set_global_volume(float volume);
     void switch_state(const bool pause);
 };

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -81,6 +81,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "export-as-png", true, export_as_png)                                                    \
     code(bool, "boot-apps-full-screen", false, boot_apps_full_screen)                                   \
     code(std::string, "audio-backend", "SDL", audio_backend)                                            \
+    code(float, "audio-volume", 1.0f, audio_volume)                                                     \
     code(bool, "ngs-enable", true, ngs_enable)                                                          \
     code(int, "sys-button", static_cast<int>(SCE_SYSTEM_PARAM_ENTER_BUTTON_CROSS), sys_button)          \
     code(int, "sys-lang", static_cast<int>(SCE_SYSTEM_PARAM_LANG_ENGLISH_US), sys_lang)                 \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -119,6 +119,7 @@ public:
         int modules_mode = ModulesMode::AUTOMATIC;
         std::vector<std::string> lle_modules = {};
         bool pstv_mode = false;
+        float audio_volume = 1.0f;
         bool ngs_enable = true;
         bool high_accuracy = false;
         int resolution_multiplier = 1;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -193,6 +193,7 @@ static bool get_custom_config(GuiState &gui, EmuEnvState &emuenv, const std::str
             // Load Emulator Config
             if (!config_child.child("emulator").empty()) {
                 const auto emulator_child = config_child.child("emulator");
+                config.audio_volume = emulator_child.attribute("audio-volume").as_float();
                 config.ngs_enable = emulator_child.attribute("enable-ngs").as_bool();
                 config.show_touchpad_cursor = emulator_child.attribute("show-touchpad-cursor").as_bool();
             }
@@ -248,6 +249,7 @@ void init_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
         config.export_as_png = emuenv.cfg.export_as_png;
         config.fps_hack = emuenv.cfg.fps_hack;
         config.pstv_mode = emuenv.cfg.pstv_mode;
+        config.audio_volume = emuenv.cfg.audio_volume;
         config.ngs_enable = emuenv.cfg.ngs_enable;
         config.show_touchpad_cursor = emuenv.cfg.show_touchpad_cursor;
         config.psn_signed_in = emuenv.cfg.psn_signed_in;
@@ -337,6 +339,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
 
         // Emulator
         auto emulator_child = config_child.append_child("emulator");
+        emulator_child.append_attribute("audio-volume") = config.audio_volume;
         emulator_child.append_attribute("enable-ngs") = config.ngs_enable;
         emulator_child.append_attribute("show-touchpad-cursor") = config.show_touchpad_cursor;
 
@@ -364,6 +367,7 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         emuenv.cfg.export_textures = config.export_textures;
         emuenv.cfg.export_as_png = config.export_as_png;
         emuenv.cfg.fps_hack = config.fps_hack;
+        emuenv.cfg.audio_volume = config.audio_volume;
         emuenv.cfg.ngs_enable = config.ngs_enable;
         emuenv.cfg.show_touchpad_cursor = config.show_touchpad_cursor;
         emuenv.cfg.psn_signed_in = config.psn_signed_in;
@@ -428,6 +432,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.cfg.current_config.export_textures = emuenv.cfg.export_textures;
         emuenv.cfg.current_config.export_as_png = emuenv.cfg.export_as_png;
         emuenv.cfg.current_config.fps_hack = emuenv.cfg.fps_hack;
+        emuenv.cfg.current_config.audio_volume = emuenv.cfg.audio_volume;
         emuenv.cfg.current_config.ngs_enable = emuenv.cfg.ngs_enable;
         emuenv.cfg.current_config.show_touchpad_cursor = emuenv.cfg.show_touchpad_cursor;
         emuenv.cfg.current_config.psn_signed_in = emuenv.cfg.psn_signed_in;
@@ -462,6 +467,8 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         emuenv.kernel.cpu_opt = emuenv.cfg.current_config.cpu_opt;
         emuenv.audio.set_backend(emuenv.cfg.audio_backend);
     }
+
+    emuenv.audio.set_global_volume(emuenv.cfg.current_config.audio_volume);
 }
 
 void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
@@ -839,6 +846,12 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
 
         if (!emuenv.io.app_path.empty())
             ImGui::EndDisabled();
+
+        int audio_volume_percent = static_cast<int>(config.audio_volume * 100);
+        ImGui::SliderInt(lang.emulator["audio_volume"].c_str(), &audio_volume_percent, 0, 100, "%d%%", ImGuiSliderFlags_AlwaysClamp);
+        config.audio_volume = static_cast<float>(audio_volume_percent) / 100.0f;
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("%s", lang.emulator["audio_volume_description"].c_str());
 
         ImGui::Checkbox(lang.emulator["enable_ngs_support"].c_str(), &config.ngs_enable);
         if (ImGui::IsItemHovered())

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -587,6 +587,8 @@ struct LangState {
             { "boot_apps_full_screen", "Boot apps in full screen" },
             { "audio_backend", "Audio Backend" },
             { "select_audio_backend", "Select your preferred audio backend." },
+            { "audio_volume", "Audio Volume" },
+            { "audio_volume_description", "Adjusts the volume percentage of all audio outputs." },
             { "enable_ngs_support", "Enable NGS support" },
             { "ngs_description", "Uncheck the box to disable support for advanced audio library NGS." },
             { "trace", "Trace" },


### PR DESCRIPTION
Adds a setting to configure a global audio volume. This works by multiplying each audio port's volume by the global volume at the adapter level. For example, if you set the global volume to 50%, it will multiply each port's volume by 0.5, cutting it in half.

The setting is only usable with the Cubeb backend, as the SDL backend does not provide a means of changing the volume.