### PR TITLE
renderer/vulkan: Ensure that the std::thread object is destroyed properly.

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -281,7 +281,7 @@ struct VKContext : public renderer::Context {
 
     explicit VKContext(VKState &state, MemState &mem);
     // TODO: properly destroy the context
-    ~VKContext() override = default;
+    ~VKContext() override;
 
     void start_recording();
     void start_render_pass(bool create_descriptor_set = true);

--- a/vita3k/renderer/src/vulkan/creation.cpp
+++ b/vita3k/renderer/src/vulkan/creation.cpp
@@ -149,6 +149,11 @@ VKContext::VKContext(VKState &state, MemState &mem)
     }
 }
 
+VKContext::~VKContext() {
+    if (gpu_request_wait_thread.joinable())
+        gpu_request_wait_thread.join();
+}
+
 VKRenderTarget::VKRenderTarget(VKState &state, const SceGxmRenderTargetParams &params)
     : color(static_cast<uint32_t>(params.width * state.res_multiplier), static_cast<uint32_t>(params.height * state.res_multiplier), vk::Format::eR8G8B8A8Unorm)
     , depthstencil(static_cast<uint32_t>(params.width * state.res_multiplier), static_cast<uint32_t>(params.height * state.res_multiplier), vk::Format::eD32SfloatS8Uint) {


### PR DESCRIPTION
- Ensure that `VKContext::gpu_request_wait_thread` is not joinable when the `VKContext` object is destroyed. (RAII)