### PR TITLE
util/log.h: Fix log_hex

### DIFF
--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -99,7 +99,7 @@ std::string log_hex(T val) {
     using unsigned_type = typename std::make_unsigned<T>::type;
     std::stringstream ss;
     ss << "0x";
-    ss << std::hex << static_cast<unsigned_type>(val);
+    ss << std::hex << std::to_string(static_cast<unsigned_type>(val));
     return ss.str();
 }
 
@@ -124,6 +124,6 @@ template <typename T>
 std::string log_hex_full(T val) {
     std::stringstream ss;
     ss << "0x";
-    ss << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex << val;
+    ss << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex << std::to_string(val);
     return ss.str();
 }


### PR DESCRIPTION
The `uint_8t` is internally `unsigned char`, so in the example below it is recognised as an ASCII code 3 and displayed incorrectly; converting it once to a string fixes this.
Before:
![image](https://github.com/user-attachments/assets/51447682-ad75-400b-b966-2b86d859c447)

After:
![image](https://github.com/user-attachments/assets/631c1ad1-eb8d-4bd3-a9a7-570fa2ece36f)
