### PR TITLE
Initial Support Linux aarch64 ci for Appimage and zip

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-latest, macos-latest]
         config: [Release]
         version: [zip, appimage]
         include:
@@ -29,6 +29,15 @@ jobs:
             extra_cmake_args: -DLINUXDEPLOY_COMMAND=/usr/local/bin/linuxdeploy-x86_64.AppImage
             cmake_preset: linux-ninja-clang-appimage
           - os: ubuntu-22.04
+            version: zip
+            cache_path: ~/.ccache
+            cmake_preset: linux-ninja-clang
+          - os: ubuntu-22.04-arm
+            version: appimage
+            cache_path: ~/.ccache
+            extra_cmake_args: -DLINUXDEPLOY_COMMAND=/usr/local/bin/linuxdeploy-aarch64.AppImage
+            cmake_preset: linux-ninja-clang-appimage
+          - os: ubuntu-22.04-arm
             version: zip
             cache_path: ~/.ccache
             cmake_preset: linux-ninja-clang
@@ -50,6 +59,7 @@ jobs:
             version: appimage
           - os: windows-latest
             version: appimage
+          
 
     steps:
       - uses: actions/checkout@v4
@@ -64,13 +74,21 @@ jobs:
           ccache --set-config=compiler_check=content
         if: matrix.os == 'macos-latest'
 
-      - name: Set up build environment (ubuntu-22.04)
+      - name: Set up build environment for (ubuntu-22.04)
         run: |
+         #easy update clang linux os from external reppo for number == clang version
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x ./llvm.sh
+          sudo ./llvm.sh 15
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100
+          sudo update-alternatives --set clang /usr/bin/clang-15
+          sudo update-alternatives --set clang++ /usr/bin/clang++-15  
           sudo add-apt-repository -y ppa:mhier/libboost-latest
           sudo add-apt-repository universe
           sudo apt update
           sudo apt -y install ccache libboost-filesystem1.83-dev libboost-program-options1.83-dev libboost-system1.83-dev libgtk-3-dev libsdl2-dev ninja-build libfuse2
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
 
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
@@ -88,7 +106,7 @@ jobs:
           choco install ccache
         if: matrix.os == 'windows-latest'
 
-      - name: Set up SDL 2.30.9 (ubuntu-22.04)
+      - name: Set up SDL 2.30.9  (ubuntu-22.04)
         run: |
           SDL2VER=2.30.9
           if [[ ! -e ~/.ccache ]]; then
@@ -104,9 +122,9 @@ jobs:
             rm SDL2-${SDL2VER}.tar.gz
           fi
           sudo make -C SDL2-${SDL2VER} install
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
 
-      - name: Set up linuxdeploy (ubuntu-22.04, appimage)
+      - name: Set up linuxdeploy x86-64 (ubuntu-22.04, appimage)
         run: |
           if [[ ! -e linuxdeploy-x86_64.AppImage ]]; then
             curl -sLO https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-x86_64.AppImage
@@ -114,6 +132,15 @@ jobs:
           sudo cp -f linuxdeploy-x86_64.AppImage /usr/local/bin/
           sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
         if: matrix.os == 'ubuntu-22.04' && matrix.version == 'appimage'
+
+      - name: Set up linuxdeploy aarch64 (ubuntu-22.04-arm, appimage)
+        run: |
+          if [[ ! -e linuxdeploy-aarch64.AppImage ]]; then
+            curl -sLO https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-aarch64.AppImage
+          fi
+          sudo cp -f linuxdeploy-aarch64.AppImage /usr/local/bin/
+          sudo chmod +x /usr/local/bin/linuxdeploy-aarch64.AppImage
+        if: matrix.os == 'ubuntu-22.04-arm' && matrix.version == 'appimage'
 
       - name: Ccache setup
         run: ccache -z
@@ -134,15 +161,23 @@ jobs:
       - name: Set Build Variable
         shell: bash
         run: echo "build_variable=$(git rev-list HEAD --count)" >> $GITHUB_ENV
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
 
