### PR TITLE
Some improve in gui & lang.

### DIFF
--- a/lang/system/da.xml
+++ b/lang/system/da.xml
@@ -51,6 +51,7 @@
 		<an_error_occurred>Der er opstået en fejl.
 Fejlkode: {}</an_error_occurred>
 		<cancel>Afbryd</cancel>
+		<close>Lukke</close>
 		<delete>Slet</delete>
 		<file_corrupted>Filen er defekt.</file_corrupted>
 		<microphone_disabled>Aktivér mikrofonen.</microphone_disabled>
@@ -331,7 +332,6 @@ Dit Vita3K-system er klart!</completed_setup>
 		</system>
 		<network name="Netværk">
 		</network>
-		<close>Lukke</close>
 		<save>Gem</save>
 	</settings_dialog>
 
@@ -394,8 +394,4 @@ Efter download er udført, vil Vita3K automatisk genstarte og derefter installer
 		<update>Opdater</update>
 		<version>Version {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Lukke</close>
-	</welcome>
 </lang>

--- a/lang/system/de.xml
+++ b/lang/system/de.xml
@@ -57,6 +57,7 @@
 		<an_error_occurred>Ein Fehle ist aufgetreten.
 Fehlercode: {}</an_error_occurred>
 		<cancel>Abbrechen</cancel>
+		<close>Schließen</close>
 		<delete>Löschen</delete>
 		<file_corrupted>Die Datei ist beschädigt.</file_corrupted>
 		<microphone_disabled>Aktiviere das Mikrofon.</microphone_disabled>
@@ -335,11 +336,8 @@ Dein Vita3K-System ist bereit!</completed_setup>
 	</settings>
 
 	<settings_dialog name="Einstellungen">
-		<system name="System">
-		</system>
 		<network name="Netzwerk">
 		</network>
-		<close>Schließen</close>
 		<save>Speichern</save>
 	</settings_dialog>
 
@@ -407,8 +405,4 @@ Nach dem Herunterladen wird Vita3K automatisch neu gestartet und die neue Aktual
 		<update>Aktualisieren</update>
 		<version>Version {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Schließen</close>
-	</welcome>
 </lang>

--- a/lang/system/en-gb.xml
+++ b/lang/system/en-gb.xml
@@ -67,8 +67,6 @@
 		<license>License</license>
 		<shaders_cache>Shaders Cache</shaders_cache>
 		<shaders_log>Shaders Log</shaders_log>
-		<export_textures>Export Textures</export_textures>
-		<import_textures>Import Textures</import_textures>
 		<manual>Manual</manual>
 		<update>Update</update>
 		<update_history>Update History</update_history>
@@ -110,6 +108,7 @@ depending on its size and your hardware.</app_delete_description>
 		<an_error_occurred>An error occurred.
 Error code: {}</an_error_occurred>
 		<cancel>Cancel</cancel>
+		<close>Close</close>
 		<delete>Delete</delete>
 		<file_corrupted>The file is corrupt.</file_corrupted>
 		<microphone_disabled>Enable the microphone.</microphone_disabled>
@@ -813,7 +812,6 @@ lower can improve performance but can make games unstable if you have bad enough
 			<unwatch_import_calls>Unwatch Import Calls</unwatch_import_calls>
 			<watch_import_calls>Watch Import Calls</watch_import_calls>
 		</debug>
-		<close>Close</close>
 		<save_reboot>Save & Reboot</save_reboot>
 		<save_apply>Save & Apply</save_apply>
 		<save>Save</save>
@@ -905,6 +903,5 @@ After the download is complete, Vita3K will restart automatically and then insta
 		<discord_help>Additional support can be found in the #help channel of the</discord_help>
 		<no_piracy>Vita3K does not condone piracy. You must dump your own games.</no_piracy>
 		<show_next_time>Show next time</show_next_time>
-		<close>Close</close>
 	</welcome>
 </lang>

--- a/lang/system/en.xml
+++ b/lang/system/en.xml
@@ -67,8 +67,6 @@
 		<license>License</license>
 		<shaders_cache>Shaders Cache</shaders_cache>
 		<shaders_log>Shaders Log</shaders_log>
-		<export_textures>Export Textures</export_textures>
-		<import_textures>Import Textures</import_textures>
 		<manual>Manual</manual>
 		<update>Update</update>
 		<update_history>Update History</update_history>
@@ -110,6 +108,7 @@ depending on its size and your hardware.</app_delete_description>
 		<an_error_occurred>An error occurred.
 Error code: {}</an_error_occurred>
 		<cancel>Cancel</cancel>
+		<close>Close</close>
 		<delete>Delete</delete>
 		<file_corrupted>The file is corrupt.</file_corrupted>
 		<microphone_disabled>Enable the microphone.</microphone_disabled>
@@ -813,7 +812,6 @@ lower can improve performance but can make games unstable if you have bad enough
 			<unwatch_import_calls>Unwatch Import Calls</unwatch_import_calls>
 			<watch_import_calls>Watch Import Calls</watch_import_calls>
 		</debug>
-		<close>Close</close>
 		<save_reboot>Save & Reboot</save_reboot>
 		<save_apply>Save & Apply</save_apply>
 		<save>Save</save>
@@ -905,6 +903,5 @@ After the download is complete, Vita3K will restart automatically and then insta
 		<discord_help>Additional support can be found in the #help channel of the</discord_help>
 		<no_piracy>Vita3K does not condone piracy. You must dump your own games.</no_piracy>
 		<show_next_time>Show next time</show_next_time>
-		<close>Close</close>
 	</welcome>
 </lang>

--- a/lang/system/es.xml
+++ b/lang/system/es.xml
@@ -64,6 +64,7 @@
 		<an_error_occurred>Ha ocurrido un error.
 Código del error: {}</an_error_occurred>
 		<cancel>Cancelar</cancel>
+		<close>Cerrar</close>
 		<delete>Eliminar</delete>
 		<file_corrupted>El archivo está dañado.</file_corrupted>
 		<microphone_disabled>Activa el micrófono.</microphone_disabled>
@@ -346,7 +347,6 @@ No apagues el sistema ni cierres la aplicación.</warning_saving>
 		</system>
 		<network name="Red">
 		</network>
-		<close>Cerrar</close>
 		<save>Guardar</save>
 	</settings_dialog>
 
@@ -427,6 +427,5 @@ Cuando la descarga se haya completado, Vita3K se reiniciará automáticamente e 
 		<discord_help>Más ayuda disponible en el canal #help del servidor de</discord_help>
 		<no_piracy>Vita3K no tolera la piratería. Debes usar tus propios juegos.</no_piracy>
 		<show_next_time>Mostrar la próxima vez</show_next_time>
-		<close>Cerrar</close>
 	</welcome>
 </lang>

--- a/lang/system/fi.xml
+++ b/lang/system/fi.xml
@@ -51,6 +51,7 @@
 		<an_error_occurred>Virhe on tapahtunut.
 Virhekoodi: {}</an_error_occurred>
 		<cancel>Peruuta</cancel>
+		<close>Sulkea</close>
 		<delete>Poista</delete>
 		<file_corrupted>Tiedosto on vioittunt.</file_corrupted>
 		<microphone_disabled>Ota mikrofoni käyttöön.</microphone_disabled>
@@ -332,7 +333,6 @@ Vita3K-järjestelmäsi on nyt käyttövalmis!</completed_setup>
 		</system>
 		<network name="Verkko">
 		</network>
-		<close>Sulkea</close>
 		<save>Tallenna</save>
 	</settings_dialog>
 
@@ -396,8 +396,4 @@ Kun lataus on valmis, Vita3K käynnistyy automaattisesti uudelleen ja asentaa si
 		<update>Päivitä</update>
 		<version>Versio {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Sulkea</close>
-	</welcome>
 </lang>

--- a/lang/system/fr.xml
+++ b/lang/system/fr.xml
@@ -85,6 +85,7 @@
 		<an_error_occurred>Une erreur est survenue.
 Code d'erreur: {}</an_error_occurred>
 		<cancel>Annuler</cancel>
+		<close>Fermer</close>
 		<delete>Supprimer</delete>
 		<file_corrupted>Le fichier est corrompu.</file_corrupted>
 		<microphone_disabled>Activez le microphone.</microphone_disabled>
@@ -436,7 +437,6 @@ Votre système Vita3K est prêt !</completed_setup>
 		</system>
 		<network name="Réseau">
 		</network>
-		<close>Fermer</close>
 		<save>Sauvegarder</save>
 	</settings_dialog>
 
@@ -507,8 +507,4 @@ Une fois le téléchargement terminé, Vita3K redémarrera automatiquement et in
 		<update>Mettre à jour</update>
 		<version>Version {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Fermer</close>
-	</welcome>
 </lang>

--- a/lang/system/it.xml
+++ b/lang/system/it.xml
@@ -57,6 +57,7 @@
 		<an_error_occurred>Si è verificato un errore.
 Codice di errore: {}</an_error_occurred>
 		<cancel>Annulla</cancel>
+		<close>Chiudersi</close>
 		<delete>Elimina</delete>
 		<file_corrupted>Il file è danneggiato.</file_corrupted>
 		<microphone_disabled>Attiva il microfono.</microphone_disabled>
@@ -350,7 +351,6 @@ Il tuo sistema Vita3K è pronto per l'uso!</completed_setup>
 		</system>
 		<network name="Rete">
 		</network>
-		<close>Chiudersi</close>
 		<save>Salva</save>
 	</settings_dialog>
 
@@ -416,8 +416,4 @@ Al termine del download, Vita3K si riavvierà automaticamente e quindi installer
 		<update>Aggiorna</update>
 		<version>Versione {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Chiudersi</close>
-	</welcome>
 </lang>

--- a/lang/system/ja.xml
+++ b/lang/system/ja.xml
@@ -55,8 +55,6 @@
 		<license>ライセンス</license>
 		<shaders_cache>シェーダーキャッシュ</shaders_cache>
 		<shaders_log>シェーダーログ</shaders_log>
-		<export_textures>出力テクスチャ</export_textures>
-		<import_textures>入力テクスチャ</import_textures>
 		<manual>マニュアル</manual>
 		<update>アップデート</update>
 		<update_history>アップデート履歴</update_history>
@@ -98,6 +96,7 @@
 		<an_error_occurred>エラーが起きました。
 エラーコード：{}</an_error_occurred>
 		<cancel>キャンセル</cancel>
+		<close>閉じる</close>
 		<delete>削除</delete>
 		<file_corrupted>ファイルが壊れています。</file_corrupted>
 		<microphone_disabled>マイクを有効にしてください。</microphone_disabled>
@@ -707,7 +706,6 @@ GUIでのアジア地域のフォントサポートに必須です。
 			<read_end_sleep_description>データを読み取る際のスリープ試行時間。
 低い値はパフォーマンスを向上させる一方で、インターネットが非常に悪い場合はゲームを不安定にする可能性があります。</read_end_sleep_description>
 		</network>
-		<close>閉じる</close>
 		<save_reboot>保存して再起動</save_reboot>
 		<save_apply>保存して適用</save_apply>
 		<save>セーブ</save>
@@ -797,6 +795,5 @@ GUIでのアジア地域のフォントサポートに必須です。
 		<discord_help>その他の相談は、#help チャンネルで行うことができます。</discord_help>
 		<no_piracy>Vita3Kは著作権侵害を認めません。所有ゲームの吸出しを行ってください。</no_piracy>
 		<show_next_time>次回以降も表示</show_next_time>
-		<close>閉じる</close>
 	</welcome>
 </lang>

--- a/lang/system/ko.xml
+++ b/lang/system/ko.xml
@@ -79,6 +79,7 @@
 		<an_error_occurred>에러기 발생했습니다.
 에러  코드: {}</an_error_occurred>
 		<cancel>취소</cancel>
+		<close>닫다</close>
 		<delete>삭제</delete>
 		<file_corrupted>파일이 손상되어 있습니다.</file_corrupted>
 		<microphone_disabled>마이크를 활성화해 주십시오.</microphone_disabled>
@@ -364,7 +365,6 @@
 		</system>
 		<network name="네트워크">
 		</network>
-		<close>닫다</close>
 		<save>저장</save>
 	</settings_dialog>
 
@@ -429,8 +429,4 @@
 		<update>업데이트</update>
 		<version>버전 {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>닫다</close>
-	</welcome>
 </lang>

--- a/lang/system/nl.xml
+++ b/lang/system/nl.xml
@@ -57,6 +57,7 @@
 		<an_error_occurred>Er is een fout opgetreden.
 Foutcode: {}</an_error_occurred>
 		<cancel>Annuleren</cancel>
+		<close>Sluiten</close>
 		<delete>Verwijderen</delete>
 		<file_corrupted>Het bestand is beschadigd.</file_corrupted>
 		<microphone_disabled>Schakel de microfoon in.</microphone_disabled>
@@ -351,7 +352,6 @@ Je Vita3K-systeem is gereed!</completed_setup>
 		</system>
 		<network name="Netwerk">
 		</network>
-		<close>Sluiten</close>
 		<save>Opslaan</save>
 	</settings_dialog>
 
@@ -415,8 +415,4 @@ Nadat het downloaden is voltooid, Vita3K automatisch opnieuw gestart en wordt de
 		<update>Update</update>
 		<version>Versie {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Sluiten</close>
-	</welcome>
 </lang>

--- a/lang/system/no.xml
+++ b/lang/system/no.xml
@@ -51,6 +51,7 @@
 		<an_error_occurred>Det har oppstått en feil.
 Feilkode: {}</an_error_occurred>
 		<cancel>Avbryt</cancel>
+		<close>Lukke</close>
 		<delete>Slett</delete>
 		<file_corrupted>Filen er korrupt.</file_corrupted>
 		<microphone_disabled>Aktiver mikrofonen.</microphone_disabled>
@@ -331,7 +332,6 @@ Vita3K-systemet ditt er klart!</completed_setup>
 		</system>
 		<network name="Nettverk">
 		</network>
-		<close>Lukke</close>
 		<save>Lagre</save>
 	</settings_dialog>
 
@@ -394,8 +394,4 @@ Etter at Etter at nedlastingen er fullført, vil Vita3K starte på nytt automati
 		<update>Oppdater</update>
 		<version>Versjon {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Lukke</close>
-	</welcome>
 </lang>

--- a/lang/system/pl.xml
+++ b/lang/system/pl.xml
@@ -67,8 +67,6 @@
 		<license>Licencja</license>
 		<shaders_cache>Pamięć podręczna cieni</shaders_cache>
 		<shaders_log>Dziennik zdarzeń cieni</shaders_log>
-		<export_textures>Eksportuj tekstury</export_textures>
-		<import_textures>Importuj tekstury</import_textures>
 		<manual>Instrukcja obsługi</manual>
 		<update>Aktualizuj</update>
 		<update_history>Historia aktualizacji</update_history>
@@ -110,6 +108,7 @@ jest to zależne od jej rozmiaru i twojego sprzętu.</app_delete_description>
 		<an_error_occurred>Wystąpił błąd.
 Kod błędu: {}</an_error_occurred>
 		<cancel>Anuluj</cancel>
+		<close>Zamknij</close>
 		<delete>Usuń</delete>
 		<file_corrupted>Plik jest uszkodzony.</file_corrupted>
 		<microphone_disabled>Włącz mikrofon.</microphone_disabled>
@@ -812,7 +811,6 @@ niższa wartość może poprawić wydajność, ale może sprawić, że gry będ�
 			<unwatch_import_calls>Przestań obserwować wywołania importu</unwatch_import_calls>
 			<watch_import_calls>Obserwuj wywołania importu</watch_import_calls>
 		</debug>
-		<close>Zamknij</close>
 		<save_reboot>Zapisz i uruchom ponownie</save_reboot>
 		<save_apply>Zapisz i zatwierdź</save_apply>
 		<save>Zapisz</save>
@@ -904,6 +902,5 @@ Po ukończeniu pobierania Vita3K zostanie automatycznie ponownie uruchomiony, a 
 		<discord_help>Dodatkowe wsparcie i pomoc dostępne są również na Discordzie na kanale #help.</discord_help>
 		<no_piracy>Vita3K nie wspiera piractwa. Musisz zgrać swoją kopię gry.</no_piracy>
 		<show_next_time>Pokaż następnym razem</show_next_time>
-		<close>Zamknij</close>
 	</welcome>
 </lang>

--- a/lang/system/pt-br.xml
+++ b/lang/system/pt-br.xml
@@ -80,6 +80,7 @@ dependendo de seu tamanho e hardware.</app_delete_description>
 		<an_error_occurred>Ocorreu um erro.
 Código de erro: {}</an_error_occurred>
 		<cancel>Cancelar</cancel>
+		<close>Fechar</close>
 		<delete>Excluir</delete>
 		<file_corrupted>O arquivo está corrompido.</file_corrupted>
 		<microphone_disabled>Ative o microfone.</microphone_disabled>
@@ -408,7 +409,6 @@ fundo</add_background>
 		</system>
 		<network name="Rede">
 		</network>
-		<close>Fechar</close>
 		<save>Salvar</save>
 	</settings_dialog>
 
@@ -476,8 +476,4 @@ Quando o download terminar, Vita3K será reiniciado automaticamente e o novo atu
 		<update>Atualizar</update>
 		<version>Versão {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Fechar</close>
-	</welcome>
 </lang>

--- a/lang/system/pt.xml
+++ b/lang/system/pt.xml
@@ -54,6 +54,7 @@
 		<an_error_occurred>Ocorreu um erro.
 Código de erro: {}</an_error_occurred>
 		<cancel>Cancelar</cancel>
+		<close>Fechar</close>
 		<delete>Eliminar</delete>
 		<file_corrupted>O ficheiro está corrompido.</file_corrupted>
 		<microphone_disabled>Ative o microfone.</microphone_disabled>
@@ -334,7 +335,6 @@ O seu sistema Vita3K está pronto!</completed_setup>
 		</system>
 		<network name="Rede">
 		</network>
-		<close>Fechar</close>
 		<save>Guardar</save>
 	</settings_dialog>
 
@@ -398,8 +398,4 @@ Uma vez concluída a transferência, Vita3K será reiniciado automaticamente e, 
 		<update>Atualizar</update>
 		<version>Versão {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Fechar</close>
-	</welcome>
 </lang>

--- a/lang/system/ru.xml
+++ b/lang/system/ru.xml
@@ -87,6 +87,7 @@
 		<an_error_occurred>Произошла ошибка.
 Код ошибки: {}</an_error_occurred>
 		<cancel>Отмена</cancel>
+		<close>Закрыть</close>
 		<delete>Удалить</delete>
 		<file_corrupted>Файл поврежден.</file_corrupted>
 		<microphone_disabled>Включите микрофон.</microphone_disabled>
@@ -539,7 +540,6 @@
 		</gui>
 		<network name="Сеть">
 		</network>
-		<close>Закрыть</close>
 		<save>Сохранить</save>
 	</settings_dialog>
 
@@ -629,6 +629,5 @@
 		<discord_help>Дополнительную информацию можно найти на канале #help в</discord_help>
 		<no_piracy>Vita3K не поощряет пиратство. Вы должны использовать дампы своих собственных игр.</no_piracy>
 		<show_next_time>Показать в следующий раз</show_next_time>
-		<close>Закрыть</close>
 	</welcome>
 </lang>

--- a/lang/system/sv.xml
+++ b/lang/system/sv.xml
@@ -51,6 +51,7 @@
 		<an_error_occurred>Ett fel har inträffat.
 Felkod: {}</an_error_occurred>
 		<cancel>Avbryt</cancel>
+		<close>Stänga</close>
 		<delete>Radera</delete>
 		<file_corrupted>Filen är skadad.</file_corrupted>
 		<microphone_disabled>Aktivera mikrofonen.</microphone_disabled>
@@ -328,11 +329,8 @@ Ditt Vita3K-system är redo!</completed_setup>
 	</settings>
 
 	<settings_dialog name="Inställningar">
-		<system name="System">
-		</system>
 		<network name="Nätverk">
 		</network>
-		<close>Stänga</close>
 		<save>Spara</save>
 	</settings_dialog>
 
@@ -394,8 +392,4 @@ När nedladdningen är slutförd kommer Vita3K automatiskt att startas om och de
 		<update>Uppdatera</update>
 		<version>Version {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Stänga</close>
-	</welcome>
 </lang>

--- a/lang/system/tr.xml
+++ b/lang/system/tr.xml
@@ -57,6 +57,7 @@
 		<an_error_occurred>Bir hata oluştu.
 Hata Kodu: {}</an_error_occurred>
 		<cancel>İptal</cancel>
+		<close>Kapat</close>
 		<delete>Sil</delete>
 		<file_corrupted>Dosya bozuk.</file_corrupted>
 		<no>Hayır</no>
@@ -338,7 +339,6 @@ Vita3K sisteminiz artık hazır!</completed_setup>
 		</system>
 		<network name="Ağ">
 		</network>
-		<close>Kapat</close>
 		<save>Kaydet</save>
 	</settings_dialog>
 
@@ -403,8 +403,4 @@ Devam etmek istediğinizden emin misiniz?</user_delete_warn>
 		<update>Güncelle</update>
 		<version>Sürüm {}</version>
 	</vita3k_update>
-
-	<welcome name="Welcome to Vita3K">
-		<close>Kapat</close>
-	</welcome>
 </lang>

--- a/lang/system/zh-s.xml
+++ b/lang/system/zh-s.xml
@@ -67,8 +67,6 @@
 		<license>授权</license>
 		<shaders_cache>着色器缓存</shaders_cache>
 		<shaders_log>着色器日志</shaders_log>
-		<export_textures>导出纹理</export_textures>
-		<import_textures>导入纹理</import_textures>
 		<manual>说明书</manual>
 		<update>升级</update>
 		<update_history>更新历史记录</update_history>
@@ -110,6 +108,7 @@
 		<an_error_occurred>发生了错误。
 错误代码：{}</an_error_occurred>
 		<cancel>取消</cancel>
+		<close>关闭</close>
 		<delete>删除</delete>
 		<file_corrupted>文件已损坏。</file_corrupted>
 		<microphone_disabled>请启用麦克风。</microphone_disabled>
@@ -648,7 +647,7 @@
 并非所有显卡都与此兼容。</spirv_shader_description>
 			<clean_shaders>清除着色器缓存以及日志</clean_shaders>
 			<fps_hack>FPS修改</fps_hack>
-			<fps_hack_description>游戏修改允许一些以30FPS运行的游戏在模拟器上以60FPS的速度运行。
+			<fps_hack_description>游戏修改允许一些以30 FPS运行的游戏在模拟器上以60 FPS的速度运行。
 请注意这只是一个修改，仅适用于某些游戏。
 在其他游戏中，它可能没有效果或使其出现两倍速。</fps_hack_description>
 		</gpu>
@@ -810,7 +809,6 @@
 			<unwatch_import_calls>取消监视导入调用</unwatch_import_calls>
 			<watch_import_calls>监视导入调用</watch_import_calls>
 		</debug>
-		<close>关闭</close>
 		<save_reboot>保存并重启</save_reboot>
 		<save_apply>保存并应用</save_apply>
 		<save>保存</save>
@@ -901,6 +899,5 @@
 		<discord_help>可以在#help频道中找到更多支持</discord_help>
 		<no_piracy>Vita3K不纵容盗版。您必须提取您自己拥有的游戏。</no_piracy>
 		<show_next_time>下次显示</show_next_time>
-		<close>关闭</close>
 	</welcome>
 </lang>

--- a/lang/system/zh-t.xml
+++ b/lang/system/zh-t.xml
@@ -22,7 +22,7 @@
 			<condition_variables>條件變量</condition_variables>
 			<lightweight_condition_variables>輕量條件變量</lightweight_condition_variables>
 			<event_flags>事件標志</event_flags>
-			<memory_allocations>内存分配</memory_allocations>
+			<memory_allocations>內存分配</memory_allocations>
 			<disassembly>反匯編</disassembly>
 		</debug>
 		<configuration name="組態">
@@ -67,8 +67,6 @@
 		<license>授權</license>
 		<shaders_cache>著色器快取</shaders_cache>
 		<shaders_log>著色器記錄</shaders_log>
-		<export_textures>導出紋理</export_textures>
-		<import_textures>導入紋理</import_textures>
 		<manual>說明書</manual>
 		<update>更新</update>
 		<update_history>更新履歷</update_history>
@@ -110,6 +108,7 @@
 		<an_error_occurred>發生錯誤。
 錯誤編號：{}</an_error_occurred>
 		<cancel>取消</cancel>
+		<close>關閉</close>
 		<delete>刪除</delete>
 		<file_corrupted>檔案已毀損。</file_corrupted>
 		<microphone_disabled>請啟用麥克風。</microphone_disabled>
@@ -648,7 +647,7 @@
 並非所有顯卡都與此兼容。</spirv_shader_description>
 			<clean_shaders>清除著色器快取以及記錄</clean_shaders>
 			<fps_hack>FPS修改</fps_hack>
-			<fps_hack_description>遊戲修改允許一些以30fps運行的遊戲在模擬器上以60fps的速度運行。
+			<fps_hack_description>遊戲修改允許一些以30 FPS運行的遊戲在模擬器上以60 FPS的速度運行。
 請注意這只是一個修改，僅適用於某些遊戲。
 在其他遊戲中，它可能沒有效果或使其出現兩倍速。</fps_hack_description>
 		</gpu>
@@ -810,7 +809,6 @@
 			<unwatch_import_calls>取消監視導入調用</unwatch_import_calls>
 			<watch_import_calls>監視導入調用</watch_import_calls>
 		</debug>
-		<close>關閉</close>
 		<save_reboot>保存並重啟</save_reboot>
 		<save_apply>保存並應用</save_apply>
 		<save>保存</save>
@@ -901,6 +899,5 @@
 		<discord_help>可以在#help頻道中取得額外支援</discord_help>
 		<no_piracy>Vita3K不縱容盜版，您必須傾印您自己擁有的遊戲。</no_piracy>
 		<show_next_time>下次顯示</show_next_time>
-		<close>關閉</close>
 	</welcome>
 </lang>

--- a/lang/user/id.xml
+++ b/lang/user/id.xml
@@ -103,6 +103,7 @@ tergantung pada ukuran dan perangkat keras Kamu.</app_delete_description>
 		<an_error_occurred>Terjadi kesalahan.
 Kode kesalahan: {}</an_error_occurred>
 		<cancel>Batal</cancel>
+		<close>Tutup</close>
 		<delete>Hapus</delete>
 		<file_corrupted>File ini udah corrupt.</file_corrupted>
 		<microphone_disabled>Nonaktifkan microphone.</microphone_disabled>
@@ -387,32 +388,6 @@ Jangan matikan sistem atau tutup aplikasi ini.</warning_saving>
 		<no_notif>Tidak ada notifikasi.</no_notif>
 		<trophy_earned>Kamu telah mendapatkan trofi!</trophy_earned>
 	</indicator>
-
-	<initial_setup>
-		<back>Kembali</back>
-		<completed_setup>Kamu sekarang telah menyelesaikan penyiapan awal.
-Sistem Vita3K Kamu sudah siap!</completed_setup>
-		<select_language>Pilih bahasa.</select_language>
-		<select_pref_path>Pilih pref path.</select_pref_path>
-		<current_emu_path>Path emulator saat ini</current_emu_path>
-		<change_emu_path>Ubah Path Emulator</change_emu_path>
-		<reset_emu_path>Path Reset Emulator</reset_emu_path>
-		<install_highly_recommended>Menginstalasi kedua file firmware sangat direkomendasikan.</install_highly_recommended>
-		<installed>Instalasi:</installed>
-		<select_interface_settings>Pilih pengaturan interface.</select_interface_settings>
-		<show_info_bar>Bar Info Terlihat</show_info_bar>
-		<info_bar_description>Centang kotak untuk menampilkan Bar info di dalam pemilih aplikasi.
-Bar info adalah jam, level baterai, dan pusat notifikasi.</info_bar_description>
-		<show_live_area_screen>Apl Dilayar Live Area</show_live_area_screen>
-		<live_area_screen_description>Centang kotak untuk membuka Live Area secara default saat mengklik aplikasi.
-Jika dinonaktifkan, klik kanan pada aplikasi untuk membukanya.</live_area_screen_description>
-		<apps_list_grid>Mode Grid</apps_list_grid>
-		<apps_list_grid_description>Centang kotak untuk mengatur daftar aplikasi ke mode grid seperti PS Vita.</apps_list_grid_description>
-		<icon_size>Ukuran Icon Aplikasi</icon_size>
-		<select_icon_size>Pilih ukuran icon pilihan kamu.</select_icon_size>
-		<completed>Telah selesai.</completed>
-		<next>Lanjut</next>
-	</initial_setup>
 
 	<install_dialog>
 		<firmware_install>
@@ -741,7 +716,6 @@ lebih rendah dapat meningkatkan performa tetapi dapat membuat game tidak stabil 
 			<unwatch_import_calls>Hapus Impor Panggilan</unwatch_import_calls>
 			<watch_import_calls>Tonton Impor Panggilan</watch_import_calls>
 		</debug>
-		<close>Tutup</close>
 		<save_reboot>Simpan & BuatUlang</save_reboot>
 		<save_apply>Simpan & Terapkan</save_apply>
 		<save>Simpan</save>
@@ -818,6 +792,5 @@ berjalan.</check_compatibility>
 		<discord_help>Dukungan tambahan dapat ditemukan di saluran #help channel dari</discord_help>
 		<no_piracy>Vita3K tidak memaafkan pembajakan. Kamu harus dump game kamu sendiri.</no_piracy>
 		<show_next_time>Tunjukkan lain kali</show_next_time>
-		<close>Tutup</close>
 	</welcome>
 </lang>

--- a/lang/user/ms.xml
+++ b/lang/user/ms.xml
@@ -105,6 +105,7 @@ bergantung pada saiznya dan perkakasan awak.</app_delete_description>
 		<an_error_occurred>Ralat berlaku.
 Kod ralat: {}</an_error_occurred>
 		<cancel>Batal</cancel>
+		<close>Tutup</close>
 		<delete>Padam</delete>
 		<file_corrupted>Fail itu rosak.</file_corrupted>
 		<microphone_disabled>Dayakan mikrofon.</microphone_disabled>
@@ -400,31 +401,6 @@ Jangan matikan sistem atau tutup apl.</warning_saving>
 		<no_notif>Tiada Notifikasi.</no_notif>
 		<trophy_earned>Awak telah memperoleh trofi!</trophy_earned>
 	</indicator>
-
-	<initial_setup>
-		<back>Kembali</back>
-		<completed_setup>Awak kini telah menyelesaikan persediaan awal.
-Sistem Vita3K awak sudah sedia!</completed_setup>
-		<select_language>Pilih bahasa.</select_language>
-		<select_pref_path>Pilih laluan pref.</select_pref_path>
-		<current_emu_path>Laluan emulator semasa</current_emu_path>
-		<change_emu_path>Tukar Laluan Emulator</change_emu_path>
-		<reset_emu_path>Tetapkan Semula Laluan Emulator</reset_emu_path>
-		<install_highly_recommended>Menginstal kedua-dua fail perisian tegar adalah sangat disyorkan.</install_highly_recommended>
-		<installed>Instalasi:</installed>
-		<select_interface_settings>Pilih tetapan antara muka.</select_interface_settings>
-		<show_info_bar>Bar Maklumat Kelihatan</show_info_bar>
-		<info_bar_description>Tandai kotak untuk menunjukkan bar maklumat dalam pemilih apl.
-Bar maklumat ialah jam, paras bateri dan pusat notifikasi.</info_bar_description>
-		<show_live_area_screen>Skrin Apl Kawasan Live</show_live_area_screen>
-		<live_area_screen_description>Tandai kotak untuk membuka Kawasan Live secara lalai apabila mengklik pada aplikasi.
-Jika dilumpuhkan, klik kanan pada apl untuk membukanya.</live_area_screen_description>
-		<apps_list_grid_description>Tandai kotak untuk menetapkan senarai apl kepada mode grid seperti PS Vita.</apps_list_grid_description>
-		<icon_size>Saiz Ikon Apl</icon_size>
-		<select_icon_size>Pilih saiz ikon pilihan awak.</select_icon_size>
-		<completed>Selesai.</completed>
-		<next>Seterusnya</next>
-	</initial_setup>
 
 	<install_dialog>
 		<firmware_install>
@@ -749,7 +725,6 @@ lebih rendah boleh meningkatkan prestasi tetapi boleh membuat permainan tidak st
 			<unwatch_import_calls>Nyahlihat Panggilan Import</unwatch_import_calls>
 			<watch_import_calls>Tonton Panggilan Import</watch_import_calls>
 		</debug>
-		<close>Tutup</close>
 		<save_reboot>Simpan & Reboot</save_reboot>
 		<save_apply>Simpan & Apply</save_apply>
 		<save>Simpan</save>
@@ -830,6 +805,5 @@ Selepas muat turun selesai, Vita3K akan dimulakan semula secara automatik dan ke
 		<discord_help>Sokongan tambahan boleh didapati dalam saluran #help</discord_help>
 		<no_piracy>Vita3K tidak membenarkan cetak rompak. Awak mesti membuang permainan awak sendiri.</no_piracy>
 		<show_next_time>Tunjukkan lainKali</show_next_time>
-		<close>Tutup</close>
 	</welcome>
 </lang>

--- a/lang/user/ua.xml
+++ b/lang/user/ua.xml
@@ -1,0 +1,864 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<lang>
+	<main_menubar>
+		<file name="Файл">
+			<open_pref_path>Відкрити бажаний шлях</open_pref_path>
+			<open_textures_path>Відкрити шлях текстур</open_textures_path>
+			<install_firmware>Завантажити прошивку</install_firmware>
+			<install_pkg>Завантажити .pkg</install_pkg>
+			<install_zip>Завантажити .zip, .vpk</install_zip>
+			<install_license>Завантажити ліцензію</install_license>
+			<exit>Вихід</exit>
+		</file>
+		<emulation name="Емуляція">
+			<last_apps_used>Останні використані програми</last_apps_used>
+		</emulation>
+		<debug>
+			<threads>Потоки</threads>
+			<semaphores>Семафори</semaphores>
+			<mutexes>М'ютекси</mutexes>
+			<lightweight_mutexes>Легковагові м'ютекси</lightweight_mutexes>
+			<condition_variables>Умовні змінні</condition_variables>
+			<lightweight_condition_variables>Легковагові умовні змінні</lightweight_condition_variables>
+			<event_flags>Маркери події</event_flags>
+			<memory_allocations>Розподіл пам'яті</memory_allocations>
+			<disassembly>Дизасемблювання</disassembly>
+		</debug>
+		<configuration name="Конфігурація">
+			<user_management>Керування користувачами</user_management>
+		</configuration>
+		<controls name="Керування">
+			<keyboard_controls>Керування клавіатурою</keyboard_controls>
+		</controls>
+		<help name="Допомога">
+			<welcome>Вітання</welcome>
+		</help>
+	</main_menubar>
+
+	<about name="Інформація">
+		<vita3k>Vita3K: Емулятор PS Vita/PS TV. Перший у світі функціонуючий емулятор PS Vita/PS TV.</vita3k>
+		<about_vita3k>Vita3K - це експериментальний емулятор PlayStation Vita/PlayStation TV з відкритим кодом, написаний на C++ для операційних систем Windows, Linux, macOS та Android.</about_vita3k>
+		<special_credit>Особлива подяка: Піктограма Vita3K була розроблена:</special_credit>
+		<github_website>Якщо ви бажаєте зробити свій внесок, перегляньте наш:</github_website>
+		<vita3k_website>Відвідайте нашу веб-сторінку, аби дізнатися більше:</vita3k_website>
+		<ko-fi_website>Якщо ви хочете підтримати нас, то можете задонатити або підписатися на наш:</ko-fi_website>
+		<vita3k_staff>Команда Vita3K</vita3k_staff>
+		<developers>Розробники</developers>
+		<contributors>Вкладники</contributors>
+		<supporters>Спонсори</supporters>
+	</about>
+
+	<app_context>
+		<check_app_state>Перевірити стан програми</check_app_state>
+		<copy_vita3k_summary>Скопіювати звіт Vita3K</copy_vita3k_summary>
+		<open_state_report>Відкрити звіт про стан</open_state_report>
+		<create_state_report>Створити звіт про стан</create_state_report>
+		<update_database>Оновити базу даних</update_database>
+		<copy_app_info>Скопіювати інформацію про програму</copy_app_info>
+		<name_and_id>Ім'я та ідентифікатор</name_and_id>
+		<app_summary>Звіт роботи програми</app_summary>
+		<custom_config>Індивідуальна конфігурація</custom_config>
+		<create>Створити</create>
+		<edit>Редагувати</edit>
+		<remove>Вилучити</remove>
+		<open_folder>Відкрити папку</open_folder>
+		<addcont>Завантажуваний вміст</addcont>
+		<license>Ліцензія</license>
+		<shaders_cache>Кеш шейдерів</shaders_cache>
+		<shaders_log>Журнал шейдерів</shaders_log>
+		<export_textures>Експорт текстур</export_textures>
+		<import_textures>Імпорт текстур</import_textures>
+		<manual>Довідка</manual>
+		<update>Оновити</update>
+		<update_history>Оновити історію</update_history>
+		<history_version>Версія {}</history_version>
+		<information>Інформація</information>
+		<delete>
+			<app_delete>Ця програма та всі пов'язані дані, враховуючи збережені дані, будуть видалені.</app_delete>
+			<app_delete_description>Видалення програми може зайняти деякий час,
+в залежності від того, скільки місця вона займає на пристрої.</app_delete_description>
+			<addcont_delete>Ви хочете видалити дані цього доповнення?</addcont_delete>
+			<license_delete>Ви хочете видалити цю ліцензію?</license_delete>
+			<saved_data_delete>Ви хочете видалити ці збережені дані?</saved_data_delete>
+		</delete>
+		<info>
+			<eligible>Допущено</eligible>
+			<ineligible>Не допущено</ineligible>
+			<level>Рівень</level>
+			<name>Ім'я</name>
+			<trophy_earning>Отримання трофеїв</trophy_earning>
+			<parental_controls>Батьківський контроль</parental_controls>
+			<updated>Оновлено</updated>
+			<size>Розмір</size>
+			<version>Версія</version>
+			<title_id>Ідентифікатор</title_id>
+			<last_time_used>Востаннє запущено</last_time_used>
+			<time_used>Часу проведено</time_used>
+			<never>Жодного разу</never>
+		</info>
+		<time_used>
+			<time_used_seconds>{}секунд</time_used_seconds>
+			<time_used_minutes>{}хвилин:{}секунд</time_used_minutes>
+			<time_used_hours>{}годин:{}хвилин:{}секунд</time_used_hours>
+			<time_used_days>{}днів:{}годин:{}хвилин:{}секунд</time_used_days>
+			<time_used_weeks>{}тижнів:{}днів:{}годин:{}хвилин:{}секунд</time_used_weeks>
+		</time_used>
+	</app_context>
+
+	<common>
+		<an_error_occurred>Сталася помилка.
+Код помилки: {}</an_error_occurred>
+		<cancel>Відміна</cancel>
+		<close>Закрити</close>
+		<delete>Видалити</delete>
+		<file_corrupted>Файл пошкоджено.</file_corrupted>
+		<microphone_disabled>Увімкніть мікрофон.</microphone_disabled>
+		<no>Ні</no>
+		<ok>Добре</ok>
+		<please_wait>Будь ласка, зачекайте...</please_wait>
+		<search>Пошук</search>
+		<select_all>Обрати все</select_all>
+		<select>Обрати</select>
+		<submit>Підтвердити</submit>
+		<yes>Так</yes>
+		<wday>
+			<day>Неділя</day>
+			<day>Понеділок</day>
+			<day>Вівторок</day>
+			<day>Середа</day>
+			<day>Четверг</day>
+			<day>П'ятниця</day>
+			<day>Субота</day>
+		</wday>
+		<ymonth>
+			<month>Січень</month>
+			<month>Лютий</month>
+			<month>Березень</month>
+			<month>Квітень</month>
+			<month>Травень</month>
+			<month>Червень</month>
+			<month>Липень</month>
+			<month>Серпень</month>
+			<month>Вересень</month>
+			<month>Жовтень</month>
+			<month>Листопад</month>
+			<month>Грудень</month>
+		</ymonth>
+		<small_ymonth>
+			<month>Січень</month>
+			<month>Лютий</month>
+			<month>Березень</month>
+			<month>Квітень</month>
+			<month>Травень</month>
+			<month>Червень</month>
+			<month>Липень</month>
+			<month>Серпень</month>
+			<month>Вересень</month>
+			<month>Жовтень</month>
+			<month>Листопад</month>
+			<month>Грудень</month>
+		</small_ymonth>
+		<mday>
+			<days></days>
+			<days>1</days>
+			<days>2</days>
+			<days>3</days>
+			<days>4</days>
+			<days>5</days>
+			<days>6</days>
+			<days>7</days>
+			<days>8</days>
+			<days>9</days>
+			<days>10</days>
+			<days>11</days>
+			<days>12</days>
+			<days>13</days>
+			<days>14</days>
+			<days>15</days>
+			<days>16</days>
+			<days>17</days>
+			<days>18</days>
+			<days>19</days>
+			<days>20</days>
+			<days>21</days>
+			<days>22</days>
+			<days>23</days>
+			<days>24</days>
+			<days>25</days>
+			<days>26</days>
+			<days>27</days>
+			<days>28</days>
+			<days>29</days>
+			<days>30</days>
+			<days>31</days>
+		</mday>
+		<small_mday>
+			<days></days>
+			<days>1</days>
+			<days>2</days>
+			<days>3</days>
+			<days>4</days>
+			<days>5</days>
+			<days>6</days>
+			<days>7</days>
+			<days>8</days>
+			<days>9</days>
+			<days>10</days>
+			<days>11</days>
+			<days>12</days>
+			<days>13</days>
+			<days>14</days>
+			<days>15</days>
+			<days>16</days>
+			<days>17</days>
+			<days>18</days>
+			<days>19</days>
+			<days>20</days>
+			<days>21</days>
+			<days>22</days>
+			<days>23</days>
+			<days>24</days>
+			<days>25</days>
+			<days>26</days>
+			<days>27</days>
+			<days>28</days>
+			<days>29</days>
+			<days>30</days>
+			<days>31</days>
+		</small_mday>
+		<hidden_trophy>Прихований трофей</hidden_trophy>
+		<one_hour_ago>Годину тому</one_hour_ago>
+		<one_minute_ago>Хвилину тому</one_minute_ago>
+		<bronze>Бронза</bronze>
+		<gold>Золото</gold>
+		<platinum>Платина</platinum>
+		<silver>Срібло</silver>
+		<hours_ago>{} Годин тому</hours_ago>
+		<minutes_ago>{} Хвилин тому</minutes_ago>
+	</common>
+
+	<compatibility name="Сумісність">
+		<states>
+			<state id = "-1">Невідомо</state>
+			<state id = "0">Не запускається</state>
+			<state id = "1">Запускається</state>
+			<state id = "2">Заставка</state>
+			<state id = "3">Меню</state>
+			<state id = "4">У грі -</state>
+			<state id = "5">У грі +</state>
+			<state id = "6">Можливо грати</state>
+		</states>
+	</compatibility>
+
+	<compat_db>
+		<error>Помилка</error>
+		<information>Інформація</information>
+		<get_failed>Не вдалося під'єднатися до бази даних сумісностей, перевірте доступ до брендмауеру/Інтернету, та спробуйте ще раз пізніше.</get_failed>
+		<download_failed>Не вдалося завантажити базу даних сумісностей програм, що була оновлена у: {}, спробуйте ще раз пізніше.</download_failed>
+		<load_failed>Не вдалося завантажити базу даних сумісностей програм, що була завантажена та оновлена у: {}.</load_failed>
+		<new_app_listed>База даних суміснотей була успішно оновлена з {} до {}.&#xA;
+{} Нову програму/програми виявлено, загалом налічується {}!</new_app_listed>
+		<app_listed>База даних суміснотей була успішно оновлена з {} до {}.&#xA;
+{} програм виявлено!</app_listed>
+		<download_app_listed>База даних сумісностей, що була оновлена у {} успішно завантажена.&#xA;
+{} програм виявлено!</download_app_listed>
+	</compat_db>
+
+	<compile_shaders>
+		<compiling_shaders>Компіляція шейдерів</compiling_shaders>
+		<pipelines_compiled>{} Конвеєрів скомпільовано</pipelines_compiled>
+		<shaders_compiled>{} Шейдерів скомпільовано</shaders_compiled>
+	</compile_shaders>
+
+	<content_manager name="Керування вмістом">
+		<application name="Програми">
+			<delete>Обрані програми та всі пов'язані дані, разом зі збереженими даними, будуть видалені.</delete>
+			<no_item>Дані відсутні.</no_item>
+		</application>
+		<saved_data name="Збережені дані">
+			<delete>Обрані збережені дані буде видалено.</delete>
+			<no_saved_data>Збережені дані не виявлено.</no_saved_data>
+		</saved_data>
+		<theme>Тема</theme>
+		<free_space>Вільного місця</free_space>
+		<clear_all>Очистити все</clear_all>
+	</content_manager>
+
+	<controllers name="Контролери">
+		<connected>{} Контролерів під'єднано</connected>
+		<name>Назва</name>
+		<num>Кількість</num>
+		<not_connected>Сумісні контролери не підключені.
+Будь ласка, підключіть контролер, сумісний з SDL2.</not_connected>
+		<motion_support>Контролер має сенсори руху</motion_support>
+		<rebind_controls>Прив'язка елементів керування</rebind_controls>
+		<led_color>Колір світлодіоду</led_color>
+		<use_custom_color>Використати власний колір</use_custom_color>
+		<use_custom_color_description>Оберіть цей пункт, аби використати власний колір світлодіоду контролера.</use_custom_color_description>
+		<red>Червоний</red>
+		<green>Зелений</green>
+		<blue>Синій</blue>
+		<reset_controller_binding>Скинути налаштування елементів керування контролера</reset_controller_binding>
+	</controllers>
+
+	<controls name="Керування">
+		<button>Кнопка</button>
+		<mapped_button>Прив'язана кнопка</mapped_button>
+		<left_stick_up>Лівий стік догори</left_stick_up>
+		<left_stick_down>Лівий стік донизу</left_stick_down>
+		<left_stick_right>Лівий стік праворуч</left_stick_right>
+		<left_stick_left>Лівий стік ліворуч</left_stick_left>
+		<right_stick_up>Правий стік догори</right_stick_up>
+		<right_stick_down>Правий стік донизу</right_stick_down>
+		<right_stick_right>Правий стік праворуч</right_stick_right>
+		<right_stick_left>Правий стік ліворуч</right_stick_left>
+		<d_pad_up>D-pad догори</d_pad_up>
+		<d_pad_down>D-pad донизу</d_pad_down>
+		<d_pad_right>D-pad праворуч</d_pad_right>
+		<d_pad_left>D-pad ліворуч</d_pad_left>
+		<square_button>Квадрат</square_button>
+		<cross_button>Хрестик</cross_button>
+		<circle_button>Кружечок</circle_button>
+		<triangle_button>Трикутник</triangle_button>
+		<start_button>Кнопка Start</start_button>
+		<select_button>Кнопка Select</select_button>
+		<ps_button>Кнопка PS</ps_button>
+		<l1_button>Кнопка L1</l1_button>
+		<r1_button>Кнопка R1</r1_button>
+		<ps_tv_mode>Лише у режимі PS TV.</ps_tv_mode>
+		<l2_button>Кнопка L2</l2_button>
+		<r2_button>Кнопка R2</r2_button>
+		<l3_button>Кнопка L3</l3_button>
+		<r3_button>Кнопка R3</r3_button>
+		<gui>Інтерфейс</gui>
+		<full_screen>Повний екран</full_screen>
+		<toggle_touch>Перемикання сенсора</toggle_touch>
+		<toggle_touch_description>Перемикання між заднім сенсором та сенсорним екраном.</toggle_touch_description>
+		<toggle_gui_visibility>Перемикання видимості інтерфейсу</toggle_gui_visibility>
+		<toggle_gui_visibility_description>Перемикає видимість інтерфейсу у верхній частині екрану коли програма функціонує.</toggle_gui_visibility_description>
+		<miscellaneous>Інше</miscellaneous>
+		<toggle_texture_replacement>Перемикання заміни текстур</toggle_texture_replacement>
+		<take_a_screenshot>Зробити знімок екрану</take_a_screenshot>
+		<error>Помилка</error>
+		<error_duplicate_key>Кнопка вже прив'язана або її неможливо прив'язати.</error_duplicate_key>
+	</controls>
+
+	<dialog>
+		<trophy>
+			<preparing_start_app>Підготовка до запуску програми...</preparing_start_app>
+		</trophy>
+		<save_data>
+			<delete>
+				<cancel_deleting>Ви хочете відмінити видалення?</cancel_deleting>
+				<deletion_complete>Видалення завершене.</deletion_complete>
+				<delete_saved_data>Ви хочете видалити ці збережені дані?</delete_saved_data>
+			</delete>
+			<info>
+				<details>Деталі</details>
+				<updated>Оновлено</updated>
+			</info>
+			<load name="Завантажити">
+				<cancel_loading>Ви хочете відмінити завантаження?</cancel_loading>
+				<no_saved_data>Збережені дані не виявлені.</no_saved_data>
+				<load_complete>Завантаження завершене.</load_complete>
+				<loading>Завантаження...</loading>
+				<load_saved_data>Ви хочете завантажити ці збережені дані?</load_saved_data>
+			</load>
+			<save name="Зберегти">
+				<cancel_saving>Ви хочете відмінити збереження?</cancel_saving>
+				<could_not_save>Не вдалося зберегти файл.
+Недостатньо вільного місця на карті пам'яті.</could_not_save>
+				<not_free_space>Недостатньо вільного місця на карті пам'яті.</not_free_space>
+				<new_saved_data>Нові збережені дані</new_saved_data>
+				<saving_complete>Збереження завершене.</saving_complete>
+				<save_the_data>Ви хочете зберегти дані?</save_the_data>
+				<saving>Збереження...</saving>
+				<warning_saving>Збереження...
+Не вимикайте систему та не закривайте програму.</warning_saving>
+				<overwrite_saved_data>Ви хочете перезаписати ці збережені дані?</overwrite_saved_data>
+			</save>
+		</save_data>
+	</dialog>
+
+	<game_data>
+		<app_close>Ця програма буде закрита.</app_close>
+		<data_delete>Дані, що будуть видалені:</data_delete>
+	</game_data>
+
+	<home_screen>
+		<filter>Фільтр</filter>
+		<sort_app>Сортувати програми за</sort_app>
+		<all>Все</all>
+		<by_region>За регіоном</by_region>
+		<usa>США</usa>
+		<europe>Європа</europe>
+		<japan>Японія</japan>
+		<asia>Азія</asia>
+		<by_type>За типом</by_type>
+		<commercial>Комерційне</commercial>
+		<homebrew>Homebrew</homebrew>
+		<by_compatibility_state>За статусом сумісності</by_compatibility_state>
+		<ver>Версія</ver>
+		<cat>Каталог</cat>
+		<comp>Сумісність</comp>
+		<last_time>Останній запуск</last_time>
+		<refresh>Оновити</refresh>
+	</home_screen>
+
+	<indicator>
+		<app_added_home>Програму було додано на головний екран.</app_added_home>
+		<delete_all>Видалити все</delete_all>
+		<notif_deleted>Сповіщення будуть видалені.</notif_deleted>
+		<install_failed>Не вдалося завантажити.</install_failed>
+		<install_complete>Завантаження завершене.</install_complete>
+		<installing>Завантаження...</installing>
+		<no_notif>Сповіщень немає.</no_notif>
+		<trophy_earned>Ви отримали трофей!</trophy_earned>
+	</indicator>
+
+	<install_dialog>
+		<firmware_install>
+			<firmware_installation>Завантаження прошивки</firmware_installation>
+			<firmware_installing>Завантаження триває, будь ласка, зачекайте...</firmware_installing>
+			<successed_install_firmware>Прошивку успішно завантажено.</successed_install_firmware>
+			<firmware_version>Версія прошивки:</firmware_version>
+			<no_font_exist>Пакет шрифтів прошивки відсутній, будь ласка, завантажте його.</no_font_exist>
+			<download_firmware_font_package>Завантажити пакет шрифтів прошивки</download_firmware_font_package>
+			<firmware_font_package_description>Пакет шрифтів прошивки потрібен для деяких програм,
+а також для підтримки шрифтів азійського регіону. (загалом рекомендовано)</firmware_font_package_description>
+			<delete_firmware>Видалити файл завантаження прошивки?</delete_firmware>
+		</firmware_install>
+		<pkg_install>
+			<select_license_type>Обрати тип ліцензії</select_license_type>
+			<select_bin_rif>Обрати work.bin/rif</select_bin_rif>
+			<enter_zrif>Ввести zRIF</enter_zrif>
+			<enter_zrif_key>Ввести ключ zRIF</enter_zrif_key>
+			<input_zrif>Будь ласка, введіть свій zRIF тут</input_zrif>
+			<copy_paste_zrif>Ctrl (Cmd) + C аби скопіювати, Ctrl (Cmd) + V аби вставити.</copy_paste_zrif>
+			<delete_pkg>Видалити файл pkg?</delete_pkg>
+			<delete_bin_rif>Видалити файл work.bin/rif?</delete_bin_rif>
+			<failed_install_package>Не вдалося завантажити пакет.
+Будь ласка, перевірте файли pkg та work.bin/rif або ключ zRIF.</failed_install_package>
+		</pkg_install>
+		<archive_install>
+			<select_install_type>Оберіть тип завантаження</select_install_type>
+			<select_file>Оберіть файл</select_file>
+			<select_directory>Оберіть директорію</select_directory>
+			<compatible_content>{} архівів з сумісним вмістом було знайдено.</compatible_content>
+			<successed_install_archive>{} архівів успішно завантажено:</successed_install_archive>
+			<update_app>Оновити програму до:</update_app>
+			<failed_install_archive>Не вдалося завантажити вміст {} архівів:</failed_install_archive>
+			<not_compatible_content>Не знайдено сумісного вмісту у {} архівах:</not_compatible_content>
+			<delete_archive>Видалити архів?</delete_archive>
+		</archive_install>
+		<license_install>
+			<successed_install_license>Ліцензію успішно завантажено.</successed_install_license>
+			<failed_install_license>Не вдалося завантажити ліцензію.
+Будь ласка, перевірте файл work.bin/rif або ключ zRIF.</failed_install_license>
+		</license_install>
+		<reinstall>
+			<reinstall_content>Перевстановити цей вміст?</reinstall_content>
+			<already_installed>Цей вміст вже встановлено.</already_installed>
+			<reinstall_overwrite>Чи бажаєте ви перевстановити його та перезаписати існуючі дані?</reinstall_overwrite>
+		</reinstall>
+	</install_dialog>
+
+	<live_area>
+		<start>Запуск</start>
+		<continue>Продовжити</continue>
+		<help>
+			<control_setting>Використовуючи конфігурацію для клавіатури в налаштуваннях керування</control_setting>
+			<firmware_not_detected>Прошивку не виявлено. Настійно рекомендується завантаження</firmware_not_detected>
+			<firmware_font_not_detected>Шрифт прошивки не виявлено. Завантаження рекомендується для шрифта тексту Live Area</firmware_font_not_detected>
+			<live_area_help>Довідка Live Area</live_area_help>
+			<browse_app>Перегляд списку програм</browse_app>
+			<browse_app_control>D-pad, лівий стік, коліщатко догори/донизу або використовуючи повзунок</browse_app_control>
+			<start_app>Запуск програми</start_app>
+			<start_app_control>натисніть на Start або на хрестик</start_app_control>
+			<show_hide>Показати/приховати Live Area під час роботи програми</show_hide>
+			<show_hide_control>Натиснути PS</show_hide_control>
+			<exit_livearea>Вийти з Live Area</exit_livearea>
+			<exit_livearea_control>Натиснути Esc або кружечок</exit_livearea_control>
+			<manual_help>Довідка по інструкції</manual_help>
+			<browse_page>Перегляд сторінки</browse_page>
+			<browse_page_control>D-pad, лівий стік, коліщатко догори/донизу, використовуючи повзунок або настиснути &lt;/&gt;</browse_page_control>
+			<hide_show>Приховати/показати кнопку</hide_show>
+			<hide_show_control>Натиснути лівий стік або трикутник</hide_show_control>
+			<exit_manual>закрити довідку</exit_manual>
+			<exit_manual_control>Натиснути Esc або PS</exit_manual_control>
+		</help>
+	</live_area>
+
+	<settings name="Налаштування">
+		<theme_background name="Тема та фон">
+			<default>За замовчуванням</default>
+			<theme name="Тема">
+				<find_a_psvita_custom_themes>Знайти користувацькі теми для PSVita</find_a_psvita_custom_themes>
+				<information name="Інформація">
+					<name>Назва</name>
+					<provider>Постачальник</provider>
+					<updated>Оновлено</updated>
+					<size>Розмір</size>
+					<version>Версія</version>
+					<content_id>Ідентифікатор вмісту</content_id>
+				</information>
+				<delete>Цю тему буде видалено.</delete>
+			</theme>
+			<start_screen name="Початковий екран">
+				<image>Зображення</image>
+				<add_image>Додати зображення</add_image>
+			</start_screen>
+			<home_screen_backgrounds name="Фон початкового екрану">
+				<delete_background>Видалити фон</delete_background>
+				<add_background>Додати фон</add_background>
+			</home_screen_backgrounds>
+		</theme_background>
+		<date_time name="Дата і час">
+			<date_format name ="Формат дати">
+				<yyyy_mm_dd>РРРР/ММ/ДД</yyyy_mm_dd>
+				<dd_mm_yyyy>ДД/ММ/РРРР</dd_mm_yyyy>
+				<mm_dd_yyyy>ММ/ДД/РРРР</mm_dd_yyyy>
+			</date_format>
+			<time_format name="Формат часу">
+				<clock_12_hour>12-годинний формат</clock_12_hour>
+				<clock_24_hour>24-годинний формат</clock_24_hour>
+			</time_format>
+		</date_time>
+		<language name="Мова">
+			<system_language>Мова системи</system_language>
+			<input_language name="Мови введення">
+				<keyboards name="Клавіатури">
+					<ime_languages>
+						<lang id="1">Данська</lang>
+						<lang id="2">Німецька</lang>
+						<lang id="262144">Англійська (Сполучене Королівство)</lang>
+						<lang id="4">Англійська (Сполучені Штати)</lang>
+						<lang id="8">Іспанська</lang>
+						<lang id="16">Французька</lang>
+						<lang id="32">Італійська</lang>
+						<lang id="64">Нідерландська</lang>
+						<lang id="128">Норвезька</lang>
+						<lang id="256">Польська</lang>
+						<lang id="131072">Португальська (Бразилія)</lang>
+						<lang id="512">Португальська (Португалія)</lang>
+						<lang id="1024">Російська</lang>
+						<lang id="2048">Фінська</lang>
+						<lang id="4096">Шведська</lang>
+						<lang id="524288">Турецька</lang>
+					</ime_languages>
+				</keyboards>
+			</input_language>
+		</language>
+	</settings>
+
+	<settings_dialog name="Налаштування">
+		<core name="Система">
+			<modules_mode>Режим модулів</modules_mode>
+			<modules_list>Список модулів</modules_list>
+			<select_modules>Оберіть бажані модулі.</select_modules>
+			<search_modules>Пошук модулів</search_modules>
+			<clear_list>Очистити список</clear_list>
+			<no_modules>Модулі відсутні.
+Будь ласка, завантажте останню прошивку PS Vita.</no_modules>
+			<refresh_list>Оновити список</refresh_list>
+		</core>
+		<cpu>
+			<unicorn>Unicorn (застарілий)</unicorn>
+			<cpu_backend>Бекенд центрального процесора</cpu_backend>
+			<select_cpu_backend>Оберіть бажаний бекенд центрального процесора.</select_cpu_backend>
+			<cpu_opt>Дозволити оптимізації</cpu_opt>
+			<cpu_opt_description>Оберіть цей пункт, аби дозволити додаткові JIT-оптимізації процесора.</cpu_opt_description>
+		</cpu>
+		<gpu>
+			<reset>Скинути</reset>
+			<backend_renderer>Рендер бекенду</backend_renderer>
+			<select_backend_renderer>Оберіть бажаний рендер бекенду.</select_backend_renderer>
+			<gpu>Графічний процесор (перезавантажте систему, аби застосувати)</gpu>
+			<select_gpu>Оберіть графічний процесор, на якому буде запускатися Vita3K.</select_gpu>
+			<standard>Стандарт</standard>
+			<high>Високо</high>
+			<renderer_accuracy>Точність рендеру</renderer_accuracy>
+			<v_sync>Вертикальна синхронізація</v_sync>
+			<v_sync_description>Вимикання вертикальної синхронізації може покращити швидкодію деяких ігор.
+Рекомендується увімкнути цей параметр, аби уникнути розривів зображення.</v_sync_description>
+			<disable_surface_sync>Вимкнути синхронізацію поверхні</disable_surface_sync>
+			<surface_sync_description>Оберіть цей пункт, аби вимкнути сихронізацію поверхонь центрального та графічного процесорів.
+Синхронізація поверхні необхідна для деяких ігор.
+Суттєво збільшує продуктивність, якщо вимкнена (особливо якщо ввімкнено апскейлінг).</surface_sync_description>
+			<async_pipeline_compilation>Асинхронна компіляція конвеєрів</async_pipeline_compilation>
+			<async_pipeline_compilation_description>Дозволяє конвеєрам компілюватись одночасно на декількох потоках.
+Це покращує якість компіляції за рахунок тимчасових графічних збоїв.</async_pipeline_compilation_description>
+			<nearest>Поблизу</nearest>
+			<bilinear>Білінійно</bilinear>
+			<bicubic>Бікубічно</bicubic>
+			<screen_filter>Фільтр екрану</screen_filter>
+			<screen_filter_description>Увімкніть фільтр постобробки, аби застосувати.</screen_filter_description>
+			<internal_resolution_upscaling>Покращення внутрішньої роздільності</internal_resolution_upscaling>
+			<internal_resolution_upscaling_description>Увімкнути покращення внутрішньої роздільності на Vita3K.
+Експериментально: правильний рендеринг ігор на роздільності більшій, ніж 1х, не гарантовано.</internal_resolution_upscaling_description>
+			<anisotropic_filtering>Анізотропна фільтрація</anisotropic_filtering>
+			<anisotropic_filtering_description>Анізотропна фільтрація - це технологія покращення якості зображення поверхонь, 
+що нахилені з точки зору глядача.
+Технологія не має недоліків, але може вплинути на продуктивність системи.</anisotropic_filtering_description>
+			<texture_replacement>Заміна текстур</texture_replacement>
+			<export_textures>Експорт текстур</export_textures>
+			<import_textures>Імпорт текстур</import_textures>
+			<texture_exporting_format>Формат екпорту текстур</texture_exporting_format>
+			<shaders>Шейдери</shaders>
+			<shader_cache>Використовувати кеш шейдерів</shader_cache>
+			<shader_cache_description>Оберіть цей пункт, аби дозволити кешу компілюватися зазделегідь під час запуску гри.
+Приберіть позначку, аби відключити функцію.</shader_cache_description>
+			<spirv_shader>Використовувати шейдер Spir-V (застарілий)</spirv_shader>
+			<spirv_shader_description>Передати отриманий шейдер Spir-V напряму до драйвера.
+Зауважте, що деякі корисні розширення будуть відключені,
+і не всі графічні процесори сумісні з цим шейдером.</spirv_shader_description>
+			<clean_shaders>Очистити кеш та журнал шейдерів</clean_shaders>
+			<fps_hack>Злам FPS</fps_hack>
+			<fps_hack_description>Злам ігор, що дозволяє запускати деякі ігри у 60 FPS замість 30.
+Зауважте, що це буде працювати лише у деяких іграх.
+У інших іграх злам не матиме ніякого ефекту, або покращить їх швидкодію.</fps_hack_description>
+		</gpu>
+		<audio name="Звук">
+			<audio_backend>Бекенд звуку</audio_backend>
+			<select_audio_backend>Оберіть бажаний бекенд звуку.</select_audio_backend>
+			<audio_volume>Гучність</audio_volume>
+			<audio_volume_description>Регулює гучність усіх аудіовиходів.</audio_volume_description>
+			<enable_ngs_support>Увімкнути підтримку NGS</enable_ngs_support>
+			<ngs_description>Приберіть позначку, аби відключити підтримку розширеної аудіотеки NGS.</ngs_description>
+		</audio>
+		<system name="Система">
+			<select_enter_button>Призначення кнопки Enter
+Оберіть кнопку 'Enter'.</select_enter_button>
+			<enter_button_description>Ця кнопка використовується для підтвердження у діалогових вікнах.
+У деяких програмах це не працюватиме, натомість буде використовуватись кнопка підтвердження за замовчуванням.</enter_button_description>
+			<circle>Кружечок</circle>
+			<cross>Хрестик</cross>
+			<pstv_mode>Режим PS TV</pstv_mode>
+			<pstv_mode_description>Оберіть цей пункт, аби ввімкнути режим емуляції PS TV.</pstv_mode_description>
+			<show_mode>Режим показу</show_mode>
+			<show_mode_description>Оберіть цей пункт, аби ввімкнути режим показу.</show_mode_description>
+			<demo_mode>Демо-режим</demo_mode>
+			<demo_mode_description>Оберіть цей пункт, аби ввімкнути демо-режим.</demo_mode_description>
+		</system>
+		<emulator name="Емулятор">
+			<boot_apps_full_screen>Запускати програми у повноекранному режимі</boot_apps_full_screen>
+			<trace>Трасування</trace>
+			<info>Інформація</info>
+			<warning>Попередження</warning>
+			<error>Помилка</error>
+			<critical>Критична</critical>
+			<off>Вимкнено</off>
+			<log_level>Рівень журналу</log_level>
+			<select_log_level>Оберіть бажаний рівень журналу.</select_log_level>
+			<archive_log>Журнал архіву</archive_log>
+			<archive_log_description>Оберіть цей пункт, аби ввімкнути журнал архіву.</archive_log_description>
+			<discord_rich_presence>Дозволити запущеній програмі відображатися у Discord.</discord_rich_presence>
+			<texture_cache>Кеш текстур</texture_cache>
+			<texture_cache_description>Приберіть позначку, аби відключити кеш текстур.</texture_cache_description>
+			<show_compile_shaders>Відображати компіляцію шейдерів</show_compile_shaders>
+			<compile_shaders_description>Приберіть позначку, аби приховати вікно компіляції шейдерів.</compile_shaders_description>
+			<show_touchpad_cursor>Відображати курсор тачпаду</show_touchpad_cursor>
+			<touchpad_cursor_description>Приберіть позначку, аби приховати курсор тачпаду на екрані.</touchpad_cursor_description>
+			<log_compat_warn>Попередження помилки сумісності журналу</log_compat_warn>
+			<log_compat_warn_description>Оберіть цей пункт, аби відображати попередження помилки сумісності журналу.</log_compat_warn_description>
+			<check_for_updates>Перевірити наявність оновлень</check_for_updates>
+			<check_for_updates_description>Автоматично перевіряти наявність оновлень під час запуску.</check_for_updates_description>
+			<performance_overlay>Оверлей продуктивності</performance_overlay>
+			<performance_overlay_description>Відображати інформацію про продуктивність на екранному оверлеї.</performance_overlay_description>
+			<minimum>Мінімум</minimum>
+			<low>Низько</low>
+			<medium>Медіум</medium>
+			<maximum>Максимум</maximum>
+			<detail>Деталі</detail>
+			<select_detail>Оберіть бажаний елемент оверлею продуктивності.</select_detail>
+			<top_left>Зверху ліворуч</top_left>
+			<top_center>Зверху по центру</top_center>
+			<top_right>Зверху праворуч</top_right>
+			<bottom_left>Знизу ліворуч</bottom_left>
+			<bottom_center>Знизу по центру</bottom_center>
+			<bottom_right>Знизу праворуч</bottom_right>
+			<position>Позиція</position>
+			<select_position>Обрати бажане місце на екрані для оверлею продуктивності.</select_position>
+			<case_insensitive>Оберіть цей пункт, аби ввімкнути не чутливий до реєстру пошук шляху на чутливих до реєстру файлових системах.
+Скидається при перезавантаженні</case_insensitive>
+			<case_insensitive_description>Дозволяє емулятору шукати файли незалежно від реєстру
+на операційних системах окрім Windows.</case_insensitive_description>
+			<emu_storage_folder>Папка емульованої системи</emu_storage_folder>
+			<current_emu_path>Чинний шлях емулятора:</current_emu_path>
+			<change_emu_path>Змінити шлях емулятора</change_emu_path>
+			<change_emu_path_description>Змінити папку емулятора Vita3K.
+Необхідно власноруч перемістити стару папку на нове місце.</change_emu_path_description>
+			<reset_emu_path>Скинути шлях емулятора</reset_emu_path>
+			<reset_emu_path_description>Скинути шлях емулятора Vita3K до налаштувань за замовчуванням.
+Необхідно власноруч перемістити стару папку на нове місце.</reset_emu_path_description>
+			<custom_config_settings>Налаштування користувацької конфігурації</custom_config_settings>
+			<clear_custom_config>Скинути користувацьку конфігурацію</clear_custom_config>
+		</emulator>
+		<gui name="Графічний інтерфейс">
+			<show_gui>Графічний інтерфейс видимий</show_gui>
+			<gui_description>Оберіть цей пункт, аби відображати графічний інтерфейс під час запуску програми.</gui_description>
+			<show_info_bar>Інформаційна панель видима</show_info_bar>
+			<info_bar_description>Оберіть цей пункт, аби відображати інформаційну панель у селекторі програм.</info_bar_description>
+			<user_lang>Мова графічного інтерфейсу</user_lang>
+			<select_user_lang>Оберіть мову користувача.</select_user_lang>
+			<display_info_message>Відображати інформаційні повідомлення</display_info_message>
+			<display_info_message_description>Приберіть позначку, аби відображати інформаційні повідомлення лише у журналі.</display_info_message_description>
+			<display_system_apps>Відображати системні програми</display_system_apps>
+			<display_system_apps_description>Приберіть позначку, аби системні програми не відображалися на головному екрані.
+Вони будуть відображатися лише на панелі у головному меню.</display_system_apps_description>
+			<show_live_area_screen>Екран програми Live Area</show_live_area_screen>
+			<live_area_screen_description>Оберіть цей пункт, аби програма Live Area відкривалася за замовчуванням при натисканні на піктограму.
+Якщо програму вимкнено, натисніть на піктограму правим стіком, аби запустити.</live_area_screen_description>
+			<stretch_the_display_area>Розтягнути зону дисплею</stretch_the_display_area>
+			<stretch_the_display_area_description>Оберіть цей пункт, аби збільшити зону дисплею, щоб він вмістився у рамки екрану.</stretch_the_display_area_description>
+			<apps_list_grid>Режим сітки</apps_list_grid>
+			<apps_list_grid_description>Оберіть цей пункт, аби перенести список програм у режим сітки.</apps_list_grid_description>
+			<icon_size>Розмір піктограми програми</icon_size>
+			<select_icon_size>Оберіть бажаний розмір піктограми.</select_icon_size>
+			<font_support>Підтримка шрифтів</font_support>
+			<asia_font_support>Азійський регіон</asia_font_support>
+			<asia_font_support_description>Оберіть цей пункт, аби увімкнути підтримку шрифтів для китайської та корейської мови.
+Цей параметр використовуватиме більше пам'яті, і вам знадобиться перезавантажити емулятор.</asia_font_support_description>
+			<firmware_font_package_description>Прошивка пакету шрифтів необхідна для деяких програм,
+підтримки шрифтів азійського регіону і графічного інтерфейсу.
+Це загалом рекомендовано для графічного інтерфейсу.</firmware_font_package_description>
+			<theme_background>Тема & Фон</theme_background>
+			<current_theme_content_id>Чинний ідентифікатор теми:</current_theme_content_id>
+			<reset_default_theme>Скинути до базової теми</reset_default_theme>
+			<using_theme_background>Використання теми/фону</using_theme_background>
+			<clean_user_backgrounds>Очистити користувацькі фони</clean_user_backgrounds>
+			<current_start_background>Чинний фон початкового екрану:</current_start_background>
+			<reset_start_background>Скинути фон початкового екрану</reset_start_background>
+			<background_alpha>Прозорість фону</background_alpha>
+			<select_background_alpha>Оберіть бажану прозорість фону.
+Мінімум - непрозорий, максимум - прозорий.</select_background_alpha>
+			<delay_background>Затримка фону</delay_background>
+			<select_delay_background>Оберіть затримку (у секундах) між зміною фону.</select_delay_background>
+			<delay_start>Затримка початкового екрану</delay_start>
+			<select_delay_start>Оберіть затримку (у секундах) перш ніж станеться повернення на початковий екран.</select_delay_start>
+		</gui>
+		<network name="Мережа">
+			<psn_signed_in>підключено до PSN</psn_signed_in>
+			<psn_signed_in_description>Якщо обрано - гра буде вважати, що користувача підключено до PSN (однак підключення насправді відсутнє).</psn_signed_in_description>
+			<enable_http>Дозволити HTTP</enable_http>
+			<enable_http_description>Оберіть цей пункт, аби ігри мали змогу використовувати HTTP-протокол інтернету.</enable_http_description>
+			<timeout_attempts>Спроби під'єднання HTTP</timeout_attempts>
+			<timeout_attempts_description>Скільки разів спробувати під'єднатися, якщо сервер не відповідає.
+Може допомогти, якщо ви маєте дуже нестабільний або дуже слабкий інтернет.</timeout_attempts_description>
+			<timeout_sleep>Перехід HTTP у режим сну</timeout_sleep>
+			<timeout_sleep_description>Спроба увійти в режим сну, якщо сервер не відповідає.
+Може допомогти, якщо ви маєте дуже нестабільний або дуже слабкий інтернет.</timeout_sleep_description>
+			<read_end_attempts>Спроби прочитати дані протоколу HTTP</read_end_attempts>
+			<read_end_attempts_description>Скільки разів спробувати прочитати дані, якщо нових даних немає,
+зниження параметру може покращити продуктивність, але ігри можуть працювати нестабільно при слабкому інтернеті.</read_end_attempts_description>
+			<read_end_sleep>Режим сну після спроб прочитати дані протоколу HTTP</read_end_sleep>
+			<read_end_sleep_description>Спроба увійти у режим сну, якщо нових даних для читання немає,
+зниження параметру може покращити продуктивність, але ігри можуть працювати нестабільно при слабкому інтернеті.</read_end_sleep_description>
+		</network>
+		<debug>
+			<log_imports>Журналювання імпорту</log_imports>
+			<log_imports_description>Журналювати символи модуля імпорту.</log_imports_description>
+			<log_exports>Журналювання експорту</log_exports>
+			<log_exports_description>Журналювати символи модуля експорту.</log_exports_description>
+			<log_active_shaders>Журналювання шейдерів</log_active_shaders>
+			<log_active_shaders_description>Журнальовані шейдери використовуються при кожному виклику відтворення.</log_active_shaders_description>
+			<log_uniforms>Рівномірне журналювання</log_uniforms>
+			<log_uniforms_description>Рівномірно журналювати назви та значення шейдерів.</log_uniforms_description>
+			<color_surface_debug>Зберегти кольорові поверхні</color_surface_debug>
+			<color_surface_debug_description>Зберегти кольорові поверхні до файлів.</color_surface_debug_description>
+			<dump_elfs>Збереження у форматі ELF</dump_elfs>
+			<dump_elfs_description>Зберегти завантажений код у вигляді ELF-файлів.</dump_elfs_description>
+			<validation_layer>Рівень валідації (необхідний перезапуск)</validation_layer>
+			<validation_layer_description>Дозволити рівень валідації технології Vulkan.</validation_layer_description>
+			<unwatch_code>Не спостерігати за кодом</unwatch_code>
+			<watch_code>Спостерігати за кодом</watch_code>
+			<unwatch_memory>Не спостерігати за пам'яттю</unwatch_memory>
+			<watch_memory>Спостерігати за пам'яттю</watch_memory>
+			<unwatch_import_calls>Не спостерігати за імпортованими викликами</unwatch_import_calls>
+			<watch_import_calls>Спостерігати за імпортованими викликами</watch_import_calls>
+		</debug>
+		<save_reboot>Зберегти & Перезапустити</save_reboot>
+		<save_apply>Зберегти & Застосувати</save_apply>
+		<save>Зберегти</save>
+		<keep_changes>Натисніть 'Зберегти', аби зберегти зміни.</keep_changes>
+	</settings_dialog>
+
+	<trophy_collection>
+		<delete_trophy>Видалити трофей</delete_trophy>
+		<trophy_deleted>Інформацію про отримання цього трофею користувачем буде видалено.</trophy_deleted>
+		<locked>Заблоковано</locked>
+		<details>Деталі</details>
+		<earned>Отримано</earned>
+		<name>Назва</name>
+		<no_trophies>Трофеїв немає.
+Ви можете отримати трофеї використовуючи програми, що підтримують функцію трофеїв.</no_trophies>
+		<not_earned>Не отримано</not_earned>
+		<original>Оригінал</original>
+		<sort>Сортувати</sort>
+		<trophies>Трофеї</trophies>
+		<grade>Ступінь</grade>
+		<progress>Прогрес</progress>
+		<updated>Оновлено</updated>
+	</trophy_collection>
+
+	<user_management>
+		<select_user>Обрати користувача</select_user>
+		<create_user>Створити користувача</create_user>
+		<user_created>Користувача було створено.</user_created>
+		<edit_user>Редагувати користувача</edit_user>
+		<open_user_folder>Відкрити папку користувача</open_user_folder>
+		<user_name_used>Це ім'я вже використовується.</user_name_used>
+		<delete_user>Видалити користувача</delete_user>
+		<user_delete>Оберіть, якого користувача ви хочете видалити.</user_delete>
+		<user_delete_msg>Цього користувача буде видалено.</user_delete_msg>
+		<user_delete_message>Якщо ви видалите цього користувача, будуть також видалені його збережені дані та трофеї.</user_delete_message>
+		<user_delete_warn>Користувача буде видалено.
+Ви впевнені, що хочете продовжити?</user_delete_warn>
+		<user_deleted>Користувача видалено.</user_deleted>
+		<choose_avatar>Обрати аватар</choose_avatar>
+		<reset_avatar>Скинути аватар</reset_avatar>
+		<name>Ім'я</name>
+		<user>Користувач</user>
+		<confirm>Підтвердити</confirm>
+		<automatic_user_login>Автоматичний вхід у систему</automatic_user_login>
+	</user_management>
+
+	<vita3k_update name="Оновлення Vita3K">
+ 		<new_version_available>Доступна нова версія Vita3K.</new_version_available>
+		<back>Назад</back>
+ 		<cancel_update>Ви хочете відмінити оновлення?</cancel_update>
+		<downloading>Завантаження...
+Після завантаження, Vita3K автоматично перезапуститься та встановить нове оновлення.</downloading>
+		<not_complete_update>Не вдалося виконати оновлення.</not_complete_update>
+		<minutes_left>{} хвилин залишилось</minutes_left>
+		<next>Далі</next>
+		<seconds_left>{} секунд залишилось</seconds_left>
+		<update_vita3k>Ви хочете оновити Vita3K?</update_vita3k>
+		<later_version_already_installed>Більш нову версію Vita3K вже встановлено.</later_version_already_installed>
+		<latest_version_already_installed>Останню версію Vita3K вже встановлено.</latest_version_already_installed>
+		<new_features>Нові функції у версії {}</new_features>
+		<authors>Автори</authors>
+		<comments>Опис</comments>
+		<update>Оновлення</update>
+		<version>Версія {}</version>
+	</vita3k_update>
+
+	<welcome name="Вітаємо у Vita3K">
+		<vita3k>Емулятор PlayStation Vita Vita3K</vita3k>
+		<about_vita3k>Vita3K - це емулятор PlayStation Vita з відкритим кодом, написаний на C++ для операційних систем Windows, Linux, macOS та Android.</about_vita3k>
+		<development_stage>Емулятор досі у розробці, тому ми були б дуже вдячні за відгуки та тестування.</development_stage>
+		<about_firmware>Аби розпочати, будь ласка, встановіть прошивку PS Vita та пакети шрифтів.</about_firmware>
+		<download_firmware>Встановити прошивку</download_firmware>
+		<vita3k_quickstart>Повне керівництво з налаштування Vita3K можна побачити</vita3k_quickstart>
+		<quickstart>Тут</quickstart>
+		<page>Сторінка.</page>
+		<check_compatibility>Перевірте списки сумісності, аби дізнатися, що нараізі запускається.</check_compatibility>
+		<commercial_compatibility_list>Список сумісності комерційних ігор</commercial_compatibility_list>
+		<homebrew_compatibility_list>Список сумісності Homebrew</homebrew_compatibility_list>
+		<welcome_contribution>Будь-який внесок вітається!</welcome_contribution>
+		<discord_help>Додаткову інформацію можна знайти в каналі #help у</discord_help>
+		<no_piracy>Vita3K не заохочує до піратства. Ви маєте використовувати власні дампи пам'яті ігор.</no_piracy>
+		<show_next_time>Відобразити наступного разу</show_next_time>
+	</welcome>
+</lang>

--- a/vita3k/gui/src/about_dialog.cpp
+++ b/vita3k/gui/src/about_dialog.cpp
@@ -56,13 +56,21 @@ void draw_about_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 display_size(emuenv.viewport_size.x, emuenv.viewport_size.y);
     const ImVec2 RES_SCALE(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
     const ImVec2 SCALE(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
+    static const auto BUTTON_SIZE = ImVec2(120.f * emuenv.dpi_scale, 0.f);
 
     auto &lang = gui.lang.about;
+    auto &common = emuenv.common_dialog.lang.common;
+
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-    ImGui::Begin(lang["title"].c_str(), &gui.help_menu.about_dialog, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
+    ImGui::Begin("##about", &gui.help_menu.about_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
+    ImGui::SetWindowFontScale(RES_SCALE.x);
+    auto title_str = lang["title"].c_str();
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title_str).x / 2.f));
+    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title_str);
+    ImGui::Spacing();
+    ImGui::Separator();
     const auto HALF_WINDOW_WIDTH = ImGui::GetWindowWidth() / 2.f;
     ImGui::SetCursorPosX(HALF_WINDOW_WIDTH - (ImGui::CalcTextSize(window_title).x / 2.f));
-    ImGui::SetWindowFontScale(RES_SCALE.x);
     ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", window_title);
 
     ImGui::Spacing();
@@ -151,6 +159,12 @@ void draw_about_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::Text("%s", supporter);
         ImGui::EndTable();
     }
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (BUTTON_SIZE.x / 2.f));
+    if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
+        gui.help_menu.about_dialog = false;
 
     ImGui::End();
 }

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -320,6 +320,7 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
     auto &savedata_str = gui.lang.content_manager.saved_data;
     auto &common = emuenv.common_dialog.lang.common;
     auto &lang_compat = gui.lang.compatibility;
+    auto &textures = gui.lang.settings_dialog.gpu;
 
     const auto is_commercial_app = title_id.starts_with("PCS") || (title_id == "NPXS10007");
     const auto is_system_app = title_id.starts_with("NPXS") && (title_id != "NPXS10007");
@@ -478,9 +479,9 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                     open_path(SHADER_CACHE_PATH.string());
                 if (fs::exists(SHADER_LOG_PATH) && ImGui::MenuItem(lang.main["shaders_log"].c_str()))
                     open_path(SHADER_LOG_PATH.string());
-                if (fs::exists(EXPORT_TEXTURES_PATH) && ImGui::MenuItem(lang.main["export_textures"].c_str()))
+                if (fs::exists(EXPORT_TEXTURES_PATH) && ImGui::MenuItem(textures["export_textures"].c_str()))
                     open_path(EXPORT_TEXTURES_PATH.string());
-                if (fs::exists(IMPORT_TEXTURES_PATH) && ImGui::MenuItem(lang.main["import_textures"].c_str()))
+                if (fs::exists(IMPORT_TEXTURES_PATH) && ImGui::MenuItem(textures["import_textures"].c_str()))
                     open_path(IMPORT_TEXTURES_PATH.string());
                 ImGui::EndMenu();
             }
@@ -508,9 +509,9 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                     fs::remove_all(SHADER_CACHE_PATH);
                 if (fs::exists(SHADER_LOG_PATH) && ImGui::MenuItem(lang.main["shaders_log"].c_str()))
                     fs::remove_all(SHADER_LOG_PATH);
-                if (fs::exists(EXPORT_TEXTURES_PATH) && ImGui::MenuItem(lang.main["export_textures"].c_str()))
+                if (fs::exists(EXPORT_TEXTURES_PATH) && ImGui::MenuItem(textures["export_textures"].c_str()))
                     fs::remove_all(EXPORT_TEXTURES_PATH);
-                if (fs::exists(IMPORT_TEXTURES_PATH) && ImGui::MenuItem(lang.main["import_textures"].c_str()))
+                if (fs::exists(IMPORT_TEXTURES_PATH) && ImGui::MenuItem(textures["import_textures"].c_str()))
                     fs::remove_all(IMPORT_TEXTURES_PATH);
                 ImGui::EndMenu();
             }

--- a/vita3k/gui/src/controllers_dialog.cpp
+++ b/vita3k/gui/src/controllers_dialog.cpp
@@ -173,17 +173,25 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 VIEWPORT_POS(emuenv.viewport_pos.x, emuenv.viewport_pos.y);
     const ImVec2 VIEWPORT_SIZE(emuenv.viewport_size.x, emuenv.viewport_size.y);
     const ImVec2 RES_SCALE(VIEWPORT_SIZE.x / emuenv.res_width_dpi_scale, VIEWPORT_SIZE.y / emuenv.res_height_dpi_scale);
+    static const auto BUTTON_SIZE = ImVec2(120.f * emuenv.dpi_scale, 0.f);
 
     auto &ctrl = emuenv.ctrl;
     auto &lang = gui.lang.controllers;
+    auto &common = emuenv.common_dialog.lang.common;
 
     const auto has_controllers = ctrl.controllers_num > 0;
 
     if (has_controllers)
         ImGui::SetNextWindowSize(ImVec2(VIEWPORT_SIZE.x / 2.5f, 0), ImGuiCond_Always);
     ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f)), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-    ImGui::Begin(lang["title"].c_str(), &gui.controls_menu.controllers_dialog, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
+    ImGui::Begin("##controllers", &gui.controls_menu.controllers_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
     ImGui::SetWindowFontScale(RES_SCALE.x);
+    auto title_str = lang["title"].c_str();
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title_str).x / 2.f));
+    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title_str);
+    ImGui::Spacing();
+    ImGui::Separator();
+
     if (has_controllers) {
         const auto connected_str = fmt::format(fmt::runtime(lang["connected"].c_str()), ctrl.controllers_num);
         ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", connected_str.c_str());
@@ -214,9 +222,16 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                     }
                     ImGui::SetNextWindowSize(ImVec2(VIEWPORT_SIZE.x / 1.4f, 0.f), ImGuiCond_Always);
                     ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f)), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-                    ImGui::Begin(lang["rebind_controls"].c_str(), &rebinds_is_open, ImGuiWindowFlags_NoSavedSettings);
