### PR TITLE
.github/workflows: Add the replace option to ghr

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -67,10 +67,6 @@ cpu:
   - changed-files:
     - any-glob-to-any-file:
       - 'vita3k/cpu/**'
-crypto:
-  - changed-files:
-    - any-glob-to-any-file:
-      - 'vita3k/crypto/**'
 ctrl:
   - changed-files:
     - any-glob-to-any-file:
@@ -170,6 +166,10 @@ packages:
   - changed-files:
     - any-glob-to-any-file:
       - 'vita3k/packages/**'
+patch:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'vita3k/patch/**'
 regmgr:
   - changed-files:
     - any-glob-to-any-file:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         repo: [master, store]
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-latest
     if: |
       github.ref == 'refs/heads/master' &&
       github.repository == 'Vita3K/Vita3K'
@@ -241,9 +241,9 @@ jobs:
             fi
           done
           ls -al artifacts/
-          wget -c https://github.com/tcnksm/ghr/releases/download/v0.16.2/ghr_v0.16.2_linux_amd64.tar.gz
-          tar xfv ghr_v0.16.2_linux_amd64.tar.gz
-          ghr_v0.16.2_linux_amd64/ghr -u Vita3K -r Vita3K -recreate -n 'Automatic CI builds' -b "$(printf "Corresponding commit: ${{ github.sha }}\nVita3K Build: ${{ env.Build_Variable }}")" continuous artifacts/
+          wget -c https://github.com/tcnksm/ghr/releases/download/v0.17.0/ghr_v0.17.0_linux_amd64.tar.gz
+          tar xfv ghr_v0.17.0_linux_amd64.tar.gz
+          ghr_v0.17.0_linux_amd64/ghr -u Vita3K -r Vita3K -recreate -replace -n 'Automatic CI builds' -b "$(printf "Corresponding commit: ${{ github.sha }}\nVita3K Build: ${{ env.Build_Variable }}")" continuous artifacts/
         if: matrix.repo == 'master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -275,9 +275,9 @@ jobs:
             fi
           done
           ls -al artifacts/
-          wget -c https://github.com/tcnksm/ghr/releases/download/v0.16.2/ghr_v0.16.2_linux_amd64.tar.gz
-          tar xfv ghr_v0.16.2_linux_amd64.tar.gz
-          ghr_v0.16.2_linux_amd64/ghr -u Vita3K -r Vita3K-builds  -n "Build: ${{ env.Build_Variable }}" -b "$(printf "Corresponding commit: [${{ env.Latest_Commit_Message }}](https://github.com/Vita3K/Vita3K/commit/${{ github.sha }}) (${{ env.Commiter_Name }})")" ${{ env.Build_Variable }} artifacts/
+          wget -c https://github.com/tcnksm/ghr/releases/download/v0.17.0/ghr_v0.17.0_linux_amd64.tar.gz
+          tar xfv ghr_v0.17.0_linux_amd64.tar.gz
+          ghr_v0.17.0_linux_amd64/ghr -u Vita3K -r Vita3K-builds  -n "Build: ${{ env.Build_Variable }}" -b "$(printf "Corresponding commit: [${{ env.Latest_Commit_Message }}](https://github.com/Vita3K/Vita3K/commit/${{ github.sha }}) (${{ env.Commiter_Name }})")" ${{ env.Build_Variable }} artifacts/
         if: matrix.repo == 'store'
         env:
           GITHUB_TOKEN: ${{ secrets.STORE_TOKEN }}


### PR DESCRIPTION
Add the `replace` option to solve the problem of failed uploads of artefacts.
```bash
-replace \        # Replace artifacts if it is already uploaded
```