### PR TITLE
renderer: Implement fractional upscaling

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -67,7 +67,7 @@ enum PerfomanceOverleyPosition {
     code(std::string, "backend-renderer", "OpenGL", backend_renderer)                                   \
     code(int, "gpu-idx", 0, gpu_idx)                                                                    \
     code(bool, "high-accuracy", true, high_accuracy)                                                    \
-    code(int, "resolution-multiplier", 1, resolution_multiplier)                                        \
+    code(float, "resolution-multiplier", 1.0f, resolution_multiplier)                                   \
     code(bool, "disable-surface-sync", true, disable_surface_sync)                                      \
     code(std::string, "screen-filter", "Bilinear", screen_filter)                                       \
     code(bool, "v-sync", true, v_sync)                                                                  \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -130,7 +130,7 @@ public:
         bool ngs_enable = true;
         bool pstv_mode = false;
         bool high_accuracy = false;
-        int resolution_multiplier = 1;
+        float resolution_multiplier = 1.0f;
         bool disable_surface_sync = false;
         std::string screen_filter = "Bilinear";
         bool v_sync = true;

--- a/vita3k/renderer/include/renderer/gl/surface_cache.h
+++ b/vita3k/renderer/include/renderer/gl/surface_cache.h
@@ -127,8 +127,8 @@ public:
         target = new_target;
     }
 
