### PR TITLE
modules/SceSysmem: Set correct start_address for USER_RW_UNCACHE

### DIFF
--- a/vita3k/modules/SceSysmem/SceSysmem.cpp
+++ b/vita3k/modules/SceSysmem/SceSysmem.cpp
@@ -125,6 +125,7 @@ EXPORT(SceUID, sceKernelAllocMemBlock, const char *pName, SceKernelMemBlockType 
     // https://wiki.henkaku.xyz/vita/SceSysmem_Types#memtype_bit_value
     Address start_address;
     switch (type) {
+    case SCE_KERNEL_MEMBLOCK_TYPE_USER_RW_UNCACHE:
     case SCE_KERNEL_MEMBLOCK_TYPE_USER_MAIN_PHYCONT_NC_RW:
         start_address = 0x70000000U;
         break;


### PR DESCRIPTION
## Description
This PR addresses a regression introduced after Build 3463 ([#3043](https://github.com/Vita3K/Vita3K/pull/3043)) that affected some games ([#3217](https://github.com/Vita3K/Vita3K/issues/3217)). The issue was caused by games incorrectly interpreting the address returned by `sceKernelGetMemBlockBase` as a signed value and treating negative values as errors.

## Changes
- Updated the `sceKernelAllocMemBlock` function in the SceSysmem module
- Set the correct `start_address` for `SCE_KERNEL_MEMBLOCK_TYPE_USER_RW_UNCACHE`

## Emulation Details
- Verified that `SCE_KERNEL_MEMBLOCK_TYPE_USER_RW_UNCACHE` uses the same memory region as `SCE_KERNEL_MEMBLOCK_TYPE_USER_MAIN_PHYCONT_NC_RW`
- Both memory block types now use the 0x70000000 address range

## Impact
This fix should resolve the regression issues reported in #3217, improving compatibility for affected games.

## Testing
- Tested with games that were previously affected by the regression
- Confirmed that memory allocation now works as expected for these cases