+                    ImGui::Begin("##rebind_controls", &rebinds_is_open, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
                     ImGui::SetWindowFontScale(RES_SCALE.x);
+                    auto rebind_controls = lang["rebind_controls"].c_str();
+                    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(rebind_controls).x / 2.f));
+                    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", rebind_controls);
+                    ImGui::Spacing();
+                    ImGui::Separator();
+
                     auto &controls = gui.lang.controls;
+
                     const auto type = SDL_GameControllerTypeForIndex(i);
                     ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", ctrl.controllers_name[i]);
                     ImGui::Separator();
@@ -298,6 +313,8 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                             config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
                         };
                         ImGui::Spacing();
+                        ImGui::Separator();
+                        ImGui::Spacing();
                         const auto led_color_str = lang["led_color"].c_str();
                         ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(led_color_str).x / 2.f));
                         ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", led_color_str);
@@ -341,6 +358,13 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                             }
                         }
                     }
+                    ImGui::Spacing();
+                    ImGui::Separator();
+                    ImGui::Spacing();
+                    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (BUTTON_SIZE.x / 2.f));
+                    if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
+                        rebinds_is_open = false;
+
                     ImGui::End();
                 }
             }
@@ -359,6 +383,12 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::Spacing();
     if (ImGui::Button(lang["reset_controller_binding"].c_str()))
         reset_controller_binding(emuenv);
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (BUTTON_SIZE.x / 2.f));
+    if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
+        gui.controls_menu.controllers_dialog = false;
 
     ImGui::End();
 }

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -113,16 +113,29 @@ static void remapper_button(GuiState &gui, EmuEnvState &emuenv, int *button, con
 }
 
 void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