-    GLuint sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const int res_multiplier, SceFVector2 &texture_size);
-    std::vector<uint32_t> dump_frame(Ptr<const void> address, uint32_t width, uint32_t height, uint32_t pitch, int res_multiplier, bool support_get_texture_sub_image);
+    GLuint sourcing_color_surface_for_presentation(Ptr<const void> address, uint32_t width, uint32_t height, const std::uint32_t pitch, float *uvs, const float res_multiplier, SceFVector2 &texture_size);
+    std::vector<uint32_t> dump_frame(Ptr<const void> address, uint32_t width, uint32_t height, uint32_t pitch, float res_multiplier, bool support_get_texture_sub_image);
 };
 } // namespace gl
 } // namespace renderer

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -54,7 +54,7 @@ struct State {
 
     Backend current_backend;
     FeatureState features;
-    int res_multiplier;
+    float res_multiplier;
     bool disable_surface_sync;
     bool stretch_the_display_area;
 

--- a/vita3k/renderer/src/creation.cpp
+++ b/vita3k/renderer/src/creation.cpp
@@ -123,8 +123,8 @@ COMMAND(handle_create_render_target) {
         uint16_t nb_macroblocks_y = (params->flags >> 12) & 0b111;
 
         // the width and height should be multiple of 128
-        (*render_target)->macroblock_width = (params->width / nb_macroblocks_x) * renderer.res_multiplier;
-        (*render_target)->macroblock_height = (params->height / nb_macroblocks_y) * renderer.res_multiplier;
+        (*render_target)->macroblock_width = static_cast<uint16_t>((params->width / nb_macroblocks_x) * renderer.res_multiplier);
+        (*render_target)->macroblock_height = static_cast<uint16_t>((params->height / nb_macroblocks_y) * renderer.res_multiplier);
     }
 
     complete_command(renderer, helper, result);

--- a/vita3k/renderer/src/gl/draw.cpp
+++ b/vita3k/renderer/src/gl/draw.cpp
@@ -155,7 +155,7 @@ void draw(GLState &renderer, GLContext &context, const FeatureState &features, S
     }
     frag_ublock.writing_mask = context.record.writing_mask;
     frag_ublock.use_raw_image = static_cast<float>(use_raw_image);
-    frag_ublock.res_multiplier = static_cast<float>(renderer.res_multiplier);
+    frag_ublock.res_multiplier = renderer.res_multiplier;
     const bool has_msaa = context.render_target->multisample_mode;
     const bool has_downscale = context.record.color_surface.downscale;
     if (has_msaa && !has_downscale)

--- a/vita3k/renderer/src/gl/sync_state.cpp
+++ b/vita3k/renderer/src/gl/sync_state.cpp
@@ -120,7 +120,8 @@ void sync_viewport_flat(const GLState &state, GLContext &context) {
     const GLsizei display_w = context.record.color_surface.width;
     const GLsizei display_h = context.record.color_surface.height;
 
-    glViewport(0, (context.current_framebuffer_height - display_h) * state.res_multiplier, display_w * state.res_multiplier, display_h * state.res_multiplier);
+    glViewport(0, static_cast<GLint>((context.current_framebuffer_height - display_h) * state.res_multiplier),
+        static_cast<GLsizei>(display_w * state.res_multiplier), static_cast<GLsizei>(display_h * state.res_multiplier));
     glDepthRange(0, 1);
 }
 
@@ -161,7 +162,8 @@ void sync_clipping(const GLState &state, GLContext &context) {
         break;
     case SCE_GXM_REGION_CLIP_OUTSIDE:
         glEnable(GL_SCISSOR_TEST);
-        glScissor(scissor_x * state.res_multiplier, scissor_y * state.res_multiplier, scissor_w * state.res_multiplier, scissor_h * state.res_multiplier);
+        glScissor(static_cast<GLint>(scissor_x * state.res_multiplier), static_cast<GLint>(scissor_y * state.res_multiplier),
+            static_cast<GLsizei>(scissor_w * state.res_multiplier), static_cast<GLsizei>(scissor_h * state.res_multiplier));
         break;
     case SCE_GXM_REGION_CLIP_INSIDE:
         // TODO: Implement SCE_GXM_REGION_CLIP_INSIDE

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -132,6 +132,10 @@ COMMAND(handle_sync_surface_data) {
         }
     }
 
+    // additional check to make sure we never try to perform surface sync on OpenGL with a non-integer resolution multiplier
+    if (renderer.current_backend == Backend::OpenGL && static_cast<int>(renderer.res_multiplier * 4.0f) % 4 != 0)
+        renderer.disable_surface_sync = true;
+
     if (renderer.disable_surface_sync || renderer.current_backend == Backend::Vulkan) {
         if (helper.cmd->status) {
             complete_command(renderer, helper, 0);

--- a/vita3k/renderer/src/vulkan/creation.cpp
+++ b/vita3k/renderer/src/vulkan/creation.cpp
@@ -86,7 +86,7 @@ VKContext::VKContext(VKState &state, MemState &mem)
     };
     scissor = vk::Rect2D{
         .offset = { 0, 0 },
-        .extent = { 960U * state.res_multiplier, 544U * state.res_multiplier }
+        .extent = { static_cast<uint32_t>(960 * state.res_multiplier), static_cast<uint32_t>(544U * state.res_multiplier) }
     };
 
     // allocate descriptor pools
@@ -153,10 +153,10 @@ VKContext::VKContext(VKState &state, MemState &mem)
 }
 
 VKRenderTarget::VKRenderTarget(VKState &state, const SceGxmRenderTargetParams &params)
-    : color(params.width * state.res_multiplier, params.height * state.res_multiplier, vk::Format::eR8G8B8A8Unorm)
-    , depthstencil(params.width * state.res_multiplier, params.height * state.res_multiplier, vk::Format::eD32SfloatS8Uint) {
-    width = params.width * state.res_multiplier;
-    height = params.height * state.res_multiplier;
+    : color(static_cast<uint32_t>(params.width * state.res_multiplier), static_cast<uint32_t>(params.height * state.res_multiplier), vk::Format::eR8G8B8A8Unorm)
+    , depthstencil(static_cast<uint32_t>(params.width * state.res_multiplier), static_cast<uint32_t>(params.height * state.res_multiplier), vk::Format::eD32SfloatS8Uint) {
+    width = static_cast<uint32_t>(params.width * state.res_multiplier);
+    height = static_cast<uint32_t>(params.height * state.res_multiplier);
 
     vk::ImageUsageFlags color_usage = vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eInputAttachment;
     if (state.features.support_shader_interlock)

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -686,8 +686,8 @@ void VKState::render_frame(const SceFVector2 &viewport_pos, const SceFVector2 &v
 
     // Check if the surface exists
     Viewport viewport;
-    viewport.width = frame.image_size.x * res_multiplier;
-    viewport.height = frame.image_size.y * res_multiplier;
+    viewport.width = static_cast<uint32_t>(frame.image_size.x * res_multiplier);
+    viewport.height = static_cast<uint32_t>(frame.image_size.y * res_multiplier);
 
     vk::ImageLayout layout = vk::ImageLayout::eGeneral;
     vk::ImageView surface_handle = surface_cache.sourcing_color_surface_for_presentation(
@@ -755,8 +755,8 @@ std::vector<uint32_t> VKState::dump_frame(DisplayState &display, uint32_t &width
         frame = display.next_rendered_frame;
     }
 
-    width = frame.image_size.x * res_multiplier;
-    height = frame.image_size.y * res_multiplier;
+    width = static_cast<uint32_t>(frame.image_size.x * res_multiplier);
+    height = static_cast<uint32_t>(frame.image_size.y * res_multiplier);
     return surface_cache.dump_frame(frame.base, width, height, frame.pitch);
 }
 

--- a/vita3k/renderer/src/vulkan/scene.cpp
+++ b/vita3k/renderer/src/vulkan/scene.cpp
@@ -419,8 +419,8 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
     vert_ublock.viewport_flag = (context.record.viewport_flat) ? 0.0f : 1.0f;
     vert_ublock.z_offset = context.record.z_offset;
     vert_ublock.z_scale = context.record.z_scale;
-    vert_ublock.screen_width = static_cast<float>(context.render_target->width / context.state.res_multiplier);
-    vert_ublock.screen_height = static_cast<float>(context.render_target->height / context.state.res_multiplier);
+    vert_ublock.screen_width = context.render_target->width / context.state.res_multiplier;
+    vert_ublock.screen_height = context.render_target->height / context.state.res_multiplier;
 
     if (context.curr_vert_ublock.changed || memcmp(&context.prev_vert_ublock, &vert_ublock, sizeof(vert_ublock)) != 0) {
         // TODO: this intermediate step can be avoided
@@ -431,7 +431,7 @@ void draw(VKContext &context, SceGxmPrimitiveType type, SceGxmIndexFormat format
 
     auto &frag_ublock = context.curr_frag_ublock.base_block;
     frag_ublock.writing_mask = context.record.writing_mask;
-    frag_ublock.res_multiplier = static_cast<float>(context.state.res_multiplier);
+    frag_ublock.res_multiplier = context.state.res_multiplier;
     const bool has_msaa = context.render_target->multisample_mode;
     const bool has_downscale = context.record.color_surface.downscale;
     if (has_msaa && !has_downscale)

--- a/vita3k/renderer/src/vulkan/sync_state.cpp
+++ b/vita3k/renderer/src/vulkan/sync_state.cpp
@@ -30,7 +30,7 @@ void sync_clipping(VKContext &context) {
     if (!context.render_target)
         return;
 
-    const int res_multiplier = context.state.res_multiplier;
+    const float res_multiplier = context.state.res_multiplier;
 
     const int scissor_x = context.record.region_clip_min.x;
     const int scissor_y = context.record.region_clip_min.y;
@@ -48,8 +48,8 @@ void sync_clipping(VKContext &context) {
         break;
     case SCE_GXM_REGION_CLIP_OUTSIDE:
         context.scissor = vk::Rect2D{
-            { scissor_x * res_multiplier, scissor_y * res_multiplier },
-            { scissor_w * res_multiplier, scissor_h * res_multiplier }
+            { static_cast<int32_t>(scissor_x * res_multiplier), static_cast<int32_t>(scissor_y * res_multiplier) },
+            { static_cast<uint32_t>(scissor_w * res_multiplier), static_cast<uint32_t>(scissor_h * res_multiplier) }
         };
         break;
     case SCE_GXM_REGION_CLIP_INSIDE:
@@ -153,7 +153,7 @@ void sync_point_line_width(VKContext &context, const bool is_front) {
         return;
 
     if (is_front && context.state.physical_device_features.wideLines)
-        context.render_cmd.setLineWidth(static_cast<float>(context.record.line_width * context.state.res_multiplier));
+        context.render_cmd.setLineWidth(context.record.line_width * context.state.res_multiplier);
 }
 
 void sync_viewport_flat(VKContext &context) {
@@ -181,7 +181,7 @@ void sync_viewport_real(VKContext &context, const float xOffset, const float yOf
     const float x = xOffset - std::abs(xScale);
     const float y = yOffset - yScale;
 
-    const int res_multiplier = context.state.res_multiplier;
+    const float res_multiplier = context.state.res_multiplier;
 
     // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkViewport.html
     // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#vertexpostproc-viewport


### PR DESCRIPTION
Implement fractional resolution upscaling.
It is now possible to set the resolution upscaling value from 0.5x to 8x, with increments of 0.25x.
This implentation relies on the fact that 32-bit floating points can represent integer values (with a fractional part of either 0, 0.25, 0.5 or 0.75) exactly up to 4 194 304.75.
Not that there may be some small issues appearing with games that don't use a width or height that is a multiple of 4.
Also I'm disabling surface sync on OpenGL if the resolution multiplier is not an integer because its implementation does not allow it.