### PR TITLE
gui/renderer: Replace sscanf when not parsing a complex string

### DIFF
--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -820,12 +820,12 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
                 std::vector<ImVec4> str_color;
 
                 if (!str_tag.color.empty()) {
-                    unsigned int color = 0xFFFFFFFF;
+                    uint32_t color = 0xFF'FF'FF'FF;
 
                     if (frame.autoflip)
-                        sscanf(str[app_path][frame.id][current_item[app_path][frame.id]].color.c_str(), "#%x", &color);
+                        std::istringstream{ str[app_path][frame.id][current_item[app_path][frame.id]].color }.ignore(1, '#') >> std::hex >> color;
                     else
-                        sscanf(str_tag.color.c_str(), "#%x", &color);
+                        std::istringstream{ str_tag.color }.ignore(1, '#') >> std::hex >> color;
 
                     str_color.emplace_back(((color >> 16) & 0xFF) / 255.f, ((color >> 8) & 0xFF) / 255.f, ((color >> 0) & 0xFF) / 255.f, 1.f);
                 } else

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -106,8 +106,7 @@ static ImU32 convert_hex_color(const std::string &src_color) {
     std::string result = src_color.substr(src_color.length() - 6, 6);
     result.insert(0, "ff");
 
-    unsigned int color;
-    sscanf(result.c_str(), "%x", &color);
+    uint32_t color = std::strtoul(result.c_str(), nullptr, 16);
     return (color & 0xFF00FF00u) | ((color & 0x00FF0000u) >> 16u) | ((color & 0x000000FFu) << 16u);
 }
 
@@ -257,8 +256,7 @@ bool init_theme(GuiState &gui, EmuEnvState &emuenv, const std::string &content_i
 
                     // Font Color
                     if (!param.child("m_fontColor").text().empty()) {
-                        unsigned int color;
-                        sscanf(param.child("m_fontColor").text().as_string(), "%x", &color);
+                        uint32_t color = std::strtoul(param.child("m_fontColor").text().as_string(), nullptr, 16);
                         gui.theme_backgrounds_font_color.emplace_back((float((color >> 16) & 0xFF)) / 255.f, (float((color >> 8) & 0xFF)) / 255.f, (float((color >> 0) & 0xFF)) / 255.f, 1.f);
                     }
                 }

--- a/vita3k/renderer/src/texture/replacement.cpp
+++ b/vita3k/renderer/src/texture/replacement.cpp
@@ -604,7 +604,7 @@ void TextureCache::refresh_available_textures() {
                 continue;
 
             uint64_t hash;
-            if (sscanf(file.filename().string().c_str(), "%llX", &hash) != 1)
+            if (!(std::istringstream{ file.filename().string() } >> std::hex >> hash))
                 continue;
 
             if (file.extension() != ".png" && file.extension() != ".dds")


### PR DESCRIPTION
- The use of `sscanf` should be reduced, to improve efficiency and get rid of the cumbersome format specifiers.