### PR TITLE
add build instructions for Fedora

### DIFF
--- a/building.md
+++ b/building.md
@@ -106,15 +106,21 @@ If you aren't satisfied with the way the Visual Studio integrates CMake projects
 
 ## Linux
 
-### Ubuntu/Debian
-
-Note: The CMake preset `linux-ninja-clang` makes use of the LLD linker, which will need to be installed in your system along with Clang.
-
 - Install dependencies.
+
+### Ubuntu/Debian
 
   ```sh
   sudo apt install git cmake ninja-build libsdl2-dev pkg-config libgtk-3-dev clang lld xdg-desktop-portal openssl libssl-dev
   ```
+
+### Fedora
+
+  ```sh
+  sudo dnf install git cmake ninja-build SDL2-devel pkg-config gtk3-devel clang lld xdg-desktop-portal openssl openssl-devel libstdc++-static
+  ```
+
+Note: The CMake preset `linux-ninja-clang` makes use of the LLD linker, which will need to be installed in your system along with Clang.
 
 - Clone this repo.
 


### PR DESCRIPTION
Adds a sub-section for Fedora dependencies (with updated package names)

also includes `libc++-static` (required for final linking to complete in tested configuration)

## Test configuration
- MacBookPro (late 2020) M1 16GB 1TB
- Fedora Asahi Remix release 40
- build [3666-52b82dd](https://github.com/Vita3K/Vita3K/commit/52b82dd)
- reuse Vita3K config dirs (firmware and ux0) from Batocera Linux SHARE partition

Build completes and verified:
1. initial setup screen: select language, prefPath, and install firmware
2. logging in as default user and navigating main PS Vita screen
3. launch pre-installed app [PCSB00302] (documented [issue launching](https://github.com/Vita3K/compatibility/issues/45#issuecomment-2439711010))

Despite run-time issue launching title, emulator appears to be stable in main UI helping verify build correctness.