### PR TITLE
gui: add keyboard navigation support for menus

### DIFF
--- a/lang/system/en.xml
+++ b/lang/system/en.xml
@@ -335,6 +335,8 @@ Connect a controller that is compatible with SDL2.</not_connected>
 		<toggle_touch_description>Toggles between back touch and screen touch.</toggle_touch_description>
 		<toggle_gui_visibility>Toggle GUI Visibility</toggle_gui_visibility>
 		<toggle_gui_visibility_description>Toggles between showing and hiding the GUI at the top of the screen while the app is running.</toggle_gui_visibility_description>
+		<menu_key>Focus Menu</menu_key>
+		<menu_key_description>Focuses on the menu key in the GUI.</menu_key_description>
 		<miscellaneous>Miscellaneous</miscellaneous>
 		<toggle_texture_replacement>Toggle Texture Replacement</toggle_texture_replacement>
 		<take_a_screenshot>Take A Screenshot</take_a_screenshot>

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -138,6 +138,7 @@ enum ScreenshotFormat {
     code(int, "keyboard-rightstick-down", 14, keyboard_rightstick_down)                                 \
     code(int, "keyboard-button-psbutton", 19, keyboard_button_psbutton)                                 \
     code(int, "keyboard-gui-toggle-gui", 10, keyboard_gui_toggle_gui)                                   \
+    code(int, "keyboard-gui-menu-key", 226, keyboard_gui_menu_key)                                   \
     code(int, "keyboard-gui-fullscreen", 68, keyboard_gui_fullscreen)                                   \
     code(int, "keyboard-gui-toggle-touch", 23, keyboard_gui_toggle_touch)                               \
     code(int, "keyboard-toggle-texture-replacement", 0, keyboard_toggle_texture_replacement)            \

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -214,6 +214,16 @@ enum ThemePreviewType {
     LOCK,
 };
 
+enum MenuType {
+    MENUTYPE_NONE,
+    MENUTYPE_FILE,
+    MENUTYPE_EMULATION,
+    MENUTYPE_DEBUG,
+    MENUTYPE_CONFIG,
+    MENUTYPE_CONTROL,
+    MENUTYPE_HELP,
+};
+
 inline const std::vector<std::pair<SceSystemParamLang, std::string>> LIST_SYS_LANG = {
     { SCE_SYSTEM_PARAM_LANG_DANISH, "Dansk" },
     { SCE_SYSTEM_PARAM_LANG_GERMAN, "Deutsch" },
@@ -289,6 +299,8 @@ struct GuiState {
 
     bool is_nav_button = false;
     bool is_key_locked = false;
+    bool is_menu_opened = false;
+    MenuType focused_menu = MenuType::MENUTYPE_NONE;
 
     std::vector<std::string> live_area_current_open_apps_list;
     int32_t live_area_app_current_open = -1;

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -181,6 +181,7 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
         remapper_button(gui, emuenv, &emuenv.cfg.keyboard_gui_fullscreen, lang["full_screen"].c_str());
         remapper_button(gui, emuenv, &emuenv.cfg.keyboard_gui_toggle_touch, lang["toggle_touch"].c_str(), lang["toggle_touch_description"].c_str());
         remapper_button(gui, emuenv, &emuenv.cfg.keyboard_gui_toggle_gui, lang["toggle_gui_visibility"].c_str(), lang["toggle_gui_visibility_description"].c_str());
+        remapper_button(gui, emuenv, &emuenv.cfg.keyboard_gui_menu_key, lang["menu_key"].c_str(), lang["menu_key_description"].c_str());
         ImGui::EndTable();
     }
 

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -711,6 +711,8 @@ void pre_init(GuiState &gui, EmuEnvState &emuenv) {
     init_font(gui, emuenv);
     lang::init_lang(gui.lang, emuenv);
 
+    auto &io = ImGui::GetIO();
+
     bool result = ImGui_ImplSdl_CreateDeviceObjects(gui.imgui_state.get());
     assert(result);
 }

--- a/vita3k/gui/src/home_screen.cpp
+++ b/vita3k/gui/src/home_screen.cpp
@@ -458,6 +458,10 @@ void browse_home_apps_list(GuiState &gui, EmuEnvState &emuenv, const uint32_t bu
         }
     };
 
+    if (gui.is_menu_opened) {
+        return;
+    }
+
     switch (button) {
     case SCE_CTRL_UP:
         if (emuenv.cfg.apps_list_grid) {

--- a/vita3k/gui/src/home_screen.cpp
+++ b/vita3k/gui/src/home_screen.cpp
@@ -554,7 +554,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
     const auto config_dialog = gui.configuration_menu.custom_settings_dialog || gui.configuration_menu.settings_dialog || gui.controls_menu.controls_dialog;
     const auto install_dialog = gui.file_menu.archive_install_dialog || gui.file_menu.firmware_install_dialog || gui.file_menu.pkg_install_dialog;
     if (!config_dialog && !install_dialog && !gui.vita_area.app_close && !gui.vita_area.app_information && !gui.help_menu.about_dialog && !gui.help_menu.welcome_dialog && !gui.is_nav_button) {
-        if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) || ImGui::IsAnyItemActive() || ImGui::IsAnyItemHovered())
+        if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) || ImGui::IsAnyItemActive() || ImGui::IsAnyItemHovered() || ImGui::IsAnyItemFocused())
             last_time["start"] = 0;
         else {
             if (last_time["start"] == 0)

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -585,6 +585,9 @@ void browse_live_area_apps_list(GuiState &gui, EmuEnvState &emuenv, const uint32
         }
     };
 
