### PR TITLE
ngs: Fix freezing for unknown reasons

### DIFF
--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -657,7 +657,7 @@ EXPORT(SceInt32, sceNgsVoiceGetInfo, ngs::Voice *voice, SceNgsVoiceInfo *info) {
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
     }
 
-    const std::lock_guard<std::mutex> guard(*voice->voice_mutex);
+    const std::lock_guard<std::mutex> guard(voice->voice_mutex);
 
     info->voice_state = ngsVoiceStateFromHLEState(voice);
     info->num_modules = static_cast<SceUInt32>(voice->datas.size());
@@ -768,7 +768,7 @@ EXPORT(SceInt32, sceNgsVoiceInit, ngs::Voice *voice, const SceNgsVoicePreset *pr
     if (voice->state == ngs::VoiceState::VOICE_STATE_ACTIVE)
         return RET_ERROR(SCE_NGS_ERROR_INVALID_STATE);
 
-    std::lock_guard<std::mutex> guard(*voice->voice_mutex);
+    std::lock_guard<std::mutex> guard(voice->voice_mutex);
 
     if (init_flags == SCE_NGS_VOICE_INIT_BASE || init_flags == SCE_NGS_VOICE_INIT_ALL) {
         voice->state = ngs::VoiceState::VOICE_STATE_AVAILABLE;
@@ -1011,7 +1011,7 @@ EXPORT(SceInt32, sceNgsVoiceSetParamsBlock, ngs::Voice *voice, const SceNgsModul
     if (!voice)
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
 
-    const std::lock_guard<std::mutex> guard(*voice->voice_mutex);
+    const std::lock_guard<std::mutex> guard(voice->voice_mutex);
 
     const SceInt32 num_errors = voice->parse_params_block(emuenv.mem, header, size);
     if (pNumErrors != nullptr) {
@@ -1032,7 +1032,7 @@ EXPORT(SceInt32, sceNgsVoiceSetPreset, ngs::Voice *voice, const SceNgsVoicePrese
     if (!voice || !preset)
         return RET_ERROR(SCE_NGS_ERROR_INVALID_ARG);
 
-    const std::lock_guard<std::mutex> guard(*voice->voice_mutex);
+    const std::lock_guard<std::mutex> guard(voice->voice_mutex);
     if (!voice->set_preset(emuenv.mem, preset))
         return RET_ERROR(SCE_NGS_ERROR);
 

--- a/vita3k/ngs/include/ngs/system.h
+++ b/vita3k/ngs/include/ngs/system.h
@@ -161,7 +161,7 @@ struct Voice {
 
     VoiceInputManager inputs;
 
-    std::unique_ptr<std::mutex> voice_mutex;
+    std::mutex voice_mutex;
     VoiceProduct products[MAX_VOICE_OUTPUT];
 
     Ptr<void> finished_callback;

--- a/vita3k/ngs/src/ngs.cpp
+++ b/vita3k/ngs/src/ngs.cpp
@@ -104,7 +104,7 @@ ModuleData::ModuleData()
 }
 
 SceNgsBufferInfo *ModuleData::lock_params(const MemState &mem) {
-    const std::lock_guard<std::mutex> guard(*parent->voice_mutex);
+    const std::lock_guard<std::mutex> guard(parent->voice_mutex);
 
     // Save a copy of previous set of data
     if (flags & PARAMS_LOCK) {
@@ -121,7 +121,7 @@ SceNgsBufferInfo *ModuleData::lock_params(const MemState &mem) {
 }
 
 bool ModuleData::unlock_params(const MemState &mem) {
-    const std::lock_guard<std::mutex> guard(*parent->voice_mutex);
+    const std::lock_guard<std::mutex> guard(parent->voice_mutex);
 
     parent->rack->modules[index]->on_param_change(mem, *this);
 
@@ -162,11 +162,10 @@ void Voice::init(Rack *mama) {
         patches[i].resize(mama->patches_per_output);
 
     inputs.init(rack->system->granularity, 1);
-    voice_mutex = std::make_unique<std::mutex>();
 }
 
 Ptr<Patch> Voice::patch(const MemState &mem, const int32_t index, int32_t subindex, int32_t dest_index, Voice *dest) {
-    const std::lock_guard<std::mutex> guard(*voice_mutex);
+    const std::lock_guard<std::mutex> guard(voice_mutex);
 
     if (index >= MAX_OUTPUT_PORT) {
         // We don't have enough port for you!
@@ -215,7 +214,7 @@ bool Voice::remove_patch(const MemState &mem, const Ptr<Patch> patch) {
     if (!patch) {
         return false;
     }
-    const std::lock_guard<std::mutex> guard(*voice_mutex);
+    const std::lock_guard<std::mutex> guard(voice_mutex);
     bool found = false;
     for (auto &patches_1 : patches) {
         if (vector_utils::contains(patches_1, patch)) {

--- a/vita3k/ngs/src/route.cpp
+++ b/vita3k/ngs/src/route.cpp
@@ -35,7 +35,7 @@ bool deliver_data(const MemState &mem, const std::vector<Voice *> &voice_queue, 
         if (!vector_utils::contains(voice_queue, patch->dest))
             continue;
 
-        const std::lock_guard<std::mutex> guard(*patch->dest->voice_mutex);
+        const std::lock_guard<std::mutex> guard(patch->dest->voice_mutex);
         patch->dest->inputs.receive(patch, data_to_deliver);
     }
 

--- a/vita3k/ngs/src/scheduler.cpp
+++ b/vita3k/ngs/src/scheduler.cpp
@@ -131,7 +131,7 @@ void VoiceScheduler::update(KernelState &kern, const MemState &mem, const SceUID
 
     for (ngs::Voice *voice : queue_copy) {
         // Modify the state, in peace....
-        std::unique_lock<std::mutex> voice_lock(*voice->voice_mutex);
+        std::unique_lock<std::mutex> voice_lock(voice->voice_mutex);
         memset(voice->products, 0, sizeof(voice->products));
 
         bool finished = false;


### PR DESCRIPTION
- In the debug build, when wrapping `ngs::Voice::voice_mutex` with `std::unique_ptr`, the process freezes at `ngs::Voice::remove_patch` (the game is _Catherine: Full Body_ [PCSG01179]).
- Even without this error, `std::mutex` should be declared directly when used as a member variable, rather than wrapped with `std::unique_ptr`.