### PR TITLE
kernel/load_self: fix memory leak

### DIFF
--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -336,7 +336,7 @@ static bool load_var_exports(const uint32_t *nids, const Ptr<uint32_t> *entries,
         auto nid_it = kernel.export_nids.find(nid);
         if (nid_it != kernel.export_nids.end()) {
             LOG_DEBUG("Found previously not found variable. nid:{}, new_entry_point:{}", log_hex(nid), log_hex(entry.address()));
-            Address old_entry_address = kernel.export_nids[nid];
+            old_entry_address = kernel.export_nids[nid];
             kernel.export_nids[nid] = entry.address();
         }
 


### PR DESCRIPTION
New variable was introduced and immediately go out of scope. Instead of this an existent variable should be used