### PR TITLE
Revert #3514

### DIFF
--- a/vita3k/renderer/src/texture/cache.cpp
+++ b/vita3k/renderer/src/texture/cache.cpp
@@ -330,7 +330,7 @@ void TextureCache::upload_texture(const SceGxmTexture &gxm_texture, MemState &me
     const SceGxmTextureBaseFormat base_format = gxm::get_base_format(fmt);
 
     if (base_format == SCE_GXM_TEXTURE_BASE_FORMAT_YUV422) {
-        LOG_ERROR_ONCE("Unimplemented YUV format {}, please report it to the developers.", log_hex(fmt::underlying(base_format)));
+        LOG_ERROR_ONCE("Unimplemented YUV format 0x{:0X}, please report it to the developers.", fmt::underlying(base_format));
         return;
     }
 

--- a/vita3k/renderer/src/texture/replacement.cpp
+++ b/vita3k/renderer/src/texture/replacement.cpp
@@ -205,7 +205,7 @@ void TextureCache::export_texture_impl(SceGxmTextureBaseFormat base_format, uint
             apply_swizzle_4<uint16_t, 5, 5, 5, 1>(pixels, data_unswizzled.data(), nb_pixels, alpha_is_1, swap_rb);
             break;
         default:
-            LOG_ERROR("Unhandled swizzle for texture format {}, please report it to the developers.", log_hex(fmt::underlying(base_format)));
+            LOG_ERROR("Unhandled swizzle for texture format 0x{:0X}, please report it to the developers.", fmt::underlying(base_format));
             return;
         }
 
@@ -332,7 +332,7 @@ void TextureCache::export_texture_impl(SceGxmTextureBaseFormat base_format, uint
             break;
         }
         default:
-            LOG_ERROR("Unhandled format for png exportation {}, please report it to the developers.", log_hex(fmt::underlying(base_format)));
+            LOG_ERROR("Unhandled format for png exportation 0x{:0X}, please report it to the developers.", fmt::underlying(base_format));
             return;
         }
 

