### PR TITLE
modules/SceMotion: Improve motion support

### DIFF
--- a/vita3k/modules/SceDriverUser/SceMotion.cpp
+++ b/vita3k/modules/SceDriverUser/SceMotion.cpp
@@ -24,9 +24,9 @@
 #include <util/tracy.h>
 TRACY_MODULE_NAME(SceMotion);
 
-EXPORT(int, sceMotionGetAngleThreshold) {
+EXPORT(SceFloat, sceMotionGetAngleThreshold) {
     TRACY_FUNC(sceMotionGetAngleThreshold);
-    return UNIMPLEMENTED();
+    return get_angle_threshold(emuenv.motion);
 }
 
 EXPORT(int, sceMotionGetBasicOrientation, SceFVector3 *basicOrientation) {
@@ -211,9 +211,10 @@ EXPORT(int, sceMotionRotateYaw, const float radians) {
     return 0;
 }
 
-EXPORT(int, sceMotionSetAngleThreshold, const float angle) {
+EXPORT(int, sceMotionSetAngleThreshold, SceFloat angle) {
     TRACY_FUNC(sceMotionSetAngleThreshold, angle);
-    return UNIMPLEMENTED();
+    set_angle_threshold(emuenv.motion, angle);
+    return 0;
 }
 
 EXPORT(int, sceMotionSetDeadband, SceBool setValue) {

--- a/vita3k/motion/include/motion/functions.h
+++ b/vita3k/motion/include/motion/functions.h
@@ -25,5 +25,9 @@ SceFVector3 get_gyroscope(const MotionState &state);
 Util::Quaternion<SceFloat> get_orientation(const MotionState &state);
 SceBool get_gyro_bias_correction(const MotionState &state);
 void set_gyro_bias_correction(MotionState &state, SceBool setValue);
+SceBool get_tilt_correction(MotionState &state);
+void set_tilt_correction(MotionState &state, SceBool setValue);
+SceBool get_deadband(MotionState &state);
+void set_deadband(MotionState &state, SceBool setValue);
 
 void refresh_motion(MotionState &state, CtrlState &ctrl_state);

--- a/vita3k/motion/include/motion/functions.h
+++ b/vita3k/motion/include/motion/functions.h
@@ -29,5 +29,7 @@ SceBool get_tilt_correction(MotionState &state);
 void set_tilt_correction(MotionState &state, SceBool setValue);
 SceBool get_deadband(MotionState &state);
 void set_deadband(MotionState &state, SceBool setValue);
+SceFloat get_angle_threshold(const MotionState &state);
+void set_angle_threshold(MotionState &state, SceFloat setValue);
 
 void refresh_motion(MotionState &state, CtrlState &ctrl_state);

--- a/vita3k/motion/include/motion/functions.h
+++ b/vita3k/motion/include/motion/functions.h
@@ -31,5 +31,6 @@ SceBool get_deadband(MotionState &state);
 void set_deadband(MotionState &state, SceBool setValue);
 SceFloat get_angle_threshold(const MotionState &state);
 void set_angle_threshold(MotionState &state, SceFloat setValue);
+SceFVector3 get_basic_orientation(const MotionState &state);
 
 void refresh_motion(MotionState &state, CtrlState &ctrl_state);

--- a/vita3k/motion/include/motion/motion_input.h
+++ b/vita3k/motion/include/motion/motion_input.h
@@ -26,6 +26,7 @@ public:
     void SetGyroscope(const Util::Vec3f &gyroscope);
     void SetQuaternion(const Util::Quaternion<SceFloat> &quaternion);
     void SetDeadband(SceFloat threshold);
+    void SetAngleThreshold(SceFloat threshold);
     void RotateYaw(SceFloat radians);
 
     void EnableGyroBias(bool enable);
@@ -42,6 +43,7 @@ public:
     [[nodiscard]] Util::Vec3f GetAcceleration() const;
     [[nodiscard]] Util::Vec3f GetGyroscope() const;
     [[nodiscard]] Util::Vec3f GetRotations() const;
+    [[nodiscard]] SceFloat GetAngleThreshold() const;
 
     [[nodiscard]] bool IsMoving(SceFloat sensitivity) const;
     [[nodiscard]] bool IsCalibrated(SceFloat sensitivity) const;
@@ -80,6 +82,9 @@ private:
 
     // Minimum gyro amplitude to detect if the device is moving
     SceFloat gyro_deadband = 0.0f;
+
+    // Minimum angle which basic motion orientation changes value
+    SceFloat angle_threshold = 0.0f;
 
     // Number of invalid sequential data
     SceFloat reset_counter = 0;

--- a/vita3k/motion/include/motion/motion_input.h
+++ b/vita3k/motion/include/motion/motion_input.h
@@ -10,6 +10,9 @@
 
 class MotionInput {
 public:
+    static constexpr float GyroMaxValue = 5.0f;
+    static constexpr float AccelMaxValue = 7.0f;
+
     explicit MotionInput();
 
     MotionInput(const MotionInput &) = default;
@@ -22,7 +25,7 @@ public:
     void SetAcceleration(const Util::Vec3f &acceleration);
     void SetGyroscope(const Util::Vec3f &gyroscope);
     void SetQuaternion(const Util::Quaternion<SceFloat> &quaternion);
-    void SetGyroThreshold(SceFloat threshold);
+    void SetDeadband(SceFloat threshold);
     void RotateYaw(SceFloat radians);
 
     void EnableGyroBias(bool enable);
@@ -30,6 +33,7 @@ public:
     void EnableDeadband(bool enable);
     void EnableReset(bool reset);
     void ResetRotations();
+    void ResetQuaternion();
 
     void UpdateRotation(SceULong64 elapsed_time);
     void UpdateOrientation(SceULong64 elapsed_time);
@@ -63,19 +67,19 @@ private:
     Util::Quaternion<SceFloat> quat{ { 0.0f, 0.0f, -1.0f }, 0.0f };
 
     // Number of full rotations in each axis
-    Util::Vec3f rotations;
+    Util::Vec3f rotations{};
 
     // Acceleration vector measurement in G force
-    Util::Vec3f accel;
+    Util::Vec3f accel{};
 
     // Gyroscope vector measurement in radians/s.
-    Util::Vec3f gyro;
+    Util::Vec3f gyro{};
 
     // Vector to be subtracted from gyro measurements
-    Util::Vec3f gyro_bias;
+    Util::Vec3f gyro_bias{};
 
     // Minimum gyro amplitude to detect if the device is moving
-    SceFloat gyro_threshold = 0.0f;
+    SceFloat gyro_deadband = 0.0f;
 
     // Number of invalid sequential data
     SceFloat reset_counter = 0;
@@ -86,9 +90,11 @@ private:
     // If the provided gyro uses bias correction
     bool bias_enabled = true;
 
-    // Stubbed values
-    bool tilt_correction_enabled = true;
+    // If the provided gyro uses gyro deadband
     bool deadband_enabled = true;
+
+    // Corrects tilt based on accelerometer measurements
+    bool tilt_correction_enabled = true;
 
     // Use accelerometer values to calculate position
     bool only_accelerometer = true;

--- a/vita3k/motion/include/motion/motion_input.h
+++ b/vita3k/motion/include/motion/motion_input.h
@@ -23,8 +23,11 @@ public:
     void SetGyroscope(const Util::Vec3f &gyroscope);
     void SetQuaternion(const Util::Quaternion<SceFloat> &quaternion);
     void SetGyroThreshold(SceFloat threshold);
+    void RotateYaw(SceFloat radians);
 
     void EnableGyroBias(bool enable);
+    void EnableTiltCorrection(bool enable);
+    void EnableDeadband(bool enable);
     void EnableReset(bool reset);
     void ResetRotations();
 
@@ -39,6 +42,8 @@ public:
     [[nodiscard]] bool IsMoving(SceFloat sensitivity) const;
     [[nodiscard]] bool IsCalibrated(SceFloat sensitivity) const;
     SceBool IsGyroBiasEnabled() const;
+    SceBool IsTiltCorrectionEnabled() const;
+    SceBool IsDeadbandEnabled() const;
 
 private:
     void ResetOrientation();
@@ -55,7 +60,7 @@ private:
     Util::Vec3f derivative_error;
 
     // Quaternion containing the device orientation
-    Util::Quaternion<SceFloat> quat{ { 0.0f, 0.0f, 1.0f }, 0.0f };
+    Util::Quaternion<SceFloat> quat{ { 0.0f, 0.0f, -1.0f }, 0.0f };
 
     // Number of full rotations in each axis
     Util::Vec3f rotations;
@@ -80,6 +85,10 @@ private:
 
     // If the provided gyro uses bias correction
     bool bias_enabled = true;
+
+    // Stubbed values
+    bool tilt_correction_enabled = true;
+    bool deadband_enabled = true;
 
     // Use accelerometer values to calculate position
     bool only_accelerometer = true;

--- a/vita3k/motion/include/motion/motion_input.h
+++ b/vita3k/motion/include/motion/motion_input.h
@@ -38,11 +38,13 @@ public:
 
     void UpdateRotation(SceULong64 elapsed_time);
     void UpdateOrientation(SceULong64 elapsed_time);
+    void UpdateBasicOrientation();
 
     [[nodiscard]] Util::Quaternion<SceFloat> GetOrientation() const;
     [[nodiscard]] Util::Vec3f GetAcceleration() const;
     [[nodiscard]] Util::Vec3f GetGyroscope() const;
     [[nodiscard]] Util::Vec3f GetRotations() const;
+    [[nodiscard]] SceFVector3 GetBasicOrientation() const;
     [[nodiscard]] SceFloat GetAngleThreshold() const;
 
     [[nodiscard]] bool IsMoving(SceFloat sensitivity) const;
@@ -84,7 +86,13 @@ private:
     SceFloat gyro_deadband = 0.0f;
 
     // Minimum angle which basic motion orientation changes value
-    SceFloat angle_threshold = 0.0f;
+    SceFloat angle_threshold = 20.0f;
+
+    // Current basic orientation of the device
+    SceFVector3 basic_orientation = {};
+
+    // It seems that the basic orientation is determined by gravity
+    SceFVector3 basic_orientation_base = {};
 
     // Number of invalid sequential data
     SceFloat reset_counter = 0;

--- a/vita3k/motion/include/motion/motion_input.h
+++ b/vita3k/motion/include/motion/motion_input.h
@@ -84,6 +84,7 @@ private:
 
     // Minimum gyro amplitude to detect if the device is moving
     SceFloat gyro_deadband = 0.0f;
+    SceFloat gyro_deadband2 = 0.0f;
 
     // Minimum angle which basic motion orientation changes value
     SceFloat angle_threshold = 20.0f;

--- a/vita3k/motion/src/motion.cpp
+++ b/vita3k/motion/src/motion.cpp
@@ -73,6 +73,14 @@ void set_deadband(MotionState &state, SceBool setValue) {
     state.motion_data.EnableDeadband(setValue);
 }
 
+SceFloat get_angle_threshold(const MotionState &state) {
+    return state.motion_data.GetAngleThreshold();
+}
+
+void set_angle_threshold(MotionState &state, SceFloat setValue) {
+    state.motion_data.SetAngleThreshold(setValue);
+}
+
 void refresh_motion(MotionState &state, CtrlState &ctrl_state) {
     if (!state.is_sampling)
         return;

--- a/vita3k/motion/src/motion.cpp
+++ b/vita3k/motion/src/motion.cpp
@@ -44,7 +44,7 @@ SceFVector3 get_gyroscope(const MotionState &state) {
 Util::Quaternion<SceFloat> get_orientation(const MotionState &state) {
     auto quat = state.motion_data.GetOrientation();
     return {
-        { quat.xyz[1], quat.xyz[0], -quat.w },
+        { -quat.xyz[1], -quat.w, quat.xyz[0] },
         -quat.xyz[2],
     };
 }
@@ -55,6 +55,22 @@ SceBool get_gyro_bias_correction(const MotionState &state) {
 
 void set_gyro_bias_correction(MotionState &state, SceBool setValue) {
     state.motion_data.EnableGyroBias(setValue);
+}
+
+SceBool get_tilt_correction(MotionState &state) {
+    return state.motion_data.IsTiltCorrectionEnabled();
+}
+
+void set_tilt_correction(MotionState &state, SceBool setValue) {
+    state.motion_data.EnableTiltCorrection(setValue);
+}
+
+SceBool get_deadband(MotionState &state) {
+    return state.motion_data.IsDeadbandEnabled();
+}
+
+void set_deadband(MotionState &state, SceBool setValue) {
+    state.motion_data.EnableDeadband(setValue);
 }
 
 void refresh_motion(MotionState &state, CtrlState &ctrl_state) {

--- a/vita3k/motion/src/motion.cpp
+++ b/vita3k/motion/src/motion.cpp
@@ -81,6 +81,10 @@ void set_angle_threshold(MotionState &state, SceFloat setValue) {
     state.motion_data.SetAngleThreshold(setValue);
 }
 
+SceFVector3 get_basic_orientation(const MotionState &state) {
+    return state.motion_data.GetBasicOrientation();
+}
+
 void refresh_motion(MotionState &state, CtrlState &ctrl_state) {
     if (!state.is_sampling)
         return;
@@ -152,6 +156,7 @@ void refresh_motion(MotionState &state, CtrlState &ctrl_state) {
 
     state.motion_data.UpdateRotation(gyro_timestamp - state.last_gyro_timestamp);
     state.motion_data.UpdateOrientation(accel_timestamp - state.last_accel_timestamp);
+    state.motion_data.UpdateBasicOrientation();
 
     state.last_gyro_timestamp = gyro_timestamp;
     state.last_accel_timestamp = accel_timestamp;

--- a/vita3k/motion/src/motion_input.cpp
+++ b/vita3k/motion/src/motion_input.cpp
@@ -62,6 +62,10 @@ void MotionInput::SetDeadband(SceFloat threshold) {
     gyro_deadband = threshold;
 }
 
+void MotionInput::SetAngleThreshold(SceFloat threshold) {
+    angle_threshold = std::clamp(threshold, 0.0f, 45.0f);
+}
+
 void MotionInput::RotateYaw(SceFloat radians) {
     const Util::Quaternion<SceFloat> yaw_rotation = {
         { 0.0f, 0.0f, -std::sin(radians / 2) },
@@ -89,6 +93,10 @@ void MotionInput::EnableReset(bool reset) {
 
 void MotionInput::ResetRotations() {
     rotations = {};
+}
+
+SceFloat MotionInput::GetAngleThreshold() const {
+    return angle_threshold;
 }
 
 void MotionInput::ResetQuaternion() {


### PR DESCRIPTION
This PR aims to make sceMotion behavior more similar to PS Vita and implement some unimplemented functions.

I made the following modifications:

1. Basic Orientation is calculated according to gravity, identical to PS Vita.
2. `sceMotionGetState` function updates basicOrientation information when called.
3. Modified gyro-related behavior to match PS Vita values. This involved modifying the `UpdateRotation` function and `get_orientation` function.

I implemented the following functions:

1. `sceMotionReset` function updates quat values to their initial values. This function has been implemented.
2. `sceMotionRotateYaw` function does exactly what its name suggests.
3. Added some stubbed functions.

Testing across multiple games is required for merging this PR.

Since I tried to solve this by modifying only variable assignments while minimizing changes to the `UpdateOrientation` function's code, there might be some parts where code readability is slightly compromised. However, since the existing implementation was already swapping rad_gyro coordinates, this should be within acceptable bounds.

Also, this PR was written assuming equivalence between a DualShock4 controller lying face-up on a desk and a PS Vita device lying face-up on a desk. This assumption was made because in the existing implementation, these scenarios resulted in identical Accelerometer and Gyroscope values between the two devices. This aspect can be modified according to policy.