-    auto &lang = gui.lang.controls;
+    const ImVec2 display_size(emuenv.viewport_size.x, emuenv.viewport_size.y);
+    const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
+    static const auto BUTTON_SIZE = ImVec2(120.f * emuenv.dpi_scale, 0.f);
+
     float height = emuenv.viewport_size.y / emuenv.dpi_scale;
     if (ImGui::BeginMainMenuBar()) {
         height = height - ImGui::GetWindowHeight() * 2;
         ImGui::EndMainMenuBar();
     }
 
+    auto &lang = gui.lang.controls;
+    auto &common = emuenv.common_dialog.lang.common;
+
     ImGui::SetNextWindowSize(ImVec2(0, height));
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f, ImGui::GetIO().DisplaySize.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-    ImGui::Begin(lang["title"].c_str(), &gui.controls_menu.controls_dialog);
+    ImGui::Begin("##controls", &gui.controls_menu.controls_dialog, ImGuiWindowFlags_NoTitleBar);
+    ImGui::SetWindowFontScale(RES_SCALE.x);
+    auto title_str = lang["title"].c_str();
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title_str).x / 2.f));
+    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title_str);
+    ImGui::Spacing();
+    ImGui::Separator();
+
     if (ImGui::BeginTable("main", 2)) {
         ImGui::TableSetupColumn("button");
         ImGui::TableSetupColumn("mapped_button");
@@ -199,14 +212,20 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f, ImGui::GetIO().DisplaySize.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     if (ImGui::BeginPopupModal(lang["error"].c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
         ImGui::Text("%s", lang["error_duplicate_key"].c_str());
-        ImGui::NewLine();
-        static const auto BUTTON_SIZE = ImVec2(120.f * emuenv.dpi_scale, 0.f);
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
         ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (BUTTON_SIZE.x / 2.f));
-        if (ImGui::Button(emuenv.common_dialog.lang.common["ok"].c_str(), BUTTON_SIZE)) {
+        if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE))
             ImGui::CloseCurrentPopup();
-        }
         ImGui::EndPopup();
     }
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (BUTTON_SIZE.x / 2.f));
+    if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
+        gui.controls_menu.controls_dialog = false;
 
     ImGui::End();
 }

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -1,4 +1,4 @@
-// Vita3K emulator project
+﻿// Vita3K emulator project
 // Copyright (C) 2024 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
