### PR TITLE
modules/SceJpeg: Improve JPEG decoding accuracy

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -34,8 +34,6 @@ union DecoderSize {
     struct {
         uint32_t width;
         uint32_t height;
-        uint32_t pitch_width;
-        uint32_t pitch_height;
     };
     struct {
         uint32_t samples;
@@ -46,8 +44,11 @@ enum DecoderColorSpace {
     COLORSPACE_UNKNOWN,
     COLORSPACE_GRAYSCALE,
     COLORSPACE_YUV444P,
+    COLORSPACE_YUV440P,
+    COLORSPACE_YUV441P,
     COLORSPACE_YUV422P,
     COLORSPACE_YUV420P,
+    COLORSPACE_YUV411P,
 };
 
 // glGet sort of API to use virtual stuff
@@ -121,14 +122,28 @@ struct H264DecoderState : public DecoderState {
     ~H264DecoderState() override;
 };
 
+struct MJpegPitch {
+    uint32_t x;
+    uint32_t y;
+};
+
+struct MJpegDecoderOptions {
+    bool use_standard_decoder;
+    int downscale_ratio;
+};
+
 struct MjpegDecoderState : public DecoderState {
-    uint32_t mcu_width;
-    uint32_t mcu_height;
+    bool use_standard_decoder = false;
+    int downscale_ratio = 1;
+
+    MJpegPitch pitch[4];
 
     DecoderColorSpace color_space_out;
 
     bool send(const uint8_t *data, uint32_t size) override;
     bool receive(uint8_t *data, DecoderSize *size) override;
+    void configure(void *options);
+    void get_pitch_info(MJpegPitch pitch[4]);
     DecoderColorSpace get_color_space();
 
     MjpegDecoderState();
@@ -265,8 +280,9 @@ struct PlayerState {
     ~PlayerState();
 };
 
-void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, int32_t inPitch);
-void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t width, uint32_t height, const DecoderColorSpace color_space);
+void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, int32_t in_pitch);
+void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t frame_width, const DecoderColorSpace color_space, bool is_bgra, MJpegPitch pitch[4]);
 int convert_yuv_to_jpeg(const uint8_t *yuv, uint8_t *jpeg, uint32_t width, uint32_t height, uint32_t max_size, const DecoderColorSpace color_space, int32_t compress_ratio);
 void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest, const uint32_t width, const uint32_t height, bool is_p3);
+void calculate_pitch_info(uint32_t width, uint32_t height, int downscale_ratio, DecoderColorSpace color_space, bool use_standard_decoder, MJpegPitch output_pitch[4]);
 std::string codec_error_name(int error);


### PR DESCRIPTION
## Description
This PR enhances the SceJpeg module to more accurately emulate the PS Vita's hardware JPEG decoder, including its specific limitations. The improvements were developed by creating and comparing with a real HomeBrew application running on PS Vita hardware, aiming to replicate its behavior and constraints as closely as possible.

## Changes
- Refined pitch calculation, which greatly improves emulation accuracy for Visual Novels
- Implemented BGRA decoding
- Added downscale decoding functionality
- Emulated PS Vita hardware limitations
- Implemented sceJpegCsc function for color space conversion from YUV444 to RGBA
- Added support for iFrameWidth argument in sceJpegMJpegCsc function

## Hardware Emulation Details
- Accurately emulated PS Vita's decoding size limits, ensuring that oversized images are handled the same way as on actual hardware
- Replicated other hardware-specific quirks and limitations discovered during the development of the HomeBrew test application

## Limitations
- Due to FFmpeg limitations, some features are not fully equivalent to PS Vita hardware:
  - YUV441 color space is not supported in the current implementation (though it's unlikely any software uses this)
  - Certain uncommon MCU configurations that would cause errors on PS Vita hardware are processed without issues in this implementation

## How Has This Been Tested?
The changes have been tested with the following games:
- Kiss Ato (PCSG00742)
- end sleep (PCSG00963)
- Ken ga Kimi for V (PCSG00553)
- Natsumegu (PCSG00650)

## Additional Notes
While BGRA decoding and downscale decoding have been implemented, it's unclear if any games actually utilize these features.
The emulation of hardware limitations is a crucial aspect of this PR, as it ensures that the emulator behaves as closely as possible to the actual PS Vita hardware, including its constraints and edge cases.