### PR TITLE
util/exec.h: Fix include

### DIFF
--- a/vita3k/util/include/util/exec.h
+++ b/vita3k/util/include/util/exec.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
-#include <vector>
+#include <array>
+#include <memory>
+#include <stdexcept>
 
 namespace util {
 


### PR DESCRIPTION
- `"exec.h"` lacks the necessary header file, and although it does not report an error at compile time (because there is no file that references it), opening the file in IDE displays with error.