### PR TITLE
renderer: Improve transfer copy and downscale

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -5378,6 +5378,8 @@ EXPORT(int, sceGxmTransferDownscale, SceGxmTransferFormat srcFormat, Ptr<void> s
     dest->address = destAddress;
     dest->x = destX;
     dest->y = destY;
+    dest->width = srcWidth / 2;
+    dest->height = srcHeight / 2;
     dest->stride = destStride;
 
     renderer::transfer_downscale(*emuenv.renderer, src, dest);

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -74,6 +74,9 @@ struct VKState : public renderer::State {
     vk::CommandPool general_command_pool;
     // Transfer pool has transient bit set.
     vk::CommandPool transfer_command_pool;
+    // command pool which can be used from multiple thread
+    vk::CommandPool multithread_command_pool;
+    std::mutex multithread_pool_mutex;
 
     // objects for which one copy is needed for every frame being rendered at the same time
     std::array<FrameObject, MAX_FRAMES_RENDERING> frames;

--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -157,6 +157,13 @@ struct PostSurfaceSyncRequest {
     ColorSurfaceCacheInfo *cache_info;
 };
 
+using CallbackRequestFunction = std::function<void()>;
+struct CallbackRequest {
+    // use a pointer so the size is similar to other elements of WaitThreadRequest
+    // and not to have to mess with move semantics
+    CallbackRequestFunction *callback;
+};
+
 // A parallel thread is handling these request and telling other waiting threads
 // when they are done
 // only used if memory mapping is enabled
@@ -165,7 +172,8 @@ typedef std::variant<
     NotificationRequest,
     FrameDoneRequest,
     PostSurfaceSyncRequest,
-    SyncSignalRequest>
+    SyncSignalRequest,
+    CallbackRequest>
     WaitThreadRequest;
 
 struct VKContext : public renderer::Context {

--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -92,6 +92,12 @@ void VKContext::wait_thread_function(const MemState &mem) {
                            wait_for_fences();
 
                            renderer::subject_done(request.sync, request.timestamp);
+                       },
+                       [&](CallbackRequest &request) {
+                           if (request.callback) {
+                               (*request.callback)();
+                               delete request.callback;
+                           }
                        } },
             *wait_request);
     }
@@ -505,6 +511,8 @@ void new_frame(VKContext &context) {
     if (context.state.features.support_memory_mapping) {
         FrameDoneRequest request = { context.frame_timestamp };
         context.state.request_queue.push(request);
+
+        context.state.surface_cache.clear_surfaces_changed();
     }
 
     context.frame_timestamp++;

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -538,6 +538,9 @@ bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state
 
         general_command_pool = device.createCommandPool(general_pool_info);
         transfer_command_pool = device.createCommandPool(transfer_pool_info);
+
+        general_pool_info.flags |= vk::CommandPoolCreateFlagBits::eTransient;
+        multithread_command_pool = device.createCommandPool(general_pool_info);
     }
 
     // Allocate Memory for Images and Buffers


### PR DESCRIPTION
Improve the transfer copy and downscale operations to look at the surface cache and wait if needed and surface sync is available.

Moreover, rewrite the transfer downscale operation with an are filter if available (this matches the PS Vita behavior).

This fixes character textures in Phantasy Star Nova (with memory mapping and surface sync enabled).