### PR TITLE
gui: improve settings dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ CMakeUserPresets.json
 compile_commands.json
 # AppImage builder
 appimage/linuxdeploy.AppImage
+/.gdbinit

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -1216,10 +1216,11 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SameLine(0, 20.f * SCALE.x);
     const auto is_apply = !emuenv.io.app_path.empty() && (!is_custom_config || (emuenv.app_path == emuenv.io.app_path));
     const auto is_reboot = (emuenv.renderer->current_backend != emuenv.backend_renderer) || (config.resolution_multiplier != emuenv.cfg.current_config.resolution_multiplier);
-    if (ImGui::Button(is_apply ? (is_reboot ? lang.main_window["save_reboot"].c_str() : lang.main_window["save_apply"].c_str()) : common.save_data.save["title"].c_str(), BUTTON_SIZE)) {
+    if (ImGui::Button(is_apply ? (is_reboot ? lang.main_window["save_reboot"].c_str() : lang.main_window["save_apply"].c_str()) : lang.main_window["save_close"].c_str(), BUTTON_SIZE)) {
         save_config(gui, emuenv);
         if (is_apply)
             set_config(gui, emuenv, emuenv.io.app_path);
+        show_settings_dialog = false;
     }
     SetTooltipEx(lang.main_window["keep_changes"].c_str());
 

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -511,7 +511,8 @@ struct LangState {
             { "title", "Settings" },
             { "save_reboot", "Save & Reboot" },
             { "save_apply", "Save & Apply" },
-            { "keep_changes", "Click on Save to keep your changes." }
+            { "keep_changes", "Click on Save to keep your changes." },
+            { "save_close", "Save & Close" }
         };
         std::map<std::string, std::string> core = {
             { "title", "Core" },


### PR DESCRIPTION
I fixed some problems with the settings dialogs.

1. As a user I don't know what the "Close" button does. Does it save & close or simply close? I renamed it to "Cancel" to make clear that is cancels the dialog.
2. "Save" does not close the dialog which means that I have to click "Close" afterwards. I changed it to close the the dialog. One click less.