### PR TITLE
renderer: Improve depth buffer accuracy

### DIFF
--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -755,7 +755,6 @@ vk::Pipeline PipelineCache::compile_pipeline(SceGxmPrimitiveType type, vk::Rende
     const bool use_shader_interlock = state.features.support_shader_interlock && gxm_fragment_shader->is_frag_color_used();
 
     const vk::PipelineRasterizationStateCreateInfo rasterizer{
-        .depthClampEnable = state.physical_device_features.depthClamp,
         .polygonMode = translate_polygon_mode(record.front_polygon_mode),
         .cullMode = translate_cull_mode(record.cull_mode),
         // front face is always counter clockwise

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -353,7 +353,6 @@ bool VKState::create(SDL_Window *window, std::unique_ptr<renderer::State> &state
 
         // use these features (because they are used by the vita GPU) if they are available
         vk::PhysicalDeviceFeatures enabled_features{
-            .depthClamp = physical_device_features.depthClamp,
             .fillModeNonSolid = physical_device_features.fillModeNonSolid,
             .wideLines = physical_device_features.wideLines,
             .samplerAnisotropy = physical_device_features.samplerAnisotropy,

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1673,6 +1673,9 @@ static spv::Function *make_vert_finalize_function(spv::Builder &b, const SpirvSh
                     z = b.createBinOp(spv::OpFMul, f32, z, z_scale);
                     z = b.createBinOp(spv::OpFAdd, f32, z, z_offset);
 
+                    // z values below 0 get clamped
+                    z = b.createBuiltinCall(f32, utils.std_builtins, GLSLstd450FMax, { z, zero });
+
                     if (!translation_state.is_vulkan) {
                         // convert [0,1] depth range (gxp, vulkan) to [-1,1] depth range (opengl)
                         z = b.createBinOp(spv::OpFMul, f32, z, b.makeFloatConstant(2.0f));


### PR DESCRIPTION
Thanks to the amazing work of Saturnsky, it looks like after viewport transformations, z values on the PS Vita have a non standard behavior:
- If the z value is strictly greater than 1 it gets clipped
- If it is less than 0 it gets clamped

Emulate this by clamping in the shader and telling the renderer to clip primitives.
This is more accurate, fixes the text in the amazing spiderman and might fix some other clipping geometry too.