### PR TITLE
mem/threads: Include some missing header files

### DIFF
--- a/vita3k/kernel/include/kernel/thread/thread_data_queue.h
+++ b/vita3k/kernel/include/kernel/thread/thread_data_queue.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include <kernel/thread/thread_state.h>
+
+#include <algorithm>
 #include <list>
 #include <set>
 

--- a/vita3k/mem/include/mem/mempool.h
+++ b/vita3k/mem/include/mem/mempool.h
@@ -20,6 +20,8 @@
 #include <mem/ptr.h>
 #include <util/align.h>
 
+#include <algorithm>
+
 struct MemspaceBlockAllocator {
     struct Block {
         std::uint32_t size;


### PR DESCRIPTION
These headers are now needed for compiling, for std::find and std::lower_bound