--- a/vita3k/renderer/src/transfer.cpp
+++ b/vita3k/renderer/src/transfer.cpp
@@ -143,13 +143,13 @@ COMMAND(handle_transfer_copy) {
     SceGxmTransferType dst_type = helper.pop<SceGxmTransferType>();
 
     if (src_fmt != dst_fmt) {
-        LOG_ERROR_ONCE("Unhandled format conversion from {} to {}", log_hex(fmt::underlying(src_fmt)), log_hex(fmt::underlying(dst_fmt)));
+        LOG_ERROR_ONCE("Unhandled format conversion from 0x{:0X} to 0x{:0X}", fmt::underlying(src_fmt), fmt::underlying(dst_fmt));
         delete[] images;
         return;
     }
 
     if (colorKeyMode != SCE_GXM_TRANSFER_COLORKEY_NONE && src_fmt != SCE_GXM_TRANSFER_FORMAT_U8U8U8U8_ABGR) {
-        LOG_ERROR_ONCE("Transfer copy with non-zero key mask not handled for format {}", log_hex(fmt::underlying(src_fmt)));
+        LOG_ERROR_ONCE("Transfer copy with non-zero key mask not handled for format 0x{:0X}", fmt::underlying(src_fmt));
     }
 
     vulkan::CallbackRequestFunction copy_operation = [=, &mem]() {
@@ -199,7 +199,7 @@ COMMAND(handle_transfer_downscale) {
     SceGxmTransferImage *dst = helper.pop<SceGxmTransferImage *>();
 
     if (src->format != dst->format) {
-        LOG_ERROR_ONCE("Unhandled format conversion from {} to {}", log_hex(fmt::underlying(src->format)), log_hex(fmt::underlying(dst->format)));
+        LOG_ERROR_ONCE("Unhandled format conversion from 0x{:0X} to 0x{:0X}", fmt::underlying(src->format), fmt::underlying(dst->format));
         return;
     }
 
@@ -233,7 +233,7 @@ COMMAND(handle_transfer_downscale) {
             // use ffmpeg with the avg filter
             SwsContext *ctx = sws_getContext(src->width, src->height, pixel_fmt, dst->width, dst->height, pixel_fmt, SWS_AREA, nullptr, nullptr, nullptr);
             if (ctx == nullptr) {
-                LOG_ERROR("Failed to get ffmpeg context for format {}", log_hex(fmt::underlying(src->format)));
+                LOG_ERROR("Failed to get ffmpeg context for format 0x{:0X}", fmt::underlying(src->format));
             } else {
                 sws_scale(ctx, &src_ptr, &src->stride, 0, src->height, &dst_ptr, &dst->stride);
                 sws_freeContext(ctx);
@@ -268,7 +268,7 @@ COMMAND(handle_transfer_downscale) {
                 break;
             default:
                 // should not happen
-                LOG_ERROR("Unhandled format {}", log_hex(fmt::underlying(src->format)));
+                LOG_ERROR("Unhandled format 0x{:0X}", fmt::underlying(src->format));
                 break;
             }
         }

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -158,7 +158,7 @@ static spv::Id get_type_basic(spv::Builder &b, const Input &input) {
 
     // clang-format on
     default: {
-        LOG_ERROR("Unsupported parameter type {} used in shader.", log_hex(fmt::underlying(input.type)));
+        LOG_ERROR("Unsupported parameter type 0x{:0X} used in shader.", fmt::underlying(input.type));
         return get_type_fallback(b);
     }
     }

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -685,7 +685,7 @@ spv::Id unpack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureStat
         return b.createFunctionCall(utils.unpack_fx10, { scalar });
     }
     default: {
-        LOG_ERROR("Unsupported unpack type: {}", log_hex(type));
+        LOG_ERROR("Unsupported unpack type: 0x{:0X}", fmt::underlying(type));
         break;
     }
     }
@@ -714,7 +714,7 @@ spv::Id pack_one(spv::Builder &b, SpirvUtilFunctions &utils, const FeatureState 
     }
 
     default: {
-        LOG_ERROR("Unsupported pack type: {}", log_hex(fmt::underlying(source_type)));
+        LOG_ERROR("Unsupported pack type: 0x{:0X}", fmt::underlying(source_type));
         break;
     }
     }

--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -99,7 +99,7 @@ std::string log_hex(T val) {
     using unsigned_type = typename std::make_unsigned<T>::type;
     std::stringstream ss;
     ss << "0x";
-    ss << std::hex << std::to_string(static_cast<unsigned_type>(val));
+    ss << std::hex << static_cast<unsigned_type>(val);
     return ss.str();
 }
 
@@ -124,6 +124,6 @@ template <typename T>
 std::string log_hex_full(T val) {
     std::stringstream ss;
     ss << "0x";
-    ss << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex << std::to_string(val);
+    ss << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex << val;
     return ss.str();
 }

--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -89,6 +89,7 @@ ExitCode add_sink(const fs::path &log_path);
 
 /*
     returns: A string with the input number formatted in hexadecimal
+    FIXME: Make this available to uint8_t
     Examples:
         * `12` returns: `"0xC"`
         * `1337` returns: `"0x539"`
@@ -105,6 +106,7 @@ std::string log_hex(T val) {
 
 /*
     returns: A string with the input number formatted in hexadecimal with padding of the inputted type size
+    FIXME: Make this available to uint8_t
     Examples:
         * `uint8_t 5` returns: `"0x05"`
         * `uint8_t 15` returns: `"0x0F"`
@@ -113,7 +115,6 @@ std::string log_hex(T val) {
         * `uint16_t 15` returns: `"0x000F"`
         * `uint16_t 1337` returns: `"0x0539"`
         * `uint16_t 65535` returns: `"0xFFFF"`
-
 
         * `uint32_t 15` returns: `"0x0000000F"`
         * `uint32_t 1337` returns: `"0x00000539"`


### PR DESCRIPTION
log_hex is broken by #3514, so revert it.
Also avoid using log_hex where fmt is used.