### PR TITLE
modules/SceNgs: Fix softlock when no callback is provided.

### DIFF
--- a/vita3k/ngs/include/ngs/system.h
+++ b/vita3k/ngs/include/ngs/system.h
@@ -194,6 +194,8 @@ struct Rack : public MempoolObject {
     int32_t max_patches_per_input;
     int32_t patches_per_output;
 
+    uint32_t initial_blocks_count;
+
     std::vector<Ptr<Voice>> voices;
     std::vector<std::unique_ptr<Module>> modules;
 

--- a/vita3k/ngs/src/scheduler.cpp
+++ b/vita3k/ngs/src/scheduler.cpp
@@ -175,7 +175,8 @@ void VoiceScheduler::update(KernelState &kern, const MemState &mem, const SceUID
         case PendingType::ReleaseRack:
             release_rack(*op.release_data.state, mem, op.system, op.release_data.rack);
             // run callback (we know it is defined)
-            kern.get_thread(thread_id)->run_callback(op.release_data.callback, { Ptr<void>(op.release_data.rack, mem).address() });
+            if (op.release_data.callback)
+                kern.get_thread(thread_id)->run_callback(op.release_data.callback, { Ptr<void>(op.release_data.rack, mem).address() });
             break;
         }
 


### PR DESCRIPTION
# About
- modules/SceNgs: Fix softlock when no callback is provided.
ngs: Add sanity check on allocator block count to avoid false double-free detection.

Relates to an old issue with Jetpack Joyride.

This PR addresses an issue where some games call sceNgsRackRelease without providing a callback, expecting the rack to be released synchronously.
However, the rack might also be released later by the engine (e.g., in VoiceScheduler::update), leading to a double destruction and potential crash or undefined behavior.

# Fix implementation
- init_rack now stores the initial allocator block count after allocation.
- release_rack compares the current block count to the stored value:
If it matches → the rack is assumed to be valid, and destruction proceeds.
If it differs → the rack is assumed to have already been released (e.g., by game-side memory reuse), so destruction is skipped.

This is a non-invasive workaround to avoid softlocks and crashes, especially in games that reuse memory aggressively or rely on single-threaded update logic.