### PR TITLE
modules/SceRtcUser: No need to subtract since the time is already from the UNIX epoch

### DIFF
--- a/vita3k/modules/SceDriverUser/SceRtcUser.cpp
+++ b/vita3k/modules/SceDriverUser/SceRtcUser.cpp
@@ -350,7 +350,7 @@ EXPORT(int, sceRtcGetTime_t, SceDateTime *datePtr, uint32_t *timePtr) {
         return RET_ERROR(SCE_RTC_ERROR_INVALID_POINTER);
     }
 
-    *timePtr = static_cast<std::uint32_t>((__RtcPspTimeToTicks(datePtr) - RTC_OFFSET) / VITA_CLOCKS_PER_SEC);
+    *timePtr = static_cast<std::uint32_t>(__RtcPspTimeToTicks(datePtr) / VITA_CLOCKS_PER_SEC);
     return 0;
 }
 
@@ -360,7 +360,7 @@ EXPORT(int, sceRtcGetTime64_t, SceDateTime *datePtr, uint64_t *timePtr) {
         return RET_ERROR(SCE_RTC_ERROR_INVALID_POINTER);
     }
 
-    *timePtr = (__RtcPspTimeToTicks(datePtr) - RTC_OFFSET) / VITA_CLOCKS_PER_SEC;
+    *timePtr = __RtcPspTimeToTicks(datePtr) / VITA_CLOCKS_PER_SEC;
     return 0;
 }
 


### PR DESCRIPTION
master:
![image](https://github.com/Vita3K/Vita3K/assets/107111782/893a3a57-934b-4087-aadd-9953dab7e077)
pr:
![image](https://github.com/Vita3K/Vita3K/assets/107111782/f35e6df1-f741-435d-8b72-1a5d183dc44b)
