### PR TITLE
ci: Limit concurrent execution of create-release jobs to prevent bugs

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -189,6 +189,9 @@ jobs:
       matrix:
         repo: [master, store]
     runs-on: ubuntu-latest
+    concurrency:
+      group: create-release
+      cancel-in-progress: false
     if: |
       github.ref == 'refs/heads/master' &&
       github.repository == 'Vita3K/Vita3K'
@@ -243,7 +246,7 @@ jobs:
           ls -al artifacts/
           wget -c https://github.com/tcnksm/ghr/releases/download/v0.17.0/ghr_v0.17.0_linux_amd64.tar.gz
           tar xfv ghr_v0.17.0_linux_amd64.tar.gz
-          ghr_v0.17.0_linux_amd64/ghr -u Vita3K -r Vita3K -recreate -replace -n 'Automatic CI builds' -b "$(printf "Corresponding commit: ${{ github.sha }}\nVita3K Build: ${{ env.Build_Variable }}")" continuous artifacts/
+          ghr_v0.17.0_linux_amd64/ghr -u Vita3K -r Vita3K -recreate -n 'Automatic CI builds' -b "$(printf "Corresponding commit: ${{ github.sha }}\nVita3K Build: ${{ env.Build_Variable }}")" continuous artifacts/
         if: matrix.repo == 'master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Requested by @Zangetsu38.
Limit concurrent execution of create-release jobs to prevent bugs.
Also removes the `replace` option that was useless to fix the bug.