### PR TITLE
main: restore serialize_config removed by #2932

### DIFF
--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -225,6 +225,7 @@ int main(int argc, char *argv[]) {
                 } else
                     return QuitRequested;
             }
+            config::serialize_config(emuenv.cfg, emuenv.config_path);
             run_execv(argv, emuenv);
         }
         gui::init(gui, emuenv);


### PR DESCRIPTION
Without this line, a fresh install of the emulator will never boot to the main app select screen. Tested on Linux.