### PR TITLE
kernel: Add support for module unloading/reloading

### DIFF
--- a/vita3k/kernel/include/kernel/load_self.h
+++ b/vita3k/kernel/include/kernel/load_self.h
@@ -27,5 +27,7 @@ struct KernelState;
 struct MemState;
 template <class T>
 class Ptr;
+struct KernelModule;
 
 SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std::string &self_path, const fs::path &log_path);
+int unload_self(KernelState &kernel, MemState &mem, KernelModule &module);

--- a/vita3k/kernel/include/kernel/types.h
+++ b/vita3k/kernel/include/kernel/types.h
@@ -26,6 +26,12 @@
 #define SCE_KERNEL_LOWEST_DEFAULT_PRIORITY (SCE_KERNEL_DEFAULT_PRIORITY + 31)
 #define SCE_KERNEL_CURRENT_THREAD_PRIORITY 0
 
+#define SCE_KERNEL_START_SUCCESS 0
+#define SCE_KERNEL_START_NO_RESIDENT 1
+#define SCE_KERNEL_START_FAILED 2
+#define SCE_KERNEL_STOP_SUCCESS 0
+#define SCE_KERNEL_STOP_FAIL 1
+
 #define SCE_KERNEL_THREAD_EVENT_TYPE_START 0x04
 #define SCE_KERNEL_THREAD_EVENT_TYPE_END 0x08
 
@@ -590,8 +596,7 @@ struct SceKernelModuleInfo {
     SceKernelSegmentInfo segments[MODULE_INFO_NUM_SEGMENTS];
     SceUInt state; //!< see:SceKernelModuleState
 };
