### PR TITLE
vita3k: Improve use of string/stringstream

### DIFF
--- a/vita3k/cpu/include/cpu/common.h
+++ b/vita3k/cpu/include/cpu/common.h
@@ -90,18 +90,19 @@ struct CPUContext {
     }
 
     std::string description() {
-        std::stringstream ss;
         uint32_t pc = get_pc();
         uint32_t sp = get_sp();
         uint32_t lr = get_lr();
 
-        ss << fmt::format("PC: 0x{:0>8x},   SP: 0x{:0>8x},   LR: 0x{:0>8x}\n", pc, sp, lr);
+        std::string str;
+        auto back_it = std::back_inserter(str);
+        fmt::format_to(back_it, "PC: 0x{:0>8x},   SP: 0x{:0>8x},   LR: 0x{:0>8x}\n", pc, sp, lr);
         for (int a = 0; a < 6; a++) {
-            ss << fmt::format("r{: <2}: 0x{:0>8x}   r{: <2}: 0x{:0>8x}\n", a, cpu_registers[a], a + 6, cpu_registers[a + 6]);
+            fmt::format_to(back_it, "r{: <2}: 0x{:0>8x}   r{: <2}: 0x{:0>8x}\n", a, cpu_registers[a], a + 6, cpu_registers[a + 6]);
         }
-        ss << fmt::format("r12: 0x{:0>8x}\n", cpu_registers[12]);
-        ss << fmt::format("Thumb: {}\n", thumb());
-        return ss.str();
+        fmt::format_to(back_it, "r12: 0x{:0>8x}\n", cpu_registers[12]);
+        fmt::format_to(back_it, "Thumb: {}\n", thumb());
+        return str;
     }
 };
 

--- a/vita3k/cpu/src/disasm.cpp
+++ b/vita3k/cpu/src/disasm.cpp
@@ -63,7 +63,7 @@ std::string disassemble(DisasmState &state, const uint8_t *code, size_t size, ui
         out << " (" << cs_strerror(err) << ")";
     }
 
