### PR TITLE
GUI: translation extension, refactoring and some improvements

### DIFF
--- a/lang/system/en.xml
+++ b/lang/system/en.xml
@@ -14,7 +14,7 @@
 		<emulation name="Emulation">
 			<last_apps_used>Last Apps used</last_apps_used>
 		</emulation>
-		<debug>
+		<debug name="Debug">
 			<threads>Threads</threads>
 			<semaphores>Semaphores</semaphores>
 			<mutexes>Mutexes</mutexes>
@@ -604,6 +604,12 @@ Check vita3k.log to see console output for details.
 			<no_modules>No modules present.
 Please download and install the last PS Vita firmware.</no_modules>
 			<refresh_list>Refresh List</refresh_list>
+			<automatic>Automatic</automatic>
+			<automatic_description>Select Automatic mode to use a preset list of modules.</automatic_description>
+			<auto_manual>Auto & Manual</auto_manual>
+			<auto_manual_description>Select this mode to load Automatic module and selected modules from the list below.</auto_manual_description>
+			<manual>Manual</manual>
+			<manual_description>Select Manual mode to load selected modules from the list below.</manual_description>
 		</core>
 		<cpu>
 			<unicorn>Unicorn (deprecated)</unicorn>
@@ -736,6 +742,8 @@ You will need to move your old folder to the new location manually.</change_emu_
 You will need to move your old folder to the new location manually.</reset_emu_path_description>
 			<custom_config_settings>Custom Config Settings</custom_config_settings>
 			<clear_custom_config>Clear Custom Config</clear_custom_config>
+			<screenshot_image_type>screenshot image type</screenshot_image_type>
+			<screenshot_format>Screenshot format</screenshot_format>
 		</emulator>
 		<gui name="GUI">
 			<show_gui>GUI Visible</show_gui>
@@ -876,7 +884,7 @@ Are you sure you want to continue?</user_delete_warn>
 	</user_management>
 
 	<vita3k_update name="Vita3K Update">
- 		<new_version_available>A new version of Vita3K is available.</new_version_available>
+		<new_version_available>A new version of Vita3K is available.</new_version_available>
 		<back>Back</back>
 		<cancel_update_resume>Do you want to cancel the update?
 If you cancel, the next time you update, Vita3K will start downloading from this point.</cancel_update_resume>

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -52,6 +52,7 @@ enum ScreenshotFormat {
 // Singular options produced in config file
 // Order is code(option_type, option_name, option_default, member_name)
 // When adding in a new macro for generation, ALL options must be stated.
+// All member names starting with "keyboard_" will be considered as key input (See controls_dialog.cpp)
 #define CONFIG_INDIVIDUAL(code)                                                                         \
     code(bool, "initial-setup", false, initial_setup)                                                   \
     code(bool, "gdbstub", false, gdbstub)                                                               \

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -208,31 +208,11 @@ enum NoticeIcon {
     NEW
 };
 
-enum ModulesModeType {
-    MODE,
-    DESCRIPTION,
-};
-
 enum ThemePreviewType {
     PACKAGE,
     HOME,
     LOCK,
 };
-
-static constexpr auto MODULES_MODE_COUNT = 3;
-using ConfigModuleMode = std::array<std::vector<const char *>, MODULES_MODE_COUNT>;
-
-inline ConfigModuleMode init_modules_mode() {
-    ConfigModuleMode m;
-
-    m[ModulesMode::AUTOMATIC] = { "Automatic", "Select Automatic mode to use a preset list of modules." };
-    m[ModulesMode::AUTO_MANUAL] = { "Auto & Manual", "Select this mode to load Automatic module and selected modules from the list below." };
-    m[ModulesMode::MANUAL] = { "Manual", "Select Manual mode to load selected modules from the list below." };
-
-    return m;
-}
-
-const ConfigModuleMode config_modules_mode = init_modules_mode();
 
 inline const std::vector<std::pair<SceSystemParamLang, std::string>> LIST_SYS_LANG = {
     { SCE_SYSTEM_PARAM_LANG_DANISH, "Dansk" },

--- a/vita3k/gui/src/about_dialog.cpp
+++ b/vita3k/gui/src/about_dialog.cpp
@@ -66,14 +66,10 @@ void draw_about_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin("##about", &gui.help_menu.about_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SetWindowFontScale(RES_SCALE.x);
-    auto title_str = lang["title"].c_str();
-    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title_str).x / 2.f));
-    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title_str);
+    TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["title"].c_str());
     ImGui::Spacing();
     ImGui::Separator();
-    const auto HALF_WINDOW_WIDTH = ImGui::GetWindowWidth() / 2.f;
-    ImGui::SetCursorPosX(HALF_WINDOW_WIDTH - (ImGui::CalcTextSize(window_title).x / 2.f));
-    ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", window_title);
+    TextColoredCentered(GUI_COLOR_TEXT_MENUBAR, window_title);
 
     ImGui::Spacing();
     ImGui::Separator();
@@ -121,14 +117,13 @@ void draw_about_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::Spacing();
 
     // Draw Vita3K Staff list
-    ImGui::SetCursorPosX(HALF_WINDOW_WIDTH - (ImGui::CalcTextSize(lang["vita3k_staff"].c_str()).x / 2.f));
-    ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", lang["vita3k_staff"].c_str());
+    TextColoredCentered(GUI_COLOR_TEXT_MENUBAR, lang["vita3k_staff"].c_str());
     ImGui::Spacing();
 
     const auto STAFF_LIST_SIZE = ImVec2(630.f * SCALE.x, 160.f * SCALE.y);
     static constexpr int STAFF_COLUMN_COUNT(3);
     const float STAFF_COLUMN_SIZE(STAFF_LIST_SIZE.x / STAFF_COLUMN_COUNT);
-    const float STAFF_COLUMN_POS(HALF_WINDOW_WIDTH - (STAFF_LIST_SIZE.x / 2.f));
+    const float STAFF_COLUMN_POS(ImGui::GetWindowWidth() / 2.f - (STAFF_LIST_SIZE.x / 2.f));
 
     ImGui::SetCursorPosX(STAFF_COLUMN_POS);
     if (ImGui::BeginTable("##vita3k_staff_table", STAFF_COLUMN_COUNT, ImGuiTableFlags_ScrollY | ImGuiTableFlags_BordersV | ImGuiTableFlags_NoSavedSettings, STAFF_LIST_SIZE)) {

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -345,17 +345,14 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                     }
                 } else {
                     ImGui::Spacing();
-                    ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(compat_state_str.c_str()).x / 2));
-                    ImGui::TextColored(compat_state_color, "%s", compat_state_str.c_str());
+                    TextColoredCentered(compat_state_color, compat_state_str.c_str());
                     ImGui::Spacing();
                     if (has_state_report) {
                         tm updated_at_tm = {};
                         SAFE_LOCALTIME(&gui.compat.app_compat_db[title_id].updated_at, &updated_at_tm);
                         auto UPDATED_AT = get_date_time(gui, emuenv, updated_at_tm);
                         ImGui::Spacing();
-                        const auto updated_at_str = fmt::format("{} {} {} {}", lang.info["updated"].c_str(), UPDATED_AT[DateTime::DATE_MINI], UPDATED_AT[DateTime::CLOCK], is_12_hour_format ? UPDATED_AT[DateTime::DAY_MOMENT] : "");
-                        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(updated_at_str.c_str()).x / 2));
-                        ImGui::TextColored(GUI_COLOR_TEXT, "%s", updated_at_str.c_str());
+                        TextColoredCentered(GUI_COLOR_TEXT, fmt::format("{} {} {} {}", lang.info["updated"].c_str(), UPDATED_AT[DateTime::DATE_MINI], UPDATED_AT[DateTime::CLOCK], is_12_hour_format ? UPDATED_AT[DateTime::DAY_MOMENT] : "").c_str());
                     }
                     ImGui::Spacing();
                     ImGui::Separator();
@@ -578,13 +575,11 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                 ImGui::GetWindowDrawList()->AddImageRounded(gui.app_selector.user_apps_icon[title_id], POS_MIN, POS_MAX, ImVec2(0, 0), ImVec2(1, 1), IM_COL32_WHITE, PUPOP_ICON_SIZE.x * SCALE.x, ImDrawFlags_RoundCornersAll);
             }
             ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
