### PR TITLE
shader, renderer/vulkan: Perform gamma correction within shaders when using shader interlock

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
+++ b/vita3k/renderer/include/renderer/vulkan/pipeline_cache.h
@@ -81,7 +81,7 @@ private:
     unordered_map_stable<Sha256Hash, vk::ShaderModule> shaders;
     unordered_map_stable<uint64_t, vk::Pipeline> pipelines;
 
-    vk::PipelineShaderStageCreateInfo retrieve_shader(const SceGxmProgram *program, const Sha256Hash &hash, bool is_vertex, bool maskupdate, MemState &mem, const shader::Hints &hints);
+    vk::PipelineShaderStageCreateInfo retrieve_shader(const SceGxmProgram *program, const Sha256Hash &hash, bool is_vertex, bool maskupdate, MemState &mem, const shader::Hints &hints, bool is_srgb = false);
     vk::PipelineVertexInputStateCreateInfo get_vertex_input_state(const SceGxmVertexProgram &vertex_program, MemState &mem);
 
     // queue containing request sent by the main thread to the compile threads

--- a/vita3k/shader/include/shader/spirv_recompiler.h
+++ b/vita3k/shader/include/shader/spirv_recompiler.h
@@ -38,6 +38,10 @@ static constexpr int COLOR_ATTACHMENT_TEXTURE_SLOT_IMAGE = 0;
 static constexpr int MASK_TEXTURE_SLOT_IMAGE = 1;
 static constexpr int COLOR_ATTACHMENT_RAW_TEXTURE_SLOT_IMAGE = 3;
 static constexpr uint32_t CURRENT_VERSION = 13;
+// fragment shader using the rendering surface as a storage image (because of shader interlock) have a line
+// layout (constant_id = GAMMA_CORRECTION_SPECIALIZATIO_ID) const bool is_srgb = false;
+// Setting this constant to true performs gamma correction in the shader
+static constexpr uint32_t GAMMA_CORRECTION_SPECIALIZATION_ID = 0;
 
 enum struct Target {
     GLSLOpenGL,

--- a/vita3k/shader/include/shader/usse_translator_types.h
+++ b/vita3k/shader/include/shader/usse_translator_types.h
@@ -106,6 +106,9 @@ struct SpirvShaderParameters {
     spv::Id thread_buffer;
 
     spv::Id render_info_id;
+
+    // When using shader interlock, specialization constant telling us if the texture is gamma corrected
+    spv::Id is_srgb_constant;
 };
 
 using Coord = std::pair<spv::Id, int>;


### PR DESCRIPTION
Using shader interlock requires the render surface to be loaded as a storage image.
However, storage images with gamma correction are mostly not supported, this was causing some graphical (darkness) issues in some games like Mortal Kombat.

The solution is to perform gamma correction in the shader. Because I'd much rather not have to specify if the surface is gamma corrected in an uniform or make two versions of each fragment shader, I instead opted to use a specialization constant. Using an old shader cache with this update won't cause any crash, but updating the shader cache is required to see the improvement.

Before:
![image](https://github.com/Vita3K/Vita3K/assets/5671744/481039da-f26a-4725-a51a-03fa27561d6e)

After:
![image](https://github.com/Vita3K/Vita3K/assets/5671744/40794684-9c69-4aaf-b5db-f98b1e387e4f)