-    return out.str();
+    return std::move(out).str();
 }
 
 bool is_returning(DisasmState &state) {

--- a/vita3k/gdbstub/src/gdb.cpp
+++ b/vita3k/gdbstub/src/gdb.cpp
@@ -101,11 +101,7 @@ static std::string to_hex(SceUID value) {
 }
 
 static uint32_t parse_hex(const std::string &hex) {
-    std::stringstream stream;
-    uint32_t value;
-    stream << std::hex << hex;
-    stream >> value;
-    return value;
+    return static_cast<uint32_t>(std::strtoul(hex.c_str(), nullptr, 16));
 }
 
 static uint8_t make_checksum(const char *data, int64_t length) {
@@ -278,12 +274,14 @@ static std::string cmd_read_registers(EmuEnvState &state, PacketCommand &command
 
     CPUState &cpu = *state.kernel.threads[state.gdb.current_thread]->cpu.get();
 
-    std::stringstream stream;
-    for (uint32_t a = 0; a <= 15; a++) {
-        stream << be_hex(fetch_reg(cpu, a));
+    std::string str;
+    str.reserve(16 * 8);
+
+    for (uint32_t a = 0; a < 16; a++) {
+        str += be_hex(fetch_reg(cpu, a));
     }
 
-    return stream.str();
+    return str;
 }
 
 static std::string cmd_write_registers(EmuEnvState &state, PacketCommand &command) {
@@ -363,13 +361,14 @@ static std::string cmd_read_memory(EmuEnvState &state, PacketCommand &command) {
     if (!check_memory_region(address, length, state.mem))
         return "EAA";
 
-    std::stringstream stream;
+    std::string str;
+    str.reserve(length * 2);
 
     for (uint32_t a = 0; a < length; a++) {
-        stream << fmt::format("{:0>2x}", *Ptr<uint8_t>(address + a).get(state.mem));
+        fmt::format_to(std::back_inserter(str), "{:02x}", *Ptr<uint8_t>(address + a).get(state.mem));
     }
 
-    return stream.str();
+    return str;
 }
 
 static std::string cmd_write_memory(EmuEnvState &state, PacketCommand &command) {
@@ -552,32 +551,27 @@ static std::string cmd_reason(EmuEnvState &state, PacketCommand &command) { retu
 
 static std::string cmd_get_first_thread(EmuEnvState &state, PacketCommand &command) {
     const auto guard = std::lock_guard(state.kernel.mutex);
-    std::stringstream stream;
-
-    stream << "m";
-    stream << to_hex(state.kernel.threads.begin()->first);
-
     state.gdb.thread_info_index = 0;
 
-    return stream.str();
+    return 'm' + to_hex(state.kernel.threads.begin()->first);
 }
 
 static std::string cmd_get_next_thread(EmuEnvState &state, PacketCommand &command) {
     const auto guard = std::lock_guard(state.kernel.mutex);
-    std::stringstream stream;
+    std::string str;
 
     ++state.gdb.thread_info_index;
     if (state.gdb.thread_info_index == state.kernel.threads.size()) {
-        stream << "l";
+        str += 'l';
     } else {
         auto iter = state.kernel.threads.begin();
         std::advance(iter, state.gdb.thread_info_index);
 
-        stream << "m";
-        stream << to_hex(iter->first);
+        str += 'm';
+        str += to_hex(iter->first);
     }
 
-    return stream.str();
+    return str;
 }
 
 static std::string cmd_add_breakpoint(EmuEnvState &state, PacketCommand &command) {

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -416,15 +416,15 @@ void ThreadState::resume(bool step) {
 std::string ThreadState::log_stack_traceback() const {
     constexpr Address START_OFFSET = 0;
     constexpr Address END_OFFSET = 1024;
-    std::stringstream ss;
+    std::string str;
     const Address sp = read_sp(*cpu);
     for (Address addr = sp - START_OFFSET; addr <= sp + END_OFFSET; addr += 4) {
         if (Ptr<uint32_t>(addr).valid(mem)) {
             const Address value = *Ptr<uint32_t>(addr).get(mem);
             const auto mod = kernel.find_module_by_addr(value);
             if (mod)
-                ss << fmt::format("{} (module: {})\n", log_hex(value), mod->module_name);
+                fmt::format_to(std::back_inserter(str), "0x{:X} (module: {})\n", value, mod->module_name);
         }
     }
-    return ss.str();
+    return str;
 }

--- a/vita3k/modules/SceFiber/SceFiber.cpp
+++ b/vita3k/modules/SceFiber/SceFiber.cpp
@@ -100,22 +100,18 @@ static CPUContext get_thread_context(FiberState &state, const SceUID &tid) {
 }
 
 static std::string describe_fiber(FiberState &state, const ThreadStatePtr &thread, SceFiber *fiber) {
-    std::stringstream ss;
-    ss << fmt::format("Fiber (name: {})\n", fiber->name);
-    ss << fmt::format("entry: {}\n", log_hex(fiber->cpu->get_pc()), log_hex(fiber->entry.address()));
-    ss << "CPU Context:\n";
-    ss << fiber->cpu->description();
-    ss << "Referenced from " << thread->id << "\n";
-    ss << "CPU Context:\n";
-    auto ctx = get_thread_context(state, thread->id);
-    ss << ctx.description();
-    return ss.str();
+    std::string str;
+    auto back_it = std::back_inserter(str);
+    fmt::format_to(back_it, "Fiber (name: {})\n", fiber->name);
+    fmt::format_to(back_it, "entry: 0x{:X}\n", fiber->entry.address());
+    fmt::format_to(back_it, "CPU Context:\n{}", fiber->cpu->description());
+    fmt::format_to(back_it, "Referenced from {}\n", thread->id);
+    fmt::format_to(back_it, "CPU Context:\n{}", get_thread_context(state, thread->id).description());
+    return str;
 }
 
 static void log_fiber(FiberState &state, const ThreadStatePtr &thread, SceFiber *fiber, const std::string &function_name) {
-    std::string log_msg = function_name + "\n";
-    log_msg += describe_fiber(state, thread, fiber);
-    LOG_INFO("{}", log_msg);
+    LOG_INFO("{}\n{}", function_name, describe_fiber(state, thread, fiber));
 }
 
 static void setup_fiber_to_run(EmuEnvState &emuenv, const ThreadStatePtr &thread, SceFiber *fiber, uint32_t thread_sp, const uint32_t &argOnRunTo) {

--- a/vita3k/renderer/src/gl/compile_program.cpp
+++ b/vita3k/renderer/src/gl/compile_program.cpp
@@ -106,13 +106,14 @@ static SharedGLObject compile_spirv(GLenum type, const std::vector<std::uint32_t
 }
 
 static std::string convert_hash_to_hex(const Sha256Hash &hash) {
-    std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    for (size_t i = 0; hash.size() > i; ++i) {
-        ss << std::setw(2) << static_cast<uint32_t>(hash[i]);
+    std::string str;
+    str.reserve(hash.size() * 2);
+
+    for (size_t i = 0; i < hash.size(); ++i) {
+        fmt::format_to(std::back_inserter(str), "{:02x}", hash[i]);
     }
 
-    return ss.str();
+    return str;
 }
 
 static SharedGLObject compile_program(ProgramCache &program_cache, const SharedGLObject &frag_shader, const SharedGLObject &vert_shader, const ProgramHashes &hashes) {

--- a/vita3k/util/include/util/tracy.h
+++ b/vita3k/util/include/util/tracy.h
@@ -26,30 +26,26 @@
 // universal to string converters for module specific types (usually enums)
 template <typename T>
 std::string to_debug_str(const MemState &mem, T type) {
-    std::stringstream datass;
+    std::ostringstream datass;
     datass << type;
-    return datass.str();
+    return std::move(datass).str();
 }
 
 // Override pointers, we want to print the address in hex
 template <typename U>
 std::string to_debug_str(const MemState &mem, U *type) {
-    std::stringstream datass;
-    datass << log_hex(Ptr<U>(type, mem).address()); // Convert host ptr to guest
-    return datass.str();
+    return log_hex(Ptr<U>(type, mem).address()); // Convert host ptr to guest
 }
 
 // Override for guest pointers, we want to print the guest address
 template <typename U>
 std::string to_debug_str(const MemState &mem, Ptr<U> type) {
-    std::stringstream datass;
-    datass << log_hex(type.address());
-    return datass.str();
+    return log_hex(type.address());
 }
 
 template <>
 inline std::string to_debug_str(const MemState &mem, Ptr<char> type) {
-    return std::string(type.address() ? log_hex(type.address()) + " " + type.get(mem) : "0x0 NULLPTR");
+    return type.address() ? fmt::format("0x{:X} {}", type.address(), type.get(mem)) : "0x0 NULLPTR";
 }
 
 // Override for char pointers as the contents are readable
@@ -57,13 +53,13 @@ template <>
 inline std::string to_debug_str(const MemState &mem, char *type) {
     // Format for correct char* should be "(address in hex (0x12345)) (string)", this is just in the
     // extreme case that the string is actually "0x0 NULLPTR" and be confusing
-    return std::string(type ? log_hex(Ptr<char *>(type, mem).address()) + " " + type : "0x0 NULLPTR");
+    return type ? fmt::format("0x{:X} {}", Ptr<char>(type, mem).address(), type) : "0x0 NULLPTR";
 }
 
 // Override for char pointers as the contents are readable
 template <>
 inline std::string to_debug_str(const MemState &mem, const char *type) {
-    return std::string(type ? log_hex(Ptr<const char *>(type, mem).address()) + " " + type : "0x0 NULLPTR");
+    return type ? fmt::format("0x{:X} {}", Ptr<const char>(type, mem).address(), type) : "0x0 NULLPTR";
 }
 
 template <>

--- a/vita3k/util/src/string_utils.cpp
+++ b/vita3k/util/src/string_utils.cpp
@@ -27,7 +27,7 @@
 namespace string_utils {
 
 std::vector<std::string> split_string(const std::string &str, char delimiter) {
-    std::stringstream str_stream(str);
+    std::istringstream str_stream(str);
     std::string segment;
     std::vector<std::string> seglist;
 
@@ -86,12 +86,14 @@ void replace(std::string &str, const std::string &in, const std::string &out) {
 
 std::vector<uint8_t> string_to_byte_array(const std::string &string) {
     std::vector<uint8_t> hex_bytes;
+    hex_bytes.reserve(string.length() / 2);
+
+    if (string.length() % 2 != 0)
+        LOG_WARN("Hex string length ({}) is not even", string.length());
 
     for (size_t i = 0; i < string.length(); i += 2) {
-        uint16_t byte;
-        std::string nextbyte = string.substr(i, 2);
-        std::istringstream(nextbyte) >> std::hex >> byte;
-        hex_bytes.push_back(static_cast<uint8_t>(byte));
+        std::string byte = string.substr(i, 2);
+        hex_bytes.push_back(static_cast<uint8_t>(std::strtoul(byte.c_str(), nullptr, 16)));
     }
     return hex_bytes;
 }


### PR DESCRIPTION
- Replace `std::stringstream::operator<<` with faster `fmt::format_to` and `std::string::operator+=`.
- Replace `std::stringstream::operator>>` with faster `std::strtoul`.
- Use `std::move` when return `std::stringstream::str`.
- Distinguish between output-only and input-only streams.