### PR TITLE
modules/SceCommonDialog: Reset button id in sceSaveDataDialogContinue.

### DIFF
--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -1008,6 +1008,7 @@ EXPORT(int, sceSaveDataDialogContinue, const SceSaveDataDialogParam *p) {
 
     emuenv.common_dialog.status = SCE_COMMON_DIALOG_STATUS_RUNNING;
     emuenv.common_dialog.substatus = SCE_COMMON_DIALOG_STATUS_RUNNING;
+    emuenv.common_dialog.savedata.button_id = SCE_SAVEDATA_DIALOG_BUTTON_ID_INVALID;
     emuenv.common_dialog.savedata.has_progress_bar = false;
 
     SceSaveDataDialogListParam *list_param;


### PR DESCRIPTION
# About
- modules/SceCommonDialog: Reset button id in sceSaveDataDialogContinue.
Prevents the app from looping back to list mode when "No" is selected.

Senran Kagura EV calls GetResult after any confirmation, but if the button ID is already set to "No" while in list mode, it doesn't transition to fixed mode for load/save confirmation. Instead, it loops back in list mode.
Other game ignore this and juste open fixed mode.