### PR TITLE
compat: change time style to yyyy-mm-dd

### DIFF
--- a/vita3k/compat/src/compat.cpp
+++ b/vita3k/compat/src/compat.cpp
@@ -106,7 +106,7 @@ bool load_app_compat_db(GuiState &gui, EmuEnvState &emuenv) {
 
     // Check if compatibility database is up to date in first load
     if (db_updated_at.empty()) {
-        db_updated_at = compatibility.attribute("db_updated_at").as_string();
+        db_updated_at = compatibility.attribute("iso_db_updated_at").as_string();
         if (update_app_compat_db(gui, emuenv))
             return true;
     }
@@ -173,7 +173,7 @@ bool update_app_compat_db(GuiState &gui, EmuEnvState &emuenv) {
     auto &lang = gui.lang.compat_db;
 
     // Get current date of last compat database updated at
-    const auto updated_at = net_utils::get_web_regex_result(latest_link, std::regex(R"(Updated at: (\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}))"));
+    const auto updated_at = net_utils::get_web_regex_result(latest_link, std::regex(R"(Last updated: (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}Z))"));
     if (updated_at.empty()) {
         gui.info_message.title = lang["error"];
         gui.info_message.level = spdlog::level::err;


### PR DESCRIPTION
Follow ISO 8601.
`yyyy-mm-dd` is defined in ISO. The compat-repo must be changed at the same time.