### PR TITLE
Fix texture export for gamma textures

### DIFF
--- a/vita3k/renderer/src/texture/replacement.cpp
+++ b/vita3k/renderer/src/texture/replacement.cpp
@@ -370,7 +370,7 @@ void TextureCache::export_texture_impl(SceGxmTextureBaseFormat base_format, uint
                 }
             } else {
                 // alpha is already linear
-                for (uint32_t i = 0; i < nb_pixels * 4; i++) {
+                for (uint32_t i = 0; i < nb_pixels; i++) {
                     pixels[i * 4 + 0] = convert_to_linear(pixels[i * 4 + 0]);
                     pixels[i * 4 + 1] = convert_to_linear(pixels[i * 4 + 1]);
                     pixels[i * 4 + 2] = convert_to_linear(pixels[i * 4 + 2]);


### PR DESCRIPTION
Probably fixes most crashes because of texture export in most games.  At least it fixes texture export in Gravity Rush.
This thing was going OOB.