-            ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(APP_INDEX->stitle.c_str()).x / 2.f), ICON_MARGIN + PUPOP_ICON_SIZE.y + (4.f * SCALE.y)));
-            ImGui::TextColored(GUI_COLOR_TEXT, "%s", APP_INDEX->stitle.c_str());
+            ImGui::SetCursorPosY(ICON_MARGIN + PUPOP_ICON_SIZE.y + (4.f * SCALE.y));
+            TextColoredCentered(GUI_COLOR_TEXT, APP_INDEX->stitle.c_str());
             ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
-            ImGui::SetCursorPos(ImVec2(WINDOW_SIZE.x / 2 - ImGui::CalcTextSize(context_dialog.c_str(), 0, false, WINDOW_SIZE.x - (108.f * SCALE.x)).x / 2, (WINDOW_SIZE.y / 2) + 10));
-            ImGui::PushTextWrapPos(WINDOW_SIZE.x - (54.f * SCALE.x));
-            ImGui::TextColored(GUI_COLOR_TEXT, "%s", context_dialog.c_str());
-            ImGui::PopTextWrapPos();
+            ImGui::SetCursorPosY((WINDOW_SIZE.y / 2) + 10);
+            TextColoredCentered(GUI_COLOR_TEXT, context_dialog.c_str(), 54.f * SCALE.x);
             if (context_dialog == lang.deleting["app_delete"])
                 SetTooltipEx(lang.deleting["app_delete_description"].c_str());
             ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);

--- a/vita3k/gui/src/common_dialog.cpp
+++ b/vita3k/gui/src/common_dialog.cpp
@@ -31,8 +31,7 @@ static void draw_ime_dialog(EmuEnvState &emuenv, DialogState &common_dialog, flo
     ImGui::SetNextWindowSize(ImVec2(0, 0));
     ImGui::Begin("##ime_dialog", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SetWindowFontScale(FONT_SCALE);
-    ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(common_dialog.ime.title).x / 2.f));
-    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", common_dialog.ime.title);
+    TextColoredCentered(GUI_COLOR_TEXT_TITLE, common_dialog.ime.title);
     ImGui::Spacing();
     // TODO: setting the bufsize to max_length + 1 is not correct (except when using only 1-byte UTF-8 characters)
     // the reason being that the max_length is the number of characters allowed but the parameter given to ImGui::InputTextMultiline/ImGui::InputText
@@ -81,11 +80,8 @@ static void draw_message_dialog(DialogState &common_dialog, float FONT_SCALE, Im
     ImGui::Begin("##Message Dialog", nullptr, ImGuiWindowFlags_NoDecoration);
     ImGui::SetCursorPosY(WINDOW_SIZE.y / 2 - 40.f * SCALE.y);
     ImGui::BeginGroup();
-    ImGui::PushTextWrapPos(WINDOW_SIZE.x - 50.f * SCALE.x);
     ImGui::SetWindowFontScale(FONT_SCALE);
-    ImGui::SetCursorPosX(WINDOW_SIZE.x / 2 - ImGui::CalcTextSize(common_dialog.msg.message.c_str(), 0, false, WINDOW_SIZE.x - 100.f * SCALE.x).x / 2);
-    ImGui::Text("%s", common_dialog.msg.message.c_str());
-    ImGui::PopTextWrapPos();
+    TextCentered(common_dialog.msg.message.c_str(), 50.f * SCALE.x);
     if (common_dialog.msg.has_progress_bar) {
         ImGui::Spacing();
         const char dummy_buf[32] = "";
@@ -95,8 +91,7 @@ static void draw_message_dialog(DialogState &common_dialog, float FONT_SCALE, Im
         ImGui::ProgressBar(common_dialog.msg.bar_percent / 100.f, PROGRESS_BAR_SIZE, dummy_buf);
         ImGui::PopStyleColor(2);
         std::string progress = std::to_string(static_cast<int>(common_dialog.msg.bar_percent)).append("%");
-        ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2 - ImGui::CalcTextSize(progress.c_str()).x / 2);
-        ImGui::Text("%s", progress.c_str());
+        TextCentered(progress.c_str());
     }
     ImGui::EndGroup();
     if (common_dialog.msg.btn_num != 0) {
@@ -541,10 +536,8 @@ static void draw_savedata_dialog(GuiState &gui, EmuEnvState &emuenv, float FONT_
                 if (existing_saves_count == 0) {
                     save_data_list_type_selected = CANCEL;
                     ImGui::SetWindowFontScale(1.56f * FONT_SCALE);
-                    const auto no_save_data = emuenv.common_dialog.lang.save_data.load["no_saved_data"].c_str();
-                    const auto TEXT_SIZE = ImGui::CalcTextSize(no_save_data);
-                    ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (TEXT_SIZE.x / 2.f), 150.f * SCALE.y));
-                    ImGui::Text("%s", no_save_data);
+                    ImGui::SetCursorPosY(150.f * SCALE.y);
+                    TextCentered(emuenv.common_dialog.lang.save_data.load["no_saved_data"].c_str());
                 }
             }
         }
@@ -591,11 +584,8 @@ static void draw_savedata_dialog(GuiState &gui, EmuEnvState &emuenv, float FONT_
         ImGui::SetCursorPosY(ICON_POS.y + THUMBNAIL_SIZE.y + (10.f * SCALE.y));
         ImGui::Separator();
         ImGui::SetWindowFontScale(1.25f * FONT_SCALE);
-        ImGui::PushTextWrapPos(WINDOW_SIZE.x - 50.f * SCALE.x);
-        const auto MSG_SIZE = ImGui::CalcTextSize(emuenv.common_dialog.savedata.msg.c_str(), 0, false, WINDOW_SIZE.x - 100.f);
-        ImGui::SetCursorPos(ImVec2(HALF_WINDOW_SIZE.x - (MSG_SIZE.x / 2), (WINDOW_SIZE.y / 2.f) + (20.f * SCALE.y)));
-        ImGui::Text("%s", emuenv.common_dialog.savedata.msg.c_str());
-        ImGui::PopTextWrapPos();
+        ImGui::SetCursorPosY((WINDOW_SIZE.y / 2.f) + (20.f * SCALE.y));
+        TextCentered(emuenv.common_dialog.savedata.msg.c_str(), 50.f * SCALE.x);
         if (emuenv.common_dialog.savedata.has_progress_bar) {
             ImGui::Spacing();
             const ImVec2 PROGRESS_BAR_SIZE = ImVec2(570.f * SCALE.x, 12.f * SCALE.y);
@@ -607,8 +597,7 @@ static void draw_savedata_dialog(GuiState &gui, EmuEnvState &emuenv, float FONT_
             ImGui::PopStyleColor(2);
             ImGui::PopStyleVar();
             const std::string progress = std::to_string(static_cast<int>(emuenv.common_dialog.savedata.bar_percent)).append("%");
-            ImGui::SetCursorPosX(HALF_WINDOW_SIZE.x - (ImGui::CalcTextSize(progress.c_str()).x / 2.f));
-            ImGui::Text("%s", progress.c_str());
+            TextCentered(progress.c_str());
         }
 
         if (emuenv.common_dialog.savedata.btn_num != 0) {

--- a/vita3k/gui/src/compile_shaders.cpp
+++ b/vita3k/gui/src/compile_shaders.cpp
@@ -64,9 +64,8 @@ void draw_pre_compiling_shaders_progress(GuiState &gui, EmuEnvState &emuenv, con
     ImGui::ProgressBar(progress_programs / 100.f, ImVec2(PROGRESS_BAR_WIDTH, 15.f * emuenv.dpi_scale), "");
     ImGui::PopStyleColor();
     ImGui::PopStyleVar();
-    const auto progress_programs_str = fmt::format("{}/{}", emuenv.renderer->programs_count_pre_compiled, total);
-    ImGui::SetCursorPos(ImVec2((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(progress_programs_str.c_str()).x / 2.f), ImGui::GetCursorPosY() + (6.f * emuenv.dpi_scale)));
-    ImGui::TextColored(GUI_COLOR_TEXT, "%s", progress_programs_str.c_str());
+    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (6.f * emuenv.dpi_scale));
+    TextColoredCentered(GUI_COLOR_TEXT, fmt::format("{}/{}", emuenv.renderer->programs_count_pre_compiled, total).c_str());
     ImGui::End();
     ImGui::PopStyleVar();
     ImGui::PopFont();

--- a/vita3k/gui/src/controllers_dialog.cpp
+++ b/vita3k/gui/src/controllers_dialog.cpp
@@ -29,8 +29,8 @@
 
 namespace gui {
 
-bool rebinds_is_open = false;
-bool is_capturing_buttons = false;
+static bool rebinds_is_open = false;
+static bool is_capturing_buttons = false;
 
 void reset_controller_binding(EmuEnvState &emuenv) {
     emuenv.cfg.controller_binds = {
@@ -219,9 +219,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f)), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin("##controllers", &gui.controls_menu.controllers_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
     ImGui::SetWindowFontScale(RES_SCALE.x);
-    auto title_str = lang["title"].c_str();
-    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title_str).x / 2.f));
-    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title_str);
+    TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["title"].c_str());
     ImGui::Spacing();
     ImGui::Separator();
 
