### PR TITLE
ngs: Fix attempts to allocate huge amounts of memory causing the process to freeze.

### DIFF
--- a/vita3k/ngs/src/modules/atrac9.cpp
+++ b/vita3k/ngs/src/modules/atrac9.cpp
@@ -185,7 +185,7 @@ bool Atrac9Module::decode_more_data(KernelState &kern, const MemState &mem, cons
         const uint32_t samples_left_after = (frame_bytes_gotten / superframe_size - 1) * samples_per_superframe;
         if (bufparam.samples_discard_end_off > samples_left_after) {
             // last chunk
-            decoded_size -= bufparam.samples_discard_end_off;
+            decoded_size -= std::min(decoded_size, bufparam.samples_discard_end_off - samples_left_after);
         }
     }
 


### PR DESCRIPTION
- `uint32_t decoded_size` may overflow to a very large number by subtracting a number larger than itself, which causes `data.extra_storage.resize(curr_pos + decoded_size * sizeof(float) * 2)` to try to allocate huge amounts of memory (and the process freezes as a result).
- I'm not actually sure if I wrote it correctly this way, I just referenced the previous line of code, but judging by the results, it works fine.