### PR TITLE
external: update sdl to version 2.30.9

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -88,9 +88,9 @@ jobs:
           choco install ccache
         if: matrix.os == 'windows-latest'
 
-      - name: Set up SDL 2.30.7 (ubuntu-latest)
+      - name: Set up SDL 2.30.9 (ubuntu-latest)
         run: |
-          SDL2VER=2.30.7
+          SDL2VER=2.30.9
           if [[ ! -e ~/.ccache ]]; then
             mkdir ~/.ccache
           fi  

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,9 +49,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up SDL 2.30.7 (ubuntu-latest)
+      - name: Set up SDL 2.30.9 (ubuntu-latest)
         run: |
-          SDL2VER=2.30.7
+          SDL2VER=2.30.9
           if [[ ! -e ~/.ccache ]]; then
             mkdir ~/.ccache
           fi  


### PR DESCRIPTION
Changelog 2.30.9:
- Fixed audio issues on Android 15
- Fixed rare audio distortion and crash when audio devices are changed on Windows
- Fixed the PS5 controller face buttons on Amazon Fire TV
- Fixed detecting the Steam Virtual Gamepad on macOS
- Added support for wired XBox controllers on macOS 15.0 Sequoia
- Added support for the Steam Virtual Gamepad on macOS Sequoia
- Fixed the Steam Virtual Gamepad from showing up when games aren't running under Steam
- Fixed flicker when entering/exiting fullscreen or moving the window between scaled and non-scaled displays under Wayland.
- Fixes for data addresses above 2gb on Emscripten
- Fixed horizontal mousewheel scale on Emscripten

Changelog 2.30.8:
- Fixed a crash in XInput code at startup
- Fixed flooding the OS with I/O when a PS4/PS5 controller is disconnected
- Added SDL_VIDEO_DOUBLE_BUFFER support to the Wayland backend
- SDL_WINDOWEVENT_EXPOSED is sent appropriately when using Wayland
- Fixed hang at startup in audio code when the application has large stack usage on Linux
- Fixed initializing KMSDRM on older Linux systems
- The pre-built SDL2.dll no longer depends on ucrtbase.dll