### PR TITLE
renderer/vulkan: Increase scenes per frame in VKRenderTarget creation

### DIFF
--- a/vita3k/renderer/src/vulkan/creation.cpp
+++ b/vita3k/renderer/src/vulkan/creation.cpp
@@ -191,7 +191,7 @@ VKRenderTarget::VKRenderTarget(VKState &state, const SceGxmRenderTargetParams &p
 
     constexpr uint16_t SCE_GXM_MAX_SCENES_PER_RENDERTARGET = 8;
     // hopefully this will always be enough
-    const uint16_t samples_per_frame = std::min<uint16_t>(params.scenesPerFrame + 2, SCE_GXM_MAX_SCENES_PER_RENDERTARGET);
+    const uint16_t samples_per_frame = std::min<uint16_t>(params.scenesPerFrame + 3, SCE_GXM_MAX_SCENES_PER_RENDERTARGET);
 
     // the maximum number of fence we will ever need simultaneously is samples_per_frame * MAX_FRAMES_RENDERING
     fences.resize(samples_per_frame * MAX_FRAMES_RENDERING);


### PR DESCRIPTION
## Description
This PR slightly increases the number of scenes per frame in the VKRenderTarget creation process. This change aims to reduce warning messages in certain games that require more scenes per frame than previously allocated.

## Changes
- Modified the calculation of `samples_per_frame` in `VKRenderTarget` constructor:
  - Changed from `params.scenesPerFrame + 2` to `params.scenesPerFrame + 3`

## How Has This Been Tested?
- Tested with PhotoKano Kiss (PCSG00139)
  - The "Render Target is using more scenes per frame than what was planned!" warning message no longer appears
  - Note: This change does not improve the actual rendering results for this game

## Additional Notes
While this change reduces warning messages in PhotoKano Kiss, I hope that we won't need to increase this value further.