@@ -266,9 +264,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f)), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
                     ImGui::Begin("##rebind_controls", &rebinds_is_open, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
                     ImGui::SetWindowFontScale(RES_SCALE.x);
-                    auto rebind_controls = lang["rebind_controls"].c_str();
-                    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(rebind_controls).x / 2.f));
-                    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", rebind_controls);
+                    TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["rebind_controls"].c_str());
                     ImGui::Spacing();
                     ImGui::Separator();
 
@@ -357,9 +353,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                         ImGui::Spacing();
                         ImGui::Separator();
                         ImGui::Spacing();
-                        const auto led_color_str = lang["led_color"].c_str();
-                        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(led_color_str).x / 2.f));
-                        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", led_color_str);
+                        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["led_color"].c_str());
                         auto &color = emuenv.cfg.controller_led_color;
                         bool has_custom_color = !color.empty();
                         if (ImGui::Checkbox(lang["use_custom_color"].c_str(), &has_custom_color)) {

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -28,23 +28,11 @@
 
 namespace gui {
 
-std::string fw_version;
-bool delete_pup_file;
-std::filesystem::path pup_path = "";
-
-static void get_firmware_version(EmuEnvState &emuenv) {
-    fs::ifstream versionFile(emuenv.pref_path / "PUP_DEC/PUP/version.txt");
-
-    if (versionFile.is_open()) {
-        std::getline(versionFile, fw_version);
-        versionFile.close();
-    } else
-        LOG_WARN("Firmware Version file not found!");
-
-    fs::remove_all(emuenv.pref_path / "PUP_DEC");
-}
-
 void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
+    static std::string fw_version;
+    static bool delete_pup_file;
+    static std::filesystem::path pup_path = "";
+
     host::dialog::filesystem::Result result = host::dialog::filesystem::Result::CANCEL;
 
     static std::mutex install_mutex;
@@ -77,7 +65,14 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 install_pup(emuenv.pref_path, fs::path(pup_path.native()), progress_callback);
                 std::lock_guard<std::mutex> lock(install_mutex);
                 finished_installing = true;
-                get_firmware_version(emuenv);
+                // get firmware version
+                fs::ifstream versionFile(emuenv.pref_path / "PUP_DEC/PUP/version.txt");
+                if (versionFile.is_open()) {
+                    std::getline(versionFile, fw_version);
+                    versionFile.close();
+                } else
+                    LOG_WARN("Firmware Version file not found!");
+                fs::remove_all(emuenv.pref_path / "PUP_DEC");
             });
             installation.detach();
         } else if (result == host::dialog::filesystem::Result::CANCEL) {
@@ -94,21 +89,18 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::OpenPopup("firmware_installation");
         if (ImGui::BeginPopupModal("firmware_installation", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration)) {
             ImGui::SetWindowFontScale(RES_SCALE.x);
-            ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(lang["firmware_installation"].c_str()).x / 2.f));
-            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["firmware_installation"].c_str());
+            TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["firmware_installation"].c_str());
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();
-            ImGui::SetCursorPos(ImVec2(178.f * SCALE.x, ImGui::GetCursorPosY() + 30.f * SCALE.y));
-            ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(lang["firmware_installing"].c_str()).x / 2.f));
-            ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["firmware_installing"].c_str());
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 30.f * SCALE.y);
+            TextColoredCentered(GUI_COLOR_TEXT, lang["firmware_installing"].c_str());
             const float PROGRESS_BAR_WIDTH = 502.f * SCALE.x;
             ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (PROGRESS_BAR_WIDTH / 2.f), ImGui::GetCursorPosY() + 30.f * SCALE.y));
             ImGui::PushStyleColor(ImGuiCol_PlotHistogram, GUI_PROGRESS_BAR);
             ImGui::ProgressBar(progress / 100.f, ImVec2(PROGRESS_BAR_WIDTH, 15.f * SCALE.x), "");
-            const auto progress_str = std::to_string(progress).append("%");
-            ImGui::SetCursorPos(ImVec2((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(progress_str.c_str()).x / 2.f), ImGui::GetCursorPosY() + 16.f * SCALE.y));
-            ImGui::TextColored(GUI_COLOR_TEXT, "%s", progress_str.c_str());
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 16.f * SCALE.y);
+            TextColoredCentered(GUI_COLOR_TEXT, std::to_string(progress).append("%").c_str());
             ImGui::PopStyleColor();
         }
         ImGui::EndPopup();
@@ -117,8 +109,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         if (ImGui::BeginPopupModal("firmware_installation", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration)) {
             ImGui::SetWindowFontScale(RES_SCALE.x);
             const auto POS_BUTTON = (WINDOW_SIZE.x / 2.f) - (BUTTON_SIZE.x / 2.f) + (10.f * SCALE.x);
-            ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(lang["successed_install_firmware"].c_str()).x / 2.f));
-            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["successed_install_firmware"].c_str());
+            TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["successed_install_firmware"].c_str());
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -63,8 +63,7 @@ void draw_info_message(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::BeginChild("##info", WINDOW_SIZE, ImGuiChildFlags_Borders, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoDecoration);
         const auto &title = gui.info_message.title;
         ImGui::SetWindowFontScale(RES_SCALE.x);
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize(title.c_str()).x) / 2);
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title.c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, title.c_str());
         ImGui::Spacing();
         ImGui::Separator();
         const auto text_size = ImGui::CalcTextSize(gui.info_message.msg.c_str(), 0, false, WINDOW_SIZE.x - (24.f * SCALE.x));
@@ -885,6 +884,32 @@ void SetTooltipEx(const char *tooltip) {
         ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
     }
+}
+
+void TextColoredCentered(const ImVec4 &col, const char *text) {
+    ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize(text).x) * 0.5f);
+    ImGui::TextColored(col, "%s", text);
+}
+
+void TextCentered(const char *text) {
+    ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize(text).x) * 0.5f);
+    ImGui::Text("%s", text);
+}
+
+void TextColoredCentered(const ImVec4 &col, const char *text, float wrap_width) {
+    const auto window_width = ImGui::GetWindowWidth();
+    ImGui::PushTextWrapPos(window_width - wrap_width);
+    ImGui::SetCursorPosX((window_width - ImGui::CalcTextSize(text, nullptr, false, window_width - 2.f * wrap_width).x) * 0.5f);
+    ImGui::TextColored(col, "%s", text);
+    ImGui::PopTextWrapPos();
+}
+
+void TextCentered(const char *text, float wrap_width) {
+    const auto window_width = ImGui::GetWindowWidth();
+    ImGui::PushTextWrapPos(window_width - wrap_width);
+    ImGui::SetCursorPosX((window_width - ImGui::CalcTextSize(text, nullptr, false, window_width - 2.f * wrap_width).x) * 0.5f);
+    ImGui::Text("%s", text);
+    ImGui::PopTextWrapPos();
 }
 
 } // namespace gui

--- a/vita3k/gui/src/home_screen.cpp
+++ b/vita3k/gui/src/home_screen.cpp
@@ -523,10 +523,10 @@ void select_app(GuiState &gui, const std::string &title_id) {
         LOG_ERROR("App with title id {} not found", title_id);
 }
 
-static constexpr ImU32 ARROW_COLOR = 0xFFFFFFFF; // White
-static float scroll_type, current_scroll_pos, max_scroll_pos;
-
 void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
+    constexpr ImU32 ARROW_COLOR = 0xFFFFFFFF; // White
+    static int scroll_type;
+
     const ImVec2 VIEWPORT_POS(emuenv.viewport_pos.x, emuenv.viewport_pos.y);
     const ImVec2 VIEWPORT_SIZE(emuenv.viewport_size.x, emuenv.viewport_size.y);
     const ImVec2 VIEWPORT_RES_SCALE(VIEWPORT_SIZE.x / emuenv.res_width_dpi_scale, VIEWPORT_SIZE.y / emuenv.res_height_dpi_scale);
@@ -738,8 +738,8 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::BeginChild("##apps_list", SIZE_APP_LIST, ImGuiChildFlags_None, child_flags);
 
     // Get Scroll Pos
