### PR TITLE
Add option to use old vita3k install app and firmware method

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -148,6 +148,7 @@ enum ScreenshotFormat {
     code(bool, "display-info-message", false, display_info_message)                                     \
     code(bool, "show-welcome", true, show_welcome)                                                      \
     code(bool, "check-for-updates", true, check_for_updates)                                            \
+    code(bool, "dencrypt-install", true, dencrypt_install)                                              \
     code(bool, "asia-font-support", false, asia_font_support)                                           \
     code(bool, "shader-cache", true, shader_cache)                                                      \
     code(bool, "spirv-shader", false, spirv_shader)                                                     \

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -62,7 +62,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
 
         if (result == host::dialog::filesystem::Result::SUCCESS) {
             std::thread installation([&emuenv]() {
-                fw_version = install_pup(emuenv.pref_path, fs::path(pup_path.native()), progress_callback);
+                fw_version = install_pup(emuenv.pref_path, fs::path(pup_path.native()), progress_callback, emuenv.cfg.dencrypt_install);
                 std::lock_guard<std::mutex> lock(install_mutex);
                 finished_installing = true;
             });

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -200,10 +200,8 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::SetWindowFontScale(RES_SCALE.x);
             draw_firmware_install_dialog(gui, emuenv);
         }
-        if(ImGui::Checkbox(emulator["dencrypt_install"].c_str(), &emuenv.cfg.dencrypt_install)){
-            set_controller_overlay_opacity(emuenv.cfg.overlay_opacity);
+        if(ImGui::Checkbox(emulator["dencrypt_install"].c_str(), &emuenv.cfg.dencrypt_install))
             config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
-        }
         SetTooltipEx(emulator["dencrypt_install_description"].c_str());
         break;
     case SELECT_INTERFACE_SETTINGS:

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -199,6 +199,11 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::SetWindowFontScale(RES_SCALE.x);
             draw_firmware_install_dialog(gui, emuenv);
         }
+        if(ImGui::Checkbox(emulator["dencrypt_install"].c_str(), &emuenv.cfg.dencrypt_install)){
+            set_controller_overlay_opacity(emuenv.cfg.overlay_opacity);
+            config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+        }
+        SetTooltipEx(emulator["dencrypt_install_description"].c_str());
         break;
     case SELECT_INTERFACE_SETTINGS:
         title_str = lang["select_interface_settings"];

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -76,6 +76,7 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 BIG_BUTTON_POS((WINDOW_SIZE.x / 2.f) - (BIG_BUTTON_SIZE.x / 2.f), WINDOW_SIZE.y - BIG_BUTTON_SIZE.y - (20.f * SCALE.y));
 
     auto &lang = gui.lang.initial_setup;
+    auto &emulator = gui.lang.settings_dialog.emulator;
     auto &common = emuenv.common_dialog.lang.common;
 
     const auto is_default_path = emuenv.cfg.pref_path == emuenv.default_path;

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -873,6 +873,9 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Checkbox(lang.emulator["check_for_updates"].c_str(), &emuenv.cfg.check_for_updates);
         SetTooltipEx(lang.emulator["check_for_updates_description"].c_str());
         ImGui::Separator();
