### PR TITLE
gui/controllers: align controller assignment behavior with Vita TV

### DIFF
--- a/vita3k/ctrl/include/ctrl/state.h
+++ b/vita3k/ctrl/include/ctrl/state.h
@@ -35,7 +35,7 @@ typedef std::shared_ptr<_SDL_Haptic> HapticPtr;
 
 struct Controller {
     GameControllerPtr controller;
-    int port; // 1-based
+    int port; // SDL_GameController index
     bool has_accel;
     bool has_gyro;
     bool has_led;
@@ -65,5 +65,5 @@ struct CtrlState {
     SceCtrlPadInputMode input_mode_ext = SCE_CTRL_MODE_DIGITAL;
 
     // last vsync the data was read
-    uint64_t last_vcount[5] = {};
+    uint64_t last_vcount[5] = {}; // sceCtrl ports.
 };

--- a/vita3k/ctrl/include/ctrl/state.h
+++ b/vita3k/ctrl/include/ctrl/state.h
@@ -35,10 +35,11 @@ typedef std::shared_ptr<_SDL_Haptic> HapticPtr;
 
 struct Controller {
     GameControllerPtr controller;
-    int port;
+    int port; // 1-based
     bool has_accel;
     bool has_gyro;
     bool has_led;
+    const char *name;
 };
 
 struct ControllerBinding {
@@ -59,8 +60,6 @@ struct CtrlState {
     ControllerList controllers;
     int controllers_num = 0;
     bool has_motion_support = false;
-    bool controllers_has_motion_support[SCE_CTRL_MAX_WIRELESS_NUM] = { false, false, false, false };
-    const char *controllers_name[SCE_CTRL_MAX_WIRELESS_NUM];
     bool free_ports[SCE_CTRL_MAX_WIRELESS_NUM] = { true, true, true, true };
     SceCtrlPadInputMode input_mode = SCE_CTRL_MODE_DIGITAL;
     SceCtrlPadInputMode input_mode_ext = SCE_CTRL_MODE_DIGITAL;

--- a/vita3k/ctrl/src/ctrl.cpp
+++ b/vita3k/ctrl/src/ctrl.cpp
@@ -72,6 +72,9 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
             if (!state.controllers.contains(guid)) {
                 Controller new_controller;
                 const GameControllerPtr controller(SDL_GameControllerOpen(joystick_index), SDL_GameControllerClose);
+                if (controller == nullptr) {
+                    continue;
+                }
                 new_controller.controller = controller;
                 new_controller.port = reserve_port(state);
                 if (new_controller.port == -1) { // Port not available
@@ -98,6 +101,10 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
                 found_gyro |= new_controller.has_gyro;
                 found_accel |= new_controller.has_accel;
                 new_controller.name = SDL_GameControllerNameForIndex(joystick_index);
+                if (new_controller.name == nullptr) {
+                    state.free_ports[new_controller.port] = true;
+                    continue;
+                }
 
                 state.controllers.emplace(guid, new_controller);
                 state.controllers_num++;

--- a/vita3k/ctrl/src/ctrl.cpp
+++ b/vita3k/ctrl/src/ctrl.cpp
@@ -74,6 +74,10 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
                 const GameControllerPtr controller(SDL_GameControllerOpen(joystick_index), SDL_GameControllerClose);
                 new_controller.controller = controller;
                 new_controller.port = reserve_port(state);
+                if (!new_controller.port) { // Port not available
+                    return;
+                }
+                SDL_GameControllerSetPlayerIndex(controller.get(), new_controller.port - 1);
 
                 new_controller.has_gyro = SDL_GameControllerHasSensor(controller.get(), SDL_SENSOR_GYRO);
                 if (new_controller.has_gyro)
@@ -93,10 +97,9 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
 
                 found_gyro |= new_controller.has_gyro;
                 found_accel |= new_controller.has_accel;
+                new_controller.name = SDL_GameControllerNameForIndex(joystick_index);
 
                 state.controllers.emplace(guid, new_controller);
-                state.controllers_name[joystick_index] = SDL_GameControllerNameForIndex(joystick_index);
-                state.controllers_has_motion_support[joystick_index] = found_gyro && found_accel;
                 state.controllers_num++;
             }
         }

--- a/vita3k/gui/src/controllers_dialog.cpp
+++ b/vita3k/gui/src/controllers_dialog.cpp
@@ -186,22 +186,27 @@ static void swap_controller_ports(CtrlState &state, int source_port, int dest_po
     auto dest_controller_it = std::find_if(state.controllers.begin(), state.controllers.end(),
         [&](const auto &pair) { return pair.second.port == (dest_port + 1); });
 
-    // Check that both controllers exist
-    if ((source_controller_it == state.controllers.end()) || (dest_controller_it == state.controllers.end())) {
-        LOG_ERROR("Unable to find one or more controllers on the specified ports.");
+    // Check that source controllers exist
+    if (source_controller_it == state.controllers.end()) {
+        LOG_ERROR("Unable to find controller on source port {}", source_port);
         return;
     }
 
-    LOG_INFO("Controller on source port {} {} swapped with controller on destination port {} {}", source_port, state.controllers_name[source_port], dest_port, state.controllers_name[dest_port]);
+    if (dest_controller_it == state.controllers.end()) {
+        LOG_INFO("Controller on source port {} {} assigned to destination port {}", source_port, source_controller_it->second.name, dest_port);
 
-    // Swap controllers port and player index
-    SDL_GameControllerSetPlayerIndex(source_controller_it->second.controller.get(), dest_port);
-    SDL_GameControllerSetPlayerIndex(dest_controller_it->second.controller.get(), source_port);
-    std::swap(source_controller_it->second.port, dest_controller_it->second.port);
+        // Assign controller to destination port
+        SDL_GameControllerSetPlayerIndex(source_controller_it->second.controller.get(), dest_port);
+        source_controller_it->second.port = dest_port + 1;
+        std::swap(state.free_ports[source_port], state.free_ports[dest_port]);
+    } else {
+        LOG_INFO("Controller on source port {} {} swapped with controller on destination port {} {}", source_port, source_controller_it->second.name, dest_port, dest_controller_it->second.name);
 
-    // Swap controller names and motion support
-    std::swap(state.controllers_name[source_port], state.controllers_name[dest_port]);
-    std::swap(state.controllers_has_motion_support[source_port], state.controllers_has_motion_support[dest_port]);
+        // Swap controllers port and player index
+        SDL_GameControllerSetPlayerIndex(source_controller_it->second.controller.get(), dest_port);
+        SDL_GameControllerSetPlayerIndex(dest_controller_it->second.controller.get(), source_port);
+        std::swap(source_controller_it->second.port, dest_controller_it->second.port);
+    }
 }
 
 void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
@@ -242,17 +247,22 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::TableSetColumnIndex(2);
             ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", "Motion Support");
             const char *port_names[] = { "1", "2", "3", "4" };
-            for (auto i = 0; i < ctrl.controllers_num; i++) {
+            for (auto i = 0; i < SCE_CTRL_MAX_WIRELESS_NUM; i++) {
+                auto controller_it = std::find_if(ctrl.controllers.begin(), ctrl.controllers.end(),
+                    [&](const auto &pair) { return pair.second.port == (i + 1); });
+                if (controller_it == ctrl.controllers.end()) {
+                    continue;
+                }
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
                 int selected_port = i;
                 ImGui::PushID(i);
                 ImGui::SetNextItemWidth(50.f * emuenv.dpi_scale);
-                if (ImGui::Combo("##swap_port", &selected_port, port_names, ctrl.controllers_num))
+                if (ImGui::Combo("##swap_port", &selected_port, port_names, SCE_CTRL_MAX_WIRELESS_NUM))
                     swap_controller_ports(ctrl, i, selected_port);
                 ImGui::PopID();
                 ImGui::TableSetColumnIndex(1);
-                if (ImGui::Button(ctrl.controllers_name[i]))
+                if (ImGui::Button(controller_it->second.name))
                     rebinds_is_open = true;
                 if (rebinds_is_open) {
                     const SDL_JoystickGUID guid = SDL_JoystickGetDeviceGUID(i);
@@ -271,7 +281,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                     auto &controls = gui.lang.controls;
 
                     const auto type = SDL_GameControllerTypeForIndex(i);
-                    ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", ctrl.controllers_name[i]);
+                    ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", controller_it->second.name);
                     ImGui::Separator();
                     if (ImGui::BeginTable("rebindControl", 2, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_BordersInnerV)) {
                         ImGui::TableSetupColumn("leftButtons");
@@ -403,7 +413,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::End();
                 }
                 ImGui::TableSetColumnIndex(2);
-                ImGui::Text("%s", ctrl.controllers_has_motion_support[i] ? common["yes"].c_str() : common["no"].c_str());
+                ImGui::Text("%s", (controller_it->second.has_accel && controller_it->second.has_gyro) ? common["yes"].c_str() : common["no"].c_str());
             }
             ImGui::EndTable();
         }

--- a/vita3k/gui/src/controllers_dialog.cpp
+++ b/vita3k/gui/src/controllers_dialog.cpp
@@ -182,9 +182,9 @@ static void swap_controller_ports(CtrlState &state, int source_port, int dest_po
 
     // Find the controllers corresponding to the source and destination ports
     auto source_controller_it = std::find_if(state.controllers.begin(), state.controllers.end(),
-        [&](const auto &pair) { return pair.second.port == (source_port + 1); });
+        [&](const auto &pair) { return pair.second.port == source_port; });
     auto dest_controller_it = std::find_if(state.controllers.begin(), state.controllers.end(),
-        [&](const auto &pair) { return pair.second.port == (dest_port + 1); });
+        [&](const auto &pair) { return pair.second.port == dest_port; });
 
     // Check that source controllers exist
     if (source_controller_it == state.controllers.end()) {
@@ -197,7 +197,7 @@ static void swap_controller_ports(CtrlState &state, int source_port, int dest_po
 
         // Assign controller to destination port
         SDL_GameControllerSetPlayerIndex(source_controller_it->second.controller.get(), dest_port);
-        source_controller_it->second.port = dest_port + 1;
+        source_controller_it->second.port = dest_port;
         std::swap(state.free_ports[source_port], state.free_ports[dest_port]);
     } else {
         LOG_INFO("Controller on source port {} {} swapped with controller on destination port {} {}", source_port, source_controller_it->second.name, dest_port, dest_controller_it->second.name);
@@ -249,7 +249,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
             const char *port_names[] = { "1", "2", "3", "4" };
             for (auto i = 0; i < SCE_CTRL_MAX_WIRELESS_NUM; i++) {
                 auto controller_it = std::find_if(ctrl.controllers.begin(), ctrl.controllers.end(),
-                    [&](const auto &pair) { return pair.second.port == (i + 1); });
+                    [&](const auto &pair) { return pair.second.port == i; });
                 if (controller_it == ctrl.controllers.end()) {
                     continue;
                 }

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -416,8 +416,9 @@ static ExitCode load_app_impl(SceUID &main_module_id, EmuEnvState &emuenv) {
     LOG_INFO("Resolution multiplier: {}", emuenv.cfg.resolution_multiplier);
     if (emuenv.ctrl.controllers_num) {
         LOG_INFO("{} Controllers Connected", emuenv.ctrl.controllers_num);
-        for (auto i = 0; i < emuenv.ctrl.controllers_num; i++)
-            LOG_INFO("Controller {}: {}", i, emuenv.ctrl.controllers_name[i]);
+        for (auto controller_it = emuenv.ctrl.controllers.begin(); controller_it != emuenv.ctrl.controllers.end(); ++controller_it) {
+            LOG_INFO("Controller {}: {}", controller_it->second.port, controller_it->second.name);
+        }
         if (emuenv.ctrl.has_motion_support)
             LOG_INFO("Controller has motion support");
     }

--- a/vita3k/modules/SceCtrl/SceCtrl.cpp
+++ b/vita3k/modules/SceCtrl/SceCtrl.cpp
@@ -195,7 +195,8 @@ EXPORT(int, sceCtrlSetActuator, int port, const SceCtrlActuator *pState) {
 
     CtrlState &state = emuenv.ctrl;
     for (const auto &controller : state.controllers) {
-        if (controller.second.port == port) {
+        if (controller.second.port + 1 == port) {
+            // sceCtrl ports are 1-based and SDL_GameController index is 0-based. Need to convert.
             SDL_GameControllerRumble(controller.second.controller.get(), pState->small * 655.35f, pState->large * 655.35f, SDL_HAPTIC_INFINITY);
 
             return 0;


### PR DESCRIPTION
Feature Implementation:
I modified the controller assignment functionality to match the Vita TV.
On Vita TV, newly connected controllers are always sequentially assigned starting from port 1 to the next available number, and users can explicitly reassign controllers to any number from 1-4. No special handling is implemented when a disconnected controller is reconnected.

Bug Fix:
I fixed an issue where incorrect behavior occurred when a connected controller was disconnected. Previously, when a disconnected controller created a gap in port numbers, only iterated through the number of connected controllers, causing issues like being unable to check controllers with higher port numbers.
