### PR TITLE
app: Disable round window corners on Windows

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -48,6 +48,12 @@
 #include <SDL_video.h>
 #include <SDL_vulkan.h>
 
+#ifdef WIN32
+#pragma comment(lib, "Dwmapi")
+#include <SDL_syswm.h>
+#include <dwmapi.h>
+#endif
+
 namespace app {
 void update_viewport(EmuEnvState &state) {
     int w = 0;
@@ -326,6 +332,15 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         LOG_ERROR("SDL failed to create window!");
         return false;
     }
+
+#ifdef WIN32
+    // Disable round corners for the game window
+    SDL_SysWMinfo wm_info;
+    SDL_VERSION(&wm_info.version);
+    SDL_GetWindowWMInfo(state.window.get(), &wm_info);
+    const auto window_preference = DWMWCP_DONOTROUND;
+    DwmSetWindowAttribute(wm_info.info.win.window, DWMWA_WINDOW_CORNER_PREFERENCE, &window_preference, sizeof(window_preference));
+#endif
 
     // initialize the renderer first because we need to know if we need a page table
     if (!state.cfg.console) {


### PR DESCRIPTION
Inspired by the Dolphin Progress report.
Disable round corners for the game window on Windows.
The round corners can hide up to 0.0005% of the game being rendered, that was unacceptable.