### PR TITLE
gui: Fix missing Chinese fonts in initial setup screen.

### DIFF
--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -271,7 +271,7 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
                     io.Fonts->AddFontFromFileTTF(fs_utils::path_to_utf8(default_font_path / "mplus-1mn-bold.ttf").c_str(), font_config.SizePixels, &font_config, japanese_and_extra_ranges.Data);
 
                     const auto sys_lang = static_cast<SceSystemParamLang>(emuenv.cfg.sys_lang);
-                    if (sys_lang == SCE_SYSTEM_PARAM_LANG_CHINESE_S)
+                    if (!emuenv.cfg.initial_setup || (sys_lang == SCE_SYSTEM_PARAM_LANG_CHINESE_T) || (sys_lang == SCE_SYSTEM_PARAM_LANG_CHINESE_S))
                         io.Fonts->AddFontFromFileTTF(fs_utils::path_to_utf8(default_font_path / "SourceHanSansSC-Bold-Min.ttf").c_str(), font_config.SizePixels, &font_config, japanese_and_extra_ranges.Data);
                     font_config.MergeMode = false;
 


### PR DESCRIPTION
- This PR is separated from #3505.
- Before this PR, Chinese fonts cannot be loaded when we launch the emulator for the first time, because the default system language is English (US).

> We can see a lot of question marks in the image, these are the characters that are missing from the font.

![image](https://github.com/user-attachments/assets/93d3593e-591e-404e-ab1d-bdf74944edd5)
![image](https://github.com/user-attachments/assets/a6f4b306-d1a3-4fe4-a9a9-52f47d12383f)
