### PR TITLE
app: Ignore XDG_DATA_DIRS for shared path

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -212,15 +212,7 @@ void init_paths(Root &root_paths) {
         if (env_home != NULL)
             root_paths.set_shared_path(fs::path(env_home) / ".local/share" / app_name / "");
 
-        if (XDG_DATA_DIRS != NULL) {
-            auto env_paths = string_utils::split_string(XDG_DATA_DIRS, ':');
-            for (auto &i : env_paths) {
-                if (fs::exists(fs::path(i) / app_name)) {
-                    root_paths.set_shared_path(fs::path(i) / app_name / "");
-                    break;
-                }
-            }
-        } else if (XDG_DATA_HOME != NULL) {
+        if (XDG_DATA_HOME != NULL) {
             root_paths.set_shared_path(fs::path(XDG_DATA_HOME) / app_name / "");
         }
 


### PR DESCRIPTION
XDG_DATA_DIRS is used mainly to find default configuration files or system-wide configuration for apps, like a window manager having a default/system configuration file in /usr/share/WM/foo.
The idea for it is that it checks that path only if there is no user configuration, but because Vita3K doesnt have a default/system-wide configuration file AND the configuration is generated on first start, it really isnt needed + shared path shouldnt be system-wide as it needs to be read-write by the user