### PR TITLE
gui/save data dialog: fix display slot on load with empty param.

### DIFF
--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -819,21 +819,18 @@ static void check_empty_param(EmuEnvState &emuenv, const SceAppUtilSaveDataSlotE
     emuenv.common_dialog.savedata.slot_info[idx].isExist = 0;
     if (empty_param) {
         emuenv.common_dialog.savedata.title[idx] = empty_param->title.get(emuenv.mem) ? empty_param->title.get(emuenv.mem) : emuenv.common_dialog.lang.save_data.save["new_saved_data"];
-        auto iconPath = empty_param->iconPath.get(emuenv.mem);
+        const auto iconPath = empty_param->iconPath.get(emuenv.mem);
         SceUChar8 *iconBuf = empty_param->iconBuf.cast<SceUChar8>().get(emuenv.mem);
-        auto iconBufSize = empty_param->iconBufSize;
-        vfs::FileBuffer thumbnail_buffer;
+        const auto iconBufSize = empty_param->iconBufSize;
+        auto &icon_buf_tmp = emuenv.common_dialog.savedata.icon_buffer[idx];
         if (iconPath) {
-            auto device = device::get_device(empty_param->iconPath.get(emuenv.mem));
-            auto thumbnail_path = translate_path(empty_param->iconPath.get(emuenv.mem), device, emuenv.io.device_paths);
-            vfs::read_file(VitaIoDevice::ux0, thumbnail_buffer, emuenv.pref_path, thumbnail_path);
-            emuenv.common_dialog.savedata.icon_buffer[idx] = thumbnail_buffer;
-        } else if (iconBuf && iconBufSize != 0) {
-            thumbnail_buffer.insert(thumbnail_buffer.end(), iconBuf, iconBuf + iconBufSize);
-            emuenv.common_dialog.savedata.icon_buffer[idx] = thumbnail_buffer;
+            auto device = device::get_device(iconPath);
+            const auto thumbnail_path = translate_path(empty_param->iconPath.get(emuenv.mem), device, emuenv.io.device_paths);
+            vfs::read_file(VitaIoDevice::ux0, icon_buf_tmp, emuenv.pref_path, thumbnail_path);
+        } else if (iconBuf && (iconBufSize > 0)) {
+            icon_buf_tmp.insert(icon_buf_tmp.end(), iconBuf, iconBuf + iconBufSize);
         }
-    } else
-        emuenv.common_dialog.savedata.title[idx] = emuenv.common_dialog.lang.save_data.save["new_saved_data"];
+    }
 }
 
 static void check_save_file(const uint32_t index, EmuEnvState &emuenv, const char *export_name) {


### PR DESCRIPTION
# About
- gui/save data dialog: fix display slot on load with empty param available like on real psvita.
fix position of title of list when is too long.
- gui/ime dialog: fix enter name.

that fix ,issue signaled by one tester compared real psvita.

# Result
- fix game with it display only load list mode with all empty param, is exactly same on psvita
![image](https://github.com/user-attachments/assets/c0d1a03b-6b2e-4024-bb58-fa59ecbb5ef6)

- And so get same result like on real psvita for app give empty param.
![image](https://github.com/user-attachments/assets/386857ed-7697-4110-8c76-d37096383537)

- No affect other game when no give empty param
![image](https://github.com/user-attachments/assets/f3d5138d-e43f-413c-b4c1-b8679f652103)


