### PR TITLE
module/load module: Add HTTPS loading with RUDP module and include it in auto-load list

### DIFF
--- a/vita3k/module/src/load_module.cpp
+++ b/vita3k/module/src/load_module.cpp
@@ -59,7 +59,7 @@ static SysmodulePaths init_sysmodule_paths() {
     p[SCE_SYSMODULE_NP_SCORE_RANKING] = { "np_ranking" };
     p[SCE_SYSMODULE_SQLITE] = { "libSceSqlite" };
     p[SCE_SYSMODULE_TRIGGER_UTIL] = { "trigger_util" };
-    p[SCE_SYSMODULE_RUDP] = { "librudp" };
+    p[SCE_SYSMODULE_RUDP] = { "libhttp", "librudp", "libssl" };
     p[SCE_SYSMODULE_CODECENGINE_PERF] = { "libcodecengine_perf" };
     p[SCE_SYSMODULE_LIVEAREA] = { "livearea_util" };
     p[SCE_SYSMODULE_NP_ACTIVITY] = { "np_activity_sdk" };
@@ -139,21 +139,22 @@ extern const SysmoduleInternalPaths sysmodule_internal_paths = init_sysmodule_in
 
 // Current modules works for loading
 static constexpr auto auto_lle_modules = {
-    SCE_SYSMODULE_SAS,
-    SCE_SYSMODULE_PGF,
-    SCE_SYSMODULE_SYSTEM_GESTURE,
-    SCE_SYSMODULE_XML,
-    SCE_SYSMODULE_MP4,
-    SCE_SYSMODULE_ATRAC,
-    SCE_SYSMODULE_AVPLAYER,
-    SCE_SYSMODULE_JSON,
     SCE_SYSMODULE_HTTP,
     SCE_SYSMODULE_SSL,
     SCE_SYSMODULE_HTTPS,
-    SCE_SYSMODULE_SMART,
-    SCE_SYSMODULE_FACE,
     SCE_SYSMODULE_ULT,
-    SCE_SYSMODULE_FIOS2
+    SCE_SYSMODULE_SAS,
+    SCE_SYSMODULE_PGF,
+    SCE_SYSMODULE_FIOS2,
+    SCE_SYSMODULE_SYSTEM_GESTURE,
+    SCE_SYSMODULE_XML,
+    SCE_SYSMODULE_RUDP,
+    SCE_SYSMODULE_MP4,
+    SCE_SYSMODULE_ATRAC,
+    SCE_SYSMODULE_FACE,
+    SCE_SYSMODULE_SMART,
+    SCE_SYSMODULE_AVPLAYER,
+    SCE_SYSMODULE_JSON
 };
 
 bool is_lle_module(SceSysmoduleModuleId module_id, EmuEnvState &emuenv) {


### PR DESCRIPTION
# About 
- module/load module: Add HTTPS loading with RUDP module.
Prevent games from calling RUDP without loading HTTPS.  
Add RUDP to the automatic modules list and reorder the list to match the enum order.