### PR TITLE
packages/sce utils: skip fself decryption for invalid SELF files.

### DIFF
--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -478,11 +478,6 @@ SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std
     const SCE_header &self_header = *static_cast<const SCE_header *>(self);
 
     // assumes little endian host
-    if (self_header.magic != 0x00454353) {
-        LOG_CRITICAL("SELF {} is corrupt or encrypted. Decryption is not yet supported.", self_path);
-        return -1;
-    }
-
     if (self_header.version != 3) {
         LOG_CRITICAL("SELF {} version {} is not supported.", self_path, self_header.version);
         return -1;

--- a/vita3k/packages/src/sce_utils.cpp
+++ b/vita3k/packages/src/sce_utils.cpp
@@ -835,6 +835,13 @@ std::tuple<uint64_t, SelfType> get_key_type(std::ifstream &file, const SceHeader
 
 std::vector<uint8_t> decrypt_fself(const std::vector<uint8_t> &fself, const uint8_t *klic) {
     const SCE_header &self_header = *reinterpret_cast<const SCE_header *>(fself.data());
+
+    // Check if a valid SELF or is still in encrypted layer
+    if (self_header.magic != SCE_MAGIC) {
+        LOG_ERROR("Invalid SELF: file is either not a SELF or is still encrypted (unsupported).");
+        return {};
+    }
+
     const segment_info *const seg_infos = reinterpret_cast<const segment_info *>(&fself[self_header.section_info_offset]);
     const AppInfoHeader app_info_hdr = AppInfoHeader(reinterpret_cast<const char *>(&fself[self_header.appinfo_offset]));
 


### PR DESCRIPTION
# About
- packages/sce utils: skip fself decryption for invalid SELF files.
Prevents crashes or errors when games try to load no valid self or content still layer-encrypted.

fix regression repoorted on https://github.com/Vita3K/compatibility/issues/154#issuecomment-2883266134