### PR TITLE
ngs/player: ngs/player: Prevent crash by rounding playback rate up.

### DIFF
--- a/vita3k/ngs/src/modules/player.cpp
+++ b/vita3k/ngs/src/modules/player.cpp
@@ -51,19 +51,24 @@ void PlayerModule::on_param_change(const MemState &mem, ModuleData &data) {
     const SceNgsPlayerParams *old_params = reinterpret_cast<SceNgsPlayerParams *>(data.last_info.data());
     SceNgsPlayerParams *new_params = static_cast<SceNgsPlayerParams *>(data.info.data.get(mem));
 
-    if (isnan(new_params->playback_scalar) || new_params->playback_scalar <= 0) {
+    // check for invalid playback values
+    const auto is_invalid_playback_value = [](const float playback_value, const float max_value) {
+        return isnan(playback_value) || (playback_value < 0.f) || (playback_value > max_value);
+    };
+
+    if (is_invalid_playback_value(new_params->playback_scalar, 10.f)) {
         new_params->playback_scalar = old_params->playback_scalar;
         LOG_ERROR_ONCE("Invalid playback rate scaling.");
-        if (isnan(new_params->playback_scalar) || new_params->playback_scalar <= 0) {
+        if (is_invalid_playback_value(new_params->playback_scalar, 10.f)) {
             new_params->playback_scalar = 1.0;
         }
     }
 
-    if (isnan(new_params->playback_frequency) || new_params->playback_frequency <= 0) {
+    if (is_invalid_playback_value(new_params->playback_frequency, 192000.f)) {
         new_params->playback_frequency = old_params->playback_frequency;
         LOG_ERROR_ONCE("Invalid playback frequency.");
-        if (isnan(new_params->playback_frequency) || new_params->playback_frequency <= 0) {
-            new_params->playback_frequency = 48000.0;
+        if (is_invalid_playback_value(new_params->playback_frequency, 192000.f)) {
+            new_params->playback_frequency = 48000.f;
         }
     }
 
@@ -202,8 +207,10 @@ bool PlayerModule::process(KernelState &kern, const MemState &mem, const SceUID 
 
                 // Get the amount of samples about to be received from the decoder and dump the value in samples_count
                 decoder->receive(nullptr, &samples_count);
+
                 // Playback rate scaling
-                if (params->playback_scalar != 1 || static_cast<int>(round(params->playback_frequency)) != sample_rate) {
+                float src_sample_rate = std::ceil(params->playback_frequency);
+                if ((params->playback_scalar != 1.f) || (static_cast<int>(src_sample_rate) != sample_rate)) {
                     LOG_INFO_ONCE("The currently running game requests playback rate scaling when decoding audio. Audio might crackle.");
 
                     // Received decoded samples from decoder
@@ -213,9 +220,8 @@ bool PlayerModule::process(KernelState &kern, const MemState &mem, const SceUID 
                     decoder->receive(decoded_data.data(), nullptr);
 
                     // resample the audio
-                    int src_sample_rate = static_cast<int>(params->playback_frequency);
                     if (params->playback_scalar != 1.0f)
-                        src_sample_rate = static_cast<int>(src_sample_rate * params->playback_scalar);
+                        src_sample_rate *= params->playback_scalar;
 
                     if (!state->swr || state->reset_swr) {
                         if (state->swr)
@@ -224,7 +230,7 @@ bool PlayerModule::process(KernelState &kern, const MemState &mem, const SceUID 
                         AVChannelLayout layout_stereo = AV_CHANNEL_LAYOUT_STEREO;
                         int ret = swr_alloc_set_opts2(&state->swr,
                             &layout_stereo, AV_SAMPLE_FMT_FLT, sample_rate,
-                            &layout_stereo, AV_SAMPLE_FMT_FLT, src_sample_rate,
+                            &layout_stereo, AV_SAMPLE_FMT_FLT, static_cast<int>(src_sample_rate),
                             0, nullptr);
                         assert(ret == 0);
 


### PR DESCRIPTION
# About
 - ngs/player: Prevent crash by rounding playback rate up.
Some Unity games set very low playback frequencies (e.g., 0.xx), causing FFmpeg to crash.
- Improve validation for playback_scalar and playback_frequency.
Replaced redundant checks for playback_scalar and playback_frequency with dedicated lambda functions for better readability and maintainability.
- Adjusted the validation logic to properly handle edge cases:
Allowed playback_scalar values between 0 and 10.
Allowed playback_frequency values between 0 and 192000.

fix crash of Looney Tunes Galactic Sports, Spongebob, Stick it to the man, etc....
credit to @bookmist for help
