### PR TITLE
vita3k: some minor bugfixes

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -206,7 +206,7 @@ public:
     bool receive(uint8_t *data, DecoderSize *size) override;
 
     explicit PCMDecoderState(const float dest_frequency);
-    ~PCMDecoderState();
+    ~PCMDecoderState() override;
 };
 
 struct AacDecoderState : public DecoderState {
@@ -221,7 +221,7 @@ struct AacDecoderState : public DecoderState {
     uint32_t get_es_size() override;
 
     explicit AacDecoderState(uint32_t sample_rate, uint32_t channels);
-    ~AacDecoderState();
+    ~AacDecoderState() override;
 };
 
 struct PlayerState {

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -228,7 +228,7 @@ public:
 
         case _INVALID:
         default: {
-            return nullptr;
+            return {};
         }
         }
 #undef SWITCH_NAMES

--- a/vita3k/gui/src/license_install_dialog.cpp
+++ b/vita3k/gui/src/license_install_dialog.cpp
@@ -117,7 +117,7 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 fs::remove(fs::path(license_path.native()));
                 delete_license_file = false;
             }
-            license_path = nullptr;
+            license_path = "";
             gui.file_menu.license_install_dialog = false;
             state.clear();
         }
@@ -129,7 +129,7 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - (20.f * SCALE.y)));
         if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
             gui.file_menu.license_install_dialog = false;
-            license_path = nullptr;
+            license_path = "";
             state.clear();
         }
     }

