### PR TITLE
[Draft] Add Linux Arm support (32-bit)

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -127,10 +127,20 @@ if(WIN32)
 	target_link_libraries(winsock INTERFACE WSOCK32 WS2_32 IPHLPAPI)
 endif()
 
+# Only enable Dynarmic for x86-64 and aarch64 architectures
+if (ARCHITECTURE STREQUAL "x86_64" OR ARCHITECTURE STREQUAL "arm64")
+	message(STATUS "Dynarmic support enabled for architecture: ${ARCHITECTURE}")
+	set(DYNARMIC_ENABLED ON CACHE BOOL "Enable Dynarmic support")
+	add_compile_definitions(DYNARMIC_ENABLED)
+else()
+	message(STATUS "Dynarmic support disabled for architecture: ${ARCHITECTURE}")
+	set(DYNARMIC_ENABLED OFF CACHE BOOL "Enable Dynarmic support")
+endif()
+
 set(DYNARMIC_TESTS OFF CACHE BOOL "")
 set(DYNARMIC_NO_BUNDLED_FMT ON CACHE BOOL "")
 set(DYNARMIC_FRONTENDS "A32" CACHE STRING "")
-add_subdirectory(dynarmic)
+add_subdirectory(dynarmic EXCLUDE_FROM_ALL)
 
 if(MSVC)
 	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -235,7 +245,7 @@ if(APPLE)
 			"${CMAKE_BINARY_DIR}/external/MoltenVK-macos.tar" SHOW_PROGRESS)
 	endif()
 	if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/MoltenVK")