@@ -478,6 +478,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const auto SCALE = ImVec2(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
 
     auto &lang = gui.lang.settings_dialog;
+    auto &common = emuenv.common_dialog.lang.common;
     auto &firmware_font = gui.lang.install_dialog.firmware_install;
 
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
@@ -983,7 +984,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("%s", lang.gui["info_bar_description"].c_str());
         ImGui::Spacing();
-        const std::string system_lang_name = fmt::format("System: {}", get_sys_lang_name(emuenv.cfg.sys_lang));
+        const std::string system_lang_name = fmt::format("{}: {}", lang.system["title"], get_sys_lang_name(emuenv.cfg.sys_lang));
         std::vector<const char *> list_user_lang_str{ system_lang_name.c_str() };
         static std::map<std::string, std::string> static_list_user_lang_names = {
             { "id", "Indonesia" },
@@ -1286,7 +1287,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::Spacing();
     static const auto BUTTON_SIZE = ImVec2(120.f * SCALE.x, 0.f);
     ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - BUTTON_SIZE.x - (10.f * SCALE.x));
-    if (ImGui::Button(lang.main_window["close"].c_str(), BUTTON_SIZE))
+    if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
         settings_dialog = false;
     ImGui::SameLine(0, 20.f * SCALE.x);
     const auto is_apply = !emuenv.io.app_path.empty() && (!is_custom_config || (emuenv.app_path == emuenv.io.app_path));

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -989,6 +989,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         static std::map<std::string, std::string> static_list_user_lang_names = {
             { "id", "Indonesia" },
             { "ms", "Malaysia" },
+            { "ua", reinterpret_cast<const char *>(u8"Українська") },
         };
         for (const auto &l : list_user_lang)
             list_user_lang_str.push_back(static_list_user_lang_names.contains(l) ? static_list_user_lang_names[l].c_str() : l.c_str());

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -618,13 +618,11 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
                 if ((user_item_rect_half > HALF_SIZE_USER) || (user_item_rect_half < HALF_SIZE_USER))
                     ImGui::SetScrollHereX(0.5f);
             }