-    current_scroll_pos = ImGui::GetScrollY();
-    max_scroll_pos = ImGui::GetScrollMaxY();
+    float current_scroll_pos = ImGui::GetScrollY();
+    float max_scroll_pos = ImGui::GetScrollMaxY();
 
     // Set Scroll Pos
     if (scroll_type != 0) {

--- a/vita3k/gui/src/ime.cpp
+++ b/vita3k/gui/src/ime.cpp
@@ -258,10 +258,10 @@ void init_ime_lang(Ime &ime, const SceImeLanguage &lang) {
 
 static std::map<int, float> key_row_pos = { { FIRST, 11.f }, { SECOND, 69.f }, { THIRD, 127.f } };
 
-static bool numeric_pad = false;
-static std::map<std::string, float> scroll_special;
-
 void draw_ime(Ime &ime, EmuEnvState &emuenv) {
+    static bool numeric_pad = false;
+    static float scroll_special_current;
+    static float scroll_special_max;
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
     const auto SCALE = ImVec2(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
@@ -292,16 +292,16 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
     ImGui::SetWindowFontScale(RES_SCALE.x);
     if (numeric_pad) {
         ImGui::SetCursorPosX(MARGE_BORDER);
-        ImGui::VSliderFloat("##scroll_special", ImVec2(42.f * SCALE.x, 140.f * SCALE.y), &scroll_special["current"], scroll_special["max"], 0, "");
+        ImGui::VSliderFloat("##scroll_special", ImVec2(42.f * SCALE.x, 140.f * SCALE.y), &scroll_special_current, scroll_special_max, 0, "");
         ImGui::SetNextWindowPos(ImVec2(WINDOW_POS.x + (74.f * SCALE.x), WINDOW_POS.y));
         ImGui::BeginChild("##special_key", ImVec2(488.f * SCALE.x, 178.f * SCALE.y), ImGuiChildFlags_None, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollWithMouse);
         const auto scroll_value = ImGui::GetIO().MouseWheel * 20.f;
         if (ImGui::GetIO().MouseWheel == 1)
-            scroll_special["current"] -= std::min(scroll_value, scroll_special["current"]);
+            scroll_special_current -= std::min(scroll_value, scroll_special_current);
         else
-            scroll_special["current"] += std::min(-scroll_value, scroll_special["max"] - scroll_special["current"]);
-        ImGui::SetScrollY(scroll_special["current"]);
-        scroll_special["max"] = ImGui::GetScrollMaxY();
+            scroll_special_current += std::min(-scroll_value, scroll_special_max - scroll_special_current);
+        ImGui::SetScrollY(scroll_special_current);
+        scroll_special_max = ImGui::GetScrollMaxY();
         ImGui::PushStyleColor(ImGuiCol_Button, IME_NUMERIC_BG);
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
         for (const auto &special : special_key) {

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -361,9 +361,9 @@ static std::string get_notice_time(GuiState &gui, EmuEnvState &emuenv, const tim
 
     return date;
 }
-static bool notice_info_state;
 
 static void draw_notice_info(GuiState &gui, EmuEnvState &emuenv) {
+    static bool notice_info_state;
     const ImVec2 VIEWPORT_POS(emuenv.viewport_pos.x, emuenv.viewport_pos.y);
     const ImVec2 VIEWPORT_SIZE(emuenv.viewport_size.x, emuenv.viewport_size.y);
     const ImVec2 RES_SCALE(VIEWPORT_SIZE.x / emuenv.res_width_dpi_scale, VIEWPORT_SIZE.y / emuenv.res_height_dpi_scale);
@@ -503,10 +503,9 @@ static void draw_notice_info(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f) - (DELETE_POPUP_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f) - (DELETE_POPUP_SIZE.y / 2.f)));
                 if (ImGui::BeginPopupModal("Delete All", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
                     ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
-                    const auto notif_deleted = lang["notif_deleted"].c_str();
                     auto &common = emuenv.common_dialog.lang.common;
-                    ImGui::SetCursorPos(ImVec2((DELETE_POPUP_SIZE.x / 2.f) - (ImGui::CalcTextSize(notif_deleted).x / 2.f), (DELETE_POPUP_SIZE.y / 2.f) - (46.f * SCALE.y)));
-                    ImGui::TextColored(GUI_COLOR_TEXT, "%s", notif_deleted);
+                    ImGui::SetCursorPosY((DELETE_POPUP_SIZE.y / 2.f) - (46.f * SCALE.y));
+                    TextColoredCentered(GUI_COLOR_TEXT, lang["notif_deleted"].c_str());
                     ImGui::SetCursorPos(ImVec2((DELETE_POPUP_SIZE.x / 2) - (BUTTON_SIZE.x + (20.f * SCALE.x)), DELETE_POPUP_SIZE.y - BUTTON_SIZE.y - (24.0f * SCALE.y)));
                     if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
                         ImGui::CloseCurrentPopup();

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -25,17 +25,6 @@
 
 namespace gui {
 
-enum InitialSetup {
-    SELECT_LANGUAGE,
-    SELECT_PREF_PATH,
-    INSTALL_FIRMWARE,
-    SELECT_INTERFACE_SETTINGS,
-    FINISHED
-};
-
-static InitialSetup setup = SELECT_LANGUAGE;
-static std::string title_str;
-
 void get_firmware_file(EmuEnvState &emuenv) {
     const std::map<int, std::string> locale_id = {
         { SCE_SYSTEM_PARAM_LANG_JAPANESE, "ja-jp" },
@@ -64,6 +53,17 @@ void get_firmware_file(EmuEnvState &emuenv) {
 }
 
 void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
+    enum InitialSetup {
+        SELECT_LANGUAGE,
+        SELECT_PREF_PATH,
+        INSTALL_FIRMWARE,
+        SELECT_INTERFACE_SETTINGS,
+        FINISHED
+    };
+
+    static InitialSetup setup = SELECT_LANGUAGE;
+    static std::string title_str;
+
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
     const auto SCALE = ImVec2(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
@@ -75,7 +75,6 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
 
     auto &lang = gui.lang.initial_setup;
     auto &common = emuenv.common_dialog.lang.common;
-    const auto completed_setup = lang["completed_setup"].c_str();
 
     const auto is_default_path = emuenv.cfg.pref_path == emuenv.default_path;
     const auto FW_PREINST_PATH{ emuenv.pref_path / "pd0" };
@@ -103,8 +102,8 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
     const auto SELECT_COLOR_HOVERED = ImVec4(0.23f, 0.68f, 0.99f, 0.80f);
     const auto SELECT_COLOR_ACTIVE = ImVec4(0.23f, 0.68f, 1.f, 1.f);
 
-    ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(title_str.c_str()).x / 2.f), (47 * SCALE.y) - (ImGui::GetFontSize() / 2.f)));
-    ImGui::Text("%s", title_str.c_str());
+    ImGui::SetCursorPosY((47 * SCALE.y) - (ImGui::GetFontSize() / 2.f));
+    TextCentered(title_str.c_str());
     ImGui::SetCursorPosY(94.f * SCALE.y);
     ImGui::Separator();
     switch (setup) {
@@ -143,11 +142,10 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         break;
     case SELECT_PREF_PATH:
         title_str = lang["select_pref_path"];
-        ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(lang["current_emu_path"].c_str()).x / 2.f), (WINDOW_SIZE.y / 2.f) - ImGui::GetFontSize()));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["current_emu_path"].c_str());
+        ImGui::SetCursorPosY((WINDOW_SIZE.y / 2.f) - ImGui::GetFontSize());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["current_emu_path"].c_str());
         ImGui::Spacing();
-        ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(emuenv.cfg.pref_path.c_str()).x / 2.f));
-        ImGui::TextWrapped("%s", emuenv.cfg.pref_path.c_str());
+        TextCentered(emuenv.cfg.pref_path.c_str(), 0);
         ImGui::SetCursorPos(!is_default_path ? ImVec2((WINDOW_SIZE.x / 2.f) - BIG_BUTTON_SIZE.x - (20.f * SCALE.x), BIG_BUTTON_POS.y) : BIG_BUTTON_POS);
         if (ImGui::Button(lang["change_emu_path"].c_str(), BIG_BUTTON_SIZE)) {
             std::filesystem::path emulator_path = "";
@@ -172,8 +170,8 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         break;
     case INSTALL_FIRMWARE:
         title_str = lang["install_firmware"];
-        ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(lang["install_highly_recommended"].c_str()).x / 2.f), (WINDOW_SIZE.y / 2.f) - (ImGui::GetFontSize() * 3.5f)));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["install_highly_recommended"].c_str());
+        ImGui::SetCursorPosY((WINDOW_SIZE.y / 2.f) - (ImGui::GetFontSize() * 3.5f));
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["install_highly_recommended"].c_str());
         ImGui::Spacing();
         if (ImGui::Button("Download Preinst Firmware", BIG_BUTTON_SIZE))
             open_path("https://bit.ly/4hlePsX");