+        ImGui::Checkbox(lang.emulator["dencrypt_install"].c_str(), &emuenv.cfg.dencrypt_install);
+        SetTooltipEx(lang.emulator["dencrypt_install_description"].c_str());
+        ImGui::Separator();
         TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang.emulator["performance_overlay"].c_str());
         ImGui::Spacing();
         ImGui::Checkbox(lang.emulator["performance_overlay"].c_str(), &emuenv.cfg.performance_overlay);

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -625,6 +625,8 @@ struct LangState {
             { "log_compat_warn_description", "Check the box to enable log compatibility warning of GitHub issue." },
             { "check_for_updates", "Check for updates" },
             { "check_for_updates_description", "Automatically check for updates at startup." },
+            { "dencrypt_install", "Dencrypt executable when install"},
+            { "dencrypt_install_description", "Dencrypt all files included eboot and libs for compability with older builds (otherwise all installed content will no longer work in older builds)" },
             { "performance_overlay", "Performance overlay" },
             { "performance_overlay_description", "Display performance information on the screen as an overlay." },
             { "minimum", "Minimum" },

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
                 LOG_INFO("Installing firmware file {}", *cfg.pup_path);
                 install_pup(cfg.get_pref_path(), *cfg.pup_path, [](uint32_t progress) {
                     LOG_INFO("Firmware installation progress: {}%", progress);
-                });
+                }, cfg.dencrypt_install);
             }
             if (cfg.pkg_path.has_value() && cfg.pkg_zrif.has_value()) {
                 LOG_INFO("Installing pkg from {} ", *cfg.pkg_path);

--- a/vita3k/packages/include/packages/functions.h
+++ b/vita3k/packages/include/packages/functions.h
@@ -29,5 +29,4 @@
 
 #include <functional>
 #include <string>
-
-std::string install_pup(const fs::path &pref_path, const fs::path &pup_path, const std::function<void(uint32_t)> &progress_callback = nullptr);
+std::string install_pup(const fs::path &pref_path, const fs::path &pup_path, const std::function<void(uint32_t)> &progress_callback = nullptr, const bool is_dencrypt = true);

--- a/vita3k/packages/include/packages/sce_types.h
+++ b/vita3k/packages/include/packages/sce_types.h
@@ -652,6 +652,8 @@ public:
 
 void register_keys(KeyStore &SCE_KEYS, int type);
 void extract_fat(const fs::path &partition_path, const std::string &partition, const fs::path &pref_path);
+void dencrypt_elf_files(const fs::path &pref_path, const fs::path &translated_module_path, std::string &zkey);
+bool is_self(const fs::path &file_path);
 std::string decompress_segments(const std::vector<uint8_t> &decrypted_data, const uint64_t &size);
 std::tuple<uint64_t, SelfType> get_key_type(std::ifstream &file, const SceHeader &sce_hdr);
 std::vector<SceSegment> get_segments(const uint8_t *input, const SceHeader &sce_hdr, KeyStore &SCE_KEYS, uint64_t sysver = -1, SelfType self_type = static_cast<SelfType>(0), int keytype = 0, const uint8_t *klic = 0);

--- a/vita3k/packages/src/pkg.cpp
+++ b/vita3k/packages/src/pkg.cpp
@@ -72,6 +72,12 @@ bool decrypt_install_nonpdrm(EmuEnvState &emuenv, const fs::path &drmlicpath, co
     fs::remove_all(title_id_src);
     fs::rename(title_id_dst, title_id_src);
 
+    if(emuenv.cfg.dencrypt_install){
+        for (const auto &file : fs::recursive_directory_iterator(title_id_src)) {
+            if (is_self(file.path()))
+                dencrypt_elf_files(emuenv.pref_path, file.path(), zRIF);
+        }
+    }
     return true;
 }
 
@@ -313,6 +319,12 @@ bool install_pkg(const fs::path &pkg_path, EmuEnvState &emuenv, std::string &p_z
         fs::remove_all(title_id_src);
         fs::rename(title_id_dst, title_id_src);
 
+        if(emuenv.cfg.dencrypt_install){
+            for (const auto &file : fs::recursive_directory_iterator(title_id_src)) {
+                if (is_self(file.path()))
+                    dencrypt_elf_files(emuenv.pref_path, file.path(), zRIF);
+            }
+        }
         break;
     case PkgType::PKG_TYPE_VITA_DLC:
 

--- a/vita3k/packages/src/sce_utils.cpp
+++ b/vita3k/packages/src/sce_utils.cpp
@@ -703,7 +703,7 @@ void dencrypt_elf_files(const fs::path &pref_path, const fs::path &translated_mo
         file_dec = decrypt_fself(std::move(file_dec), temp_klicensee.data());
     }
     
-    LOG_INFO("Decrypted {}", translated_module_path.c_str());
+    LOG_INFO("Decrypted {}", translated_module_path);
     fs::ofstream d{ translated_module_path, fs::ofstream::binary };
     if (!d){
         LOG_ERROR("Failed to open output {}", translated_module_path);

--- a/vita3k/packages/src/sce_utils.cpp
+++ b/vita3k/packages/src/sce_utils.cpp
@@ -22,6 +22,9 @@
 
 #include <fat16/fat16.h>
 #include <miniz.h>
+#include <io/device.h>
+#include <io/state.h>
+#include <io/vfs.h>
 #include <openssl/evp.h>
 #include <packages/sce_types.h>
 #include <util/string_utils.h>

--- a/vita3k/packages/src/sce_utils.cpp
+++ b/vita3k/packages/src/sce_utils.cpp
@@ -692,7 +692,7 @@ void dencrypt_elf_files(const fs::path &pref_path, const fs::path &translated_mo
     f.close();
     
     if (file_dec.empty()) {
-        LOG_ERROR("Failed to decrypt {}", translated_module_path.c_str());
+        LOG_ERROR("Failed to decrypt {}", translated_module_path);
         return;
     }else if (zkey == "pup"){
         file_dec = decrypt_fself(std::move(file_dec), 0);


### PR DESCRIPTION
Add option to install app / firmware in unencrypted like old version vita3k, so app can run in old version vita3k (before this pr : https://github.com/Vita3K/Vita3K/pull/3459 ) without reinstall again

![Screenshot_20250313_231440_Vita3K ZX](https://github.com/user-attachments/assets/c7649f1e-8fd0-4800-bf20-65dbc831d54d)