-      - name: Bundle Shared Objects
-        id: bundle_shared_objects
+      - name: Bundle Shared Objects (x86-64)
+        id: bundle_shared_objects_x86_64
         run: |
             cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
             cp /usr/lib/x86_64-linux-gnu/libssl.so.3 ./libssl.so.3
             cp /usr/lib/x86_64-linux-gnu/libcrypto.so.3 ./libcrypto.so.3
         if: matrix.os == 'ubuntu-22.04'
+
+      - name: Bundle Shared Objects (aarch64)
+        id: bundle_shared_objects_aarch64
+        run: |
+            cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
+            cp /usr/lib/aarch64-linux-gnu/libssl.so.3 ./libssl.so.3
+            cp /usr/lib/aarch64-linux-gnu/libcrypto.so.3 ./libcrypto.so.3
+        if: matrix.os == 'ubuntu-22.04-arm'
 
       - name: Ccache statistics
         run: ccache -s  
@@ -162,7 +197,7 @@ jobs:
           rm -rf Vita3K.app
         if: matrix.os == 'macos-latest'
 
-      - name: Clean appimage build (ubuntu-22.04, appimage)
+      - name: Clean appimage x86-64 build (ubuntu-22.04, appimage)
         run: |
           cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
           cp -f *AppImage* ../
