### PR TITLE
gui: Fix load_image pointer validity check

### DIFF
--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -128,6 +128,6 @@ void draw_trophies_unlocked(GuiState &gui, EmuEnvState &emuenv);
 void draw_touchpad_cursor(EmuEnvState &emuenv);
 void draw_perf_overlay(GuiState &gui, EmuEnvState &emuenv);
 
-ImTextureID load_image(GuiState &gui, const uint8_t *data, const std::uint32_t size);
+ImTextureID load_image(GuiState &gui, const uint8_t *data, const int size);
 
 } // namespace gui

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -684,14 +684,14 @@ std::map<DateTime, std::string> get_date_time(GuiState &gui, EmuEnvState &emuenv
     return date_time_str;
 }
 
-ImTextureID load_image(GuiState &gui, const uint8_t *data, const std::uint32_t size) {
+ImTextureID load_image(GuiState &gui, const uint8_t *data, const int size) {
     int width;
     int height;
 
     stbi_uc *img_data = stbi_load_from_memory(data, size, &width, &height,
         nullptr, STBI_rgb_alpha);
 
-    if (!data)
+    if (!img_data)
         return nullptr;
 
     const auto handle = ImGui_ImplSdl_CreateTexture(gui.imgui_state.get(), img_data, width, height);

--- a/vita3k/gui/src/trophy_unlocked.cpp
+++ b/vita3k/gui/src/trophy_unlocked.cpp
@@ -53,7 +53,7 @@ static void draw_trophy_unlocked(GuiState &gui, EmuEnvState &emuenv, NpTrophyUnl
             gui.trophy_window_pos = ImVec2(ImGui::GetIO().DisplaySize.x + TROPHY_WINDOW_MARGIN_PADDING, TROPHY_WINDOW_Y_POS);
 
             // Load icon
-            gui.trophy_window_icon = load_image(gui, callback_data.icon_buf.data(), static_cast<std::uint32_t>(callback_data.icon_buf.size()));
+            gui.trophy_window_icon = load_image(gui, callback_data.icon_buf.data(), static_cast<int>(callback_data.icon_buf.size()));
         } else if (gui.trophy_window_frame_stage == TrophyAnimationStage::SLIDE_IN && gui.trophy_window_pos.x > target_window_pos.x) {
             gui.trophy_window_pos.x -= TROPHY_MOVE_DELTA;
         } else if (gui.trophy_window_frame_stage == TrophyAnimationStage::SLIDE_OUT && gui.trophy_window_pos.x < target_window_pos.x) {


### PR DESCRIPTION
Also set the correct type for `size`, `stbi_load_from_memory` uses an `int`
```
STBIDEF stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
```