@@ -214,8 +212,8 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         break;
     case FINISHED:
         title_str = lang["completed"];
-        ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (ImGui::CalcTextSize(completed_setup).x / 2.f), (WINDOW_SIZE.y / 2.f) - ImGui::GetFontSize()));
-        ImGui::Text("%s", completed_setup);
+        ImGui::SetCursorPosY((WINDOW_SIZE.y / 2.f) - ImGui::GetFontSize());
+        TextCentered(lang["completed_setup"].c_str());
         ImGui::SetCursorPos(BIG_BUTTON_POS);
         if (ImGui::Button(common["ok"].c_str(), BIG_BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross)))
             emuenv.cfg.initial_setup = true;

--- a/vita3k/gui/src/license_install_dialog.cpp
+++ b/vita3k/gui/src/license_install_dialog.cpp
@@ -24,10 +24,6 @@
 
 namespace gui {
 
-static std::string state, title, zRIF;
-std::filesystem::path license_path = "";
-static bool delete_license_file;
-
 void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const auto display_size = ImGui::GetIO().DisplaySize;
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
@@ -39,6 +35,20 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     auto &indicator = gui.lang.indicator;
     auto &common = emuenv.common_dialog.lang.common;
 
+    enum class State {
+        UNDEFINED,
+        LICENSE,
+        ZRIF,
+        SUCCESS,
+        FAIL
+    };
+
+    static State state = State::UNDEFINED;
+
+    static std::string title, zRIF;
+    static std::filesystem::path license_path = "";
+    static bool delete_license_file;
+
     ImGui::SetNextWindowPos(ImVec2(0.f, 0.f), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size);
     ImGui::Begin("##license_install", &gui.file_menu.license_install_dialog, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
@@ -47,40 +57,44 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f * SCALE.x);
     ImGui::BeginChild("##license_install_child", ImVec2(616.f * SCALE.x, 264.f * SCALE.y), ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     const auto POS_BUTTON = (ImGui::GetWindowWidth() / 2.f) - (BUTTON_SIZE.x / 2.f) + (10.f * SCALE.x);
-    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title.c_str()).x / 2.f));
-    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title.c_str());
+    TextColoredCentered(GUI_COLOR_TEXT_TITLE, title.c_str());
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
-    if (state.empty()) {
+    switch (state) {
+    case State::UNDEFINED: {
         ImGui::SetCursorPosX(POS_BUTTON);
         title = license["select_license_type"];
         if (ImGui::Button(license["select_bin_rif"].c_str(), BUTTON_SIZE))
-            state = "license";
+            state = State::LICENSE;
         ImGui::SetCursorPosX(POS_BUTTON);
         if (ImGui::Button(license["enter_zrif"].c_str(), BUTTON_SIZE))
-            state = "zrif";
+            state = State::ZRIF;
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
         ImGui::SetCursorPosX(POS_BUTTON);
         if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE))
             gui.file_menu.license_install_dialog = false;
-    } else if (state == "license") {
+        break;
+    }
+    case State::LICENSE: {
         host::dialog::filesystem::Result result = host::dialog::filesystem::Result::CANCEL;
         result = host::dialog::filesystem::open_file(license_path, { { "PlayStation Vita software license file", { "bin", "rif" } } });
         if (result == host::dialog::filesystem::Result::SUCCESS) {
             if (copy_license(emuenv, fs::path(license_path.native())))
-                state = "success";
+                state = State::SUCCESS;
             else
-                state = "fail";
+                state = State::FAIL;
         } else {
             if (result == host::dialog::filesystem::Result::ERROR)
                 LOG_CRITICAL("Error initializing file dialog: {}", host::dialog::filesystem::get_error());
 
-            state.clear();
+            state = State::UNDEFINED;
         }
-    } else if (state == "zrif") {
+        break;
+    }
+    case State::ZRIF: {
         title = license["enter_zrif_key"];
         ImGui::PushItemWidth(640.f * SCALE.x);
         ImGui::InputTextWithHint("##enter_zrif", license["input_zrif"].c_str(), &zRIF);
@@ -91,17 +105,19 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::SetCursorPos(ImVec2(POS_BUTTON - (BUTTON_SIZE.x / 2) - 10.f * emuenv.dpi_scale, ImGui::GetWindowSize().y / 2));
         if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE)) {
-            state.clear();
+            state = State::UNDEFINED;
             zRIF.clear();
         }
         ImGui::SameLine(0, 20.f * SCALE.x);
         if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) && !zRIF.empty()) {
             if (create_license(emuenv, zRIF))
-                state = "success";
+                state = State::SUCCESS;
             else
-                state = "fail";
+                state = State::FAIL;
         }
-    } else if (state == "success") {
+        break;
+    }
+    case State::SUCCESS: {
         title = indicator["install_complete"];
         ImGui::Spacing();
         ImGui::TextColored(GUI_COLOR_TEXT, "%s\n%s: %s\n%s: %s", lang["successed_install_license"].c_str(), gui.lang.settings.theme_background.theme.information["content_id"].c_str(), emuenv.license_content_id.c_str(), gui.lang.app_context.info["title_id"].c_str(), emuenv.license_title_id.c_str());
@@ -118,19 +134,21 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             }
             license_path = "";
             gui.file_menu.license_install_dialog = false;
-            state.clear();
+            state = State::UNDEFINED;
         }
-    } else if (state == "fail") {
+        break;
+    }
+    case State::FAIL: {
         title = indicator["install_failed"];
-        auto FAILED_INSTALL_STR = lang["failed_install_license"].c_str();
-        ImGui::SetCursorPos(ImVec2((ImGui::GetWindowSize().x / 2.f) - (ImGui ::CalcTextSize(FAILED_INSTALL_STR).x / 2.f), ImGui::GetWindowSize().y / 2.f - 20.f));
-        ImGui::TextColored(GUI_COLOR_TEXT, "%s", FAILED_INSTALL_STR);
+        ImGui::SetCursorPosY(ImGui::GetWindowSize().y / 2.f - 20.f);
+        TextColoredCentered(GUI_COLOR_TEXT, lang["failed_install_license"].c_str());
         ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - (20.f * SCALE.y)));
         if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
             gui.file_menu.license_install_dialog = false;
             license_path = "";
-            state.clear();
+            state = State::UNDEFINED;
         }