--- a/vita3k/gui/src/threads_dialog.cpp
+++ b/vita3k/gui/src/threads_dialog.cpp
@@ -27,7 +27,7 @@
 namespace gui {
 
 void draw_thread_details_dialog(GuiState &gui, EmuEnvState &emuenv) {
-    ThreadStatePtr &thread = emuenv.kernel.threads[gui.thread_watch_index];
+    ThreadStatePtr thread = emuenv.kernel.get_thread(gui.thread_watch_index);
     CPUState &cpu = *thread->cpu;
 
     ImGui::Begin("Thread Viewer", &gui.debug_menu.thread_details_dialog);

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -889,10 +889,10 @@ SceUID create_overlay(IOState &io, SceFiosProcessOverlay *fios_overlay) {
     // lower order first and in case of equality, last one inserted first
     while (overlay_index < io.overlays.size() && overlay.order < io.overlays[overlay_index].order)
         overlay_index++;
-
+    auto res = overlay.id;
     io.overlays.insert(io.overlays.begin() + overlay_index, std::move(overlay));
 
-    return overlay.id;
+    return res;
 }
 
 std::string resolve_path(IOState &io, const char *input, const bool is_write, const SceUInt32 min_order, const SceUInt32 max_order) {

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -158,7 +158,7 @@ Ptr<Ptr<void>> KernelState::get_thread_tls_addr(MemState &mem, SceUID thread_id,
     Ptr<Ptr<void>> address(0);
     // magic numbers taken from decompiled source. There is 0x400 unused bytes of unknown usage
     if (key <= 0x100 && key >= 0) {
-        const ThreadStatePtr thread = util::find(thread_id, threads);
+        const ThreadStatePtr thread = get_thread(thread_id);
         address = thread->tls.get_ptr<Ptr<void>>() + key;
     } else {
         LOG_ERROR("Wrong tls slot index. TID:{} index:{}", thread_id, key);

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -415,10 +415,12 @@ std::string ThreadState::log_stack_traceback() const {
     std::stringstream ss;
     const Address sp = read_sp(*cpu);
     for (Address addr = sp - START_OFFSET; addr <= sp + END_OFFSET; addr += 4) {
-        const Address value = *Ptr<uint32_t>(addr).get(mem);
-        const auto mod = kernel.find_module_by_addr(value);
-        if (mod)
-            ss << fmt::format("{} (module: {})\n", log_hex(value), mod->module_name);
+        if (Ptr<uint32_t>(addr).valid(mem)) {
+            const Address value = *Ptr<uint32_t>(addr).get(mem);
+            const auto mod = kernel.find_module_by_addr(value);
+            if (mod)
+                ss << fmt::format("{} (module: {})\n", log_hex(value), mod->module_name);
+        }
     }
     return ss.str();
 }

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -337,7 +337,7 @@ int main(int argc, char *argv[]) {
         emuenv.app_sku_flag = get_license_sku_flag(emuenv, emuenv.app_info.app_content_id);
 
     if (cfg.console) {
-        auto main_thread = emuenv.kernel.threads.at(emuenv.main_thread_id);
+        auto main_thread = emuenv.kernel.get_thread(emuenv.main_thread_id);
         auto lock = std::unique_lock<std::mutex>(main_thread->mutex);
         main_thread->status_cond.wait(lock, [&]() {
             return main_thread->status == ThreadStatus::dormant;

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -899,7 +899,7 @@ static void display_entry_thread(EmuEnvState &emuenv) {
     const Address callback_address = emuenv.gxm.params.displayQueueCallback.address();
     const ThreadStatePtr display_thread = emuenv.kernel.get_thread(emuenv.gxm.display_queue_thread);
     if (!display_thread) {
-        LOG_CRITICAL("display_thread not found. thid:{}", display_thread->id);
+        LOG_CRITICAL("display_thread not found. thid:{}", emuenv.gxm.display_queue_thread);
         return;
     }
     Ptr<SceGxmSyncObject> previous_sync = Ptr<SceGxmSyncObject>();
@@ -2672,7 +2672,7 @@ EXPORT(int, sceGxmInitialize, const SceGxmInitializeParams *params) {
     const uint32_t max_queue_size = std::max(std::min(params->displayQueueMaxPendingCount, 3U) - 1, 1U);
     emuenv.gxm.display_queue.maxPendingCount_ = max_queue_size;
 
-    const ThreadStatePtr main_thread = util::find(thread_id, emuenv.kernel.threads);
+    const ThreadStatePtr main_thread = emuenv.kernel.get_thread(thread_id);
     const ThreadStatePtr display_queue_thread = emuenv.kernel.create_thread(emuenv.mem, "SceGxmDisplayQueue", Ptr<void>(0), SCE_KERNEL_HIGHEST_PRIORITY_USER, SCE_KERNEL_THREAD_CPU_AFFINITY_MASK_DEFAULT, SCE_KERNEL_STACK_SIZE_USER_DEFAULT, nullptr);
     if (!display_queue_thread) {
         return RET_ERROR(SCE_GXM_ERROR_DRIVER);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -330,7 +330,7 @@ EXPORT(int, sceClibSnprintf, char *dst, SceSize dst_max_size, const char *fmt, m
         return SCE_KERNEL_ERROR_INVALID_ARGUMENT;
     }
 
-    return SCE_KERNEL_OK;
+    return result;
 }
 
 EXPORT(int, sceClibSnprintfChk) {

--- a/vita3k/shader/include/shader/usse_program_analyzer.h
+++ b/vita3k/shader/include/shader/usse_program_analyzer.h
@@ -88,6 +88,7 @@ public:
     USSEBaseNode *get_parent() const {
         return parent;
     }
+    virtual ~USSEBaseNode() = default;
 
     std::size_t children_count() const {
         return children.size();

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -124,7 +124,7 @@ struct VertexProgramOutputProperties {
     std::uint32_t location;
 
     VertexProgramOutputProperties()
-        : name(nullptr)
+        : name("")
         , component_count(0)
         , location(0) {}
 

--- a/vita3k/vkutil/include/vkutil/objects.h
+++ b/vita3k/vkutil/include/vkutil/objects.h
@@ -102,6 +102,7 @@ public:
     uint32_t data_offset = 0;
 
     explicit RingBuffer(vk::BufferUsageFlags usage, const size_t capacity);
+    virtual ~RingBuffer() = default;
     virtual void create() = 0;
 
     // Allocate new data from ring buffer


### PR DESCRIPTION
kernel/thread: fix possible crash in log_stack_traceback
modules/SceLibKernel: more correct sceClibSnprintf
kernel/load_self: fix possible crash on incorrect library modules. load process params from first loaded module (eboot.bin) only
modules/SceGxm: fix crash if display_thread not found
kernel/debugger: remove direct access to mem.memory to support memory mapping more complete
vita3k: remove direct access to kernel.threads (it's not thread-safe)
vita3k: implement and fix virtual destructors for class hierarchies to prevent memory leaks
clang-tidy warning: Constructing string from nullptr is undefined behaviour
clang warning: use after std::move