### PR TITLE
shader/translator/texture: Ignore lod mode bias unimplemented.

### DIFF
--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -201,12 +201,6 @@ bool USSETranslatorVisitor::smp(
     Imm7 src0_n,
     Imm7 src1_n,
     Imm7 src2_n) {
-    // LOD mode: none, bias, replace, gradient
-    if ((lod_mode != 0) && (lod_mode != 2) && (lod_mode != 3)) {
-        LOG_ERROR("Sampler LOD replace not implemented!");
-        return true;
-    }
-
     // Decode src0
     Instruction inst;
     inst.opr.src0 = decode_src0(inst.opr.src0, src0_n, src0_bank, src0_ext, true, 8, m_second_program);
@@ -341,7 +335,12 @@ bool USSETranslatorVisitor::smp(
             inst.opr.src2 = decode_src12(inst.opr.src2, src2_n, src2_bank, src2_ext, true, 8, m_second_program);
             inst.opr.src2.type = inst.opr.src0.type;
 
+            // LOD mode: none, bias, replace, gradient
             switch (lod_mode) {
+            case 1:
+                LOG_ERROR("Sampler LOD bias not implemented!");
+                break;
+
             case 2:
                 extra1 = load(inst.opr.src2, 0b1);
                 break;


### PR DESCRIPTION
# About 
- shader/translator/texture: Ignore lod mode bias unimplemented.
Fix texture missing on one game

Problem on this game founded by @saturnsky with game using lod_mod 1, and current code literally skip using texture of shader only because lod mode bias is not impelented, no have sense.
Lod detail level relate distance is not very importante in computer compare psvita
But so yes, need implement it on days...

# Result
- Before
![image](https://github.com/user-attachments/assets/fb6a587d-f566-41d1-b7fc-5f126858a0d5)
- After
![image](https://github.com/user-attachments/assets/d9467243-ae21-4feb-ab01-b7aaddcd8677)