### PR TITLE
[gui] common_dialog.cpp fix save info dialog crash

### DIFF
--- a/vita3k/gui/src/common_dialog.cpp
+++ b/vita3k/gui/src/common_dialog.cpp
@@ -237,7 +237,9 @@ void browse_save_data_dialog(GuiState &gui, EmuEnvState &emuenv, const uint32_t 
 
         const auto prev_save_data_slot = save_data_slot_list[std::max(list_index - 1, 0)];
         const auto next_save_data_slot = save_data_slot_list[std::min(list_index + 1, save_data_slot_list_size)];
-        const auto is_save_exist = emuenv.common_dialog.savedata.slot_info[current_selected_save_data_slot].isExist == 1;
+        const auto is_save_exist = (current_selected_save_data_slot >= 0 && 
+                                    current_selected_save_data_slot < emuenv.common_dialog.savedata.slot_info.size() && 
+                                    emuenv.common_dialog.savedata.slot_info[current_selected_save_data_slot].isExist == 1);
 
         const auto confirm = [&]() {
             switch (save_data_list_type_selected) {

--- a/vita3k/gui/src/common_dialog.cpp
+++ b/vita3k/gui/src/common_dialog.cpp
@@ -237,9 +237,7 @@ void browse_save_data_dialog(GuiState &gui, EmuEnvState &emuenv, const uint32_t 
 
         const auto prev_save_data_slot = save_data_slot_list[std::max(list_index - 1, 0)];
         const auto next_save_data_slot = save_data_slot_list[std::min(list_index + 1, save_data_slot_list_size)];
-        const auto is_save_exist = (current_selected_save_data_slot >= 0 && 
-                                    current_selected_save_data_slot < emuenv.common_dialog.savedata.slot_info.size() && 
-                                    emuenv.common_dialog.savedata.slot_info[current_selected_save_data_slot].isExist == 1);
+        const auto is_save_exist = (current_selected_save_data_slot >= 0 && current_selected_save_data_slot < emuenv.common_dialog.savedata.slot_info.size() && emuenv.common_dialog.savedata.slot_info[current_selected_save_data_slot].isExist == 1);
 
         const auto confirm = [&]() {
             switch (save_data_list_type_selected) {


### PR DESCRIPTION
If you use the [I] button to view info for a save file in the save dialog then press the down button a few times with your controller there is an access violation on this patched line.  Tales of Innocence R where the info contains stats of 8 members of the party and requires scrolling down to view.  This fixes a crash that could cause a person to lose progress if inside the info dialog.