-		execute_process(COMMAND tar xf "${CMAKE_BINARY_DIR}/external/MoltenVK-macos.tar" --strip-components=1 MoltenVK/MoltenVK 
+		execute_process(COMMAND tar xf "${CMAKE_BINARY_DIR}/external/MoltenVK-macos.tar" --strip-components=1 MoltenVK/MoltenVK
 			WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external")
 	endif()
 	target_include_directories(vulkan INTERFACE "${CMAKE_BINARY_DIR}/external/MoltenVK/include")
@@ -260,6 +270,12 @@ elseif(ANDROID AND NOT (CMAKE_BUILD_TYPE STREQUAL "Release"))
 
 		file(COPY "${CMAKE_BINARY_DIR}/external/validation_layers/${VALIDATION_BINARY}/${ANDROID_ABI}" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/../android/prebuilt")
 	endif()
+endif()
+
+# See https://github.com/KhronosGroup/Vulkan-Hpp?tab=readme-ov-file#cc-interop-for-handles
+if(ARCHITECTURE STREQUAL "arm")
+	message(STATUS "Enabling Vulkan-Hpp typesafe conversion for arm architecture")
+	target_compile_definitions(vulkan INTERFACE VULKAN_HPP_TYPESAFE_CONVERSION=1)
 endif()
 
 add_library(vma INTERFACE)
@@ -329,7 +345,7 @@ if(NOT OPENSSL_FOUND OR FORCE_BUILD_OPENSSL_MAC)
 				if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/openssl/arm64")
 					file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external/openssl/arm64")
 					execute_process(COMMAND perl ../Configure darwin64-arm64 -mmacosx-version-min=11 WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/openssl/arm64")
-					execute_process(COMMAND make -j${CPU_COUNT} WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/openssl/arm64" OUTPUT_QUIET)	
+					execute_process(COMMAND make -j${CPU_COUNT} WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/openssl/arm64" OUTPUT_QUIET)
 				endif()
 				if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/openssl/x86_64")
 					file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external/openssl/x86_64")

--- a/vita3k/cpu/CMakeLists.txt
+++ b/vita3k/cpu/CMakeLists.txt
@@ -2,15 +2,20 @@ set(SOURCE_LIST
 include/cpu/state.h
 include/cpu/common.h
 include/cpu/functions.h
-include/cpu/impl/dynarmic_cpu.h
 include/cpu/impl/interface.h
 include/cpu/disasm/functions.h
 include/cpu/disasm/state.h
 
 src/disasm.cpp
 src/cpu.cpp
-src/dynarmic_cpu.cpp
 )
+
+if(DYNARMIC_ENABLED)
+    list(APPEND SOURCE_LIST
+        include/cpu/impl/dynarmic_cpu.h
+        src/dynarmic_cpu.cpp
+    )
+endif()
 
 add_library(
 cpu
@@ -22,4 +27,10 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_LIST})
 
 target_include_directories(cpu PUBLIC include)
 target_link_libraries(cpu PUBLIC mem util)
-target_link_libraries(cpu PRIVATE dynarmic capstone merry::mcl)
+
+set(CPU_LINK_LIBRARIES capstone merry::mcl)
+if(DYNARMIC_ENABLED)
+    list(APPEND CPU_LINK_LIBRARIES dynarmic)
+endif()
+
+target_link_libraries(cpu PRIVATE ${CPU_LINK_LIBRARIES})

--- a/vita3k/cpu/src/cpu.cpp
+++ b/vita3k/cpu/src/cpu.cpp
@@ -17,7 +17,9 @@
 
 #include <cpu/disasm/functions.h>
 #include <cpu/functions.h>
+#if DYNARMIC_ENABLED
 #include <cpu/impl/dynarmic_cpu.h>
+#endif
 #include <cpu/impl/interface.h>
 #include <cpu/state.h>
 #include <mem/ptr.h>
@@ -56,8 +58,10 @@ CPUStatePtr init_cpu(bool cpu_opt, SceUID thread_id, std::size_t processor_id, M
         return CPUStatePtr();
     }
 
+#if DYNARMIC_ENABLED
     Dynarmic::ExclusiveMonitor *monitor = static_cast<Dynarmic::ExclusiveMonitor *>(protocol->get_exclusive_monitor());
     state->cpu = std::make_unique<DynarmicCPU>(state.get(), processor_id, monitor, cpu_opt);
+#endif
 
     return state;
 }

--- a/vita3k/mem/include/mem/state.h
+++ b/vita3k/mem/include/mem/state.h
@@ -76,5 +76,5 @@ struct MemState {
 
     bool use_page_table = false;
     PageTable page_table;
-    std::map<uint64_t, MemExternalMapping, std::greater<>> external_mapping;
+    std::map<uintptr_t, MemExternalMapping, std::greater<>> external_mapping;
 };

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -263,7 +263,7 @@ bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcep
     if (fault_addr < memory_addr || fault_addr >= memory_addr + TOTAL_MEM_SIZE) {
         if (state.use_page_table) {
             // this may come from an external mapping
-            uint64_t addr_val = std::bit_cast<uint64_t>(addr);
+            uintptr_t addr_val = std::bit_cast<uintptr_t>(addr);
             auto it = state.external_mapping.lower_bound(addr_val);
             if (it != state.external_mapping.end() && addr_val < it->first + it->second.size) {
                 vaddr = static_cast<Address>(addr_val - it->first + it->second.address);
@@ -371,7 +371,7 @@ void add_external_mapping(MemState &mem, Address addr, uint32_t size, uint8_t *a
     if (!mem.use_page_table)
         return;
 
-    uint64_t addr_value = std::bit_cast<uint64_t>(addr_ptr);
+    uintptr_t addr_value = std::bit_cast<uintptr_t>(addr_ptr);
     uint8_t *page_table_entry = addr_ptr - addr;
     uint8_t *original_address = &mem.memory[addr];
     for (int block = 0; block < size / KiB(4); block++) {
@@ -390,7 +390,7 @@ void add_external_mapping(MemState &mem, Address addr, uint32_t size, uint8_t *a
 }
 
 void remove_external_mapping(MemState &mem, uint8_t *addr_ptr, uint32_t size) {
-    uint64_t addr_value = std::bit_cast<uint64_t>(addr_ptr);
+    uintptr_t addr_value = std::bit_cast<uintptr_t>(addr_ptr);
     MemExternalMapping mapping;
     if (mem.use_page_table) {
         const std::unique_lock<std::mutex> lock(mem.protect_mutex);
@@ -545,7 +545,14 @@ static void register_access_violation_handler(const AccessViolationHandler &hand
 static void signal_handler(int sig, siginfo_t *info, void *uct) noexcept {
     auto context = static_cast<ucontext_t *>(uct);
 
-#ifdef __aarch64__
+#ifdef __arm__
+    // TODO: handle ARM exceptions
+    const bool is_executing = false;
+    const bool is_writing = false;
+    LOG_CRITICAL("Unhandled ARM access violation at {}", log_hex(reinterpret_cast<uintptr_t>(info->si_addr)));
+    raise(SIGTRAP);
+    return;
+#elif __aarch64__
 #ifdef __APPLE__
     const uint32_t esr = context->uc_mcontext->__es.__esr;
 #else
@@ -583,7 +590,7 @@ static void signal_handler(int sig, siginfo_t *info, void *uct) noexcept {
         }
     }
 
-    LOG_CRITICAL("Unhandled access to 0x{:X}", reinterpret_cast<uintptr_t>(info->si_addr));
+    LOG_CRITICAL("Unhandled access to {}", log_hex(reinterpret_cast<uintptr_t>(info->si_addr)));
     raise(SIGTRAP);
     return;
 }

--- a/vita3k/ngs/src/modules/player.cpp
+++ b/vita3k/ngs/src/modules/player.cpp
@@ -53,7 +53,7 @@ void PlayerModule::on_param_change(const MemState &mem, ModuleData &data) {
 
     // check for invalid playback values
     const auto is_invalid_playback_value = [](const float playback_value, const float max_value) {
-        return isnan(playback_value) || (playback_value < 0.f) || (playback_value > max_value);
+        return std::isnan(playback_value) || (playback_value < 0.f) || (playback_value > max_value);
     };
 
     if (is_invalid_playback_value(new_params->playback_scalar, 10.f)) {

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -1243,8 +1243,8 @@ bool VKState::map_memory(MemState &mem, Ptr<void> address, uint32_t size) {
             .preferredFlags = vk::MemoryPropertyFlagBits::eHostCached,
         };
         buffer.init_buffer(mapped_memory_flags, memory_mapped_alloc);
-        const uint64_t buffer_ptr_val = std::bit_cast<uint64_t>(buffer.mapped_data);
-        const uint64_t buffer_offset = align(buffer_ptr_val, KiB(4)) - buffer_ptr_val;
+        const uintptr_t buffer_ptr_val = std::bit_cast<uintptr_t>(buffer.mapped_data);
+        const intptr_t buffer_offset = align(buffer_ptr_val, KiB(4)) - buffer_ptr_val;
         buffer.mapped_data = std::bit_cast<void *>(buffer_ptr_val + buffer_offset);
 
         vk::BufferDeviceAddressInfoKHR address_info{

--- a/vita3k/util/src/float_to_half.cpp
+++ b/vita3k/util/src/float_to_half.cpp
@@ -26,7 +26,7 @@ we can have 2 cases
 
 #include <cstdint>
 
-#if defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__)
 #include <arm_neon.h>
 void float_to_half(const float *src, uint16_t *dest, const int total) {
     // use the native type __fp16

--- a/vita3k/util/src/instrset_detect.cpp
+++ b/vita3k/util/src/instrset_detect.cpp
@@ -17,7 +17,7 @@
 // Header files for non-vector intrinsic functions including _BitScanReverse(int), __cpuid(int[4],int), _xgetbv(int)
 #if defined(_MSC_VER) // Microsoft compiler or compatible Intel compiler
 #include <intrin.h>
-#elif !defined(__aarch64__)
+#elif !defined(__arm__) && !defined(__aarch64__)
 #include <x86intrin.h> // Gcc or Clang compiler
 #endif
 
@@ -28,7 +28,7 @@ namespace util {
 // input:  functionnumber = leaf (eax), ecxleaf = subleaf(ecx)
 // output: output[0] = eax, output[1] = ebx, output[2] = ecx, output[3] = edx
 static inline void cpuid(int output[4], int functionnumber, int ecxleaf) {
-#if defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__)
     return;
 
 #elif defined(__GNUC__) || defined(__clang__) // use inline assembly, Gnu/AT&T syntax
@@ -61,7 +61,7 @@ static inline void cpuid(int output[4], int functionnumber, int ecxleaf) {
 
 // Define interface to xgetbv instruction
 static inline uint64_t xgetbv(int ctr) {
-#if defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__)
     return 0;
 #elif (defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 160040000) || (defined(__INTEL_COMPILER) && __INTEL_COMPILER >= 1200)
     // Microsoft or Intel compiler supporting _xgetbv intrinsic
@@ -108,7 +108,7 @@ namespace instrset {
    10  or above = AVX512VL, AVX512BW, AVX512DQ
 */
 int instrset_detect(void) {
-#ifdef __aarch64__
+#if defined(__arm__) || defined(__aarch64__)
     return 0;
 #else
     static int iset = -1; // remember value for next call

--- a/vita3k/vkutil/include/vkutil/objects.h
+++ b/vita3k/vkutil/include/vkutil/objects.h
@@ -166,7 +166,8 @@ public:
             return;
 
         destroy_list.push_back(static_cast<uint64_t>(T::objectType));
-        destroy_list.push_back(std::bit_cast<uint64_t>(vk_object));
+        auto raw_handle = static_cast<typename T::CType>(vk_object);
+        destroy_list.push_back(reinterpret_cast<uint64_t>(raw_handle));
         vk_object = nullptr;
     }
 

--- a/vita3k/vkutil/src/objects.cpp
+++ b/vita3k/vkutil/src/objects.cpp
@@ -252,7 +252,7 @@ void DestroyQueue::add_image(Image &image) {
     if (image.image) {
         add(image.image);
         image.image = nullptr;
-        destroy_list.push_back(std::bit_cast<uint64_t>(image.allocation));
+        destroy_list.push_back(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(static_cast<VmaAllocation>(image.allocation))));
     }
 }
 
@@ -260,7 +260,7 @@ void DestroyQueue::add_buffer(Buffer &buffer) {
     if (buffer.buffer) {
         add(buffer.buffer);
         buffer.buffer = nullptr;
-        destroy_list.push_back(std::bit_cast<uint64_t>(buffer.allocation));
+        destroy_list.push_back(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(static_cast<VmaAllocation>(buffer.allocation))));
     }
 }
 
@@ -290,7 +290,7 @@ void DestroyQueue::destroy_objects() {
         case vk::ObjectType::eImage: {
             // special case: this is a vma allocation
             auto image = std::bit_cast<vk::Image>(el);
-            auto allocation = std::bit_cast<vma::Allocation>(destroy_list[idx++]);
+            auto allocation = reinterpret_cast<VmaAllocation>(static_cast<uintptr_t>(destroy_list[idx++]));
             allocator.destroyImage(image, allocation);
             break;
         }
@@ -298,16 +298,16 @@ void DestroyQueue::destroy_objects() {
         case vk::ObjectType::eBuffer: {
             // special case: this is a vma allocation
             auto buffer = std::bit_cast<vk::Buffer>(el);
-            auto allocation = std::bit_cast<vma::Allocation>(destroy_list[idx++]);
+            auto allocation = reinterpret_cast<VmaAllocation>(static_cast<uintptr_t>(destroy_list[idx++]));
             allocator.destroyBuffer(buffer, allocation);
             break;
         }
 
         case vk::ObjectType::eCommandBuffer: {
             // special case: we must specify the command pool
-            auto cmd_buffer = std::bit_cast<vk::CommandBuffer>(el);
+            auto cmd_buffer = reinterpret_cast<VkCommandBuffer>(static_cast<uintptr_t>(el));
             auto cmd_pool = std::bit_cast<vk::CommandPool>(destroy_list[idx++]);
-            device.freeCommandBuffers(cmd_pool, cmd_buffer);
+            device.freeCommandBuffers(cmd_pool, vk::CommandBuffer(cmd_buffer));
             break;
         }
 


### PR DESCRIPTION
Initial support to compile for Linux Arm 32-bit.
This is the first step to progressively implement **_native execution_** on Arm 32-bit ([vita2hos](https://github.com/xerpi/vita2hos) is a proof-of-concept that shows this should be feasible).

The main changes are:
- Disable Dynarmic when targeting 32-bit Arm.
- Change `uint64_t` that acted as pointers on 64-bit architectures to `uintptr_t`
- Handling exceptions on 32-bit Arm is a TODO
- I also had to bump ffmpeg to a newer version because the current one was not compiling

Note: it still doesn't compile yet. Dynarmic's exclusive monitor allocation has to be moved/refactored (probably to Dynarmic's `CPUInterface` backend class)