### PR TITLE
ci: use ubuntu-22.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   format-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,16 +19,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
         config: [Release]
         version: [zip, appimage]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             version: appimage
             cache_path: ~/.ccache
             extra_cmake_args: -DLINUXDEPLOY_COMMAND=/usr/local/bin/linuxdeploy-x86_64.AppImage
             cmake_preset: linux-ninja-clang-appimage
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             version: zip
             cache_path: ~/.ccache
             cmake_preset: linux-ninja-clang
@@ -64,13 +64,13 @@ jobs:
           ccache --set-config=compiler_check=content
         if: matrix.os == 'macos-latest'
 
-      - name: Set up build environment (ubuntu-latest)
+      - name: Set up build environment (ubuntu-22.04)
         run: |
           sudo add-apt-repository -y ppa:mhier/libboost-latest
           sudo add-apt-repository universe
           sudo apt update
           sudo apt -y install ccache libboost-filesystem1.83-dev libboost-program-options1.83-dev libboost-system1.83-dev libgtk-3-dev libsdl2-dev ninja-build libfuse2
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
 
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
@@ -88,7 +88,7 @@ jobs:
           choco install ccache
         if: matrix.os == 'windows-latest'
 
-      - name: Set up SDL 2.30.9 (ubuntu-latest)
+      - name: Set up SDL 2.30.9 (ubuntu-22.04)
         run: |
           SDL2VER=2.30.9
           if [[ ! -e ~/.ccache ]]; then
@@ -104,16 +104,16 @@ jobs:
             rm SDL2-${SDL2VER}.tar.gz
           fi
           sudo make -C SDL2-${SDL2VER} install
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
 
-      - name: Set up linuxdeploy (ubuntu-latest, appimage)
+      - name: Set up linuxdeploy (ubuntu-22.04, appimage)
         run: |
           if [[ ! -e linuxdeploy-x86_64.AppImage ]]; then
             curl -sLO https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-x86_64.AppImage
           fi
           sudo cp -f linuxdeploy-x86_64.AppImage /usr/local/bin/
           sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
-        if: matrix.os == 'ubuntu-latest' && matrix.version == 'appimage'
+        if: matrix.os == 'ubuntu-22.04' && matrix.version == 'appimage'
 
       - name: Ccache setup
         run: ccache -z
@@ -134,7 +134,7 @@ jobs:
       - name: Set Build Variable
         shell: bash
         run: echo "build_variable=$(git rev-list HEAD --count)" >> $GITHUB_ENV
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
 
       - name: Bundle Shared Objects
         id: bundle_shared_objects
@@ -142,7 +142,7 @@ jobs:
             cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
             cp /usr/lib/x86_64-linux-gnu/libssl.so.3 ./libssl.so.3
             cp /usr/lib/x86_64-linux-gnu/libcrypto.so.3 ./libcrypto.so.3
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
 
       - name: Ccache statistics
         run: ccache -s  
@@ -162,14 +162,14 @@ jobs:
           rm -rf Vita3K.app
         if: matrix.os == 'macos-latest'
 
-      - name: Clean appimage build (ubuntu-latest, appimage)
+      - name: Clean appimage build (ubuntu-22.04, appimage)
         run: |
           cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
           cp -f *AppImage* ../
           rm -rf ./*
           cp -f ../*AppImage* ./
           rm -f ../*AppImage*
-        if: matrix.os == 'ubuntu-latest' && matrix.version == 'appimage'
+        if: matrix.os == 'ubuntu-22.04' && matrix.version == 'appimage'
 
       - uses: actions/upload-artifact@v4
         with:
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         repo: [master, store]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     concurrency:
       group: create-release
       cancel-in-progress: false
@@ -221,13 +221,13 @@ jobs:
         shell: bash
         run: |
           mkdir artifacts/
-          files=$(find . -name "*latest")
+          files=$(find . \( -name "*latest" -o -name "ubuntu-22.04" \))
           for f in $files; do
             if [[ $f == *macos-latest ]]
             then
               cp $(basename $f)/$(basename $f).dmg artifacts/macos-latest.dmg
             else
-              if [[ $f == *ubuntu-latest ]]
+              if [[ $f == *ubuntu-22.04 ]]
               then
                 if [[ $f == *appimage* ]]
                 then
@@ -255,13 +255,13 @@ jobs:
         shell: bash
         run: |
           mkdir artifacts/
-          files=$(find . -name "*latest")
+          files=$(find . \( -name "*latest" -o -name "ubuntu-22.04" \))
           for f in $files; do
             if [[ $f == *macos-latest ]]
             then
               cp $(basename $f)/$(basename $f).dmg artifacts/vita3k-${{ env.Build_Variable }}-${{ env.Short_SHA }}_macos.dmg
             else
-              if [[ $f == *ubuntu-latest ]]
+              if [[ $f == *ubuntu-22.04 ]]
               then
                 if [[ $f == *appimage* ]]
                 then


### PR DESCRIPTION
The `ubuntu-latest` CI was just changed today to use ubuntu 24.04. This had the effect of breaking normal linux operation due to it being built with a newer version of libc than we previously targeted. The libc version on 24.04 is not backwards compatible with 22.04, so the binary could not be run on 22.04-based systems.

Ubuntu 22.04 will be supported by Canonical until 2027, though GitHub may end its support sooner (though this is doubtful seeing as they still have a 20.04 runner, and non-LTS 20.04 support is to be axed in April 2025).

I'm like 98% sure this won't change the artifact names due to how it handles it with basename/cut, so nothing else SHOULD need changed in response to this PR.