### PR TITLE
.github: push builds to store repository

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -234,3 +234,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Push to store repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: artifacts/
+          destination-github-username: 'Vita3K'
+          destination-repository-name: 'Vita3K-builds'
+          target-branch: master
+          target-directory: Builds/
+          commit-message: "Build: ${{ env.Build_Variable }}"
+          user-name: github-actions[bot]
+          user-email: github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
~~Vita3K can run more games and regressions are not unusual for now, it is better to retain past builds.
Looking at PCSX2, there does not appear to be a capacity limit on releases.
Release looks like this.
![image](https://github.com/Vita3K/Vita3K/assets/107111782/bf69487e-f405-4483-bc58-9bc53187a8be)
If you do not want a large number of releases created, i can change code to have a release created when a tag is created.~~

Edited: To avoid makeing dirty the main repository, changed approach to push builds to store repository(https://github.com/Vita3K/Vita3K-builds)
we can also create a release there, maybe need to give push permission for token.