### PR TITLE
modules/SceGxm: add ptr.valid check in sceGxmDestroyRenderTarget

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2025,6 +2025,8 @@ EXPORT(int, sceGxmDestroyRenderTarget, Ptr<SceGxmRenderTarget> renderTarget) {
 
     if (!renderTarget)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
+    if (!renderTarget.valid(mem))
+        return RET_ERROR(SCE_GXM_ERROR_DRIVER);
 
     renderer::destroy_render_target(*emuenv.renderer, renderTarget.get(mem)->renderer);
 


### PR DESCRIPTION
Fix crashes for games which call this functions more then once (with same target). 
For example [PCSB00882] SENRAN KAGURA ESTIVAL VERSUS
Fix bug when game crash immediately after exit from main menu