### PR TITLE
gui/vita3k updater: Fix batch script path handling on Windows.

### DIFF
--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -186,7 +186,7 @@ static void download_update(const fs::path &base_path) {
             SDL_PushEvent(&event);
 
 #ifdef WIN32
-            const auto vita3K_batch = fmt::format("\"{}/update-vita3k.bat\"", base_path);
+            const auto vita3K_batch = fmt::format("\"{}\\update-vita3k.bat\"", base_path);
             FreeConsole();
 #elif defined(__APPLE__)
             const auto vita3K_batch = fmt::format("sh \"{}/update-vita3k.sh\"", base_path);


### PR DESCRIPTION
- gui/vita3k updater: Fix batch script path handling on Windows.
Replaced '/' with '\\' to fix path handling and resolve issues caused by incorrect path interpretation.

that totaly fix update batch not run anymore on last version of windows