### PR TITLE
modules/SceKernel: Implement sceKernelGetEventPattern

### DIFF
--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -249,9 +249,16 @@ EXPORT(int, _sceKernelGetEventInfo) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, _sceKernelGetEventPattern) {
-    TRACY_FUNC(_sceKernelGetEventPattern);
-    return UNIMPLEMENTED();
+EXPORT(SceInt32, _sceKernelGetEventPattern, SceUID event_id, SceUInt32 *get_pattern) {
+    TRACY_FUNC(_sceKernelGetEventPattern, event_id, get_pattern);
+    const SimpleEventPtr event = lock_and_find(event_id, emuenv.kernel.simple_events, emuenv.kernel.mutex);
+    if (!event)
+        return RET_ERROR(SCE_KERNEL_ERROR_UNKNOWN_EVENT_ID);
+    if (!get_pattern)
+        return RET_ERROR(SCE_KERNEL_ERROR_ILLEGAL_ADDR);
+
+    *get_pattern = event->pattern;
+    return SCE_KERNEL_OK;
 }
 
 EXPORT(int, _sceKernelGetLwCondInfo) {

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
@@ -64,6 +64,7 @@ DECL_EXPORT(SceInt32, _sceKernelWaitEventFlagCB, SceUID evfId, SceUInt32 bitPatt
 DECL_EXPORT(SceInt32, _sceKernelWaitSema, SceUID semaId, SceInt32 needCount, SceUInt32 *pTimeout);
 DECL_EXPORT(SceInt32, _sceKernelWaitSemaCB, SceUID semaId, SceInt32 needCount, SceUInt32 *pTimeout);
 DECL_EXPORT(SceInt32, _sceKernelGetEventFlagInfo, SceUID evfId, Ptr<SceKernelEventFlagInfo> pInfo);
+DECL_EXPORT(SceInt32, _sceKernelGetEventPattern, SceUID event_id, SceUInt32 *get_pattern);
 DECL_EXPORT(int, _sceKernelPollEventFlag, SceUID event_id, unsigned int flags, unsigned int wait, unsigned int *outBits);
 DECL_EXPORT(SceInt32, _sceKernelCancelEventFlag, SceUID event_id, SceUInt pattern, SceUInt32 *num_wait_thread);
 DECL_EXPORT(int, _sceKernelCancelSema, SceUID semaId, SceInt32 setCount, SceUInt32 *pNumWaitThreads);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -1317,9 +1317,9 @@ EXPORT(int, sceKernelGetEventInfo) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelGetEventPattern) {
-    TRACY_FUNC(sceKernelGetEventPattern);
-    return UNIMPLEMENTED();
+EXPORT(SceInt32, sceKernelGetEventPattern, SceUID event_id, SceUInt32 *get_pattern) {
+    TRACY_FUNC(sceKernelGetEventPattern, event_id, get_pattern);
+    return CALL_EXPORT(_sceKernelGetEventPattern, event_id, get_pattern);
 }
 
 EXPORT(int, sceKernelGetLwCondInfo) {


### PR DESCRIPTION
## Description
This PR implements the `sceKernelGetEventPattern` function in the SceLibKernel module, enhancing the emulation of the PS Vita's event handling system.

## Changes
- Implemented `sceKernelGetEventPattern` function in SceLibKernel module
- Implemented `_sceKernelGetEventPattern` function in SceKernelThreadMgr module
- Updated function signatures and declarations in header files

## Emulation Details
- The implementation follows the expected behavior of the PS Vita's kernel, retrieving the event pattern for a given event ID
- While this implementation covers the basic functionality, there might be edge cases or specific hardware behaviors that are not yet fully emulated

## Additional Notes
- The implementation follows the code convention used in other `event_id` related functions for consistency