### PR TITLE
Fix GDB remote connection

### DIFF
--- a/vita3k/gdbstub/src/gdb.cpp
+++ b/vita3k/gdbstub/src/gdb.cpp
@@ -696,7 +696,8 @@ constexpr bool cmp_less(T t, U u) noexcept {
 }
 
 static bool command_begins_with(PacketCommand &command, const std::string_view small_str) {
-    if (!cmp_less(small_str.size(), command.content_length))
+    //If the command's content is shorter than small_str, it can't match
+    if (static_cast<size_t>(command.content_length) < small_str.size())
         return false;
 
     return std::memcmp(command.content_start, small_str.data(), small_str.size()) == 0;
@@ -737,8 +738,10 @@ static int64_t server_next(EmuEnvState &state) {
 
             PacketCommand command = parse_command(buffer + a, length - a);
             if (command.is_valid) {
+                bool found_command = false;
                 for (const auto &function : functions) {
                     if (command_begins_with(command, function.name)) {
+                        found_command = true;
                         LOG_GDB("GDB Server Recognized Command as {}. {}", function.name,
                             std::string(command.content_start, command.content_length));
                         state.gdb.last_reply = function.function(state, command);
@@ -748,8 +751,11 @@ static int64_t server_next(EmuEnvState &state) {
                         break;
                     }
                 }
-                LOG_GDB("GDB Server Unrecognized Command. {}", std::string(command.content_start, command.content_length));
-
+                if (!found_command) {
+                    LOG_GDB("GDB Server Unrecognized Command. {}", std::string(command.content_start, command.content_length));
+                    state.gdb.last_reply = "";
+                    server_reply(state.gdb, state.gdb.last_reply.c_str());
+                }
                 a += command.content_length + 3;
 
             } else {

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -299,6 +299,8 @@ bool ThreadState::run_loop() {
             something_to_do.wait(lock);
             break;
         case ThreadToDo::suspend:
+            update_status(ThreadStatus::suspend);
+            something_to_do.wait(lock);
             break;
         }
     }


### PR DESCRIPTION
The change in thread.cpp allows the thread to be resumed by the GDB stub correctly by registering the thread as suspended. This also reduces CPU usage as the thread isn't just running when it's supposed to be suspended.

GDB command matching now won't find a match with just any command that contains the first letter if the command is shorter than what is passed. This was a problem when just sending 'q' and it would find a match with longer commands that started with 'q'.  Lastly, arm-vita-eabi-gdb would complain that unrecognized commands were received and then hang. This was due to some double parsing being caused by calling 
`LOG_GDB("GDB Server Unrecognized Command. {}", std::string(command.content_start, command.content_length));`
even after finding a matching command.