### PR TITLE
Fix for zombiebound

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -203,7 +203,7 @@ bool install_archive_content(EmuEnvState &emuenv, GuiState *gui, const ZipPtr &z
         }
     }
 
-    if (fs::exists(output_path / "sce_sys/package/")) {
+    if (fs::exists(output_path / "sce_sys/package/") && emuenv.app_info.app_title_id.starts_with("PCS")) {
         update_progress();
         if (is_nonpdrm(emuenv, output_path))
             decrypt_progress = 100.f;


### PR DESCRIPTION
#3330 Installation fails because zombiebound is homebrew but has an empty `sce_sys/package/work.bin`.
Check `title_id` instead.
If you have a better way of identifying commercial and homebrew games, please let me know.