-
-typedef std::shared_ptr<SceKernelModuleInfo> SceKernelModuleInfoPtr;
+static_assert(sizeof(SceKernelModuleInfo) == 0x1B8);
 
 struct SceKernelStartModuleOpt {
     SceSize size;
@@ -600,7 +605,12 @@ struct SceKernelStartModuleOpt {
     SceUInt32 start;
 };
 
-static_assert(sizeof(SceKernelModuleInfo) == 0x1B8);
+struct SceKernelStopModuleOpt {
+    SceSize size;
+    SceUInt32 flags;
+    SceUInt32 epilogue;
+    SceUInt32 stop;
+};
 
 struct SceKernelMemBlockInfo {
     SceSize size;

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -191,14 +191,14 @@ void KernelState::resume_threads() {
     paused_threads_status.clear();
 }
 
-std::shared_ptr<SceKernelModuleInfo> KernelState::find_module_by_addr(Address address) {
-    const auto lock = std::lock_guard(mutex);
-    for (auto [_, mod] : loaded_modules) {
-        for (auto seg : mod->segments) {
+SceKernelModuleInfo *KernelState::find_module_by_addr(Address address) {
+    const std::lock_guard<std::mutex> guard(mutex);
+    for (auto &[_, mod] : loaded_modules) {
+        for (auto &seg : mod->info.segments) {
             if (!seg.size)
                 continue;
             if (seg.vaddr.address() <= address && address <= seg.vaddr.address() + seg.memsz) {
-                return mod;
+                return &mod->info;
             }
         }
     }

--- a/vita3k/module/src/load_module.cpp
+++ b/vita3k/module/src/load_module.cpp
@@ -90,5 +90,7 @@ bool is_lle_module(const std::string &module_name, EmuEnvState &emuenv) {
 }
 
 bool is_module_loaded(KernelState &kernel, SceSysmoduleModuleId module_id) {
-    return std::find(kernel.loaded_sysmodules.begin(), kernel.loaded_sysmodules.end(), module_id) != kernel.loaded_sysmodules.end();
+    std::lock_guard<std::mutex> guard(kernel.mutex);
+    auto it = kernel.loaded_sysmodules.find(module_id);
+    return it != kernel.loaded_sysmodules.end();
 }

--- a/vita3k/modules/SceKernelModulemgr/SceModulemgr.h
+++ b/vita3k/modules/SceKernelModulemgr/SceModulemgr.h
@@ -22,5 +22,8 @@
 #include <kernel/types.h>
 
 DECL_EXPORT(SceUID, _sceKernelLoadModule, char *path, int flags, SceKernelLMOption *option);
-DECL_EXPORT(SceUID, _sceKernelLoadStartModule, const char *moduleFileName, SceSize args, const Ptr<void> argp, SceUInt32 flags, const SceKernelLMOption *pOpt, int *pRes);
-DECL_EXPORT(int, _sceKernelStartModule, SceUID uid, SceSize args, const Ptr<void> argp, SceUInt32 flags, const Ptr<SceKernelStartModuleOpt> pOpt, int *pRes);
+DECL_EXPORT(SceUID, _sceKernelLoadStartModule, const char *moduleFileName, SceSize args, const Ptr<const void> argp, SceUInt32 flags, const SceKernelLMOption *pOpt, int *pRes);
+DECL_EXPORT(int, _sceKernelStartModule, SceUID uid, SceSize args, Ptr<const void> argp, SceUInt32 flags, const SceKernelStartModuleOpt *pOpt, int *pRes);
+DECL_EXPORT(int, _sceKernelStopModule, SceUID uid, SceSize args, Ptr<const void> argp, SceUInt32 flags, const SceKernelStopModuleOpt *pOpt, int *pRes);
+DECL_EXPORT(int, _sceKernelStopUnloadModule, SceUID uid, SceSize args, Ptr<const void> argp, SceUInt32 flags, const void *pOpt, int *pRes);
+DECL_EXPORT(int, _sceKernelUnloadModule, SceUID uid, SceUInt32 flags, const void *pOpt);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -1525,7 +1525,7 @@ EXPORT(SceUID, sceKernelLoadModule, char *path, int flags, SceKernelLMOption *op
     return CALL_EXPORT(_sceKernelLoadModule, path, flags, option);
 }
 
-EXPORT(SceUID, sceKernelLoadStartModule, const char *moduleFileName, SceSize args, const Ptr<void> argp, SceUInt32 flags, const SceKernelLMOption *pOpt, int *pRes) {
+EXPORT(SceUID, sceKernelLoadStartModule, const char *moduleFileName, SceSize args, Ptr<const void> argp, SceUInt32 flags, const SceKernelLMOption *pOpt, int *pRes) {
     TRACY_FUNC(sceKernelLoadStartModule, moduleFileName, args, argp, flags, pOpt, pRes);
     return CALL_EXPORT(_sceKernelLoadStartModule, moduleFileName, args, argp, flags, pOpt, pRes);
 }
@@ -1718,24 +1718,24 @@ EXPORT(int, sceKernelStackChkFail) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelStartModule, SceUID uid, SceSize args, const Ptr<void> argp, SceUInt32 flags, const Ptr<SceKernelStartModuleOpt> pOpt, int *pRes) {
+EXPORT(int, sceKernelStartModule, SceUID uid, SceSize args, Ptr<const void> argp, SceUInt32 flags, const SceKernelStartModuleOpt *pOpt, int *pRes) {
     TRACY_FUNC(sceKernelStartModule, uid, args, argp, flags, pOpt, pRes);
     return CALL_EXPORT(_sceKernelStartModule, uid, args, argp, flags, pOpt, pRes);
 }
 
-EXPORT(int, sceKernelStartThread, SceUID thid, SceSize arglen, Ptr<void> argp) {
+EXPORT(int, sceKernelStartThread, SceUID thid, SceSize arglen, const Ptr<void> argp) {
     TRACY_FUNC(sceKernelStartThread, thid, arglen, argp);
     return CALL_EXPORT(_sceKernelStartThread, thid, arglen, argp);
 }
 
-EXPORT(int, sceKernelStopModule) {
-    TRACY_FUNC(sceKernelStopModule);
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelStopModule, SceUID uid, SceSize args, Ptr<const void> argp, SceUInt32 flags, const SceKernelStopModuleOpt *pOpt, int *pRes) {
+    TRACY_FUNC(sceKernelStopModule, uid, args, argp, flags, pOpt, pRes);
+    return CALL_EXPORT(_sceKernelStopModule, uid, args, argp, flags, pOpt, pRes);
 }
 
-EXPORT(int, sceKernelStopUnloadModule) {
-    TRACY_FUNC(sceKernelStopUnloadModule);
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelStopUnloadModule, SceUID uid, SceSize args, Ptr<const void> argp, SceUInt32 flags, const void *pOpt, int *pRes) {
+    TRACY_FUNC(sceKernelStopUnloadModule, uid, args, argp, flags, pOpt, pRes);
+    return CALL_EXPORT(_sceKernelStopUnloadModule, uid, args, argp, flags, pOpt, pRes);
 }
 
 EXPORT(int, sceKernelTryLockLwMutex, Ptr<SceKernelLwMutexWork> workarea, int lock_count) {
@@ -1782,9 +1782,9 @@ EXPORT(int, sceKernelTrySendMsgPipeVector) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelUnloadModule) {
-    TRACY_FUNC(sceKernelUnloadModule);
-    return UNIMPLEMENTED();
+EXPORT(int, sceKernelUnloadModule, SceUID uid, SceUInt32 flags, const void *pOpt) {
+    TRACY_FUNC(sceKernelUnloadModule, uid, flags, pOpt);
+    return CALL_EXPORT(_sceKernelUnloadModule, uid, flags, pOpt);
 }
 
 EXPORT(int, sceKernelUnlockLwMutex, Ptr<SceKernelLwMutexWork> workarea, int unlock_count) {

--- a/vita3k/modules/include/modules/module_parent.h
+++ b/vita3k/modules/include/modules/module_parent.h
@@ -35,8 +35,10 @@ void call_import(EmuEnvState &emuenv, CPUState &cpu, uint32_t nid, SceUID thread
  * \return UID of the loaded module object or SCE_ERROR on failure
  */
 SceUID load_module(EmuEnvState &emuenv, const std::string &module_path);
+int unload_module(EmuEnvState &emuenv, SceUID module_id);
 
-uint32_t start_module(EmuEnvState &emuenv, const std::shared_ptr<SceKernelModuleInfo> &module, SceSize args = 0, const Ptr<void> argp = Ptr<void>{});
+uint32_t start_module(EmuEnvState &emuenv, const SceKernelModuleInfo &module, SceSize args = 0, Ptr<const void> argp = Ptr<const void>{});
+uint32_t stop_module(EmuEnvState &emuenv, const SceKernelModuleInfo &module, SceSize args = 0, Ptr<const void> argp = Ptr<const void>{});
 
 /**
  * \brief Loads and run a system module
@@ -45,6 +47,7 @@ uint32_t start_module(EmuEnvState &emuenv, const std::shared_ptr<SceKernelModule
  * \return False on failure, true on success
  */
 bool load_sys_module(EmuEnvState &emuenv, SceSysmoduleModuleId module_id);
+int unload_sys_module(EmuEnvState &emuenv, SceSysmoduleModuleId module_id);
 bool load_sys_module_internal_with_arg(EmuEnvState &emuenv, SceUID thread_id, SceSysmoduleInternalModuleId module_id, SceSize args, Ptr<void> argp, int *retcode);
 
 Address resolve_export(KernelState &kernel, uint32_t nid);


### PR DESCRIPTION
This PR adds support for module unloading and reloading (for both sysmodules and user modules).

This is allowed thanks to the recent dynarmic update which made memory invalidation thread safe.
This requires tracking all the imported and exported variables and functions for all the modules.
In the way I fixed a lot of thread races and other issues.

This allows Final Fantasy X to be playable.