### PR TITLE
gui/interface: Fix reinstall using DnD and Vulkan

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -111,7 +111,7 @@ void update_time_app_used(GuiState &gui, EmuEnvState &emuenv, const std::string 
 void save_notice_list(EmuEnvState &emuenv);
 
 void draw_begin(GuiState &gui, EmuEnvState &emuenv);
-void draw_end(GuiState &emuenv);
+void draw_end(GuiState &gui);
 void draw_vita_area(GuiState &gui, EmuEnvState &emuenv);
 void draw_ui(GuiState &gui, EmuEnvState &emuenv);
 

--- a/vita3k/gui/src/reinstall.cpp
+++ b/vita3k/gui/src/reinstall.cpp
@@ -28,6 +28,7 @@ void draw_reinstall_dialog(GenericDialogState *status, GuiState &gui, EmuEnvStat
     auto &info = gui.lang.app_context.info;
     auto &common = emuenv.common_dialog.lang.common;
 
+    ImGui::PushFont(gui.vita_font);
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f, ImGui::GetIO().DisplaySize.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(0, 0));
     ImGui::Begin(lang["reinstall_content"].c_str());
@@ -44,6 +45,7 @@ void draw_reinstall_dialog(GenericDialogState *status, GuiState &gui, EmuEnvStat
         *status = CANCEL_STATE;
     }
     ImGui::End();
+    ImGui::PopFont();
 }
 
 } // namespace gui

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -150,16 +150,11 @@ bool install_archive_content(EmuEnvState &emuenv, GuiState *gui, const ZipPtr &z
             gui::GenericDialogState status = gui::UNK_STATE;
 
             while (handle_events(emuenv, *gui) && (status == gui::UNK_STATE)) {
-                ImGui_ImplSdl_NewFrame(gui->imgui_state.get());
-                glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+                gui::draw_begin(*gui, emuenv);
                 gui::draw_ui(*gui, emuenv);
-                ImGui::PushFont(gui->vita_font);
                 gui::draw_reinstall_dialog(&status, *gui, emuenv);
-                ImGui::PopFont();
-                glViewport(0, 0, static_cast<int>(ImGui::GetIO().DisplaySize.x), static_cast<int>(ImGui::GetIO().DisplaySize.y));
-                ImGui::Render();
-                ImGui_ImplSdl_RenderDrawData(gui->imgui_state.get());
-                SDL_GL_SwapWindow(emuenv.window.get());
+                gui::draw_end(*gui);
+                emuenv.renderer->swap_window(emuenv.window.get());
             }
             switch (status) {
             case gui::CANCEL_STATE:


### PR DESCRIPTION
With a vpk installed and the renderer backend set to Vulkan, trying to reinstall the same vpk using drag and drop will crash the app. Using OpenGL related functions with Vulkan is not a good idea, this PR fixes it.