+    if (gui.is_menu_opened) {
+        return;
+    }
     switch (button) {
     case SCE_CTRL_UP: {
         if (manual_found)

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -306,6 +306,8 @@ struct LangState {
         { "toggle_touch_description", "Toggles between back touch and screen touch." },
         { "toggle_gui_visibility", "Toggle GUI Visibility" },
         { "toggle_gui_visibility_description", "Toggles between showing and hiding the GUI at the top of the screen while the app is running." },
+        { "menu_key", "Focus Menu" },
+        { "menu_key_description", "Focuses on the menu key in the GUI" },
         { "miscellaneous", "Miscellaneous" },
         { "toggle_texture_replacement", "Toggle Texture Replacement" },
         { "take_a_screenshot", "Take A Screenshot" },


### PR DESCRIPTION
This is a PR for implementing keyboard-based menu navigation. It's still in WIP status as there are several concerns to address. I plan to implement joystick-based menu control after this work. The main implementation goal is to eliminate the need for touch menu control on devices like the SteamDeck. I'd like to hear others' thoughts on these issues and the current implementation direction.

Current implementation:
Pressing Alt moves focus to the menu, after which the menu can be controlled via keyboard. While the menu has focus, home_screen control is blocked. Menu state is shared between mouse and keyboard menu access. When moving between menu items left and right, I set having the menu expanded as the default state.

Issue 1: I couldn't find a way to achieve the goal without using imgui_internal. This may result in higher version dependency on imgui, which I'm not happy about.
Issue 2: The is_any_dialog_open function... is there really no other way? I couldn't find an alternative in imgui.

Better implementation might be possible by directly accessing ImGuiContext, but I wanted to avoid this at all costs. While both depend on imgui_internal, I judged that function access versus direct member variable access would have different maintenance costs going forward.
While the functionality works as intended, I'm not satisfied with the current implementation for the reasons mentioned above. However, if there seems to be no other implementation method available, this appears to be unavoidable.


Points to consider:

Using Alt for menu access was arbitrarily decided based on typical Windows programs, but the relevant key will differ by OS, and there could be conflicts with user-set keymaps. This needs more consideration.
For joystick control, I'm thinking of using the PS button (Xbox button) in the home menu to move focus to the menu. This should guarantee no conflicts. (@Zangetsu38 Did you know could there be any conflict cases?)


Tasks to proceed with in this PR later:

1. ~~Game controls are currently not blocked. Game controls should also be blocked when the menu has focus.~~ Updated
2. ~~Joystick control has not been implemented~~
