### PR TITLE
renderer/vulkan: Improve depth/stencil retrieval

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/surface_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/surface_cache.h
@@ -49,6 +49,8 @@ enum struct SurfaceTiling {
 struct SurfaceCacheInfo {
     vkutil::Image texture;
     SurfaceTiling tiling;
+    // for d32s8 surfaces, this is the size of the depth part
+    uint32_t total_bytes;
 };
 
 struct Framebuffer {
@@ -78,7 +80,6 @@ struct ColorSurfaceCacheInfo : public SurfaceCacheInfo {
     uint16_t original_width;
     uint16_t original_height;
     uint32_t stride_bytes;
-    uint32_t total_bytes;
     uint64_t last_frame_rendered;
 
     SceGxmColorBaseFormat format;
@@ -113,8 +114,8 @@ struct DepthSurfaceView {
     vkutil::Image stencil_view;
     // used so that we copy the depth stencil at most once per scene
     uint64_t scene_timestamp;
-    uint32_t width;
-    uint32_t height;
+    uint32_t delta_col;
+    uint32_t delta_row;
 };
 
 struct DepthStencilSurfaceCacheInfo : public SurfaceCacheInfo {

--- a/vita3k/vkutil/include/vkutil/vkutil.h
+++ b/vita3k/vkutil/include/vkutil/vkutil.h
@@ -114,7 +114,7 @@ enum struct ImageLayout {
     ColorAttachmentReadWrite,
     SampledImage,
     StorageImage,
-    DepthReadOnly
+    DepthStencilReadOnly
 };
 void transition_image_layout(vk::CommandBuffer cmd_buffer, vk::Image image, ImageLayout src_layout, ImageLayout dst_layout, const vk::ImageSubresourceRange &range = color_subresource_range);
 // transition image layout assuming you don't care about the former image content

--- a/vita3k/vkutil/src/vkutil.cpp
+++ b/vita3k/vkutil/src/vkutil.cpp
@@ -139,7 +139,7 @@ static constexpr ImageLayoutTransition layout_transitions[] = {
         vk::ImageLayout::eGeneral,
         vk::PipelineStageFlagBits::eFragmentShader | vk::PipelineStageFlagBits::eComputeShader,
         vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite },
-    // DepthReadOnly
+    // DepthStencilReadOnly
     {
         vk::ImageLayout::eDepthStencilReadOnlyOptimal,
         vk::PipelineStageFlagBits::eFragmentShader,


### PR DESCRIPTION
Allow games to sample only a part of a depth/stencil (instead of only the whole or upper part).
This fixes shadows in Ratchet and Clank games.

I alsor renamed the DepthReadOnly layout to DepthStencilReadOnly because it is also used for stencil reading.