### PR TITLE
shader, external: Update glslang

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -207,11 +207,11 @@ if(USE_DISCORD_RICH_PRESENCE)
 endif()
 
 option(BUILD_EXTERNAL "Build external dependencies in /External" OFF)
-option(SKIP_GLSLANG_INSTALL "Skip installation" ON)
 option(ENABLE_SPVREMAPPER "Enables building of SPVRemapper" OFF)
 option(ENABLE_GLSLANG_BINARIES "Builds glslang and spirv-remap" OFF)
 option(ENABLE_HLSL "Enables HLSL input support" OFF)
-option(ENABLE_CTEST "Enables testing" OFF)
+option(GLSLANG_TESTS "Enable glslang testing" OFF)
+option(ENABLE_OPT "Enables spirv-opt capability if present" OFF)
 add_subdirectory(glslang)
 
 option(SPIRV_CROSS_CLI "Build the CLI binary. Requires SPIRV_CROSS_STATIC." OFF)

--- a/vita3k/shader/include/shader/usse_utilities.h
+++ b/vita3k/shader/include/shader/usse_utilities.h
@@ -94,7 +94,7 @@ template <typename F>
 void make_for_loop(spv::Builder &b, spv::Id iterator, spv::Id initial_value_ite, spv::Id iterator_limit, F body) {
     auto blocks = b.makeNewLoop();
     b.createStore(initial_value_ite, iterator);
-    b.createBranch(&blocks.head);
+    b.createBranch(true, &blocks.head);
 
     b.setBuildPoint(&blocks.head);
 
@@ -110,10 +110,10 @@ void make_for_loop(spv::Builder &b, spv::Id iterator, spv::Id initial_value_ite,
     spv::Id add_to_me = b.createBinOp(spv::OpIAdd, b.makeIntegerType(32, true), b.createLoad(iterator, spv::NoPrecision), b.makeIntConstant(1));
     b.createStore(add_to_me, iterator);
 
-    b.createBranch(&blocks.continue_target);
+    b.createBranch(true, &blocks.continue_target);
 
     b.setBuildPoint(&blocks.continue_target);
-    b.createBranch(&blocks.head);
+    b.createBranch(true, &blocks.head);
 
     b.setBuildPoint(&blocks.merge);
     b.closeLoop();

--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -1763,8 +1763,8 @@ static SpirvCode convert_gxp_to_spirv_impl(const SceGxmProgram &program, const s
 
     spv::SpvBuildLogger spv_logger;
     spv::Builder b(spv_version, 0x1337 << 12, &spv_logger);
-    b.setSourceFile(shader_hash);
-    b.setEmitOpLines();
+    b.setEmitSpirvDebugInfo();
+    b.setDebugMainSourceFile(shader_hash);
     b.addSourceExtension("gxp");
     if (features.support_memory_mapping)
         b.setMemoryModel(spv::AddressingModelPhysicalStorageBuffer64, spv::MemoryModelGLSL450);

--- a/vita3k/shader/src/translator/alu.cpp
+++ b/vita3k/shader/src/translator/alu.cpp
@@ -127,7 +127,7 @@ bool USSETranslatorVisitor::vmad(
         inst.opr.src2.flags |= RegisterFlags::Negative;
     }
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     set_repeat_multiplier(2, 2, 2, 4);
 
@@ -264,7 +264,7 @@ bool USSETranslatorVisitor::vmad2(
     LOG_DISASM("{:016x}: {}{}2 {} {} {} {}", m_instr, disasm::e_predicate_str(static_cast<ExtPredicate>(pred)), disasm::opcode_str(op), disasm::operand_to_str(inst.opr.dest, dest_mask),
         disasm::operand_to_str(inst.opr.src0, dest_mask), disasm::operand_to_str(inst.opr.src1, dest_mask), disasm::operand_to_str(inst.opr.src2, dest_mask));
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     // Translate the instruction
     spv::Id vsrc0 = load(inst.opr.src0, dest_mask, 0);
@@ -361,7 +361,7 @@ bool USSETranslatorVisitor::vdp(
         inst.opr.src2.flags |= RegisterFlags::Absolute;
     }
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     // Decoding done
     BEGIN_REPEAT(repeat_count)
@@ -607,7 +607,7 @@ bool USSETranslatorVisitor::v32nmad(
         disasm::operand_to_str(inst.opr.src1, source_mask), disasm::operand_to_str(inst.opr.src2, source_mask));
 
     // Recompile
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
     spv::Id result = do_alu_op(inst, source_mask, dest_mask);
 
     if (result != spv::NoResult) {
@@ -729,7 +729,7 @@ bool USSETranslatorVisitor::vcomp(
     // (upper bound on the) number of components to set in the destination
     const uint32_t nb_components = std::bit_width(write_mask);
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     // TODO: Log
     BEGIN_REPEAT(repeat_count)

--- a/vita3k/shader/src/translator/branch_cond.cpp
+++ b/vita3k/shader/src/translator/branch_cond.cpp
@@ -279,7 +279,7 @@ spv::Id USSETranslatorVisitor::vtst_impl(Instruction inst, ExtPredicate pred, in
 
     const char *used_comp_str = tb_comp_str[compare_include_equal][sign_test];
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     if (is_sub_opcode(inst.opcode)) {
         if (mask) {

--- a/vita3k/shader/src/translator/data.cpp
+++ b/vita3k/shader/src/translator/data.cpp
@@ -151,7 +151,7 @@ bool USSETranslatorVisitor::vmov(
 
     // Recompile
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     if ((move_data_type == DataType::F16) || (move_data_type == DataType::F32)) {
         set_repeat_multiplier(2, 2, 2, 2);
@@ -463,7 +463,7 @@ bool USSETranslatorVisitor::vpck(
     }
 
     // Recompile
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     // Doing this extra dest type check for future change in case I'm wrong (pent0)
     if (is_integer_data_type(inst.opr.dest.type)) {

--- a/vita3k/shader/src/translator/special.cpp
+++ b/vita3k/shader/src/translator/special.cpp
@@ -87,7 +87,7 @@ bool USSETranslatorVisitor::depthf(
         disasm::operand_to_str(inst.opr.src0, 0b0001, 0), disasm::operand_to_str(inst.opr.src1, 0b0001, 0),
         disasm::operand_to_str(inst.opr.src2, 0b0001, 0));
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     if (frag_depth_id == 0) {
         frag_depth_id = m_b.createVariable(spv::NoPrecision, spv::StorageClassOutput, type_f32, "gl_FragDepth");
@@ -153,7 +153,7 @@ bool USSETranslatorVisitor::smbo(Imm1 nosched,
     Imm12 src2_offset) {
     LOG_DISASM("{:016x}: SMBO {}, {}, {}, {}", m_instr, dest_offset, src0_offset, src1_offset, src2_offset);
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     auto parse_offset = [&](const int idx, Imm12 offset) {
         for (int i = 0; i < 17; i++) {
@@ -172,7 +172,7 @@ bool USSETranslatorVisitor::kill(
     ShortPredicate pred) {
     LOG_DISASM("{:016x}: KILL {}", m_instr, disasm::s_predicate_str(pred));
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
     m_b.makeStatementTerminator(spv::OpKill, "kill");
 
     return true;

--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -290,7 +290,7 @@ bool USSETranslatorVisitor::smp(
     LOG_DISASM("{:016x}: {}SMP{}d.{}.{}{} {} {} {} {}", m_instr, disasm::e_predicate_str(pred), dim, disasm::data_type_str(inst.opr.dest.type), disasm::data_type_str(inst.opr.src0.type), additional_info,
         disasm::operand_to_str(inst.opr.dest, 0b0001), disasm::operand_to_str(inst.opr.src0, coord_mask), disasm::operand_to_str(inst.opr.src1, 0b0000), (lod_mode == 0) ? "" : disasm::operand_to_str(inst.opr.src2, 0b0001));
 
-    m_b.setLine(m_recompiler.cur_pc);
+    m_b.setDebugSourceLocation(m_recompiler.cur_pc, nullptr);
 
     // Generate simple stuff
     // Load the coord
@@ -413,7 +413,7 @@ bool USSETranslatorVisitor::smp(
                 const Imm4 dest_mask = (1U << smp->component_count) - 1;
                 store(inst.opr.dest, result, dest_mask);
 
-                m_b.addSwitchBreak();
+                m_b.addSwitchBreak(true);
             }
             m_b.endSwitch(segment_blocks);
         } else if (sb_mode == 0) {

--- a/vita3k/shader/src/usse_translator_entry.cpp
+++ b/vita3k/shader/src/usse_translator_entry.cpp
@@ -994,12 +994,12 @@ void USSERecompiler::compile_conditional_node(const usse::USSEConditionalNode &c
 void USSERecompiler::compile_loop_node(const usse::USSELoopNode &loop) {
     spv::Builder::LoopBlocks loops = b.makeNewLoop();
 
-    b.createBranch(&loops.head);
+    b.createBranch(true, &loops.head);
     b.setBuildPoint(&loops.head);
 
     // In the head we only want to branch to body. We always do while do anyway
     b.createLoopMerge(&loops.merge, &loops.continue_target, 0, {});
-    b.createBranch(&loops.body);
+    b.createBranch(true, &loops.body);
 
     // Emit body content
     b.setBuildPoint(&loops.body);
@@ -1008,11 +1008,11 @@ void USSERecompiler::compile_loop_node(const usse::USSELoopNode &loop) {
     const usse::USSEBlockNode &content_block = *(loop.content_block());
     compile_block(content_block);
 
-    b.createBranch(&loops.continue_target);
+    b.createBranch(true, &loops.continue_target);
 
     // Emit continue target
     b.setBuildPoint(&loops.continue_target);
-    b.createBranch(&loops.head);
+    b.createBranch(true, &loops.head);
 
     // Merge point
     b.setBuildPoint(&loops.merge);

--- a/vita3k/shader/src/usse_utilities.cpp
+++ b/vita3k/shader/src/usse_utilities.cpp
@@ -177,8 +177,9 @@ static spv::Function *make_fx10_unpack_func(spv::Builder &b, const SpirvUtilFunc
     spv::Id type_f32_v3 = b.makeVectorType(type_f32, 3);
 
     spv::Function *fx10_unpack_func = b.makeFunctionEntry(
-        spv::NoPrecision, type_f32_v3, "unpack3xFX10", { type_f32 }, { "to_unpack" },
+        spv::NoPrecision, type_f32_v3, "unpack3xFX10", spv::LinkageTypeMax, { type_f32 },
         decorations, &fx10_unpack_func_block);
+    b.setupFunctionDebugInfo(fx10_unpack_func, "unpack3xFX10", { type_f32 }, { "to_unpack" });
 
     spv::Id extracted = fx10_unpack_func->getParamId(0);
 
@@ -258,8 +259,9 @@ static spv::Function *make_unpack_func(spv::Builder &b, const FeatureState &feat
     }
 
     spv::Function *unpack_func = b.makeFunctionEntry(
-        spv::NoPrecision, output_type, func_name.c_str(), { type_f32 }, { "to_unpack" },
+        spv::NoPrecision, output_type, func_name.c_str(), spv::LinkageTypeMax, { type_f32 },
         decorations, &unpack_func_block);
+    b.setupFunctionDebugInfo(unpack_func, func_name.c_str(), { type_f32 }, { "to_unpack" });
     spv::Id extracted = unpack_func->getParamId(0);
 
     const spv::Id result_type = is_signed ? type_i32 : type_ui32;
@@ -334,8 +336,9 @@ static spv::Function *make_pack_func(spv::Builder &b, const FeatureState &featur
     }
 
     spv::Function *pack_func = b.makeFunctionEntry(
-        spv::NoPrecision, type_f32, func_name.c_str(), { input_type }, { "to_pack" },
+        spv::NoPrecision, type_f32, func_name.c_str(), spv::LinkageTypeMax, { input_type },
         decorations, &pack_func_block);
+    b.setupFunctionDebugInfo(pack_func, func_name.c_str(), { input_type }, { "to_pack" });
 
     spv::Id extracted = pack_func->getParamId(0);
     const int comp_bits = 32 / comp_count;
@@ -367,8 +370,9 @@ static spv::Function *make_f16_unpack_func(spv::Builder &b, const SpirvUtilFunct
     spv::Id type_f32_v2 = b.makeVectorType(type_f32, 2);
 
     spv::Function *f16_unpack_func = b.makeFunctionEntry(
-        spv::NoPrecision, type_f32_v2, "unpack2xF16", { type_f32 }, { "to_unpack" },
+        spv::NoPrecision, type_f32_v2, "unpack2xF16", spv::LinkageTypeMax, { type_f32 },
         decorations, &f16_unpack_func_block);
+    b.setupFunctionDebugInfo(f16_unpack_func, "unpack2xF16", { type_f32 }, { "to_unpack" });
 
     spv::Id extracted = f16_unpack_func->getParamId(0);
 
@@ -392,8 +396,9 @@ static spv::Function *make_f16_pack_func(spv::Builder &b, const SpirvUtilFunctio
     spv::Id type_f32_v2 = b.makeVectorType(type_f32, 2);
 
     spv::Function *f16_pack_func = b.makeFunctionEntry(
-        spv::NoPrecision, type_f32, "pack2xF16", { type_f32_v2 }, { "to_pack" },
+        spv::NoPrecision, type_f32, "pack2xF16", spv::LinkageTypeMax, { type_f32_v2 },
         decorations, &f16_pack_func_block);
+    b.setupFunctionDebugInfo(f16_pack_func, "pack2xF16", { type_f32_v2 }, { "to_pack" });
 
     spv::Id extracted = f16_pack_func->getParamId(0);
 
@@ -423,8 +428,9 @@ static spv::Function *make_fetch_memory_func_for_array(spv::Builder &b, spv::Id 
 
     const std::string func_name = fmt::format("fetchMemoryForBuffer{}Base{}", buffer_index, info.base);
 
-    spv::Function *fetch_func = b.makeFunctionEntry(spv::NoPrecision, type_f32, func_name.c_str(), { type_i32 }, { "addr" },
+    spv::Function *fetch_func = b.makeFunctionEntry(spv::NoPrecision, type_f32, func_name.c_str(), spv::LinkageTypeMax, { type_i32 },
         {}, &func_block);
+    b.setupFunctionDebugInfo(fetch_func, func_name.c_str(), { type_i32 }, { "addr" });
 
     spv::Id sixteen_cst = b.makeIntConstant(16);
     spv::Id eight_cst = b.makeIntConstant(8);
@@ -479,8 +485,10 @@ static spv::Function *make_fetch_memory_func(spv::Builder &b, const SpirvShaderP
     spv::Block *func_block;
     spv::Block *last_build_point = b.getBuildPoint();
 
-    spv::Function *fetch_func = b.makeFunctionEntry(spv::NoPrecision, type_f32, "fetchMemory", { type_i32 }, { "addr" },
+    spv::Function *fetch_func = b.makeFunctionEntry(spv::NoPrecision, type_f32, "fetchMemory", spv::LinkageTypeMax, { type_i32 },
         {}, &func_block);
+    b.setupFunctionDebugInfo(fetch_func, "fetchMemory", { type_i32 }, { "addr" });
+
     spv::Id addr = fetch_func->getParamId(0);
 
     std::stack<std::unique_ptr<spv::Builder::If>> fetch_stacks;


### PR DESCRIPTION
The current version of glslang Vita3K was using no longer builds on the latest gcc (see [here](https://github.com/KhronosGroup/glslang/issues/3950)). Therefore update glslang to the latest release and also fix the breaking changes. The generated shader code should be the same.

cc @EXtremeExploit 