### PR TITLE
gui: Remove High DPI support on Linux

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -297,27 +297,11 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
         state.display.fullscreen = true;
         window_type |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
-#if defined(_WIN32) || defined(__linux__)
-    const auto isSteamDeck = []() {
-#ifdef __linux__
-        std::ifstream file("/etc/os-release");
-        if (file.is_open()) {
-            std::string line;
-            while (std::getline(file, line)) {
-                if (line.find("VARIANT_ID=steamdeck") != std::string::npos)
-                    return true;
-            }
-        }
-#endif
-        return false;
-    };
-
-    if (!isSteamDeck()) {
-        float ddpi, hdpi, vdpi;
-        SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi);
-        window_type |= SDL_WINDOW_ALLOW_HIGHDPI;
-        state.dpi_scale = ddpi / 96;
-    }
+#if defined(_WIN32)
+    float ddpi, hdpi, vdpi;
+    SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi);
+    window_type |= SDL_WINDOW_ALLOW_HIGHDPI;
+    state.dpi_scale = ddpi / 96;
 #endif
     state.res_width_dpi_scale = static_cast<uint32_t>(DEFAULT_RES_WIDTH * state.dpi_scale);
     state.res_height_dpi_scale = static_cast<uint32_t>(DEFAULT_RES_HEIGHT * state.dpi_scale);


### PR DESCRIPTION
Currently, there are various HighDPI-related issues in Linux.
I want to disable High DPI with this PR until High DPI is properly implemented in Linux.
This will solve the problem where Vita3K couldn't be used in some Linux desktop environments.

Here are the detailed issues:

1. In Linux environments, the SDL_GetDisplayDPI function returns the monitor's physical DPI.
   * On some displays where the monitor's length is not provided, this value becomes 0. In such cases, Vita3K's screen does not display properly.
   * On some HighDPI displays, the physical DPI is too high, causing Vita3K's window to exceed 100% of the screen. In this case, it becomes impossible to use Vita3K normally.
2. Even when native DPI scaling is supported in the desktop environment, there are cases where Vita3K's screen doesn't render properly.
   * In Wayland environments, depending on the settings, Windows and other elements can be drawn at sizes larger than the given parameters. In this case, the window size is rendered larger, and text within the window can also be expanded according to the DPI multiplier, causing the rendering results to overflow on the screen.
   * In other words, rendering issues always occur when the detected dpi_scale value is not 1.

I considered only stopping the operation in certain situations, thinking there might be environments where High DPI implementation could be used properly, but testing showed that such environments barely exist.