### PR TITLE
packages/sfo: Refactor and handle all supported SFO data fmt.

### DIFF
--- a/vita3k/packages/include/packages/sfo.h
+++ b/vita3k/packages/include/packages/sfo.h
@@ -34,6 +34,13 @@
 
 static const char *EBOOT_PATH = "eboot.bin";
 
+enum SfoDataFormat : uint16_t {
+    UTF8 = 0x0004, // UTF-8 Encoding
+    UTF8_NULL = 0x0204, // UTF-8 Null Terminated
+    ASCII = 0x0402, // ASCII Encoding
+    UINT32_T = 0x0404, // 32-bit Unsigned Integer
+};
+
 struct SfoHeader {
     uint32_t magic;
     uint32_t version;


### PR DESCRIPTION
# About
- packages/sfo: Refactor and handle all supported SFO data fmt.
Properly handle ASCII, UTF-8, UTF-8 NULL-terminated, and 32-bit unsigned integer formats during parsing.
Remove dirty hacks for memory handling and string conversions, ensuring cleaner and more reliable code.

Split other pr for get this commit alone