-#if defined(__Win32__) && !defined(__linux__) && !defined(__APPLE__)
             if (ImGui::BeginPopupContextItem("##user_context_menu")) {
                 if (ImGui::MenuItem(lang["open_user_folder"].c_str()))
                     open_path((user_path / user.first).string());
                 ImGui::EndPopup();
             }
-#endif
             ImGui::SetCursorPos(ImVec2(USER_POS.x + USER_NAME_PADDING, USER_POS.y + MED_AVATAR_SIZE.y + (5.f * SCALE.y)));
             ImGui::PushTextWrapPos(USER_POS.x + MED_AVATAR_SIZE.x - USER_NAME_PADDING);
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", user.second.name.c_str());

--- a/vita3k/gui/src/welcome_dialog.cpp
+++ b/vita3k/gui/src/welcome_dialog.cpp
@@ -27,13 +27,20 @@ namespace gui {
 void draw_welcome_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 display_size(emuenv.viewport_size.x, emuenv.viewport_size.y);
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
+    static const auto BUTTON_SIZE = ImVec2(120.f * emuenv.dpi_scale, 0.f);
 
     auto &lang = gui.lang.welcome;
+    auto &common = emuenv.common_dialog.lang.common;
 
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
-    ImGui::Begin(lang["title"].c_str(), &gui.help_menu.welcome_dialog, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
+    ImGui::Begin("##welcome", &gui.help_menu.welcome_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SetWindowFontScale(RES_SCALE.x);
+    auto title_str = lang["title"].c_str();
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title_str).x / 2.f));
+    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title_str);
+    ImGui::Spacing();
+    ImGui::Separator();
     ImGui::PopStyleColor();
     ImGui::Spacing();
     ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["vita3k"].c_str());
