### PR TITLE
modules: Add SceUlobjDbg related new NIDs

### DIFF
--- a/vita3k/modules/CMakeLists.txt
+++ b/vita3k/modules/CMakeLists.txt
@@ -192,6 +192,7 @@ set(SOURCE_LIST
 	SceTouch/SceTouch.cpp
 	SceTriggerUtil/SceTriggerUtil.cpp
 	SceUdcd/SceUdcd.cpp
+	SceUlobjDbg/SceUlobjDbg.cpp
 	SceUlobjMgr/SceUlobjMgr.cpp
 	SceUlt/SceUlt.cpp
 	SceUsbd/SceUsbdForUser.cpp

--- a/vita3k/modules/SceUlobjDbg/SceUlobjDbg.cpp
+++ b/vita3k/modules/SceUlobjDbg/SceUlobjDbg.cpp
@@ -1,0 +1,26 @@
+// Vita3K emulator project
+// Copyright (C) 2024 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <module/module.h>
+
+EXPORT(int, SceUlobjDbg_D7F0F610) {
+    return UNIMPLEMENTED();
+}
+
+EXPORT(int, SceUlobjDbg_F9C0F5DA) {
+    return UNIMPLEMENTED();
+}

--- a/vita3k/nids/include/nids/nids.inc
+++ b/vita3k/nids/include/nids/nids.inc
@@ -7186,6 +7186,10 @@ NID(sceUdcdGetDrvState, 0x99B3DA5D)
 NID(sceUdcdRegisterCallback, 0xA7070093)
 NID(sceUdcdUnregisterCallback, 0xC3FBA889)
 NID(sceUdcdWaitState, 0x59EFFAF1)
+// Module "SceUlobjDbg"
+// Library "SceUlobjDbg"
+NID(SceUlobjDbg_D7F0F610, 0xD7F0F610)
+NID(SceUlobjDbg_F9C0F5DA, 0xF9C0F5DA)
 // Module "SceUlobjMgr"
 // Library "SceUlobjMgr"
 NID(_sceUlobjMgrRegisterLibultProtocolRevision, 0x50F2F2AA)


### PR DESCRIPTION
## Description
This PR adds NIDs for SceUlobjDbg-related functions that were not previously included in Vita3K. The names of these functions are not known anywhere, and it is only known that they belong to the corresponding module.
This modification does not change any functionality of Vita3K. When NID error messages related to SceUlobjDbg occur in Vita3K's logs, it only reduces the time developers spend pondering over messages like "Import function for NID 0xd7f0f610 not found".

## Changes
- Added NIDs for the SceUlobjDbg module to the appropriate NID database file