+    }
     }
     ImGui::EndChild();
     ImGui::PopStyleVar();

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -1158,21 +1158,17 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::OpenPopup("Live Area Help");
         ImGui::SetNextWindowPos(ImVec2(WINDOW_SIZE.x / 2.f, WINDOW_SIZE.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
         if (ImGui::BeginPopupModal("Live Area Help", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
-            auto help_str = gui.lang.main_menubar.help["title"].c_str();
-            ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize(help_str).x / 2.f));
-            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", help_str);
+            TextColoredCentered(GUI_COLOR_TEXT_TITLE, gui.lang.main_menubar.help["title"].c_str());
             ImGui::Spacing();
-            auto TextColoredCentered = [](GuiState &gui, const ImVec4 &col, const char *text_id) {
-                auto str = gui.lang.live_area.help[text_id].c_str();
-                ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (ImGui::CalcTextSize(str).x / 2.f));
-                ImGui::TextColored(col, "%s", str);
+            auto TextColoredCenteredEx = [](GuiState &gui, const ImVec4 &col, const char *text_id) {
+                TextColoredCentered(col, gui.lang.live_area.help[text_id].c_str());
                 ImGui::Spacing();
             };
-            TextColoredCentered(gui, GUI_COLOR_TEXT, "control_setting");
+            TextColoredCenteredEx(gui, GUI_COLOR_TEXT, "control_setting");
             if (gui.modules.empty())
-                TextColoredCentered(gui, GUI_COLOR_TEXT, "firmware_not_detected");
+                TextColoredCenteredEx(gui, GUI_COLOR_TEXT, "firmware_not_detected");
             if (!gui.fw_font)
-                TextColoredCentered(gui, GUI_COLOR_TEXT, "firmware_font_not_detected");
+                TextColoredCenteredEx(gui, GUI_COLOR_TEXT, "firmware_font_not_detected");
             ImGui::Separator();
             ImGui::Spacing();
             ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["live_area_help"].c_str());

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -103,7 +103,7 @@ static void draw_emulation_menu(GuiState &gui, EmuEnvState &emuenv) {
 
 static void draw_debug_menu(GuiState &gui, DebugMenuState &state) {
     auto &lang = gui.lang.main_menubar.debug;
-    if (ImGui::BeginMenu("Debug")) {
+    if (ImGui::BeginMenu(lang["title"].c_str())) {
         ImGui::MenuItem(lang["threads"].c_str(), nullptr, &state.threads_dialog);
         ImGui::MenuItem(lang["semaphores"].c_str(), nullptr, &state.semaphores_dialog);
         ImGui::MenuItem(lang["mutexes"].c_str(), nullptr, &state.mutexes_dialog);

--- a/vita3k/gui/src/private.h
+++ b/vita3k/gui/src/private.h
@@ -78,5 +78,9 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv);
 void reevaluate_code(GuiState &gui, EmuEnvState &emuenv);
 
 void SetTooltipEx(const char *tooltip);
+void TextColoredCentered(const ImVec4 &col, const char *text);
+void TextCentered(const char *text);
+void TextColoredCentered(const ImVec4 &col, const char *text, float wrap_width);
+void TextCentered(const char *text, float wrap_width);
 
 } // namespace gui

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -485,13 +485,11 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
     ImGui::SetNextWindowPos(ImVec2(emuenv.viewport_pos.x + (display_size.x / 2.f), emuenv.viewport_pos.y + (display_size.y / 2.f)), ImGuiCond_Always, ImVec2(0.5f, 0.48f));
     const auto is_custom_config = gui.configuration_menu.custom_settings_dialog;
-    auto &settings_dialog = is_custom_config ? gui.configuration_menu.custom_settings_dialog : gui.configuration_menu.settings_dialog;
-    ImGui::Begin("##settings", &settings_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings);
+    auto show_settings_dialog = is_custom_config ? gui.configuration_menu.custom_settings_dialog : gui.configuration_menu.settings_dialog;
+    ImGui::Begin("##settings", &show_settings_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings);
     ImGui::SetWindowFontScale(0.7f * RES_SCALE.x);
-    auto settings_str = lang.main_window["title"].c_str();
-    const auto title = is_custom_config ? fmt::format("{}: {} [{}]", settings_str, get_app_index(gui, emuenv.app_path)->title, emuenv.app_path) : settings_str;
-    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title.c_str()).x / 2.f));
-    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title.c_str());
+    const auto settings_str = lang.main_window["title"];
+    TextColoredCentered(GUI_COLOR_TEXT_TITLE, (is_custom_config ? fmt::format("{}: {} [{}]", settings_str, get_app_index(gui, emuenv.app_path)->title, emuenv.app_path) : settings_str).c_str());
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::BeginTabBar("SettingsTabBar", ImGuiTabBarFlags_None);
@@ -669,8 +667,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
 
         // Resolution Upscaling
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(lang.gpu["internal_resolution_upscaling"].c_str()).x / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang.gpu["internal_resolution_upscaling"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.gpu["internal_resolution_upscaling"].c_str());
         ImGui::Spacing();
         ImGui::PushID("Res scal");
         if (config.resolution_multiplier == 0.5f)
@@ -715,8 +712,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
 
         // Anisotropic Filtering
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(lang.gpu["anisotropic_filtering"].c_str()).x / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang.gpu["anisotropic_filtering"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.gpu["anisotropic_filtering"].c_str());
         ImGui::Spacing();
         ImGui::PushID("Aniso filter");
         if (config.anisotropic_filtering == 1)
@@ -754,8 +750,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
 
         // Texture Replacement
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(lang.gpu["texture_replacement"].c_str()).x / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang.gpu["texture_replacement"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.gpu["texture_replacement"].c_str());
         ImGui::Spacing();
         ImGui::Checkbox(lang.gpu["export_textures"].c_str(), &config.export_textures);
         ImGui::SameLine();
@@ -767,8 +762,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
             config.export_as_png = export_format_pos == 0;
 
         // Shaders
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(lang.gpu["shaders"].c_str()).x / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang.gpu["shaders"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.gpu["shaders"].c_str());
         ImGui::Spacing();
         ImGui::Checkbox(lang.gpu["shader_cache"].c_str(), &emuenv.cfg.shader_cache);
         SetTooltipEx(lang.gpu["shader_cache_description"].c_str());
@@ -878,9 +872,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Checkbox(lang.emulator["check_for_updates"].c_str(), &emuenv.cfg.check_for_updates);
         SetTooltipEx(lang.emulator["check_for_updates_description"].c_str());
         ImGui::Separator();
-        const auto performance_overlay_size = ImGui::CalcTextSize(lang.emulator["performance_overlay"].c_str()).x;
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (performance_overlay_size / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang.emulator["performance_overlay"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.emulator["performance_overlay"].c_str());
         ImGui::Spacing();
         ImGui::Checkbox(lang.emulator["performance_overlay"].c_str(), &emuenv.cfg.performance_overlay);
         SetTooltipEx(lang.emulator["performance_overlay_description"].c_str());
@@ -898,8 +890,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         SetTooltipEx(lang.emulator["case_insensitive_description"].c_str());
 #endif
         ImGui::Separator();
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(lang.emulator["emu_storage_folder"].c_str()).x / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang.emulator["emu_storage_folder"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.emulator["emu_storage_folder"].c_str());
         ImGui::Spacing();
         ImGui::PushItemWidth(320);
         ImGui::TextColored(GUI_COLOR_TEXT, "%s %s", lang.emulator["current_emu_path"].c_str(), emuenv.cfg.pref_path.c_str());
@@ -923,8 +914,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         }
         ImGui::Spacing();
         ImGui::Separator();
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(lang.emulator["custom_config_settings"].c_str()).x / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang.emulator["custom_config_settings"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.emulator["custom_config_settings"].c_str());
         ImGui::Spacing();
         if (ImGui::Button(lang.emulator["clear_custom_config"].c_str())) {
             if (fs::remove_all(emuenv.config_path / "config")) {
@@ -933,8 +923,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         }
         ImGui::Spacing();
         ImGui::Separator();
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(lang.emulator["screenshot_image_type"].c_str()).x / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, lang.emulator["screenshot_image_type"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.emulator["screenshot_image_type"].c_str());
         ImGui::Spacing();
         const char *LIST_IMG_FORMAT[] = { "NULL", "JPEG", "PNG" };
         ImGui::Combo(lang.emulator["screenshot_format"].c_str(), &emuenv.cfg.screenshot_format, LIST_IMG_FORMAT, IM_ARRAYSIZE(LIST_IMG_FORMAT));
@@ -994,9 +983,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
-        const auto font_size = ImGui::CalcTextSize(lang.gui["font_support"].c_str()).x;
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (font_size / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", lang.gui["font_support"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_MENUBAR, lang.gui["font_support"].c_str());
         ImGui::Spacing();
         if (gui.fw_font) {
             ImGui::Checkbox(lang.gui["asia_font_support"].c_str(), &emuenv.cfg.asia_font_support);
@@ -1010,9 +997,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
-        const auto title = ImGui::CalcTextSize(lang.gui["theme_background"].c_str()).x;
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (title / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", lang.gui["theme_background"].c_str());
+        TextColoredCentered(GUI_COLOR_TEXT_MENUBAR, lang.gui["theme_background"].c_str());
         ImGui::Spacing();
         ImGui::TextColored(GUI_COLOR_TEXT, "%s %s", lang.gui["current_theme_content_id"].c_str(), gui.users[emuenv.io.user_id].theme_id.c_str());
         if (gui.users[emuenv.io.user_id].theme_id != "default") {
@@ -1080,9 +1065,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
 
         // PSN
-        const auto psn = ImGui::CalcTextSize("PlayStation Network").x;
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (psn / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "PlayStation Network");
+        TextColoredCentered(GUI_COLOR_TEXT_MENUBAR, "PlayStation Network");
         ImGui::Spacing();
         ImGui::Checkbox(lang.network["psn_signed_in"].c_str(), &config.psn_signed_in);
         SetTooltipEx(lang.network["psn_signed_in_description"].c_str());
@@ -1091,9 +1074,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
-        const auto http = ImGui::CalcTextSize("HTTP").x;
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (http / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "HTTP");
+        TextColoredCentered(GUI_COLOR_TEXT_MENUBAR, "HTTP");
         ImGui::Spacing();
         ImGui::Checkbox(lang.network["enable_http"].c_str(), &emuenv.cfg.http_enable);
         SetTooltipEx(lang.network["enable_http_description"].c_str());
@@ -1231,7 +1212,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
     static const auto BUTTON_SIZE = ImVec2(120.f * SCALE.x, 0.f);
     ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - BUTTON_SIZE.x - (10.f * SCALE.x));
     if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
-        settings_dialog = false;
+        show_settings_dialog = false;
     ImGui::SameLine(0, 20.f * SCALE.x);
     const auto is_apply = !emuenv.io.app_path.empty() && (!is_custom_config || (emuenv.app_path == emuenv.io.app_path));
     const auto is_reboot = (emuenv.renderer->current_backend != emuenv.backend_renderer) || (config.resolution_multiplier != emuenv.cfg.current_config.resolution_multiplier);

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -503,12 +503,14 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         if (!gui.modules.empty()) {
             ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang.core["modules_mode"].c_str());
             ImGui::Spacing();
-            for (auto m = 0; m < MODULES_MODE_COUNT; m++) {
-                if (m)
-                    ImGui::SameLine();
-                ImGui::RadioButton(config_modules_mode[m][ModulesModeType::MODE], &config.modules_mode, m);
-                SetTooltipEx(config_modules_mode[m][ModulesModeType::DESCRIPTION]);
-            }
+            ImGui::RadioButton(lang.core["automatic"].c_str(), &config.modules_mode, 0);
+            SetTooltipEx(lang.core["automatic_description"].c_str());
+            ImGui::SameLine();
+            ImGui::RadioButton(lang.core["auto_manual"].c_str(), &config.modules_mode, 1);
+            SetTooltipEx(lang.core["auto_manual_description"].c_str());
+            ImGui::SameLine();
+            ImGui::RadioButton(lang.core["manual"].c_str(), &config.modules_mode, 2);
+            SetTooltipEx(lang.core["manual_description"].c_str());
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();
@@ -849,7 +851,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Checkbox(lang.emulator["boot_apps_full_screen"].c_str(), &emuenv.cfg.boot_apps_full_screen);
         ImGui::Spacing();
 
-        const char *LIST_LOG_LEVEL[] = { lang.emulator["trace"].c_str(), "Debug", lang.emulator["info"].c_str(), lang.emulator["warning"].c_str(), lang.emulator["error"].c_str(), lang.emulator["critical"].c_str(), lang.emulator["off"].c_str() };
+        const char *LIST_LOG_LEVEL[] = { lang.emulator["trace"].c_str(), gui.lang.main_menubar.debug["title"].c_str(), lang.emulator["info"].c_str(), lang.emulator["warning"].c_str(), lang.emulator["error"].c_str(), lang.emulator["critical"].c_str(), lang.emulator["off"].c_str() };
         if (ImGui::Combo(lang.emulator["log_level"].c_str(), &emuenv.cfg.log_level, LIST_LOG_LEVEL, IM_ARRAYSIZE(LIST_LOG_LEVEL)))
             logging::set_level(static_cast<spdlog::level::level_enum>(emuenv.cfg.log_level));
         SetTooltipEx(lang.emulator["select_log_level"].c_str());
@@ -931,11 +933,11 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         }
         ImGui::Spacing();
         ImGui::Separator();
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize("screenshot image type").x / 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "screenshot image type");
+        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(lang.emulator["screenshot_image_type"].c_str()).x / 2.f));
+        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, lang.emulator["screenshot_image_type"].c_str());
         ImGui::Spacing();
         const char *LIST_IMG_FORMAT[] = { "NULL", "JPEG", "PNG" };
