### PR TITLE
Add support for mingw-w64

### DIFF
--- a/external/CppCommon/include/cpu.h
+++ b/external/CppCommon/include/cpu.h
@@ -9,6 +9,7 @@
 #ifndef CPPCOMMON_SYSTEM_CPU_H
 #define CPPCOMMON_SYSTEM_CPU_H
 
+#include <cstdint>
 #include <string>
 
 namespace CppCommon {

--- a/external/CppCommon/source/environment.cpp
+++ b/external/CppCommon/source/environment.cpp
@@ -28,8 +28,7 @@ extern char **environ;
 #include <windows.h>
 #include <winternl.h>
 #define STATUS_SUCCESS 0x00000000
-#include <map>
-#include <vector>
+#include <locale>
 #endif
 
 namespace CppCommon {

--- a/tools/gen-modules/gen-modules.cpp
+++ b/tools/gen-modules/gen-modules.cpp
@@ -17,7 +17,7 @@
 
 #include <yaml-cpp/yaml.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #else
@@ -148,7 +148,7 @@ static void gen_module_stubs(const Modules &modules) {
     for (const Module &module : modules) {
         const std::string module_path = "vita3k/modules/" + module.first;
 
-#ifdef WIN32
+#ifdef _WIN32
         CreateDirectoryA(module_path.c_str(), nullptr);
 #else
         const int mode = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -45,7 +45,7 @@
 #include <SDL_video.h>
 #include <SDL_vulkan.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <SDL_syswm.h>
 #include <dwmapi.h>
 #endif
@@ -298,7 +298,7 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         state.display.fullscreen = true;
         window_type |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
-#if defined(WIN32) || defined(__linux__)
+#if defined(_WIN32) || defined(__linux__)
     const auto isSteamDeck = []() {
 #ifdef __linux__
         std::ifstream file("/etc/os-release");
@@ -329,7 +329,7 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         return false;
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     // Disable round corners for the game window
     SDL_SysWMinfo wm_info;
     SDL_VERSION(&wm_info.version);

--- a/vita3k/ctrl/include/ctrl/state.h
+++ b/vita3k/ctrl/include/ctrl/state.h
@@ -23,6 +23,7 @@
 #include <SDL_haptic.h>
 #include <SDL_joystick.h>
 
+#include <cstring>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -405,11 +405,11 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                                 "%23 Vita3K summary%0A- Version: {}%0A- Build number: {}%0A- Commit hash: https://github.com/vita3k/vita3k/commit/{}%0A- CPU backend: {}%0A- GPU backend: {}",
                                 app_version, app_number, app_hash, get_cpu_backend(gui, emuenv, app_path), emuenv.cfg.backend_renderer);
 
-#ifdef WIN32
+#ifdef _WIN32
                             const auto user = std::getenv("USERNAME");
 #else
                             auto user = std::getenv("USER");
-#endif // WIN32
+#endif // _WIN32
 
                             // Test environment summary
                             const auto test_env_summary = fmt::format(

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -891,7 +891,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
             SetTooltipEx(lang.emulator["select_position"].c_str());
         }
         ImGui::Spacing();
-#ifndef WIN32
+#ifndef _WIN32
         ImGui::Checkbox(lang.emulator["case_insensitive"].c_str(), &emuenv.io.case_isens_find_enabled);
         SetTooltipEx(lang.emulator["case_insensitive_description"].c_str());
 #endif

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -28,7 +28,7 @@
 
 #include <SDL.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <combaseapi.h>
 #endif
 
@@ -153,7 +153,7 @@ static void download_update(const fs::path &base_path) {
     progress_state.pause = false;
     std::thread download([base_path]() {
         std::string download_continuous_link = "https://github.com/Vita3K/Vita3K/releases/download/continuous";
-#ifdef WIN32
+#ifdef _WIN32
         download_continuous_link += "/windows-latest.zip";
 #elif defined(__APPLE__)
         download_continuous_link += "/macos-latest.dmg";
@@ -214,7 +214,7 @@ static void download_update(const fs::path &base_path) {
             event.type = SDL_QUIT;
             SDL_PushEvent(&event);
 
-#ifdef WIN32
+#ifdef _WIN32
             const auto vita3K_batch = fmt::format("\"{}\\update-vita3k.bat\"", base_path);
             FreeConsole();
 #elif defined(__APPLE__)

--- a/vita3k/io/include/io/filesystem.h
+++ b/vita3k/io/include/io/filesystem.h
@@ -19,7 +19,7 @@
 
 #include <util/fs.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <util/string_utils.h>
 #endif
 
@@ -31,7 +31,7 @@ typedef std::shared_ptr<FILE> FilePtr;
 
 // For opening Boost.Filesystem files, Boost returns wide strings for Windows, normal strings for other OS
 // Dirent and FILE only accept and return wide char strings for Windows, and normal for other OS
-#ifdef WIN32
+#ifdef _WIN32
 const wchar_t *translate_open_mode(const int flags);
 
 inline FilePtr create_shared_file(const fs::path &path, const int open_mode) {

--- a/vita3k/io/src/filesystem.cpp
+++ b/vita3k/io/src/filesystem.cpp
@@ -18,7 +18,7 @@
 #include <io/filesystem.h>
 #include <io/util.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 // To open wide files for Boost.Filesystem, we also need the appropriate wide mode flags for Windows, and normal flags for other OS
 const wchar_t *translate_open_mode(const int flags) {
     if (flags & SCE_O_WRONLY) {

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -28,7 +28,7 @@
 #include <util/preprocessor.h>
 #include <util/string_utils.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #else
@@ -125,7 +125,7 @@ bool init(IOState &io, const fs::path &cache_path, const fs::path &log_path, con
 
     io.redirect_stdio = redirect_stdio;
 
-#ifndef WIN32
+#ifndef _WIN32
     io.case_isens_find_enabled = true;
 #endif
 
@@ -552,7 +552,7 @@ int stat_file(IOState &io, const char *file, SceIoStat *statp, const fs::path &p
     creation_time_ticks = (uint64_t)sb.st_ctime * VITA_CLOCKS_PER_SEC;
     last_modification_time_ticks = (uint64_t)sb.st_mtime * VITA_CLOCKS_PER_SEC;
 
-#ifndef WIN32
+#ifndef _WIN32
 #undef st_atime
 #undef st_mtime
 #undef st_ctime

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -44,7 +44,7 @@
 #include <app/discord.h>
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <combaseapi.h>
 #include <process.h>
 #endif
@@ -78,7 +78,7 @@ static void run_execv(char *argv[], EmuEnvState &emuenv) {
         args[3] = nullptr;
 
         // Execute the emulator again with some arguments
-#ifdef WIN32
+#ifdef _WIN32
     FreeConsole();
     _execv(argv[0], args);
 #elif defined(__unix__) || defined(__APPLE__) && defined(__MACH__)
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
 
     // Check admin privs before init starts to avoid creating of file as other user by accident
     bool adminPriv = false;
-#ifdef WIN32
+#ifdef _WIN32
     // https://stackoverflow.com/questions/8046097/how-to-check-if-a-process-has-the-administrative-rights
     HANDLE hToken = NULL;
     if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken)) {
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
         return InitConfigFailed;
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     {
         auto res = CoInitializeEx(NULL, COINIT_MULTITHREADED);
         LOG_ERROR_IF(res == S_FALSE, "Failed to initialize COM Library");
@@ -460,7 +460,7 @@ int main(int argc, char *argv[]) {
         FrameMark; // Tracy - Frame end mark for game rendering loop
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     CoUninitialize();
 #endif
 

--- a/vita3k/mem/include/mem/atomic.h
+++ b/vita3k/mem/include/mem/atomic.h
@@ -19,11 +19,11 @@
 
 #include <memory>
 
-#if WIN32
+#ifdef _MSC_VER
 #include <intrin.h>
 #endif
 
-#if WIN32
+#ifdef _MSC_VER
 
 inline bool atomic_compare_and_swap(volatile uint8_t *pointer, uint8_t value, uint8_t expected) {
     const uint8_t result = _InterlockedCompareExchange8(reinterpret_cast<volatile char *>(pointer), value, expected);

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -25,7 +25,7 @@
 #include <util/safe_time.h>
 #include <util/tracy.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock.h>
 #else
 #include <unistd.h>

--- a/vita3k/modules/SceHttp/SceHttp.cpp
+++ b/vita3k/modules/SceHttp/SceHttp.cpp
@@ -21,7 +21,7 @@
 #include <filesystem>
 #include <http/state.h>
 
-#ifdef WIN32 // windows moment
+#ifdef _WIN32 // windows moment
 #include <io.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -567,11 +567,11 @@ EXPORT(SceInt, sceHttpDeleteConnection, SceInt connId) {
 
     if (connIt == emuenv.http.connections.end())
         return RET_ERROR(SCE_HTTP_ERROR_INVALID_ID);
-#ifdef WIN32
+#ifdef _WIN32
     closesocket(connIt->second.sockfd);
 #else
     close(connIt->second.sockfd);
-#endif // WIN32
+#endif // _WIN32
 
     emuenv.http.connections.erase(connIt);
 

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -381,7 +381,7 @@ EXPORT(int, sceClibStrlcpyChk) {
 
 EXPORT(int, sceClibStrncasecmp, const char *s1, const char *s2, SceSize len) {
     TRACY_FUNC(sceClibStrncasecmp, s1, s2, len);
-#ifdef WIN32
+#ifdef _WIN32
     return _strnicmp(s1, s2, len);
 #else
     return strncasecmp(s1, s2, len);

--- a/vita3k/modules/SceLibc/SceLibc.cpp
+++ b/vita3k/modules/SceLibc/SceLibc.cpp
@@ -1162,10 +1162,13 @@ EXPORT(int, sscanf_s) {
     return UNIMPLEMENTED();
 }
 
+#pragma push_macro("strcasecmp")
+#undef strcasecmp
 EXPORT(int, strcasecmp) {
     TRACY_FUNC(strcasecmp);
     return UNIMPLEMENTED();
 }
+#pragma pop_macro("strcasecmp")
 
 EXPORT(Ptr<char>, strcat, Ptr<char> destination, Ptr<char> source) {
     TRACY_FUNC(strcat, destination, source);
@@ -1239,10 +1242,13 @@ EXPORT(int, strlen, char *str) {
     return static_cast<int>(strlen(str));
 }
 
+#pragma push_macro("strncasecmp")
+#undef strncasecmp
 EXPORT(int, strncasecmp) {
     TRACY_FUNC(strncasecmp);
     return UNIMPLEMENTED();
 }
+#pragma pop_macro("strncasecmp")
 
 EXPORT(int, strncat) {
     TRACY_FUNC(strncat);

--- a/vita3k/modules/SceNet/SceNet.cpp
+++ b/vita3k/modules/SceNet/SceNet.cpp
@@ -290,7 +290,7 @@ EXPORT(int, sceNetGetMacAddress, SceNetEtherAddr *addr, int flags) {
     if (addr == nullptr) {
         return RET_ERROR(SCE_NET_EINVAL);
     }
-#ifdef WIN32
+#ifdef _WIN32
     IP_ADAPTER_INFO AdapterInfo[16];
     DWORD dwBufLen = sizeof(AdapterInfo);
     if (GetAdaptersInfo(AdapterInfo, &dwBufLen) != ERROR_SUCCESS) {
@@ -362,7 +362,7 @@ EXPORT(unsigned short int, sceNetHtons, unsigned short int n) {
 EXPORT(Ptr<const char>, sceNetInetNtop, int af, const void *src, Ptr<char> dst, unsigned int size) {
     TRACY_FUNC(sceNetInetNtop, af, src, dst, size);
     char *dst_ptr = dst.get(emuenv.mem);
-#ifdef WIN32
+#ifdef _WIN32
     const char *res = InetNtop(af, src, dst_ptr, size);
 #else
     const char *res = inet_ntop(af, src, dst_ptr, size);
@@ -376,7 +376,7 @@ EXPORT(Ptr<const char>, sceNetInetNtop, int af, const void *src, Ptr<char> dst, 
 
 EXPORT(int, sceNetInetPton, int af, const char *src, void *dst) {
     TRACY_FUNC(sceNetInetPton, af, src, dst);
-#ifdef WIN32
+#ifdef _WIN32
     int res = InetPton(af, src, dst);
 #else
     int res = inet_pton(af, src, dst);
@@ -395,7 +395,7 @@ EXPORT(int, sceNetInit, SceNetInitParam *param) {
     if (!param || !param->memory.address() || param->size < 0x4000 || param->flags != 0)
         return RET_ERROR(SCE_NET_ERROR_EINVAL);
 
-#ifdef WIN32
+#ifdef _WIN32
     WORD versionWanted = MAKEWORD(2, 2);
     WSADATA wsaData;
     WSAStartup(versionWanted, &wsaData);
@@ -588,7 +588,7 @@ EXPORT(int, sceNetTerm) {
     if (!emuenv.net.inited) {
         return RET_ERROR(SCE_NET_ERROR_ENOTINIT);
     }
-#ifdef WIN32
+#ifdef _WIN32
     WSACleanup();
 #endif
     emuenv.net.inited = false;

--- a/vita3k/net/include/net/socket.h
+++ b/vita3k/net/include/net/socket.h
@@ -19,7 +19,7 @@
 
 #include <net/types.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #include <Ws2tcpip.h>

--- a/vita3k/net/src/posixsocket.cpp
+++ b/vita3k/net/src/posixsocket.cpp
@@ -19,7 +19,7 @@
 #include <net/socket.h>
 
 // NOTE: This should be SCE_NET_##errname but it causes vitaQuake to softlock in online games
-#ifdef WIN32
+#ifdef _WIN32
 #define ERROR_CASE(errname) \
     case (WSA##errname):    \
         return SCE_NET_ERROR_##errname;
@@ -31,12 +31,12 @@
 
 static int translate_return_value(int retval) {
     if (retval < 0) {
-#ifdef WIN32
+#ifdef _WIN32
         switch (WSAGetLastError()) {
 #else
         switch (errno) {
 #endif
-#ifndef WIN32 // These errorcodes don't exist in WinSock
+#ifndef _WIN32 // These errorcodes don't exist in WinSock
             ERROR_CASE(EPERM)
             ERROR_CASE(ENOENT)
             ERROR_CASE(ESRCH)
@@ -92,7 +92,7 @@ static int translate_return_value(int retval) {
             ERROR_CASE(EPROTOTYPE)
             ERROR_CASE(ENOPROTOOPT)
             ERROR_CASE(EPROTONOSUPPORT)
-#if defined(__APPLE__) || defined(WIN32)
+#if defined(__APPLE__) || defined(_WIN32)
             ERROR_CASE(EOPNOTSUPP)
 #endif
             ERROR_CASE(EAFNOSUPPORT)
@@ -173,7 +173,7 @@ int PosixSocket::get_socket_address(SceNetSockaddr *name, unsigned int *namelen)
 }
 
 int PosixSocket::close() {
-#ifdef WIN32
+#ifdef _WIN32
     auto out = closesocket(sock);
 #else
     auto out = ::close(sock);
@@ -184,7 +184,7 @@ int PosixSocket::close() {
 SocketPtr PosixSocket::accept(SceNetSockaddr *addr, unsigned int *addrlen) {
     sockaddr addr2;
     abs_socket new_socket = ::accept(sock, &addr2, (socklen_t *)addrlen);
-#ifdef WIN32
+#ifdef _WIN32
     if (new_socket != INVALID_SOCKET) {
 #else
     if (new_socket >= 0) {
@@ -246,7 +246,7 @@ int PosixSocket::set_socket_options(int level, int optname, const void *optval, 
                 return SCE_NET_ERROR_EFAULT;
             }
             memcpy(&sockopt_so_nbio, optval, optlen);
-#ifdef WIN32
+#ifdef _WIN32
             static_assert(sizeof(u_long) == sizeof(sockopt_so_nbio), "type used for ioctlsocket value does not have the expected size");
             return translate_return_value(ioctlsocket(sock, FIONBIO, (u_long *)&sockopt_so_nbio));
 #else

--- a/vita3k/renderer/src/texture/cache.cpp
+++ b/vita3k/renderer/src/texture/cache.cpp
@@ -35,7 +35,7 @@
 #define XXH_INLINE_ALL
 #include <xxhash.h>
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #include <execution>
 #endif
 

--- a/vita3k/renderer/src/vulkan/context.cpp
+++ b/vita3k/renderer/src/vulkan/context.cpp
@@ -298,21 +298,21 @@ void VKContext::start_render_pass(bool create_descriptor_set) {
     if (!is_recording)
         start_recording();
 
-    curr_renderpass_info = {
+    curr_renderpass_info = vk::RenderPassBeginInfo{
         .renderPass = current_render_pass,
         .framebuffer = current_framebuffer
     };
 
     if (render_target->has_macroblock_sync && !ignore_macroblock) {
         // set the render area to the correct macroblock
-        curr_renderpass_info.renderArea = {
+        curr_renderpass_info.renderArea = vk::Rect2D{
             .offset = {
                 last_macroblock_x * render_target->macroblock_width,
                 last_macroblock_y * render_target->macroblock_height },
             .extent = { render_target->macroblock_width, render_target->macroblock_height }
         };
     } else {
-        curr_renderpass_info.renderArea = {
+        curr_renderpass_info.renderArea = vk::Rect2D{
             .offset = { 0, 0 },
             .extent = { render_target->width, render_target->height }
         };

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -152,7 +152,7 @@ std::string get_driver_version(uint32_t vendor_id, uint32_t version_raw) {
     if (vendor_id == 4318)
         return fmt::format("{}.{}.{}.{}", (version_raw >> 22) & 0x3ff, (version_raw >> 14) & 0x0ff, (version_raw >> 6) & 0x0ff, version_raw & 0x003f);
 
-#ifdef WIN32
+#ifdef _WIN32
     // Intel drivers on Windows
     if (vendor_id == 0x8086)
         return fmt::format("{}.{}", version_raw >> 14, version_raw & 0x3fff);

--- a/vita3k/util/include/util/exec.h
+++ b/vita3k/util/include/util/exec.h
@@ -25,7 +25,7 @@ template <size_t MaxOutSize>
 std::string exec(const std::string &cmd) {
     std::array<char, MaxOutSize> buffer;
     std::string result;
-#ifdef WIN32
+#ifdef _WIN32
     std::unique_ptr<FILE, decltype(&_pclose)> pipe(_popen(cmd.c_str(), "r"), _pclose);
 #else
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);

--- a/vita3k/util/include/util/safe_time.h
+++ b/vita3k/util/include/util/safe_time.h
@@ -19,7 +19,7 @@
 
 #include <ctime>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define SAFE_GMTIME(time, result) gmtime_s(result, time)
 #define SAFE_LOCALTIME(time, result) localtime_s(result, time)
 #else

--- a/vita3k/util/include/util/string_utils.h
+++ b/vita3k/util/include/util/string_utils.h
@@ -31,7 +31,7 @@ std::string utf16_to_utf8(const std::u16string &str);
 std::u16string utf8_to_utf16(const std::string &str);
 std::string remove_special_chars(std::string str);
 void replace(std::string &str, const std::string &in, const std::string &out);
-std::basic_string<uint8_t> string_to_byte_array(const std::string &string);
+std::vector<uint8_t> string_to_byte_array(const std::string &string);
 std::string toupper(const std::string &s);
 std::string tolower(const std::string &s);
 int stoi_def(const std::string &str, int default_value = 0, const char *name = "value");

--- a/vita3k/util/src/logging.cpp
+++ b/vita3k/util/src/logging.cpp
@@ -51,7 +51,7 @@ ExitCode init(const Root &root_paths, bool use_stdout) {
         assert(0);
     });
 
-#ifdef WIN32
+#ifdef _WIN32
     // set console codepage to UTF-8
     SetConsoleOutputCP(65001);
     SetConsoleTitle("Vita3K PSVita Emulator");
@@ -99,7 +99,7 @@ ExitCode add_sink(const fs::path &log_path) {
 }
 
 // log exceptions and flush log file on exceptions
-#ifdef WIN32
+#ifdef _WIN32
 static LONG WINAPI exception_handler(PEXCEPTION_POINTERS pExp) noexcept {
     const unsigned ec = pExp->ExceptionRecord->ExceptionCode;
     switch (ec) {

--- a/vita3k/util/src/net_utils.cpp
+++ b/vita3k/util/src/net_utils.cpp
@@ -314,7 +314,7 @@ bool parseResponse(const std::string &res, SceRequestResponse &reqres) {
 }
 
 bool socketSetBlocking(int sockfd, bool blocking) {
-#ifdef WIN32
+#ifdef _WIN32
     u_long blocking_tmp = blocking;
     ioctlsocket(sockfd, FIONBIO, &blocking_tmp);
 #else

--- a/vita3k/util/src/string_utils.cpp
+++ b/vita3k/util/src/string_utils.cpp
@@ -96,7 +96,7 @@ std::basic_string<uint8_t> string_to_byte_array(const std::string &string) {
     return hex_bytes;
 }
 
-#ifdef WIN32
+#ifdef _MSC_VER
 std::string utf16_to_utf8(const std::u16string &str) {
     std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t> myconv;
     auto p = reinterpret_cast<const int16_t *>(str.data());

--- a/vita3k/util/src/string_utils.cpp
+++ b/vita3k/util/src/string_utils.cpp
@@ -84,8 +84,8 @@ void replace(std::string &str, const std::string &in, const std::string &out) {
     }
 }
 
-std::basic_string<uint8_t> string_to_byte_array(const std::string &string) {
-    std::basic_string<uint8_t> hex_bytes;
+std::vector<uint8_t> string_to_byte_array(const std::string &string) {
+    std::vector<uint8_t> hex_bytes;
 
     for (size_t i = 0; i < string.length(); i += 2) {
         uint16_t byte;


### PR DESCRIPTION
These commits make it possible to compile the emulator on Windows with GCC and Clang. It does not build because the unicorn submodule needs an update for mingw-w64. I will submit it later.