### PR TITLE
external: update MoltenVK to 1.2.11

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -240,7 +240,7 @@ target_include_directories(vulkan INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-
 if(APPLE)
 	if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/MoltenVK-macos.tar")
 		message(STATUS "Downloading MoltenVK...")
-		file(DOWNLOAD https://github.com/KhronosGroup/MoltenVK/releases/download/v1.2.9/MoltenVK-macos.tar
+		file(DOWNLOAD https://github.com/KhronosGroup/MoltenVK/releases/download/v1.2.11-artifacts/MoltenVK-macos.tar
 			"${CMAKE_BINARY_DIR}/external/MoltenVK-macos.tar" SHOW_PROGRESS)
 	endif()
 	if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/MoltenVK")


### PR DESCRIPTION
The `MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE` setting is not working as expected.
This issue seems to be caused by an older version of MoltenVK, as a recent fix related to this setting has been applied.
Updating MoltenVK to the latest version should resolve this problem.

> Ensure all MoltenVK config info set by VK_EXT_layer_settings is used
https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.11