-        ImGui::Combo("Screenshot format", &emuenv.cfg.screenshot_format, LIST_IMG_FORMAT, IM_ARRAYSIZE(LIST_IMG_FORMAT));
+        ImGui::Combo(lang.emulator["screenshot_format"].c_str(), &emuenv.cfg.screenshot_format, LIST_IMG_FORMAT, IM_ARRAYSIZE(LIST_IMG_FORMAT));
         ImGui::EndTabItem();
     } else
         ImGui::PopStyleColor();
@@ -1113,7 +1115,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
 
     // Debug
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
-    if (ImGui::BeginTabItem("Debug")) {
+    if (ImGui::BeginTabItem(gui.lang.main_menubar.debug["title"].c_str())) {
         ImGui::PopStyleColor();
         ImGui::Spacing();
         ImGui::Checkbox(lang.debug["log_imports"].c_str(), &emuenv.kernel.debugger.log_imports);

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -704,10 +704,8 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
     }
     case CONFIRM: {
         ImGui::SetWindowFontScale(0.8f);
-        const std::string msg = lang["user_created"];
-        const auto calc_text = (SIZE_USER.x / 2.f) - (ImGui::CalcTextSize(msg.c_str()).x / 2.f);
-        ImGui::SetCursorPos(ImVec2(calc_text, (44.f * SCALE.y)));
-        ImGui::TextColored(GUI_COLOR_TEXT, "%s", msg.c_str());
+        ImGui::SetCursorPosY(44.f * SCALE.y);
+        TextColoredCentered(GUI_COLOR_TEXT, lang["user_created"].c_str());
         const auto AVATAR_CONFIRM_POS = ImVec2((SIZE_USER.x / 2) - (MED_AVATAR_SIZE.x / 2.f), 96.f * SCALE.y);
         draw_avatar(user_id_selected, MEDIUM, AVATAR_CONFIRM_POS);
         ImGui::SetWindowFontScale(0.7f);
@@ -726,10 +724,10 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
         title = lang["delete_user"];
         if (user_id_selected.empty()) {
             ImGui::SetWindowFontScale(1.f);
-            ImGui::SetCursorPos(ImVec2((SIZE_USER.x / 2.f) - (ImGui::CalcTextSize(lang["user_delete"].c_str()).x / 2.f), 5.f * SCALE.y));
             const auto CHILD_DELETE_USER_SIZE = ImVec2(674 * SCALE.x, 308.f * SCALE.y);
             const auto SELECT_SIZE = ImVec2(674.f * SCALE.x, 46.f * SCALE.y);
-            ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["user_delete"].c_str());
+            ImGui::SetCursorPosY(5.f * SCALE.y);
+            TextColoredCentered(GUI_COLOR_TEXT, lang["user_delete"].c_str());
             ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.f);
             const auto CHILD_DELETE_USER_POS = ImVec2(WINDOW_SIZE.x / 2.f, (168.f * SCALE.y));
             ImGui::SetNextWindowPos(CHILD_DELETE_USER_POS, ImGuiCond_Always, ImVec2(0.5f, 0.f));
@@ -775,9 +773,8 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
                 if (ImGui::Button(common["delete"].c_str(), BUTTON_SIZE))
                     del_menu = "warn";
             } else if (del_menu == "warn") {
-                const auto calc_text = (SIZE_USER.x / 2.f) - (ImGui::CalcTextSize(lang["user_delete_warn"].c_str()).x / 2.f);
-                ImGui::SetCursorPos(ImVec2(calc_text, 146.f * SCALE.y));
-                ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["user_delete_warn"].c_str());
+                ImGui::SetCursorPosY(146.f * SCALE.y);
+                TextColoredCentered(GUI_COLOR_TEXT, lang["user_delete_warn"].c_str());
                 ImGui::SetCursorPos(BUTTON_POS);
                 ImGui::SetWindowFontScale(1.f);
                 ImGui::SetCursorPos(ImVec2((SIZE_USER.x / 2.f) - BUTTON_SIZE.x - 20.f, BUTTON_POS.y));
