### PR TITLE
.github/workflows: Changed concurrency setting

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -190,7 +190,7 @@ jobs:
         repo: [master, store]
     runs-on: ubuntu-22.04
     concurrency:
-      group: create-release
+      group: create-release-${{ matrix.repo }}
       cancel-in-progress: false
     if: |
       github.ref == 'refs/heads/master' &&


### PR DESCRIPTION
Allow concurrent execution when uploading to different repos (master and store).