### PR TITLE
modules/SceGxm: Improve sync object handling and simplify display queue logic

### DIFF
--- a/vita3k/gxm/include/gxm/state.h
+++ b/vita3k/gxm/include/gxm/state.h
@@ -36,6 +36,7 @@ struct DisplayCallback {
     Address data;
     Ptr<SceGxmSyncObject> old_sync;
     Ptr<SceGxmSyncObject> new_sync;
+    uint32_t old_sync_timestamp;
     uint32_t new_sync_timestamp;
     bool frame_predicted;
 };
@@ -52,7 +53,6 @@ struct GxmState {
     Queue<DisplayCallback> display_queue;
     SceUID display_queue_thread;
 
-    Ptr<SceGxmSyncObject> last_fbo_sync_object;
     // global timestamp used by sync objects
     std::atomic<uint32_t> global_timestamp{ 1 };
     // last display operation, as given by the global timestamp

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -901,7 +901,6 @@ static void display_entry_thread(EmuEnvState &emuenv) {
         LOG_CRITICAL("display_thread not found. thid:{}", emuenv.gxm.display_queue_thread);
         return;
     }
-    Ptr<SceGxmSyncObject> previous_sync = Ptr<SceGxmSyncObject>();
 
     while (true) {
         auto display_callback = display_queue.top();
@@ -911,7 +910,10 @@ static void display_entry_thread(EmuEnvState &emuenv) {
         SceGxmSyncObject *old_sync = display_callback->old_sync.get(emuenv.mem);
         SceGxmSyncObject *new_sync = display_callback->new_sync.get(emuenv.mem);
 
-        renderer::wishlist(new_sync, display_callback->new_sync_timestamp);
+        // sceGxmDisplayQueueAddEntry waits for both buffers to complete
+        renderer::wishlist(old_sync, display_callback->old_sync_timestamp);
+        if (old_sync != new_sync)
+            renderer::wishlist(new_sync, display_callback->new_sync_timestamp);
 
         // now we can remove the thread from the display queue
         display_queue.pop();
@@ -923,17 +925,13 @@ static void display_entry_thread(EmuEnvState &emuenv) {
         // Now run callback
         display_thread->run_guest_function(callback_address, display_callback->data);
 
+        // Notifies the renderer of the completion of the callback for the display_entry.
+        // The last_display of the entry, when pushed into the queue, is guaranteed to be timestamp_ahead + 1 at the time of the call.
+        renderer::subject_done(old_sync, display_callback->old_sync_timestamp + 1);
+        if (old_sync != new_sync)
+            renderer::subject_done(new_sync, display_callback->new_sync_timestamp + 1);
+
         free(emuenv.mem, display_callback->data);
-
-        // The only thing old buffer should be waiting for is to stop being displayed
-        renderer::subject_done(old_sync, std::min(old_sync->timestamp_current + 1, old_sync->timestamp_ahead.load()));
-        if (previous_sync && display_callback->old_sync != previous_sync) {
-            // in this case, also set the previous sync object to avoid deadlocks
-            SceGxmSyncObject *other_old_sync = previous_sync.get(emuenv.mem);
-            renderer::subject_done(other_old_sync, std::min(other_old_sync->timestamp_current + 1, other_old_sync->timestamp_ahead.load()));
-        }
-
-        previous_sync = display_callback->new_sync;
     }
 }
 
@@ -2047,7 +2045,7 @@ EXPORT(int, sceGxmDisplayQueueAddEntry, Ptr<SceGxmSyncObject> oldBuffer, Ptr<Sce
 
     DisplayFrameInfo *frame = predict_next_image(emuenv, newBuffer.address());
 
-    // Block future rendering by setting value2 of sync object
+    // Block future rendering by setting values of sync object
     SceGxmSyncObject *oldBufferSync = oldBuffer.get(emuenv.mem);
     SceGxmSyncObject *newBufferSync = newBuffer.get(emuenv.mem);
 
@@ -2055,36 +2053,15 @@ EXPORT(int, sceGxmDisplayQueueAddEntry, Ptr<SceGxmSyncObject> oldBuffer, Ptr<Sce
         .data = address,
         .old_sync = oldBuffer,
         .new_sync = newBuffer,
-        .new_sync_timestamp = newBufferSync->timestamp_ahead++,
+        .old_sync_timestamp = oldBufferSync->timestamp_ahead,
+        .new_sync_timestamp = newBufferSync->timestamp_ahead,
         .frame_predicted = frame != nullptr
     };
 
-    if (newBuffer == emuenv.gxm.last_fbo_sync_object) {
-        // don't know why, some games like NFS send twice in a row the same buffer to the front...
-        // act like it is not displaying anymore
-        renderer::subject_done(newBufferSync, newBufferSync->last_display);
-    }
-
-    if (oldBufferSync->last_operation_global > emuenv.gxm.last_display_global
-        && oldBufferSync->last_operation_global < newBufferSync->last_operation_global) {
-        // if we do nothing we will softlock
-        // so just act as if the old buffer is already done being displayed
-        renderer::subject_done(oldBufferSync, oldBufferSync->last_display);
-    }
-
-    newBufferSync->last_display = newBufferSync->timestamp_ahead.load();
-    emuenv.gxm.last_fbo_sync_object = newBuffer;
+    oldBufferSync->last_display = ++oldBufferSync->timestamp_ahead;
+    if (oldBufferSync != newBufferSync)
+        newBufferSync->last_display = ++newBufferSync->timestamp_ahead;
     emuenv.gxm.last_display_global = emuenv.gxm.global_timestamp.fetch_add(1, std::memory_order_relaxed);
-
-    // needed the first time the sync object is used as the old front buffer
-    if (oldBufferSync->last_display == 0) {
-        // resogun draws to the front buffer using the fact that the sync object prevents
-        // it from doing so until it is swapped, the first time it happens must be handled
-        // as a special case
-        renderer::wishlist(oldBufferSync, oldBufferSync->timestamp_ahead);
-
-        oldBufferSync->last_display = ++oldBufferSync->timestamp_ahead;
-    }
 
     // function may be blocking here (expected behavior)
     emuenv.gxm.display_queue.push(display_callback);


### PR DESCRIPTION
This PR is intended to address issue #3403.

The logic of `sceGxmDisplayQueueAddEntry` has been modified according to the implementation of the PS Vita, so that it now waits for both `oldBufferSync` and `newBufferSync`. After this change, workaround codes that seemed unnecessary have also been removed. Additionally, the `handle_wait_sync_object` command has been removed, as it no longer appears logically necessary after these changes. Now, blocks related to `SyncObject` exist only within the logic of `sceGxmDisplayQueueAddEntry` (specifically in `display_entry_thread`).

This is a very aggressive modification, so there is a possibility of errors. However, based on my understanding, this change does not seem to introduce any logical issues.

The part related to frame prediction has been left unchanged as I couldn't fully assess the complexity. However, it may also be necessary to modify the frame prediction to target both the old and new buffers. This aspect is outside the scope of this PR.

Although I did not observe any regressions in my game library, I cannot be entirely certain that there are no issues due to the large scale of the changes. Additionally, there is a possibility that I misunderstood the existing lock logic and proceeded with development based on incorrect assumptions. Therefore, I am approaching this PR with caution.