### PR TITLE
audio, code: Improve Audio output accuracy

### DIFF
--- a/vita3k/audio/include/audio/state.h
+++ b/vita3k/audio/include/audio/state.h
@@ -41,6 +41,10 @@ struct AudioOutPort {
     float volume = 1.0f;
     // length of the buffer for each call
     int len_bytes = 0;
+    // number of microseconds a buffer lasts for
+    uint64_t len_microseconds = 0;
+    // last time sceAudioOutOutput was called with this port (timestamp in microseconds)
+    uint64_t last_output = 0;
 
     // current config
     int type = 0;

--- a/vita3k/codec/src/atrac9.cpp
+++ b/vita3k/codec/src/atrac9.cpp
@@ -42,7 +42,8 @@ uint32_t Atrac9DecoderState::get(DecoderQuery query) {
 
     switch (query) {
     case DecoderQuery::CHANNELS: return info->channels;
-    case DecoderQuery::BIT_RATE: return 0;
+    // The bit rate is the size of a superframe times the number of superframes per second (times 8)
+    case DecoderQuery::BIT_RATE: return static_cast<uint32_t>((info->superframeSize * 8ULL * info->samplingRate) / (info->frameSamples * info->framesInSuperframe));
     case DecoderQuery::SAMPLE_RATE: return info->samplingRate;
     case DecoderQuery::AT9_SAMPLE_PER_FRAME: return info->frameSamples;
     case DecoderQuery::AT9_SAMPLE_PER_SUPERFRAME: return info->frameSamples * info->framesInSuperframe;

--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
@@ -154,14 +154,14 @@ static int create_decoder(EmuEnvState &emuenv, SceAudiodecCtrl *ctrl, SceAudiode
         DecoderPtr decoder = std::make_shared<Atrac9DecoderState>(info.config_data);
         state->decoders[handle] = decoder;
 
-        ctrl->es_size_max = SCE_AUDIODEC_AT9_MAX_ES_SIZE;
-        ctrl->pcm_size_max = decoder->get(DecoderQuery::AT9_SAMPLE_PER_FRAME)
-            * decoder->get(DecoderQuery::CHANNELS) * sizeof(int16_t);
         info.channels = decoder->get(DecoderQuery::CHANNELS);
         info.bit_rate = decoder->get(DecoderQuery::BIT_RATE);
         info.sample_rate = decoder->get(DecoderQuery::SAMPLE_RATE);
         info.super_frame_size = decoder->get(DecoderQuery::AT9_SUPERFRAME_SIZE);
         info.frames_in_super_frame = decoder->get(DecoderQuery::AT9_FRAMES_IN_SUPERFRAME);
+        ctrl->es_size_max = std::min(info.super_frame_size, SCE_AUDIODEC_AT9_MAX_ES_SIZE);
+        ctrl->pcm_size_max = decoder->get(DecoderQuery::AT9_SAMPLE_PER_FRAME)
+            * decoder->get(DecoderQuery::CHANNELS) * sizeof(int16_t);
         return 0;
     }
     case SCE_AUDIODEC_TYPE_AAC: {


### PR DESCRIPTION
The expected behavior of `sceAudioOutOutput` is to block until the previous buffer has been completely used. If we were to do that, this would cause a lot of audio noise, because the host audio parameters are different compared to the PS Vita's one.
Instead, what we are doing right now is make sure a good enough amount of audio is kept so that there is no shortage for the host of audio samples to output. This often causes a call to sceAudioOutOutput to return immediatly while it would have blocked a bit on a PS Vita.

Ar Nosurge plus is periodically decoding atrac9 audio to feed it to NGS, but because of our previous approach, there could be two subsequent immediate calls to NGS and the second audio update was not able to get audio, causing many audio accuracies.

To solve this issue, sceAudioOutOutput now blocks at least half of the time it should block on a PS Vita (it can't be fully accurate due to the reasons mentioned above). This fixes the audio issues in Ar Nosurge plus. Hopefully it doesn't create any additional issues in other games.

Also implement the bitrate parameter for the Atrac9 decoder.