@@ -171,12 +206,22 @@ jobs:
           rm -f ../*AppImage*
         if: matrix.os == 'ubuntu-22.04' && matrix.version == 'appimage'
 
+      - name: Clean appimage aarch64 build (ubuntu-22.04-arm, appimage)
+        run: |
+          cd build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
+          cp -f *AppImage* ../
+          rm -rf ./*
+          cp -f ../*AppImage* ./
+          rm -f ../*AppImage*
+        if: matrix.os == 'ubuntu-22.04-arm' && matrix.version == 'appimage'
+
       - uses: actions/upload-artifact@v4
         with:
           name: vita3k-${{ env.git_short_sha }}-${{ matrix.version }}-${{ matrix.os }}
           # path is set up to be <binary_dir>/bin/<config_type> since that's how multi-config
           # generators work on CMake
           path: build/${{ matrix.cmake_preset }}/bin/${{ matrix.config }}
+
 
     outputs:
       BuildTag: ${{ env.build_variable }}
@@ -221,26 +266,34 @@ jobs:
         shell: bash
         run: |
           mkdir artifacts/
-          files=$(find . \( -name "*latest" -o -name "*22.04" \))
+          files=$(find . \( -name "*latest" -o -name "*22.04*" \))
           for f in $files; do
             if [[ $f == *macos-latest ]]
             then
               cp $(basename $f)/$(basename $f).dmg artifacts/macos-latest.dmg
-            else
-              if [[ $f == *ubuntu-22.04 ]]
+            elif [[ $f == *ubuntu-22.04 ]]
+            then
+              if [[ $f == *appimage* ]]
               then
-                if [[ $f == *appimage* ]]
-                then
-                  cp $(basename $f)/*.AppImage* artifacts/
-                else
-                  rm -f $(basename $f)/*.AppImage*
-                  echo "Compressing $f"
-                  (cd $(basename $f) && zip -r ../artifacts/$(basename $f  | cut -d "-" -f 4)-latest.zip *)
-                fi
+                cp $(basename $f)/*.AppImage* artifacts/
               else
+                rm -f $(basename $f)/*.AppImage*
                 echo "Compressing $f"
-                (cd $(basename $f) && zip -r ../artifacts/$(basename $f  | cut -d "-" -f 4)-latest.zip *)
+                (cd $(basename $f) && zip -r ../artifacts/$(basename $f | cut -d "-" -f 4)-x86-64-latest.zip *)
               fi
+            elif [[ $f == *ubuntu-22.04-arm ]]
+            then
+              if [[ $f == *appimage* ]]
+              then
+                cp $(basename $f)/*.AppImage* artifacts/
+              else
+                rm -f $(basename $f)/*.AppImage*
+                echo "Compressing $f"
+                (cd $(basename $f) && zip -r ../artifacts/$(basename $f | cut -d "-" -f 4)-aarch64-latest.zip *)
+              fi
+            else
+              echo "Compressing $f"
+              (cd $(basename $f) && zip -r ../artifacts/$(basename $f | cut -d "-" -f 4)-latest.zip *)
             fi
           done
           ls -al artifacts/
@@ -255,26 +308,34 @@ jobs:
         shell: bash
         run: |
           mkdir artifacts/
-          files=$(find . \( -name "*latest" -o -name "*22.04" \))
+          files=$(find . \( -name "*latest" -o -name "*22.04*" \))
           for f in $files; do
             if [[ $f == *macos-latest ]]
             then
               cp $(basename $f)/$(basename $f).dmg artifacts/vita3k-${{ env.Build_Variable }}-${{ env.Short_SHA }}_macos.dmg
-            else
-              if [[ $f == *ubuntu-22.04 ]]
+            elif [[ $f == *ubuntu-22.04 ]]
+            then
+              if [[ $f == *appimage* ]]
               then
-                if [[ $f == *appimage* ]]
-                then
-                  cp $(basename $f)/*.AppImage* artifacts/
-                else
-                  rm -f $(basename $f)/*.AppImage*
-                  echo "Compressing $f"
-                  7z a -mx=9 artifacts/vita3k-${{ env.Build_Variable }}-${{ env.Short_SHA }}_ubuntu.7z $(basename $f)
-                fi
+                cp $(basename $f)/*.AppImage* artifacts/
               else
+                rm -f $(basename $f)/*.AppImage*
                 echo "Compressing $f"
-                7z a -mx=9 artifacts/vita3k-${{ env.Build_Variable }}-${{ env.Short_SHA }}_windows.7z $(basename $f)
+                7z a -mx=9 artifacts/vita3k-${{ env.Build_Variable }}-${{ env.Short_SHA }}_ubuntu-x86-64.7z $(basename $f)
               fi
+            elif [[ $f == *ubuntu-22.04-arm ]]
+            then
+              if [[ $f == *appimage* ]]
+              then
+                cp $(basename $f)/*.AppImage* artifacts/
+              else
+                rm -f $(basename $f)/*.AppImage*
+                echo "Compressing $f"
+                7z a -mx=9 artifacts/vita3k-${{ env.Build_Variable }}-${{ env.Short_SHA }}_ubuntu-aarch64.7z $(basename $f)
+              fi
+            else
+              echo "Compressing $f"
+              7z a -mx=9 artifacts/vita3k-${{ env.Build_Variable }}-${{ env.Short_SHA }}_windows.7z $(basename $f)
             fi
           done
           ls -al artifacts/

--- a/appimage/build_updater.sh
+++ b/appimage/build_updater.sh
@@ -3,6 +3,17 @@
 # Note: The documentation at https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/blob/master/README.md for embedding update info is wrong.
 # The correct env-variable name to use is UPDATE_INFORMATION, and *not* LDAI_UPDATE_INFORMATION.
 
-echo "Executing linuxdeploy with cmdline: LDAI_VERBOSE=1 UPDATE_INFORMATION=\"gh-releases-zsync|Vita3K|Vita3K|latest|Vita3K-x86_64.AppImage.zsync\" $@"
 
-LDAI_VERBOSE=1 UPDATE_INFORMATION="gh-releases-zsync|Vita3K|Vita3K|latest|Vita3K-x86_64.AppImage.zsync" $@
+ARCH=$(uname -m)
+
+#detec arch
+if [ "$ARCH" = "x86_64" ]; then
+    UPDATE_INFO="gh-releases-zsync|Vita3K|Vita3K|latest|Vita3K-x86_64.AppImage.zsync"
+elif [ "$ARCH" = "aarch64" ]; then
+    UPDATE_INFO="gh-releases-zsync|Vita3K|Vita3K|latest|Vita3K-aarch64.AppImage.zsync"
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+LDAI_VERBOSE=1 UPDATE_INFORMATION="$UPDATE_INFO" $@

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -154,11 +154,15 @@ static void download_update(const fs::path &base_path) {
     std::thread download([base_path]() {
         std::string download_continuous_link = "https://github.com/Vita3K/Vita3K/releases/download/continuous";
 #ifdef _WIN32
-        download_continuous_link += "/windows-latest.zip";
+    download_continuous_link += "/windows-latest.zip";
 #elif defined(__APPLE__)
-        download_continuous_link += "/macos-latest.dmg";
-#else
-        download_continuous_link += "/ubuntu-latest.zip";
+    download_continuous_link += "/macos-latest.dmg";
+#elif defined(__linux__)
+    #if defined(__x86_64__)
+        download_continuous_link += "/ubuntu-x86-64-latest.zip";
+    #elif defined(__aarch64__)
+        download_continuous_link += "/ubuntu-aarch64-latest.zip";
+    #endif
 #endif
 
 #ifdef __APPLE__

--- a/vita3k/script/update-linux.sh
+++ b/vita3k/script/update-linux.sh
@@ -1,26 +1,42 @@
 #!/bin/sh
+
 echo ============================================================
 echo ====================== Vita3K Updater ======================
 echo ============================================================
+
 # cd to the correct path so the update doesn't happen outside the vita3k dir
-cd $(dirname $(readlink -f "$0"))
+cd "$(dirname "$(readlink -f "$0")")"
+
+# Detect the system architecture
+ARCH=$(uname -m)
+
+# Set the .zip file name based on the architecture
+if [ "$ARCH" = "x86_64" ]; then
+    ZIP_FILE="ubuntu-x86-64-latest.zip"
+elif [ "$ARCH" = "aarch64" ]; then
+    ZIP_FILE="ubuntu-aarch64-latest.zip"
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+fi
 
 boot=0
-if [ ! -e vita3k-latest.zip ]; then
-    echo Checking for Vita3K updates...
-    echo Attempting to download and extract the latest Vita3K version in progress...
-    curl -L https://github.com/Vita3K/Vita3K/releases/download/continuous/ubuntu-latest.zip -o ./vita3k-latest.zip
+if [ ! -e "$ZIP_FILE" ]; then
+    echo "Checking for Vita3K updates..."
+    echo "Attempting to download and extract the latest Vita3K version in progress..."
+    curl -L "https://github.com/Vita3K/Vita3K/releases/download/continuous/$ZIP_FILE" -o "./$ZIP_FILE"
 else
     boot=1
 fi
 
-echo Installing update ...
-unzip -q -o ./vita3k-latest.zip
-rm -f ./vita3k-latest.zip
+echo "Installing update ..."
+unzip -q -o "./$ZIP_FILE"
+rm -f "./$ZIP_FILE"
 chmod +x ./Vita3K
-echo Vita3K updated with success
-if [ $boot -eq 1 ]; then
-    echo start Vita3K
+echo "Vita3K updated with success"
+
+if [ "$boot" -eq 1 ]; then
+    echo "Starting Vita3K..."
     ./Vita3K
 else
     read -p "Press [Enter] key to continue..."


### PR DESCRIPTION
Set clang-15 in linux ci now 
Specifically it's to fix missing features added after clang in aarch64 + gnu13 and fmt chrono broken.
But since we're at it using the link to the official script that will help us in the future. If we need newer clangs, we can do it with a single changing the number 15 to the clang version .
As for Ubuntu x86-64, you'll probably need to download it again because I changed it to ubuntu-x86-64-latest-zip for the design script to differentiate it by architecture.

Test it  .