@@ -84,8 +91,10 @@ void draw_welcome_dialog(GuiState &gui, EmuEnvState &emuenv) {
     if (ImGui::Checkbox(lang["show_next_time"].c_str(), &emuenv.cfg.show_welcome))
         config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
     ImGui::Spacing();
-    if (ImGui::Button(lang["close"].c_str()))
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (BUTTON_SIZE.x / 2.f));
+    if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
         gui.help_menu.welcome_dialog = false;
+
     ImGui::End();
 }
 

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -33,6 +33,7 @@ struct DialogLangState {
     std::map<std::string, std::string> common = {
         { "an_error_occurred", "An error occurred.\nError code: {}" },
         { "cancel", "Cancel" },
+        { "close", "Close" },
         { "delete", "Delete" },
         { "file_corrupted", "The file is corrupt." },
         { "microphone_disabled", "Enable the microphone." },
@@ -166,8 +167,6 @@ struct LangState {
             { "license", "License" },
             { "shaders_cache", "Shaders Cache" },
             { "shaders_log", "Shaders Log" },
-            { "export_textures", "Export Textures" },
-            { "import_textures", "Import Textures" },
             { "manual", "Manual" },
             { "update", "Update" },
             { "update_history", "Update History" },
@@ -512,7 +511,6 @@ struct LangState {
     struct SettingsDialog {
         std::map<std::string, std::string> main_window = {
             { "title", "Settings" },
-            { "close", "Close" },
             { "save_reboot", "Save & Reboot" },
             { "save_apply", "Save & Apply" },
             { "save", "Save" },
@@ -802,8 +800,7 @@ struct LangState {
         { "welcome_contribution", "Contributions are welcome!" },
         { "discord_help", "Additional support can be found in the #help channel of the" },
         { "no_piracy", "Vita3K does not condone piracy. You must dump your own games." },
-        { "show_next_time", "Show next time" },
-        { "close", "Close" }
+        { "show_next_time", "Show next time" }
     };
     struct Common {
         std::vector<std::string> wday = {


### PR DESCRIPTION
Some improve in gui & lang.

- gui/lang: Minor lang strings code cleanup.
- gui: Unified window interface.
- gui/user management: Fixed the Open User Folder menuitem.
- lang: Remove `initial_setup` in id/ms.xml. Because not official language on PS Vita, and also the reason is couldn't change user language in Initial Setup.
- gui/settings dialog: Add ua (Ukraine language) user language. translation by @Valeriy-Lednikov (#3220)

![image](https://github.com/Vita3K/Vita3K/assets/61804715/65f5495d-2abf-4bf5-83cd-8ced068d4503)
![image](https://github.com/Vita3K/Vita3K/assets/61804715/a3a83c1a-f8f6-4165-9493-9e0d010c6cd0)

