### PR TITLE
renderer/gl: fix bcn compressed size in upload_texture_impl

### DIFF
--- a/vita3k/renderer/src/gl/texture.cpp
+++ b/vita3k/renderer/src/gl/texture.cpp
@@ -149,7 +149,7 @@ void GLTextureCache::upload_texture_impl(SceGxmTextureBaseFormat base_format, ui
         glPixelStorei(GL_UNPACK_COMPRESSED_BLOCK_HEIGHT, 4);
 
         const GLenum format = translate_format(base_format);
-        size_t compressed_size = renderer::texture::get_compressed_size(base_format, pixels_per_stride, height);
+        size_t compressed_size = renderer::texture::get_compressed_size(base_format, width, height);
         glCompressedTexSubImage2D(upload_type, mip_index, 0, 0, width, height, format, static_cast<GLsizei>(compressed_size), pixels);
 
         glPixelStorei(GL_UNPACK_COMPRESSED_BLOCK_SIZE, 0);


### PR DESCRIPTION
Fix #2032 
Fix these errors in logs:
```
|D| [debug_output_callback]: [OPENGL - ERROR - HIGH] GL_INVALID_VALUE in glCompressedTexSubImage2D(size=X)
|E| [after_callback]: OpenGL: glCompressedTexSubImage2D set error 1281.
```
**Fuuraiki 3 master**
![fuuraiki-3-master](https://github.com/user-attachments/assets/12243422-539c-4f2b-8778-49e7ec4a05f5)
**Fuuraiki 3 PR**
![fuuraiki-3-pr](https://github.com/user-attachments/assets/65271e40-e5cc-474b-ac9f-8e9bdaee75e4)
**Danganronpa v3 master**
![danganronpa-v3-master](https://github.com/user-attachments/assets/076530dc-83d0-4f38-af29-7c68be07195c)
**Danganronpa v3 PR**
![danganronpa-v3-pr](https://github.com/user-attachments/assets/26271380-61f2-446b-bb5c-5decd88ae8ec)