### PR TITLE
modules/SceJpeg: Implement MCU-based decoding and pitch calculation

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -34,6 +34,8 @@ union DecoderSize {
     struct {
         uint32_t width;
         uint32_t height;
+        uint32_t pitch_width;
+        uint32_t pitch_height;
     };
     struct {
         uint32_t samples;
@@ -120,6 +122,9 @@ struct H264DecoderState : public DecoderState {
 };
 
 struct MjpegDecoderState : public DecoderState {
+    uint32_t mcu_width;
+    uint32_t mcu_height;
+
     DecoderColorSpace color_space_out;
 
     bool send(const uint8_t *data, uint32_t size) override;

--- a/vita3k/codec/src/mjpeg.cpp
+++ b/vita3k/codec/src/mjpeg.cpp
@@ -25,9 +25,85 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
+#include <util/align.h>
 #include <util/log.h>
 
 #include <cassert>
+
+namespace {
+
+struct JpegInfo {
+    int mcu_width;
+    int mcu_height;
+    int width;
+    int height;
+};
+
+struct ChannelInfo {
+    uint32_t width_divisor;
+    uint32_t height_divisor;
+    uint32_t offset;
+};
+
+JpegInfo parse_jpeg_header(const uint8_t *data, uint32_t size) {
+    // JPEG marker codes
+    const uint8_t MARKER_SOI = 0xD8;
+    const uint8_t MARKER_EOI = 0xD9;
+    const uint8_t MARKER_SOS = 0xDA;
+    const uint8_t MARKER_SOF0 = 0xC0;
+
+    JpegInfo info = { 0 };
+
+    if (size < 2 || data[0] != 0xFF || data[1] != MARKER_SOI) {
+        return info;
+    }
+
+    uint32_t offset = 2;
+    while (offset < size - 1) {
+        if (data[offset] != 0xFF) {
+            offset++;
+            continue;
+        }
+
+        uint8_t marker = data[offset + 1];
+        offset += 2;
+
+        if (marker == MARKER_EOI || marker == MARKER_SOS) {
+            break;
+        }
+
+        if (marker == MARKER_SOF0) {
+            if (offset + 8 > size)
+                break;
+
+            info.height = (data[offset + 3] << 8) | data[offset + 4];
+            info.width = (data[offset + 5] << 8) | data[offset + 6];
+            int components = data[offset + 7];
+
+            int max_h_factor = 0, max_v_factor = 0;
+            for (int i = 0; i < components; i++) {
+                int h_factor = (data[offset + 8 + i * 3 + 1] >> 4) & 0xF;
+                int v_factor = data[offset + 8 + i * 3 + 1] & 0xF;
+                max_h_factor = (h_factor > max_h_factor) ? h_factor : max_h_factor;
+                max_v_factor = (v_factor > max_v_factor) ? v_factor : max_v_factor;
+            }
+
+            info.mcu_width = max_h_factor * 8;
+            info.mcu_height = max_v_factor * 8;
+
+            break;
+        }
+
+        if (offset + 2 > size)
+            break;
+        uint16_t segment_length = (data[offset] << 8) | data[offset + 1];
+        offset += segment_length;
+    }
+
+    return info;
+}
+
+} // anonymous namespace
 
 void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t width, uint32_t height, const DecoderColorSpace color_space) {
     AVPixelFormat format = AV_PIX_FMT_YUVJ444P;
@@ -250,6 +326,12 @@ bool MjpegDecoderState::send(const uint8_t *data, uint32_t size) {
         LOG_WARN("Error sending Mjpeg packet: {}.", codec_error_name(error));
         return false;
     }
+
+    // Parse JPEG header to get MCU size
+    JpegInfo jpeg_info = parse_jpeg_header(data, size);
+    this->mcu_height = jpeg_info.mcu_height;
+    this->mcu_width = jpeg_info.mcu_width;
+
     return true;
 }
 
@@ -262,75 +344,76 @@ bool MjpegDecoderState::receive(uint8_t *data, DecoderSize *size) {
         return false;
     }
 
-    if (data) {
-        switch (frame->format) {
-        case AV_PIX_FMT_YUVJ444P: {
-            uint8_t *channels[] = {
-                &data[0], // y
-                &data[frame->width * frame->height], // u
-                &data[frame->width * frame->height * 2], // v
-            };
-
-            // Copy YUV444 data.
-            for (uint32_t a = 0; a < 3; a++) {
-                for (int b = 0; b < frame->height; b++) {
-                    std::memcpy(&channels[a][b * frame->width], &frame->data[a][b * frame->linesize[a]], frame->width);
-                }
-            }
-            break;
-        }
-        case AV_PIX_FMT_YUVJ422P: {
-            uint8_t *channels[] = {
-                &data[0], // y
-                &data[frame->width * frame->height], // u
-                &data[frame->width * frame->height * 3 / 2], // v
-            };
-
-            // Copy YUV422 data.
-            for (uint32_t a = 0; a < 3; a++) {
-                for (int b = 0; b < frame->height; b++) {
-                    std::memcpy(&channels[a][b * frame->width / (a ? 2 : 1)], &frame->data[a][b * frame->linesize[a]], frame->width / (a ? 2 : 1));
-                }
-            }
-            break;
-        }
-        case AV_PIX_FMT_YUVJ420P: {
-            uint8_t *channels[] = {
-                &data[0], // y
-                &data[frame->width * frame->height], // u
-                &data[frame->width * frame->height * 5 / 4], // v
-            };
-
-            // Copy YUV420 data.
-            for (uint32_t a = 0; a < 3; a++) {
-                for (int b = 0; b < frame->height / (a ? 2 : 1); b++) {
-                    std::memcpy(&channels[a][b * frame->width / (a ? 2 : 1)], &frame->data[a][b * frame->linesize[a]], frame->width / (a ? 2 : 1));
-                }
-            }
-            break;
-        }
-        }
+    if (mcu_width == 0 || mcu_height == 0) {
+        LOG_WARN_ONCE("Mjpeg MCU size is not set. Falling back to 8x8.");
+        mcu_width = mcu_height = 8;
     }
 
-    switch (frame->format) {
-    case AV_PIX_FMT_YUVJ444P:
-        this->color_space_out = COLORSPACE_YUV444P;
-        break;
-    case AV_PIX_FMT_YUVJ422P:
-        this->color_space_out = COLORSPACE_YUV422P;
-        break;
-    case AV_PIX_FMT_YUVJ420P:
-        this->color_space_out = COLORSPACE_YUV420P;
-        break;
-    default:
-        LOG_WARN("Mjpeg frame is in unimplemented format {}.", frame->format);
-        av_frame_free(&frame);
-        return false;
+    // Calculate MCU-aligned dimensions
+    uint32_t aligned_width = align(frame->width, mcu_width);
+    uint32_t aligned_height = align(frame->height, mcu_height);
+
+    if (frame->width != aligned_width || frame->height != aligned_height) {
+        LOG_INFO_ONCE("Mjpeg frame dimensions are not MCU-aligned. MCU size: {}x{}, frame size: {}x{} -> aligned size: {}x{}.",
+            mcu_width, mcu_height, frame->width, frame->height, aligned_width, aligned_height);
+    }
+
+    if (data) {
+        ChannelInfo channel_info[3];
+        uint32_t total_pixel_count = aligned_width * aligned_height;
+
+        switch (frame->format) {
+        case AV_PIX_FMT_YUVJ444P:
+            for (int i = 0; i < 3; i++) {
+                channel_info[i] = { 1, 1, total_pixel_count * i };
+            }
+            this->color_space_out = COLORSPACE_YUV444P;
+            break;
+        case AV_PIX_FMT_YUVJ422P:
+            channel_info[0] = { 1, 1, 0 };
+            channel_info[1] = { 2, 1, total_pixel_count };
+            channel_info[2] = { 2, 1, total_pixel_count * 3 / 2 };
+            this->color_space_out = COLORSPACE_YUV422P;
+            break;
+        case AV_PIX_FMT_YUVJ420P:
+            channel_info[0] = { 1, 1, 0 };
+            channel_info[1] = { 2, 2, total_pixel_count };
+            channel_info[2] = { 2, 2, total_pixel_count * 5 / 4 };
+            this->color_space_out = COLORSPACE_YUV420P;
+            break;
+        default:
+            LOG_WARN("Mjpeg frame is in unimplemented format {}.", frame->format);
+            av_frame_free(&frame);
+            return false;
+        }
+
+        for (int a = 0; a < 3; a++) {
+            uint32_t component_width = aligned_width / channel_info[a].width_divisor;
+            uint32_t component_height = aligned_height / channel_info[a].height_divisor;
+            uint32_t frame_component_width = frame->width / channel_info[a].width_divisor;
+            uint32_t frame_component_height = frame->height / channel_info[a].height_divisor;
+
+            for (uint32_t y = 0; y < component_height; y++) {
+                uint8_t *dst = &data[channel_info[a].offset + y * component_width];
+                const uint8_t *src = frame->data[a] + (y < frame_component_height ? y * frame->linesize[a] : (frame_component_height - 1) * frame->linesize[a]);
+
+                if (y < frame_component_height) {
+                    std::memcpy(dst, src, frame_component_width);
+                    // Pad the rest with the last pixel value
+                    std::memset(dst + frame_component_width, dst[frame_component_width - 1], component_width - frame_component_width);
+                } else {
+                    // Copy the last row for padding
+                    std::memcpy(dst, dst - component_width, component_width);
+                }
+            }
+        }
     }
 
     if (size) {
         size->width = frame->width;
         size->height = frame->height;
+        size->pitch_width = aligned_width;
+        size->pitch_height = aligned_height;
     }
 
     av_frame_free(&frame);

--- a/vita3k/modules/SceJpeg/SceJpegUser.cpp
+++ b/vita3k/modules/SceJpeg/SceJpegUser.cpp
@@ -144,10 +144,10 @@ EXPORT(int, sceJpegDecodeMJpeg, const unsigned char *pJpeg, SceSize isize, uint8
     state->decoder->send(pJpeg, isize);
     state->decoder->receive(temporary.data(), &size);
 
-    convert_yuv_to_rgb(temporary.data(), pRGBA, size.width, size.height, state->decoder->get_color_space());
+    convert_yuv_to_rgb(temporary.data(), pRGBA, size.pitch_width, size.pitch_height, state->decoder->get_color_space());
 
-    // Top 16 bits = width, bottom 16 bits = height.
-    return (size.width << 16u) | size.height;
+    // Top 16 bits = pitch_width, bottom 16 bits = pitch_height.
+    return (size.pitch_width << 16u) | size.pitch_height;
 }
 
 EXPORT(int, sceJpegDecodeMJpegYCbCr, const uint8_t *pJpeg, SceSize isize,
@@ -164,8 +164,8 @@ EXPORT(int, sceJpegDecodeMJpegYCbCr, const uint8_t *pJpeg, SceSize isize,
     state->decoder->send(pJpeg, isize);
     state->decoder->receive(pYCbCr, &size);
 
-    // Top 16 bits = width, bottom 16 bits = height.
-    return (size.width << 16u) | size.height;
+    // Top 16 bits = pitch_width, bottom 16 bits = pitch_height.
+    return (size.pitch_width << 16u) | size.pitch_height;
 }
 
 EXPORT(int, sceJpegDeleteSplitDecoder) {
@@ -205,39 +205,39 @@ EXPORT(int, sceJpegGetOutputInfo, const uint8_t *pJpeg, SceSize isize,
     output->height = size.height;
     output->color_space = convert_color_space_decoder_to_jpeg(state->decoder->get_color_space());
     output->pitch[0] = {
-        .x = size.width,
-        .y = size.height
+        .x = size.pitch_width,
+        .y = size.pitch_height
     };
     // Should be 0 most of the time but I believe it causes more problems
     // for it to be 0 when it shouldn't than the opposite
     output->coef_buffer_size = 0x100;
     if (format == SCE_JPEG_PIXEL_RGBA8888) {
-        output->output_size = size.width * size.height * 4;
+        output->output_size = size.pitch_width * size.pitch_height * 4;
         // put something greater than 0
         output->temp_buffer_size = 0x100;
     } else {
         switch (output->color_space) {
         case SCE_JPEG_COLORSPACE_GRAYSCALE:
-            output->output_size = size.width * size.height;
+            output->output_size = size.pitch_width * size.pitch_height;
             break;
         case SCE_JPEG_COLORSPACE_YUV444:
-            output->output_size = size.width * size.height * 3;
+            output->output_size = size.pitch_width * size.pitch_height * 3;
             output->pitch[1] = output->pitch[0];
             output->pitch[2] = output->pitch[0];
             break;
         case SCE_JPEG_COLORSPACE_YUV422:
-            output->output_size = size.width * size.height * 2;
+            output->output_size = size.pitch_width * size.pitch_height * 2;
             output->pitch[1] = {
-                .x = size.width / 2,
-                .y = size.height
+                .x = size.pitch_width / 2,
+                .y = size.pitch_height
             };
             output->pitch[2] = output->pitch[1];
             break;
         case SCE_JPEG_COLORSPACE_YUV420:
-            output->output_size = size.width * size.height * 3 / 2;
+            output->output_size = size.pitch_width * size.pitch_height * 3 / 2;
             output->pitch[1] = {
-                .x = size.width / 2,
-                .y = size.height / 2
+                .x = size.pitch_width / 2,
+                .y = size.pitch_height / 2
             };
             output->pitch[2] = output->pitch[1];
             break;


### PR DESCRIPTION
## Description
This PR implements MCU-based decoding for JPEG images to more accurately emulate the PS Vita's hardware decoder behavior. The PS Vita primarily uses hardware decoding for JPEG images, which includes certain assumptions in its output. Some games have hardcoded these assumptions, leading to compatibility issues with our previous implementation.

## Changes
- Modified JPEG decoding to always output images in multiples of MCU size
- Updated pitch calculation to reflect this MCU-based approach

## How Has This Been Tested?
- Tested with AI Kiss (PCSG01325) and Kiss Ato (PCSG00742), resolving image issues during JPEG decoding

## Additional Notes
This change is based on the assumption that the PS Vita's hardware decoder always outputs images in multiples of MCU size. While this fixes known issues in some games, further testing across a wider range of titles is recommended to ensure no unintended side effects.