### PR TITLE
shader: replaced std map by std array to store shader code in convert_gxp_usse_to_spirv

### DIFF
--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -436,7 +436,7 @@ struct ProgramInput {
 };
 
 enum class ShaderPhase {
-    SampleRate, // Secondary phase
+    SampleRate = 0, // Secondary phase
     Pixel, // Primary phase
 
     Max,

--- a/vita3k/shader/include/shader/usse_types.h
+++ b/vita3k/shader/include/shader/usse_types.h
@@ -436,7 +436,7 @@ struct ProgramInput {
 };
 
 enum class ShaderPhase {
-    SampleRate = 0, // Secondary phase
+    SampleRate, // Secondary phase
     Pixel, // Primary phase
 
     Max,

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -25,7 +25,6 @@
 #include <shader/usse_translator_types.h>
 #include <util/log.h>
 
-#include <map>
 #include <optional>
 
 namespace shader::usse {
@@ -1078,13 +1077,13 @@ void convert_gxp_usse_to_spirv(spv::Builder &b, const SceGxmProgram &program, co
     const uint64_t *secondary_program_start = program.secondary_program_start();
     const uint64_t *secondary_program_end = program.secondary_program_end();
 
-    std::map<ShaderPhase, std::pair<const std::uint64_t *, std::uint64_t>> shader_code;
+    std::array<std::pair<const std::uint64_t *, std::uint64_t>, (size_t)ShaderPhase::Max> shader_code;
 
     // Collect instructions of Pixel (primary) phase
-    shader_code[ShaderPhase::Pixel] = std::make_pair(primary_program, primary_program_instr_count);
+    shader_code[static_cast<size_t>(ShaderPhase::Pixel)] = std::make_pair(primary_program, primary_program_instr_count);
 
     // Collect instructions of Sample rate (secondary) phase
-    shader_code[ShaderPhase::SampleRate] = std::make_pair(secondary_program_start, secondary_program_end - secondary_program_start);
+    shader_code[static_cast<size_t>(ShaderPhase::SampleRate)] = std::make_pair(secondary_program_start, secondary_program_end - secondary_program_start);
 
     if (begin_hook_func)
         b.createFunctionCall(begin_hook_func, {});
@@ -1094,7 +1093,7 @@ void convert_gxp_usse_to_spirv(spv::Builder &b, const SceGxmProgram &program, co
     usse::USSERecompiler recomp(b, program, features, parameters, utils, end_hook_func, queries, render_info_id);
 
     for (uint32_t phase = 0; phase < static_cast<uint32_t>(ShaderPhase::Max); ++phase) {
-        const auto cur_phase_code = shader_code[(ShaderPhase)phase];
+        const auto cur_phase_code = shader_code[phase];
 
         if (cur_phase_code.second != 0) {
             if (static_cast<ShaderPhase>(phase) == ShaderPhase::SampleRate) {


### PR DESCRIPTION
The std map seems unnecessary here and can safely be replaced by std array. Doing so will avoid unnecessary dynamic allocations and more expensive iterations/lookups.