### PR TITLE
modules/SceSysmodule: Avoid reloading already loaded module.

### DIFF
--- a/vita3k/module/src/load_module.cpp
+++ b/vita3k/module/src/load_module.cpp
@@ -208,6 +208,5 @@ bool is_lle_module(const std::string &module_name, EmuEnvState &emuenv) {
 
 bool is_module_loaded(KernelState &kernel, SceSysmoduleModuleId module_id) {
     std::lock_guard<std::mutex> guard(kernel.mutex);
-    auto it = kernel.loaded_sysmodules.find(module_id);
-    return it != kernel.loaded_sysmodules.end();
+    return kernel.loaded_sysmodules.contains(module_id);
 }

--- a/vita3k/modules/SceSysmodule/SceSysmodule.cpp
+++ b/vita3k/modules/SceSysmodule/SceSysmodule.cpp
@@ -198,6 +198,8 @@ EXPORT(int, sceSysmoduleLoadModule, SceSysmoduleModuleId module_id) {
         return RET_ERROR(SCE_SYSMODULE_ERROR_INVALID_VALUE);
 
     LOG_INFO("Loading module ID: {}", to_debug_str(emuenv.mem, module_id));
+    if (is_module_loaded(emuenv.kernel, module_id))
+        return SCE_SYSMODULE_LOADED;
     if (is_module_enabled(emuenv, module_id)) {
         if (load_sys_module(emuenv, module_id))
             return SCE_SYSMODULE_LOADED;


### PR DESCRIPTION
# About
- modules/SceSysmodule: Avoid reloading already loaded module.
- module/load_module: Use contains() instead of find() in is_module_loaded.


fix regression on sao move for ingame to bootable, with no can using fios module already loaded.

# Result
- get back to ingame again
![image](https://github.com/user-attachments/assets/7313923c-349b-4396-909a-45839f143510)