### PR TITLE
SceCommonDialog: Add common_dialog.savedata.display_type == 0

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -1,11 +1,11 @@
 name: Feature Request
 description: Template for feature request
 title: "[Feature Request]: "
-labels: "Feature Request"
+labels: "feature request"
 body:
   - type: markdown
     attributes:
-      value: Tech support does not belong here. You should only file an issue here if you are requesting a feature you believe would make Vit3K better.
+      value: Tech support does not belong here. You should only file an issue here if you are requesting a feature you believe would make Vita3K better.
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?

--- a/vita3k/dialog/include/dialog/types.h
+++ b/vita3k/dialog/include/dialog/types.h
@@ -52,6 +52,7 @@ enum SceSaveDataDialogListItemStyle {
 };
 
 enum SceSaveDataDialogType {
+    SCE_SAVEDATA_DIALOG_TYPE_HIDDEN = 0,
     SCE_SAVEDATA_DIALOG_TYPE_SAVE = 1,
     SCE_SAVEDATA_DIALOG_TYPE_LOAD = 2,
     SCE_SAVEDATA_DIALOG_TYPE_DELETE = 3

--- a/vita3k/gui/src/common_dialog.cpp
+++ b/vita3k/gui/src/common_dialog.cpp
@@ -615,12 +615,12 @@ static void draw_savedata_dialog(GuiState &gui, EmuEnvState &emuenv, float FONT_
             ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 12.f * SCALE.x);
             const auto BUTTON_SIZE_HEIGHT = 46.f * SCALE.y;
             const ImVec2 buttons_size(320.f * SCALE.x, BUTTON_SIZE_HEIGHT);
-            const auto boutton_height_pos = WINDOW_SIZE.y - BUTTON_SIZE_HEIGHT - (22 * SCALE.y);
-            const auto boutton_width_pos = HALF_WINDOW_SIZE.x - (emuenv.common_dialog.savedata.btn_num == 2 ? (buttons_size.x + (20.f * SCALE.x)) : (buttons_size.x / 2.f));
+            const auto button_height_pos = WINDOW_SIZE.y - BUTTON_SIZE_HEIGHT - (22 * SCALE.y);
+            const auto button_width_pos = HALF_WINDOW_SIZE.x - (emuenv.common_dialog.savedata.btn_num == 2 ? (buttons_size.x + (20.f * SCALE.x)) : (buttons_size.x / 2.f));
             ImGui::BeginGroup();
             for (int i = 0; i < emuenv.common_dialog.savedata.btn_num; i++) {
                 ImGui::PushID(i);
-                const ImVec2 button_id_pos(boutton_width_pos + (i * (buttons_size.x + (40.f * SCALE.x))), boutton_height_pos);
+                const ImVec2 button_id_pos(button_width_pos + (i * (buttons_size.x + (40.f * SCALE.x))), button_height_pos);
                 ImGui::SetCursorPos(button_id_pos);
                 if (ImGui::Button(emuenv.common_dialog.savedata.btn[i].c_str(), buttons_size)) {
                     emuenv.common_dialog.savedata.button_id = emuenv.common_dialog.savedata.btn_val[i];

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -942,6 +942,9 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
         break;
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_FINISHED:
         switch (emuenv.common_dialog.savedata.display_type) {
+        case SCE_SAVEDATA_DIALOG_TYPE_HIDDEN:
+            emuenv.common_dialog.status = SCE_COMMON_DIALOG_STATUS_FINISHED;
+            break;
         case SCE_SAVEDATA_DIALOG_TYPE_SAVE:
             emuenv.common_dialog.savedata.msg = save["saving_complete"];
             break;


### PR DESCRIPTION
Tried fix to prevent this strange dialog from appearing.(This dialog don't show up on vita)
![image](https://github.com/Vita3K/Vita3K/assets/107111782/f61fa355-cf61-4c09-bae4-5a077e41d346)
I don't know if the change is correct, but the dialog will no longer appear.
The dialog is only displayed when creating save data.