### PR TITLE
Set a pixel perfect ratio for 16:9 resolutions in fullscreen mode

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -88,6 +88,15 @@ void update_viewport(EmuEnvState &state) {
     if (h > 0) {
         const float window_aspect = static_cast<float>(w) / h;
         const float vita_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / DEFAULT_RES_HEIGHT;
+        float cmp_aspect;
+
+        if (!state.display.fullscreen)
+            cmp_aspect = vita_aspect;
+        else {
+            const float sixteen_nine_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / (DEFAULT_RES_HEIGHT - 4);
+            cmp_aspect = sixteen_nine_aspect;
+        }
+
         if (state.cfg.stretch_the_display_area) {
             // Match the aspect ratio to the screen size.
             state.logical_viewport_size.x = static_cast<SceFloat>(state.window_size.x);
@@ -99,7 +108,7 @@ void update_viewport(EmuEnvState &state) {
             state.drawable_viewport_size.y = static_cast<SceFloat>(state.drawable_size.y);
             state.drawable_viewport_pos.x = 0;
             state.drawable_viewport_pos.y = 0;
-        } else if (window_aspect > vita_aspect) {
+        } else if (window_aspect > cmp_aspect) {
             // Window is wide. Pin top and bottom.
             state.logical_viewport_size.x = state.window_size.y * vita_aspect;
             state.logical_viewport_size.y = static_cast<SceFloat>(state.window_size.y);

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -521,6 +521,7 @@ static void handle_window_event(EmuEnvState &state, const SDL_WindowEvent &event
 
 static void switch_full_screen(EmuEnvState &emuenv) {
     emuenv.display.fullscreen = !emuenv.display.fullscreen;
+    emuenv.renderer->set_fullscreen(emuenv.display.fullscreen);
 
     SDL_SetWindowFullscreen(emuenv.window.get(), emuenv.display.fullscreen.load() ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 

--- a/vita3k/modules/SceDriverUser/SceRtcUser.cpp
+++ b/vita3k/modules/SceDriverUser/SceRtcUser.cpp
@@ -447,7 +447,7 @@ EXPORT(int, sceRtcSetWin32FileTime) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceRtcTickAddDays, SceRtcTick *pTick0, const SceRtcTick *pTick1, SceLong64 lAdd) {
+EXPORT(int, sceRtcTickAddDays, SceRtcTick *pTick0, const SceRtcTick *pTick1, SceInt lAdd) {
     TRACY_FUNC(sceRtcTickAddDays, pTick0, pTick1, lAdd);
     if (pTick0 == nullptr || pTick1 == nullptr) {
         return RET_ERROR(SCE_RTC_ERROR_INVALID_POINTER);
@@ -457,7 +457,7 @@ EXPORT(int, sceRtcTickAddDays, SceRtcTick *pTick0, const SceRtcTick *pTick1, Sce
     return 0;
 }
 
-EXPORT(int, sceRtcTickAddHours, SceRtcTick *pTick0, const SceRtcTick *pTick1, SceLong64 lAdd) {
+EXPORT(int, sceRtcTickAddHours, SceRtcTick *pTick0, const SceRtcTick *pTick1, SceInt lAdd) {
     TRACY_FUNC(sceRtcTickAddHours, pTick0, pTick1, lAdd);
     if (pTick0 == nullptr || pTick1 == nullptr) {
         return RET_ERROR(SCE_RTC_ERROR_INVALID_POINTER);
@@ -529,7 +529,7 @@ EXPORT(int, sceRtcTickAddTicks, SceRtcTick *pTick0, const SceRtcTick *pTick1, Sc
     return 0;
 }
 
-EXPORT(int, sceRtcTickAddWeeks, SceRtcTick *pTick0, const SceRtcTick *pTick1, SceLong64 lAdd) {
+EXPORT(int, sceRtcTickAddWeeks, SceRtcTick *pTick0, const SceRtcTick *pTick1, SceInt lAdd) {
     TRACY_FUNC(sceRtcTickAddWeeks, pTick0, pTick1, lAdd);
     if (pTick0 == nullptr || pTick1 == nullptr) {
         return RET_ERROR(SCE_RTC_ERROR_INVALID_POINTER);

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -56,6 +56,7 @@ struct State {
     float res_multiplier;
     bool disable_surface_sync;
     bool stretch_the_display_area;
+    bool fullscreen = 0;
 
     Context *context;
 
@@ -107,6 +108,9 @@ struct State {
     }
     void set_stretch_display(bool enable) {
         stretch_the_display_area = enable;
+    }
+    void set_fullscreen(bool enable) {
+        fullscreen = enable;
     }
     virtual bool map_memory(MemState &mem, Ptr<void> address, uint32_t size) {
         return true;

--- a/vita3k/renderer/src/vulkan/screen_filters.cpp
+++ b/vita3k/renderer/src/vulkan/screen_filters.cpp
@@ -280,13 +280,22 @@ void SinglePassScreenFilter::render(bool is_pre_renderpass, vk::ImageView src_im
         // compute viewport now
         const float window_aspect = static_cast<float>(screen.extent.width) / screen.extent.height;
         const float vita_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / DEFAULT_RES_HEIGHT;
+        float cmp_aspect;
+
+        if (!screen.state.fullscreen)
+            cmp_aspect = vita_aspect;
+        else {
+            const float sixteen_nine_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / (DEFAULT_RES_HEIGHT - 4);
+            cmp_aspect = sixteen_nine_aspect;
+        }
+
         if (screen.state.stretch_the_display_area) {
             // Match the aspect ratio to the screen size.
             viewport.width = static_cast<float>(screen.extent.width);
             viewport.height = static_cast<float>(screen.extent.height);
             viewport.x = 0.0f;
             viewport.y = 0.0f;
-        } else if (window_aspect > vita_aspect) {
+        } else if (window_aspect > cmp_aspect) {
             // Window is wide. Pin top and bottom.
             viewport.width = screen.extent.height * vita_aspect;
             viewport.height = static_cast<float>(screen.extent.height);
@@ -512,13 +521,22 @@ void FSRScreenFilter::on_resize() {
     // compute the extent
     const float window_aspect = static_cast<float>(screen.extent.width) / screen.extent.height;
     const float vita_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / DEFAULT_RES_HEIGHT;
+    float cmp_aspect;
+
+    if (!screen.state.fullscreen)
+        cmp_aspect = vita_aspect;
+    else {
+        const float sixteen_nine_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / (DEFAULT_RES_HEIGHT - 4);
+        cmp_aspect = sixteen_nine_aspect;
+    }
+
     if (screen.state.stretch_the_display_area) {
         // Match the aspect ratio to the screen size.
         output_size.width = static_cast<float>(screen.extent.width);
         output_size.height = static_cast<float>(screen.extent.height);
         output_offset.width = 0.0f;
         output_offset.height = 0.0f;
-    } else if (window_aspect > vita_aspect) {
+    } else if (window_aspect > cmp_aspect) {
         // Window is wide. Pin top and bottom.
         output_size.width = static_cast<uint32_t>(std::round(screen.extent.height * vita_aspect));
         output_size.height = screen.extent.height;


### PR DESCRIPTION
Since the resolution of the PS Vita is very close from a 16:9 one (just 4 extra height pixels), I propose this change. It allows to take all the screen width and crop 2 pixels in the top and the bottom in fullscreen mode when the resolution of the screen is 16:9 only. It's especially interesting for 1080p (pixels x 4) and 4K (pixels x 16) resolutions which are integer multiples of 960x540 to get the best possible rendering. The same method is used by the plugin Sharpscale on PSTV with the Integer mode in 1080i.