### PR TITLE
renderer/gl: Implement F32 base color format

### DIFF
--- a/vita3k/renderer/src/gl/color_formats.cpp
+++ b/vita3k/renderer/src/gl/color_formats.cpp
@@ -121,6 +121,9 @@ GLenum translate_internal_format(SceGxmColorBaseFormat base_format) {
     case SCE_GXM_COLOR_BASE_FORMAT_F32F32:
         return GL_RG32F;
 
+    case SCE_GXM_COLOR_BASE_FORMAT_F32:
+        return GL_R32F;
+
     case SCE_GXM_COLOR_BASE_FORMAT_F16:
         return GL_R16F;
 
@@ -155,6 +158,7 @@ GLenum translate_format(SceGxmColorBaseFormat base_format) {
     case SCE_GXM_COLOR_BASE_FORMAT_U8U8U8:
         return GL_RGB;
 
+    case SCE_GXM_COLOR_BASE_FORMAT_F32:
     case SCE_GXM_COLOR_BASE_FORMAT_F16:
     case SCE_GXM_COLOR_BASE_FORMAT_U8:
         return GL_RED;
@@ -183,6 +187,7 @@ GLenum translate_type(SceGxmColorBaseFormat base_format) {
     case SCE_GXM_COLOR_BASE_FORMAT_F11F11F10:
         return GL_UNSIGNED_INT_10F_11F_11F_REV;
 
+    case SCE_GXM_COLOR_BASE_FORMAT_F32:
     case SCE_GXM_COLOR_BASE_FORMAT_F32F32:
         return GL_FLOAT;
 
@@ -218,6 +223,7 @@ const GLint *translate_swizzle(SceGxmColorFormat fmt) {
 
     case SCE_GXM_COLOR_BASE_FORMAT_U8:
     case SCE_GXM_COLOR_BASE_FORMAT_F16:
+    case SCE_GXM_COLOR_BASE_FORMAT_F32:
         return translate_swizzle(static_cast<SceGxmColorSwizzle1Mode>(swizzle));
 
     default:
@@ -243,6 +249,7 @@ size_t bytes_per_pixel_in_gl_storage(SceGxmColorBaseFormat base_format) {
     case SCE_GXM_COLOR_BASE_FORMAT_U8U8U8U8:
     case SCE_GXM_COLOR_BASE_FORMAT_S8S8S8S8:
     case SCE_GXM_COLOR_BASE_FORMAT_U2U10U10U10:
+    case SCE_GXM_COLOR_BASE_FORMAT_F32:
         return 4;
     case SCE_GXM_COLOR_BASE_FORMAT_F16F16F16F16:
     case SCE_GXM_COLOR_BASE_FORMAT_F32F32:


### PR DESCRIPTION
## Description
This PR adds support for the `SCE_GXM_COLOR_BASE_FORMAT_F32` color format in the OpenGL renderer. This format was previously unsupported, which could lead to rendering issues in games that use it.

## Changes
- Added `SCE_GXM_COLOR_BASE_FORMAT_F32` to the `translate_internal_format` function, mapping it to `GL_R32F`
- Updated `translate_format` to return `GL_RED` for `SCE_GXM_COLOR_BASE_FORMAT_F32`
- Modified `translate_type` to return `GL_FLOAT` for `SCE_GXM_COLOR_BASE_FORMAT_F32`
- Updated `translate_swizzle` to handle `SCE_GXM_COLOR_BASE_FORMAT_F32`
- Added `SCE_GXM_COLOR_BASE_FORMAT_F32` to `bytes_per_pixel_in_gl_storage`, returning 4 bytes per pixel

## How Has This Been Tested?
- Tested with Gundam EXTREME VS-FORCE (PCSG00738), the error that occurred in OpenGL has been fixed. And when depth accuracy is applied, it will be possible to play the game.
