### PR TITLE
npCommon: Fix NpCmpNpId

### DIFF
--- a/vita3k/modules/SceNpManager/SceNpManager.cpp
+++ b/vita3k/modules/SceNpManager/SceNpManager.cpp
@@ -126,8 +126,13 @@ EXPORT(int, sceNpManagerGetNpId, np::SceNpId *id) {
         return SCE_NP_MANAGER_ERROR_ID_NOT_AVAIL;
     }
     // Fill the unused stuffs to 0 (prevent some weird things happen)
-    memset(id, 0, sizeof(*id));
+    memset(id, 0, sizeof(np::SceNpId));
     strcpy(id->handle.data, emuenv.io.user_name.c_str());
+    id->isIdValid = true;
+    id->opt.platformType[0] = 'p';
+    id->opt.platformType[1] = 's';
+    id->opt.platformType[2] = 'p';
+    id->opt.platformType[3] = '2';
     return 0;
 }
 

--- a/vita3k/np/include/np/common.h
+++ b/vita3k/np/include/np/common.h
@@ -33,12 +33,21 @@ struct SceNpOnlineId {
     char term;
     char dummy[3];
 };
+static_assert(sizeof(SceNpOnlineId) == 0x14, "SceNpOnlineId is an invalid size");
+
+struct SceNpIdOptParam {
+    SceUChar8 unknown[4];
+    char platformType[4];
+};
+static_assert(sizeof(SceNpIdOptParam) == 0x8, "SceNpIdOptParam is an invalid size");
 
 struct SceNpId {
     SceNpOnlineId handle;
-    SceUChar8 opt[8];
-    SceUChar8 reserved[8];
+    SceNpIdOptParam opt;
+    SceInt8 isIdValid;
+    SceUChar8 reserved[7];
 };
+static_assert(sizeof(SceNpId) == 0x24, "SceNpId is an invalid size");
 
 struct CommunicationID {
     char data[9];


### PR DESCRIPTION
Old implementation is just wrong and causes segfault in some cases. Implement it according RE.