### PR TITLE
vita3k: Fix some arm64 running issues

### DIFF
--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -806,7 +806,7 @@ bool VKState::map_memory(MemState &mem, Ptr<void> address, uint32_t size) {
         // also make sure later the mapped address is 4K aligned
         vkutil::Buffer buffer(size + KiB(4));
         constexpr vma::AllocationCreateInfo memory_mapped_alloc = {
-            .flags = vma::AllocationCreateFlagBits::eMapped,
+            .flags = vma::AllocationCreateFlagBits::eHostAccessSequentialWrite | vma::AllocationCreateFlagBits::eMapped,
             .usage = vma::MemoryUsage::eAutoPreferHost,
             .requiredFlags = vk::MemoryPropertyFlagBits::eHostCoherent,
             .preferredFlags = vk::MemoryPropertyFlagBits::eHostCached,

--- a/vita3k/vkutil/include/vkutil/vkutil.h
+++ b/vita3k/vkutil/include/vkutil/vkutil.h
@@ -83,6 +83,7 @@ static constexpr vk::ColorComponentFlags default_color_mask = vk::ColorComponent
     | vk::ColorComponentFlagBits::eA;
 
 static constexpr vma::AllocationCreateInfo vma_auto_alloc = {
+    .flags = vma::AllocationCreateFlagBits::eHostAccessSequentialWrite,
     .usage = vma::MemoryUsage::eAuto
 };
 


### PR DESCRIPTION
```
Vita3K: /media/fan/odin2/soft/Vita3K/external/VulkanMemoryAllocator-Hpp/VulkanMemoryAllocator/include/vk_mem_alloc.h:14965: VkResult VmaAllocator_T::CalcAllocationParams(VmaAllocationCreateInfo &, bool, bool): Assertion `(inoutCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0 && "When using VMA_ALLOCATION_CREATE_MAPPED_BIT and usage = VMA_MEMORY_USAGE_AUTO*, you must also specify VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT."' failed.
```
When I tried running it on arm64 Linux, I encountered this error. The game crashes as soon as I start it. However, after I made some modifications to the memory allocation part, I was able to successfully enter the game.