### PR TITLE
Add the run status to sceKernelStartThread immediately after calling it

### DIFF
--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -156,6 +156,7 @@ int ThreadState::start(SceSize arglen, const Ptr<void> argp, bool run_entry_call
         kernel.debugger.wait_for_debugger = false;
     } else {
         to_do = ThreadToDo::run;
+        status = ThreadStatus::run;
     }
     something_to_do.notify_one();
 

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -725,7 +725,7 @@ EXPORT(int, _sceKernelStartThread, SceUID thid, SceSize arglen, Ptr<void> argp) 
     }
 
     std::this_thread::sleep_for(std::chrono::microseconds(1));
-    
+
     return res;
 }
 

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -723,6 +723,9 @@ EXPORT(int, _sceKernelStartThread, SceUID thid, SceSize arglen, Ptr<void> argp) 
     if (res < 0) {
         return RET_ERROR(res);
     }
+
+    std::this_thread::sleep_for(std::chrono::microseconds(1));
+    
     return res;
 }
 

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -723,9 +723,6 @@ EXPORT(int, _sceKernelStartThread, SceUID thid, SceSize arglen, Ptr<void> argp) 
     if (res < 0) {
         return RET_ERROR(res);
     }
-
-    std::this_thread::sleep_for(std::chrono::microseconds(1));
-
     return res;
 }
 


### PR DESCRIPTION
Add a small delay after sceKernelStartThread. If this delay is not put, sceKernelWaitThreadEnd and sceKernelDeleteThread functions which are too close work randomly and many glitches can appear. Tested with Ciel Nosurge Offline, fixes all the random freezes and graphical glitches with 3D models. 1µs is enough with tests I made. However, more tests could be performed to make sure it works properly everywhere since it's a very crucial function.