### PR TITLE
touch: Validate all input params and simplify code

### DIFF
--- a/vita3k/modules/SceTouch/SceTouch.cpp
+++ b/vita3k/modules/SceTouch/SceTouch.cpp
@@ -51,7 +51,7 @@ EXPORT(int, sceTouchDisableTouchForce, SceUInt32 port) {
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
     touch_set_force_mode(port, false);
-    return 0;
+    return SCE_TOUCH_OK;
 }
 
 EXPORT(int, sceTouchDisableTouchForceExt) {
@@ -70,7 +70,7 @@ EXPORT(int, sceTouchEnableTouchForce, SceUInt32 port) {
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
     touch_set_force_mode(port, true);
-    return 0;
+    return SCE_TOUCH_OK;
 }
 
 EXPORT(int, sceTouchEnableTouchForceExt) {
@@ -85,84 +85,81 @@ EXPORT(int, sceTouchGetDeviceInfo) {
 
 EXPORT(int, sceTouchGetPanelInfo, SceUInt32 port, SceTouchPanelInfo *pPanelInfo) {
     TRACY_FUNC(sceTouchGetPanelInfo, port, pPanelInfo);
-    switch (port) {
-    case SCE_TOUCH_PORT_FRONT:
-        // Active Area
-        pPanelInfo->minAaX = 0;
-        pPanelInfo->minAaY = 0;
-        pPanelInfo->maxAaX = 1919;
-        pPanelInfo->maxAaY = 1087;
-
-        // Display
-        pPanelInfo->minDispX = 0;
-        pPanelInfo->minDispY = 0;
-        pPanelInfo->maxDispX = 1919;
-        pPanelInfo->maxDispY = 1087;
-
-        // Force
-        pPanelInfo->minForce = 1;
-        pPanelInfo->maxForce = 128;
-
-        return 0;
-    case SCE_TOUCH_PORT_BACK:
-        // Active Area
-        pPanelInfo->minAaX = 0;
-        pPanelInfo->minAaY = 108;
-        pPanelInfo->maxAaX = 1919;
-        pPanelInfo->maxAaY = 889;
-
-        // Display
-        pPanelInfo->minDispX = 0;
-        pPanelInfo->minDispY = 0;
-        pPanelInfo->maxDispX = 1919;
-        pPanelInfo->maxDispY = 1087;
-
-        // Force
-        pPanelInfo->minForce = 1;
-        pPanelInfo->maxForce = 128;
-
-        return 0;
-    default:
-        return SCE_TOUCH_ERROR_INVALID_ARG;
+    if (port >= SCE_TOUCH_PORT_MAX_NUM) {
+        return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
+    if (pPanelInfo == nullptr) {
+        return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
+    }
+
+    // Active Area
+    pPanelInfo->minAaX = 0;
+    pPanelInfo->minAaY = 0;
+    pPanelInfo->maxAaX = 1919;
+    pPanelInfo->maxAaY = 1087;
+
+    // Display
+    pPanelInfo->minDispX = 0;
+    pPanelInfo->minDispY = 0;
+    pPanelInfo->maxDispX = 1919;
+    pPanelInfo->maxDispY = 1087;
+
+    // Force
+    pPanelInfo->minForce = 1;
+    pPanelInfo->maxForce = 128;
+
+    if (port == SCE_TOUCH_PORT_BACK) {
+        pPanelInfo->minAaY = 108;
+        pPanelInfo->maxAaY = 889;
+    }
+
+    return SCE_TOUCH_OK;
 }
 
 EXPORT(int, sceTouchGetPixelDensity, float *p1, float *p2) {
     TRACY_FUNC(sceTouchGetPixelDensity, p1, p2);
-    if (!p1 || !p2)
-        return SCE_TOUCH_ERROR_INVALID_ARG;
-    STUBBED("Return constant values (22.0)");
-    /* In disasmed source this function can return one of two set of values depends of hardware info.
-     * I dont know how to get this info, so I just return one of them.
-     */
-    *p1 = 22.0;
-    *p2 = 22.0;
-    /*
-     *p1 = 17.54;
-     *p2 = 17.54;
-     */
-    return 0;
+    if (p1 == nullptr || p2 == nullptr) {
+        return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
+    }
+
+    // This function can return one of two set of values depending on the output of GetHardwareInfo NID 0xCBD6D8BC
+    // for now this value is hardcoded until the function is implemented
+    int hardware_info = 0x30;
+
+    if (hardware_info == 0x30 || hardware_info == 0x31) {
+        *p1 = 22.0f;
+        *p2 = 22.0f;
+    } else {
+        *p1 = 17.54f;
+        *p2 = 17.54f;
+    }
+
+    return SCE_TOUCH_OK;
 }
 
 EXPORT(int, sceTouchGetPixelDensity2, float *p1, float *p2, float *p3, float *p4) {
     TRACY_FUNC(sceTouchGetPixelDensity2, p1, p2, p3, p4);
-    if (!p1 || !p2 || !p3 || !p4)
+    if (p1 == nullptr || p2 == nullptr || p3 == nullptr || p4 == nullptr) {
         return SCE_TOUCH_ERROR_INVALID_ARG;
-    STUBBED("Return constant values (22.0)");
-    /* In disasmed source this function can return one of two set of values depends of hardware info.
-     * I dont know how to get this info, so I just return one of them.
-     */
-    *p1 = 22.0;
-    *p2 = 22.0;
-    *p3 = 22.0;
-    *p4 = 22.0;
-    /*
-     *p1 = 17.54;
-     *p2 = 17.54;
-     *p3 = 17.54;
-     *p4 = 17.54; or 24.23;
-     */
-    return 0;
+    }
+
+    // This function can return one of two set of values depending on the output of GetHardwareInfo NID 0xCBD6D8BC
+    // for now this value is hardcoded until the function is implemented
+    int hardware_info = 0x30;
+
+    if (hardware_info == 0x30 || hardware_info == 0x31) {
+        *p1 = 22.0f;
+        *p2 = 22.0f;
+        *p3 = 22.0f;
+        *p4 = 22.0f;
+    } else {
+        *p1 = 17.54f;
+        *p2 = 17.54f;
+        *p3 = 17.54f;
+        *p4 = 17.54f;
+    }
+
+    return SCE_TOUCH_OK;
 }
 
 EXPORT(int, sceTouchGetProcessInfo) {
@@ -179,7 +176,7 @@ EXPORT(int, sceTouchGetSamplingState, SceUInt32 port, SceTouchSamplingState *pSt
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
     *pState = emuenv.touch.touch_mode[port];
-    return 0;
+    return SCE_TOUCH_OK;
 }
 
 EXPORT(int, sceTouchGetSamplingStateExt) {
@@ -195,6 +192,9 @@ EXPORT(int, sceTouchPeek, SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs) 
     if (pData == nullptr) {
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
+    if (nBufs > MAX_TOUCH_BUFFER_SAVED) {
+        return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
+    }
 
     return touch_get(thread_id, emuenv, port, pData, nBufs, true);
 }
@@ -207,12 +207,18 @@ EXPORT(int, sceTouchPeek2, SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs)
     if (pData == nullptr) {
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
+    if (nBufs > MAX_TOUCH_BUFFER_SAVED) {
+        return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
+    }
 
     return touch_get(thread_id, emuenv, port, pData, nBufs, true);
 }
 
 EXPORT(int, sceTouchPeekRegion, SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs, int region) {
     TRACY_FUNC(sceTouchPeekRegion, port, pData, nBufs, region);
+    if (region > 0xFF) {
+        return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
+    }
     STUBBED("Ignore region");
     return CALL_EXPORT(sceTouchPeek, port, pData, nBufs);
 }
@@ -230,6 +236,10 @@ EXPORT(int, sceTouchRead, SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs) 
     if (pData == nullptr) {
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
+    if (nBufs > MAX_TOUCH_BUFFER_SAVED) {
+        return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
+    }
+
     return touch_get(thread_id, emuenv, port, pData, nBufs, false);
 }
 
@@ -239,6 +249,9 @@ EXPORT(int, sceTouchRead2, SceUInt32 port, SceTouchData *pData, SceUInt32 nBufs)
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
     if (pData == nullptr) {
+        return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
+    }
+    if (nBufs > MAX_TOUCH_BUFFER_SAVED) {
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
 
@@ -279,7 +292,7 @@ EXPORT(int, sceTouchSetSamplingState, SceUInt32 port, SceTouchSamplingState stat
         return RET_ERROR(SCE_TOUCH_ERROR_INVALID_ARG);
     }
     emuenv.touch.touch_mode[port] = state;
-    return 0;
+    return SCE_TOUCH_OK;
 }
 
 EXPORT(int, sceTouchSetSamplingStateExt) {

--- a/vita3k/touch/include/touch/touch.h
+++ b/vita3k/touch/include/touch/touch.h
@@ -20,6 +20,7 @@
 #include <util/types.h>
 
 #define SCE_TOUCH_MAX_REPORT 8
+#define MAX_TOUCH_BUFFER_SAVED 64
 
 struct SDL_ControllerTouchpadEvent;
 struct SDL_TouchFingerEvent;
@@ -30,6 +31,7 @@ enum SceTouchSamplingState {
 };
 
 enum SceTouchErrorCode : uint32_t {
+    SCE_TOUCH_OK = 0x0,
     SCE_TOUCH_ERROR_INVALID_ARG = 0x80350001,
     SCE_TOUCH_ERROR_PRIV_REQUIRED = 0x80350002,
     SCE_TOUCH_ERROR_FATAL = 0x803500FF
@@ -49,6 +51,7 @@ struct SceTouchReport {
     SceUInt8 reserved[8];
     SceUInt16 info;
 };
+static_assert(sizeof(SceTouchReport) == 0x10, "SceTouchReport is an invalid size");
 
 struct SceTouchPanelInfo {
     SceInt16 minAaX;
@@ -63,6 +66,7 @@ struct SceTouchPanelInfo {
     SceUInt8 maxForce;
     SceUInt8 reserved[30];
 };
+static_assert(sizeof(SceTouchPanelInfo) == 0x30, "SceTouchPanelInfo is an invalid size");
 
 struct SceTouchData {
     SceUInt64 timeStamp;
@@ -70,3 +74,4 @@ struct SceTouchData {
     SceUInt32 reportNum;
     SceTouchReport report[SCE_TOUCH_MAX_REPORT];
 };
+static_assert(sizeof(SceTouchData) == 0x90, "SceTouchData is an invalid size");

--- a/vita3k/touch/src/touch.cpp
+++ b/vita3k/touch/src/touch.cpp
@@ -27,8 +27,6 @@
 
 #include <cstring>
 
-constexpr int MAX_TOUCH_BUFFER_SAVED = 64;
-
 static SceTouchData touch_buffers[MAX_TOUCH_BUFFER_SAVED][2];
 static int touch_buffer_idx = 0;
 static bool is_touchpad = false;


### PR DESCRIPTION
This is a quick pass to the current touch code. I don't expect any games be affected by these changes.

- Ensures all input parameters are properly validated to return the same error code as the actual console
- Removes a bit of duplication code in `sceTouchGetPanelInfo` to simplify reading.
- ~~Partially implements `sceTouchGetPixelDensity` with `GetHardwareInfo` calls~~. In reality these values are stored in a global set at module init but vita3k doesn't seem to have any proper initialization for modules. 