### PR TITLE
vita3k: Use hex for error codes

### DIFF
--- a/lang/system/en.xml
+++ b/lang/system/en.xml
@@ -519,7 +519,7 @@ Check work.bin/rif file or zRIF key.</failed_install_license>
 	</live_area>
 
 	<message>
-		<load_app_failed>Failed to load "{}".
+		<load_app_failed>Failed to load {}.
 Check vita3k.log to see console output for details.
 1. Do you have installed firmware?
 2. Dump your own app(s)/game(s) and install it on Vita3K.

--- a/vita3k/Windows.manifest
+++ b/vita3k/Windows.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <!-- 
 Vita3K emulator project
-Copyright (C) 2021 Vita3K team
+Copyright (C) 2024 Vita3K team
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/vita3k/codec/src/atrac9.cpp
+++ b/vita3k/codec/src/atrac9.cpp
@@ -93,7 +93,7 @@ bool Atrac9DecoderState::send(const uint8_t *data, uint32_t size) {
 
     const int res = Atrac9Decode(decoder_handle, data, reinterpret_cast<short *>(result.data()), &decode_used);
     if (res != At9Status::ERR_SUCCESS) {
-        LOG_ERROR("Decode failure with code {}", res);
+        LOG_ERROR("Decode failure with code {}", log_hex(res));
         return false;
     }
 

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -238,7 +238,7 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
         large_font_config.SizePixels = 116.f;
         gui.large_font = io.Fonts->AddFontFromFileTTF(fs_utils::path_to_utf8(latin_fw_font_path).c_str(), large_font_config.SizePixels, &large_font_config, large_font_chars);
     } else {
-        LOG_WARN("Could not find firmware font file at \"{}\", install firmware fonts package to fix this.", latin_fw_font_path);
+        LOG_WARN("Could not find firmware font file at {}, install firmware fonts package to fix this.", latin_fw_font_path);
         font_config.SizePixels = 22.f;
 
         // Set up default font path
@@ -260,7 +260,7 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
 
             LOG_INFO("Using default Vita3K font.");
         } else
-            LOG_WARN("Could not find default Vita3K font at \"{}\", using default ImGui font.", default_font_path);
+            LOG_WARN("Could not find default Vita3K font at {}, using default ImGui font.", default_font_path);
     }
 
     // Build font atlas loaded and upload to GPU

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -390,7 +390,7 @@ int write_file(SceUID fd, const void *data, const SceSize size, const IOState &i
     assert(size >= 0);
 
     if (fd < 0) {
-        LOG_WARN("Error writing fd: {}, size: {}", fd, size);
+        LOG_WARN("Error writing fd: {}, size: {}", log_hex(fd), size);
         return IO_ERROR(SCE_ERROR_ERRNO_EBADFD);
     }
 

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -46,7 +46,7 @@ struct DialogLangState {
         { "submit", "Submit" },
         { "yes", "Yes" }
     };
-    std::map<std::string, std::string> message = { { "load_app_failed", "Failed to load \"{}\".\nCheck vita3k.log to see console output for details.\n1. Do you have installed firmware?\n2. Dump your own app(s)/game(s) and install it on Vita3K.\n3. If you want to install or boot Vitamin, it is not supported." } };
+    std::map<std::string, std::string> message = { { "load_app_failed", "Failed to load {}.\nCheck vita3k.log to see console output for details.\n1. Do you have installed firmware?\n2. Dump your own app(s)/game(s) and install it on Vita3K.\n3. If you want to install or boot Vitamin, it is not supported." } };
     std::map<std::string, std::string> trophy = { { "preparing_start_app", "Preparing to start the application..." } };
     struct SaveData {
         std::map<std::string, std::string> deleting = {


### PR DESCRIPTION
I don't like to see big negative numbers in log (´･д･`)

# Before
![image](https://github.com/user-attachments/assets/45852e60-4527-4734-bf5f-4830f8b21d78)

# After
![image](https://github.com/user-attachments/assets/22abddef-927f-477b-8c4a-f4a220d063a2)