@@ -789,8 +786,8 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
                 if (ImGui::Button(common["yes"].c_str(), BUTTON_SIZE))
                     delete_user(gui, emuenv);
             } else if (del_menu == "confirm") {
-                ImGui::SetCursorPos(ImVec2((SIZE_USER.x / 2.f) - (ImGui::CalcTextSize(lang["user_deleted"].c_str()).x / 2.f), 146.f * SCALE.y));
-                ImGui::TextColored(GUI_COLOR_TEXT, "%s", lang["user_deleted"].c_str());
+                ImGui::SetCursorPosY(146.f * SCALE.y);
+                TextColoredCentered(GUI_COLOR_TEXT, lang["user_deleted"].c_str());
                 ImGui::SetWindowFontScale(1.f);
                 ImGui::SetCursorPos(BUTTON_POS);
                 if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -267,40 +267,33 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::GetBackgroundDrawList()->AddRectFilled(WINDOW_POS, display_size, IM_COL32(36.f, 120.f, 12.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
 
     ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
-    ImGui::SetCursorPos(ImVec2((display_size.x / 2.f) - (ImGui::CalcTextSize(lang["title"].c_str()).x / 2.f), 44.f * SCALE.y));
-    ImGui::Text("%s", lang["title"].c_str());
+    ImGui::SetCursorPosY(44.f * SCALE.y);
+    TextCentered(lang["title"].c_str());
     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (6.f * SCALE.y));
     ImGui::Separator();
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f * SCALE.x);
     ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
     switch (state) {
     case NOT_COMPLETE_UPDATE:
-        ImGui::SetCursorPos(ImVec2(display_size.x / 2.f - (ImGui::CalcTextSize(lang["not_complete_update"].c_str()).x / 2.f), (display_size.y / 2.f) - ImGui::GetFontSize()));
-        ImGui::Text("%s", lang["not_complete_update"].c_str());
+        ImGui::SetCursorPosY((display_size.y / 2.f) - ImGui::GetFontSize());
+        TextCentered(lang["not_complete_update"].c_str());
 
         break;
-    case NO_UPDATE: {
-        const auto no_update_str = app_number > git_version ? lang["later_version_already_installed"].c_str() : lang["latest_version_already_installed"].c_str();
-        ImGui::SetCursorPos(ImVec2(display_size.x / 2.f - (ImGui::CalcTextSize(no_update_str).x / 2.f), display_size.y / 2.f));
-        ImGui::Text("%s", no_update_str);
-
+    case NO_UPDATE:
+        ImGui::SetCursorPosY(display_size.y / 2.f);
+        TextCentered(app_number > git_version ? lang["later_version_already_installed"].c_str() : lang["latest_version_already_installed"].c_str());
         break;
-    }
     case HAS_UPDATE: {
-        ImGui::SetCursorPos(ImVec2((display_size.x / 2.f) - (ImGui::CalcTextSize(lang["new_version_available"].c_str()).x / 2.f), (display_size.y / 2.f) - ImGui::GetFontSize()));
-        ImGui::Text("%s", lang["new_version_available"].c_str());
-        const auto version_str = fmt::format(fmt::runtime(lang["version"]), git_version);
-        ImGui::SetCursorPos(ImVec2((display_size.x / 2.f) - (ImGui::CalcTextSize(version_str.c_str()).x / 2.f), ImGui::GetCursorPosY() + (40.f * SCALE.x)));
-        ImGui::Text("%s", version_str.c_str());
-
+        ImGui::SetCursorPosY((display_size.y / 2.f) - ImGui::GetFontSize());
+        TextCentered(lang["new_version_available"].c_str());
+        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (40.f * SCALE.x));
+        TextCentered(fmt::format(fmt::runtime(lang["version"]), git_version).c_str());
         break;
     }
     case DESCRIPTION: {
         ImGui::Spacing();
         ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
-        const auto new_features_str = fmt::format(fmt::runtime(lang["new_features"]), git_version);
-        ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2) - (ImGui::CalcTextSize(new_features_str.c_str()).x / 2.f));
-        ImGui::Text("%s", new_features_str.c_str());
+        TextCentered(fmt::format(fmt::runtime(lang["new_features"]), git_version).c_str());
         ImGui::Spacing();
         ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, 136.0f * SCALE.y), ImGuiCond_Always, ImVec2(0.5f, 0.f));
         ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f * SCALE.x);
@@ -343,8 +336,8 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
         break;
     }
     case UPDATE_VITA3K:
-        ImGui::SetCursorPos(ImVec2(display_size.x / 2.f - (ImGui::CalcTextSize(lang["update_vita3k"].c_str()).x / 2.f), (display_size.y / 2.f) - ImGui::GetFontSize()));
-        ImGui::Text("%s", lang["update_vita3k"].c_str());
+        ImGui::SetCursorPosY((display_size.y / 2.f) - ImGui::GetFontSize());
+        TextCentered(lang["update_vita3k"].c_str());
 
         break;
     case DOWNLOAD: {
@@ -361,9 +354,8 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SetCursorPos(ImVec2((ImGui::GetWindowWidth() / 2) - (PROGRESS_BAR_WIDTH / 2.f), display_size.y - (186.f * SCALE.y)));
         ImGui::PushStyleColor(ImGuiCol_PlotHistogram, GUI_PROGRESS_BAR);
         ImGui::ProgressBar(progress / 100.f, ImVec2(PROGRESS_BAR_WIDTH, 15.f * SCALE.y), "");
-        const auto &progress_str = std::to_string(uint32_t(progress)).append("%");
-        ImGui::SetCursorPos(ImVec2((ImGui::GetWindowWidth() / 2.f) - (ImGui::CalcTextSize(progress_str.c_str()).x / 2.f), ImGui::GetCursorPosY() + 16.f * emuenv.dpi_scale));
-        ImGui::TextColored(GUI_COLOR_TEXT, "%s", progress_str.c_str());
+        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 16.f * emuenv.dpi_scale);
+        TextColoredCentered(GUI_COLOR_TEXT, std::to_string(uint32_t(progress)).append("%").c_str());
         ImGui::PopStyleColor();
 
         break;

--- a/vita3k/gui/src/welcome_dialog.cpp
+++ b/vita3k/gui/src/welcome_dialog.cpp
@@ -37,9 +37,7 @@ void draw_welcome_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
     ImGui::Begin("##welcome", &gui.help_menu.welcome_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SetWindowFontScale(RES_SCALE.x);
-    auto title_str = lang["title"].c_str();
-    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (ImGui::CalcTextSize(title_str).x / 2.f));
-    ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", title_str);
+    TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["title"].c_str());
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::PopStyleColor();

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -421,7 +421,8 @@ static ExitCode load_app_impl(SceUID &main_module_id, EmuEnvState &emuenv) {
         if (emuenv.ctrl.has_motion_support)
             LOG_INFO("Controller has motion support");
     }
-    LOG_INFO("modules mode: {}", config_modules_mode[emuenv.cfg.current_config.modules_mode][ModulesModeType::MODE]);
+    constexpr std::array modules_mode_names{ "Automatic", "Auto & Manual", "Manual" };
+    LOG_INFO("modules mode: {}", modules_mode_names.at(emuenv.cfg.current_config.modules_mode));
     if ((emuenv.cfg.current_config.modules_mode != ModulesMode::AUTOMATIC) && !emuenv.cfg.current_config.lle_modules.empty()) {
         std::string modules;
         for (const auto &mod : emuenv.cfg.current_config.lle_modules) {

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -112,6 +112,7 @@ struct LangState {
             { "last_apps_used", "Last Apps used" }
         };
         std::map<std::string, std::string> debug = {
+            { "title", "Debug" },
             { "threads", "Threads" },
             { "semaphores", "Semaphores" },
             { "mutexes", "Mutexes" },
@@ -525,7 +526,13 @@ struct LangState {
             { "search_modules", "Search Modules" },
             { "clear_list", "Clear List" },
             { "no_modules", "No modules present.\nPlease download and install the last PS Vita firmware." },
-            { "refresh_list", "Refresh List" }
+            { "refresh_list", "Refresh List" },
+            { "automatic", "Automatic" },
+            { "automatic_description", "Select Automatic mode to use a preset list of modules." },
+            { "auto_manual", "Auto & Manual" },
+            { "auto_manual_description", "Select this mode to load Automatic module and selected modules from the list below." },
+            { "manual", "Manual" },
+            { "manual_description", "Select Manual mode to load selected modules from the list below." }
         };
         std::map<std::string, std::string> cpu = {
             { "unicorn", "Unicorn (deprecated)" },
@@ -643,7 +650,9 @@ struct LangState {
             { "reset_emu_path", "Reset Emulator Path" },
             { "reset_emu_path_description", "Reset Vita3K emulator path to the default.\nYou will need to move your old folder to the new location manually." },
             { "custom_config_settings", "Custom Config Settings" },
-            { "clear_custom_config", "Clear Custom Config" }
+            { "clear_custom_config", "Clear Custom Config" },
+            { "screenshot_image_type", "screenshot image type" },
+            { "screenshot_format", "Screenshot format" }
         };
         std::map<std::string, std::string> gui = {
             { "title", "GUI" },


### PR DESCRIPTION
* lang: more verbose error on wrong lang.xml
* gui: refactoring: replace magic strings to enum types, move static vars inside corresponding functions, fix datatypes
* gui: refactoring: minor fixes: global vars as static, add or remove ref if needed
* gui: fix a bug when one button could be mapped to two commands (for screenshots and texture replacement)
* gui: refactoring: Extract functions to draw text centered
* gui: Settings dialog: more translatable strings

