### PR TITLE
gui/interface: Ignore simultaneous identical keydown events from controller

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -648,6 +648,9 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
         }
     };
 
+    // A set to store the last pressed buttons to prevent duplicate inputs from the controller.
+    std::set<uint32_t> last_buttons;
+
     SDL_Event event;
     while (SDL_PollEvent(&event)) {
         ImGui_ImplSdl_ProcessEvent(gui.imgui_state.get(), &event);
@@ -743,6 +746,10 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
 
             for (const auto &binding : get_controller_bindings_ext(emuenv)) {
                 if (event.cbutton.button == binding.controller) {
+                    if (last_buttons.find(binding.button) != last_buttons.end()) {
+                        continue;
+                    }
+                    last_buttons.insert(binding.button);
                     ui_navigation(binding.button);
 
                     break;

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -722,8 +722,13 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             if (event.key.keysym.scancode == emuenv.cfg.keyboard_take_screenshot && !gui.is_key_capture_dropped)
                 take_screenshot(emuenv);
 
-            if (sce_ctrl_btn != 0)
+            if (sce_ctrl_btn != 0) {
+                if (last_buttons.find(sce_ctrl_btn) != last_buttons.end()) {
+                    continue;
+                }
+                last_buttons.insert(sce_ctrl_btn);
                 ui_navigation(sce_ctrl_btn);
+            }
 
             break;
         }


### PR DESCRIPTION
The purpose of this PR is to block ui_navigation for second and subsequent inputs when multiple controllers simultaneously trigger SDL_CONTROLLERBUTTONDOWN events for the same key.

-----

Here's why this PR is necessary. I've written a detailed explanation since this PR might seem unnecessary at first glance.

Many controllers use the Xbox 360 Controller driver in Windows environments. Since the Xbox 360 Controller driver doesn't support gyro functionality, the gyro hardware often can't be practically used even when it exists in the controller.

There are several third-party solutions to work around this issue. The most well-known approach is using cemuhookudp (which isn't yet supported by Vita3K), but there's also an approach that emulates a Dualshock 4 controller by combining controller inputs with motion sensor inputs.
The problem arises when emulating a Dualshock 4 controller because two controllers simultaneously exist in the system, and since the Xbox 360 controller and Dualshock 4 controller always transmit identical key inputs, UI navigation receives inputs twice. This is generally not an intended situation.

Fortunately, this issue doesn't occur during gameplay because controller numbers are distinguished, but it would still be better to resolve this problem.

Additionally, in some linux environments, Steam doesn't hide the existing controller while emulating the Steam Controller, so the same issue occurs when running Vita3K through Steam. Since there's a growing trend of people managing all gaming software through Steam Big Picture Mode on gaming PCs, it would be better to resolve this issue as well.

This PR solves these problems with a simple method that ignores duplicate inputs when the same key is input multiple times in one event cycle.

Of course, with this solution, there's a theoretical issue where if two people actually navigate the UI simultaneously with two controllers and press buttons at the same time, only one navigation action will occur. However, I don't think this creates a usability problem. It's difficult to imagine a situation where two people need to navigate simultaneously on the home screen.
Therefore, this solution can solve the above problems simply without penalties.