### PR TITLE
Add the "Fullscreen HD res pixel perfect" checkbox in the GUI section

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -87,7 +87,8 @@ void update_viewport(EmuEnvState &state) {
     if (h > 0) {
         const float window_aspect = static_cast<float>(w) / h;
         const float vita_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / DEFAULT_RES_HEIGHT;
-        if (state.cfg.stretch_the_display_area) {
+        const bool fullscreen_hd_res_pixel_perfect_en = state.cfg.fullscreen_hd_res_pixel_perfect & state.display.fullscreen & !(w % DEFAULT_RES_WIDTH) & !(h % (DEFAULT_RES_HEIGHT - 4));
+        if (state.cfg.stretch_the_display_area && !fullscreen_hd_res_pixel_perfect_en) {
             // Match the aspect ratio to the screen size.
             state.logical_viewport_size.x = static_cast<SceFloat>(state.window_size.x);
             state.logical_viewport_size.y = static_cast<SceFloat>(state.window_size.y);
@@ -98,7 +99,7 @@ void update_viewport(EmuEnvState &state) {
             state.drawable_viewport_size.y = static_cast<SceFloat>(state.drawable_size.y);
             state.drawable_viewport_pos.x = 0;
             state.drawable_viewport_pos.y = 0;
-        } else if (window_aspect > vita_aspect) {
+        } else if ((window_aspect > vita_aspect) && !fullscreen_hd_res_pixel_perfect_en) {
             // Window is wide. Pin top and bottom.
             state.logical_viewport_size.x = state.window_size.y * vita_aspect;
             state.logical_viewport_size.y = static_cast<SceFloat>(state.window_size.y);

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -68,6 +68,7 @@ enum ScreenshotFormat {
     code(bool, "apps-list-grid", false, apps_list_grid)                                                 \
     code(bool, "display-system-apps", true, display_system_apps)                                        \
     code(bool, "stretch_the_display_area", false, stretch_the_display_area)                             \
+    code(bool, "fullscreen_hd_res_pixel_perfect", false, fullscreen_hd_res_pixel_perfect)               \
     code(bool, "show-live-area-screen", true, show_live_area_screen)                                    \
     code(int, "icon-size", 64, icon_size)                                                               \
     code(bool, "archive-log", false, archive_log)                                                       \

--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -141,6 +141,7 @@ public:
         bool export_as_png = false;
         bool fps_hack = false;
         bool stretch_the_display_area = false;
+        bool fullscreen_hd_res_pixel_perfect = false;
         bool show_touchpad_cursor = true;
         bool psn_signed_in = false;
     };

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -272,6 +272,7 @@ void init_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path
 
     get_modules_list(gui, emuenv);
     config.stretch_the_display_area = emuenv.cfg.stretch_the_display_area;
+    config.fullscreen_hd_res_pixel_perfect = emuenv.cfg.fullscreen_hd_res_pixel_perfect;
     config_cpu_backend = set_cpu_backend(config.cpu_backend);
     current_aniso_filter_log = static_cast<int>(log2f(static_cast<float>(config.anisotropic_filtering)));
     max_aniso_filter_log = static_cast<int>(log2f(static_cast<float>(emuenv.renderer->get_max_anisotropic_filtering())));
@@ -374,10 +375,20 @@ static void save_config(GuiState &gui, EmuEnvState &emuenv) {
         emuenv.cfg.psn_signed_in = config.psn_signed_in;
     }
 
+    bool update_viewport_en = false;
+
+    if (emuenv.cfg.fullscreen_hd_res_pixel_perfect != config.fullscreen_hd_res_pixel_perfect) {
+        emuenv.cfg.fullscreen_hd_res_pixel_perfect = config.fullscreen_hd_res_pixel_perfect;
+        update_viewport_en = true;
+    }
+
     if (emuenv.cfg.stretch_the_display_area != config.stretch_the_display_area) {
         emuenv.cfg.stretch_the_display_area = config.stretch_the_display_area;
-        app::update_viewport(emuenv);
+        update_viewport_en = true;
     }
+
+    if (update_viewport_en)
+        app::update_viewport(emuenv);
 
     config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
 }
@@ -458,6 +469,7 @@ void set_config(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
     emuenv.renderer->res_multiplier = emuenv.cfg.current_config.resolution_multiplier;
     emuenv.renderer->set_anisotropic_filtering(emuenv.cfg.current_config.anisotropic_filtering);
     emuenv.renderer->set_stretch_display(emuenv.cfg.stretch_the_display_area);
+    emuenv.renderer->stretch_hd_pixel_perfect(emuenv.cfg.fullscreen_hd_res_pixel_perfect);
     emuenv.renderer->get_texture_cache()->set_replacement_state(emuenv.cfg.current_config.import_textures, emuenv.cfg.current_config.export_textures, emuenv.cfg.current_config.export_as_png);
     emuenv.renderer->set_async_compilation(emuenv.cfg.current_config.async_pipeline_compilation);
     emuenv.display.fps_hack = emuenv.cfg.current_config.fps_hack;
@@ -975,6 +987,9 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::Checkbox(lang.gui["apps_list_grid"].c_str(), &emuenv.cfg.apps_list_grid);
         SetTooltipEx(lang.gui["apps_list_grid_description"].c_str());
+        ImGui::SameLine();
+        ImGui::Checkbox(lang.gui["fullscreen_hd_res_pixel_perfect"].c_str(), &config.fullscreen_hd_res_pixel_perfect);
+        SetTooltipEx(lang.gui["fullscreen_hd_res_pixel_perfect_description"].c_str());
         if (!emuenv.cfg.apps_list_grid) {
             ImGui::Spacing();
             ImGui::SliderInt(lang.gui["icon_size"].c_str(), &emuenv.cfg.icon_size, 64, 128);

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -507,6 +507,7 @@ static void handle_window_event(EmuEnvState &state, const SDL_WindowEvent &event
 
 static void switch_full_screen(EmuEnvState &emuenv) {
     emuenv.display.fullscreen = !emuenv.display.fullscreen;
+    emuenv.renderer->set_fullscreen(emuenv.display.fullscreen);
 
     SDL_SetWindowFullscreen(emuenv.window.get(), emuenv.display.fullscreen.load() ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -665,6 +665,8 @@ struct LangState {
             { "live_area_screen_description", "Check the box to open the Live Area by default when clicking on an application\nIf disabled, right click on an application to open it." },
             { "stretch_the_display_area", "Stretch The Display Area" },
             { "stretch_the_display_area_description", "Check the box to enlarge the display area to fit the screen size." },
+            { "fullscreen_hd_res_pixel_perfect", "Fullscreen HD res pixel perfect" },
+            { "fullscreen_hd_res_pixel_perfect_description", "Check the box to get a pixel perfect rendering with HD resolutions (1080p, 4K) in Fullscreen at the price of slight cropping at the top and the bottom of the screen." },
             { "apps_list_grid", "Grid Mode" },
             { "apps_list_grid_description", "Check the box to set the app list to grid mode." },
             { "icon_size", "App Icon Size" },

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -56,6 +56,8 @@ struct State {
     float res_multiplier;
     bool disable_surface_sync;
     bool stretch_the_display_area;
+    bool fullscreen_hd_res_pixel_perfect;
+    bool fullscreen = false;
 
     Context *context;
 
@@ -107,6 +109,12 @@ struct State {
     }
     void set_stretch_display(bool enable) {
         stretch_the_display_area = enable;
+    }
+    void stretch_hd_pixel_perfect(bool enable) {
+        fullscreen_hd_res_pixel_perfect = enable;
+    }
+    void set_fullscreen(bool enable) {
+        fullscreen = enable;
     }
     virtual bool map_memory(MemState &mem, Ptr<void> address, uint32_t size) {
         return true;

--- a/vita3k/renderer/src/vulkan/screen_filters.cpp
+++ b/vita3k/renderer/src/vulkan/screen_filters.cpp
@@ -280,13 +280,14 @@ void SinglePassScreenFilter::render(bool is_pre_renderpass, vk::ImageView src_im
         // compute viewport now
         const float window_aspect = static_cast<float>(screen.extent.width) / screen.extent.height;
         constexpr float vita_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / DEFAULT_RES_HEIGHT;
-        if (screen.state.stretch_the_display_area) {
+        const bool fullscreen_hd_res_pixel_perfect_en = screen.state.fullscreen_hd_res_pixel_perfect & screen.state.fullscreen & !(screen.extent.width % DEFAULT_RES_WIDTH) & !(screen.extent.height % (DEFAULT_RES_HEIGHT - 4));
+        if (screen.state.stretch_the_display_area && !fullscreen_hd_res_pixel_perfect_en) {
             // Match the aspect ratio to the screen size.
             vk_viewport.width = static_cast<float>(screen.extent.width);
             vk_viewport.height = static_cast<float>(screen.extent.height);
             vk_viewport.x = 0.0f;
             vk_viewport.y = 0.0f;
-        } else if (window_aspect > vita_aspect) {
+        } else if ((window_aspect > vita_aspect) && !fullscreen_hd_res_pixel_perfect_en) {
             // Window is wide. Pin top and bottom.
             vk_viewport.width = screen.extent.height * vita_aspect;
             vk_viewport.height = static_cast<float>(screen.extent.height);
@@ -512,13 +513,14 @@ void FSRScreenFilter::on_resize() {
     // compute the extent
     const float window_aspect = static_cast<float>(screen.extent.width) / screen.extent.height;
     const float vita_aspect = static_cast<float>(DEFAULT_RES_WIDTH) / DEFAULT_RES_HEIGHT;
-    if (screen.state.stretch_the_display_area) {
+    const bool fullscreen_hd_res_pixel_perfect_en = screen.state.fullscreen_hd_res_pixel_perfect & screen.state.fullscreen & !(screen.extent.width % DEFAULT_RES_WIDTH) & !(screen.extent.height % (DEFAULT_RES_HEIGHT - 4));
+    if (screen.state.stretch_the_display_area && !fullscreen_hd_res_pixel_perfect_en) {
         // Match the aspect ratio to the screen size.
         output_size.width = static_cast<float>(screen.extent.width);
         output_size.height = static_cast<float>(screen.extent.height);
         output_offset.width = 0.0f;
         output_offset.height = 0.0f;
-    } else if (window_aspect > vita_aspect) {
+    } else if ((window_aspect > vita_aspect) && !fullscreen_hd_res_pixel_perfect_en) {
         // Window is wide. Pin top and bottom.
         output_size.width = static_cast<uint32_t>(std::round(screen.extent.height * vita_aspect));
         output_size.height = screen.extent.height;


### PR DESCRIPTION
Since the resolution of the PS Vita is very close from a 16:9 one (just 4 extra height pixels), I propose this change. It allows to take all the screen width and crop 2 pixels in the top and the bottom in fullscreen mode when the resolution of the screen is 16:9 only. It's especially interesting for 1080p (pixels x 4) and 4K (pixels x 16) resolutions which are integer multiples of 960x540 to get the best possible rendering. The same method is used by the plugin Sharpscale on PSTV with the Integer mode in 1080i.

If you prefer, we could also add a combo box with three modes to replace the "Stretch to Display Area" one:

- Fit (Standard mode)
- Stretch to full screen
- Stretch to full width (keep aspect ratio)

This time, I think I did things properly with the pull request ^^