### PR TITLE
gui: Apply Dynamic Font Rendering introduced in ImGui 1.20

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -63,7 +63,6 @@ void update_viewport(EmuEnvState &state) {
 
     state.system_dpi_scale = SDL_GetWindowPixelDensity(state.window.get());
     state.manual_dpi_scale = SDL_GetDisplayContentScale(SDL_GetDisplayForWindow(state.window.get()));
-    ImGui::GetIO().FontGlobalScale = 1.f * state.manual_dpi_scale;
 
     if (h > 0) {
         const float window_aspect = static_cast<float>(w) / h;
@@ -106,6 +105,9 @@ void update_viewport(EmuEnvState &state) {
 
         state.gui_scale.x = state.logical_viewport_size.x / static_cast<float>(DEFAULT_RES_WIDTH) / state.manual_dpi_scale;
         state.gui_scale.y = state.logical_viewport_size.y / static_cast<float>(DEFAULT_RES_HEIGHT) / state.manual_dpi_scale;
+
+        // Update font scale to include both manual_dpi_scale and gui_scale
+        ImGui::GetStyle().FontScaleMain = state.manual_dpi_scale * state.gui_scale.x;
     } else {
         state.logical_viewport_pos.x = 0;
         state.logical_viewport_pos.y = 0;
@@ -116,20 +118,6 @@ void update_viewport(EmuEnvState &state) {
         state.drawable_viewport_pos.y = 0;
         state.drawable_viewport_size.x = 0;
         state.drawable_viewport_size.y = 0;
-    }
-
-    // Update nearest font level
-    float scale = state.gui_scale.y * state.system_dpi_scale * state.manual_dpi_scale;
-    state.current_font_level = 0;
-    for (int i = 0; i <= state.max_font_level; i++) {
-        if (i == state.max_font_level || scale <= FontScaleCandidates[i]) {
-            state.current_font_level = i;
-            break;
-        }
-        if (FontScaleCandidates[i] / scale > scale / FontScaleCandidates[i + 1]) {
-            state.current_font_level = i;
-            break;
-        }
     }
 }
 

--- a/vita3k/emuenv/include/emuenv/state.h
+++ b/vita3k/emuenv/include/emuenv/state.h
@@ -174,8 +174,6 @@ public:
     FVector2 gui_scale = { 1.f, 1.f };
     GDBState &gdb;
     HTTPState &http;
-    int max_font_level = 0;
-    int current_font_level = 0;
 
     EmuEnvState();
     // declaring a destructor is necessary to forward declare unique_ptrs

--- a/vita3k/gui/include/gui/imgui_impl_sdl.h
+++ b/vita3k/gui/include/gui/imgui_impl_sdl.h
@@ -19,6 +19,7 @@
 
 #include <emuenv/window.h>
 #include <gui/imgui_impl_sdl_state.h>
+#include <imgui.h>
 
 union SDL_Event;
 struct SDL_Window;
@@ -33,6 +34,12 @@ IMGUI_API bool ImGui_ImplSdl_ProcessEvent(ImGui_State *state, SDL_Event *event);
 IMGUI_API ImTextureID ImGui_ImplSdl_CreateTexture(ImGui_State *state, void *data, int width, int height);
 IMGUI_API void ImGui_ImplSdl_DeleteTexture(ImGui_State *state, ImTextureID texture);
 
+// (Advanced) Use e.g. if you need to precisely control the timing of texture updates (e.g. for staged rendering), by setting ImDrawData::Textures = NULL to handle this manually.
+IMGUI_API void ImGui_ImplSdl_UpdateTexture(ImGui_State *state, ImTextureData *tex);
+
 // Use if you want to reset your rendering device without losing ImGui state.
 IMGUI_API void ImGui_ImplSdl_InvalidateDeviceObjects(ImGui_State *state);
 IMGUI_API bool ImGui_ImplSdl_CreateDeviceObjects(ImGui_State *state);
+
+// SDL to ImGui key conversion utilitiy (For ImGui 1.91.5+)
+IMGUI_API ImGuiKey ImGui_ImplSdl_ScancodeToImGuiKey(int scancode);

--- a/vita3k/gui/include/gui/imgui_impl_sdl_gl3.h
+++ b/vita3k/gui/include/gui/imgui_impl_sdl_gl3.h
@@ -4,6 +4,7 @@
 
 // Implemented features:
 //  [X] User texture binding. Cast 'GLuint' OpenGL texture identifier as void*/ImTextureID. Read the FAQ about ImTextureID in imgui.cpp.
+//  [X] Renderer: Texture updates support for dynamic font atlas (ImGuiBackendFlags_RendererHasTextures).
 // Missing features:
 //  [ ] SDL2 handling of IME under Windows appears to be broken and it explicitly disable the regular Windows IME. You can restore Windows IME by compiling SDL with SDL_DISABLE_WINDOWS_IME.
 
@@ -27,6 +28,8 @@ struct ImGui_GLState : public ImGui_State {
     uint32_t attribute_location_tex = 0, attribute_projection_mat = 0;
     uint32_t attribute_position_location = 0, attribute_uv_location = 0, attribute_color_location = 0;
     uint32_t vbo = 0, elements = 0;
+    int32_t max_texture_size = 0;
+    ImVector<char> temp_buffer;
 
     // GL actually never needs the renderer. Putting it here just in case it is needed in the future.
     inline renderer::gl::GLState &get_renderer() {
@@ -40,6 +43,9 @@ IMGUI_API void ImGui_ImplSdlGL3_RenderDrawData(ImGui_GLState &state);
 
 IMGUI_API ImTextureID ImGui_ImplSdlGL3_CreateTexture(void *data, int width, int height);
 IMGUI_API void ImGui_ImplSdlGL3_DeleteTexture(ImTextureID texture);
+
+// (Advanced) Use e.g. if you need to precisely control the timing of texture updates (e.g. for staged rendering), by setting ImDrawData::Textures = NULL to handle this manually.
+IMGUI_API void ImGui_ImplSdlGL3_UpdateTexture(ImGui_GLState &state, ImTextureData *tex);
 
 // Use if you want to reset your rendering device without losing ImGui state.
 IMGUI_API void ImGui_ImplSdlGL3_InvalidateDeviceObjects(ImGui_GLState &state);

--- a/vita3k/gui/include/gui/imgui_impl_sdl_state.h
+++ b/vita3k/gui/include/gui/imgui_impl_sdl_state.h
@@ -49,7 +49,7 @@ struct ImGui_State {
 
 class ImGui_Texture {
     ImGui_State *state = nullptr;
-    ImTextureID texture_id = nullptr;
+    ImTextureID texture_id = 0;
 
 public:
     ImGui_Texture() = default;
@@ -65,6 +65,8 @@ public:
 
     ImGui_Texture &operator=(ImGui_Texture &&texture) noexcept;
     ImGui_Texture &operator=(const ImGui_Texture &texture) = delete;
+
+    operator ImTextureRef() const;
 
     ~ImGui_Texture();
 };

--- a/vita3k/gui/include/gui/imgui_impl_sdl_vulkan.h
+++ b/vita3k/gui/include/gui/imgui_impl_sdl_vulkan.h
@@ -86,6 +86,10 @@ struct ImGui_VulkanState : public ImGui_State {
 
     // Render buffers
     ImGui_ImplVulkanH_WindowRenderBuffers MainWindowRenderBuffers;
+
+    // Texture management
+    vk::CommandPool TexCommandPool{};
+    vk::CommandBuffer TexCommandBuffer{};
 };
 
 IMGUI_API ImGui_VulkanState *ImGui_ImplSdlVulkan_Init(renderer::State *renderer, SDL_Window *window);
@@ -95,6 +99,9 @@ IMGUI_API void ImGui_ImplSdlVulkan_RenderDrawData(ImGui_VulkanState &state);
 // if is_alpha is set to true, the texture only has one alpha component, the other channels map to 1
 IMGUI_API ImTextureID ImGui_ImplSdlVulkan_CreateTexture(ImGui_VulkanState &state, void *pixels, int width, int height, bool is_alpha = false);
 IMGUI_API void ImGui_ImplSdlVulkan_DeleteTexture(ImGui_VulkanState &state, ImTextureID texture);
+
+// (Advanced) Use e.g. if you need to precisely control the timing of texture updates (e.g. for staged rendering), by setting ImDrawData::Textures = NULL to handle this manually.
+IMGUI_API void ImGui_ImplSdlVulkan_UpdateTexture(ImGui_VulkanState &state, ImTextureData *tex);
 
 // Use if you want to reset your rendering device without losing ImGui state.
 IMGUI_API void ImGui_ImplSdlVulkan_InvalidateDeviceObjects(ImGui_VulkanState &state);

--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -245,10 +245,6 @@ struct InfoMessage {
     std::string msg;
 };
 
-// 2.f is enough for the current font size.
-const float FontScaleCandidates[] = { 1.f, 1.5f, 2.f };
-const int FontScaleCandidatesSize = std::size(FontScaleCandidates);
-
 struct GuiState {
     std::unique_ptr<ImGui_State> imgui_state;
 
@@ -347,8 +343,8 @@ struct GuiState {
     ImVec2 trophy_window_pos;
 
     // imgui
-    ImFont *monospaced_font[FontScaleCandidatesSize]{};
-    ImFont *vita_font[FontScaleCandidatesSize]{};
-    ImFont *large_font[FontScaleCandidatesSize]{};
+    ImFont *monospaced_font;
+    ImFont *vita_font;
+    ImFont *large_font;
     bool fw_font = false;
 };

--- a/vita3k/gui/src/about_dialog.cpp
+++ b/vita3k/gui/src/about_dialog.cpp
@@ -65,7 +65,7 @@ void draw_about_dialog(GuiState &gui, EmuEnvState &emuenv) {
 
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin("##about", &gui.help_menu.about_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["title"].c_str());
     ImGui::Spacing();
     ImGui::Separator();

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -547,7 +547,7 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                 ImGui::TextColored(GUI_COLOR_TEXT, "\n");
             }
             ImGui::EndChild();
-            ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.4f);
             ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (BUTTON_SIZE.x / 2.f), WINDOW_SIZE.y - BUTTON_SIZE.y - (22.f * SCALE.y)));
         } else {
             // Delete Data
@@ -558,23 +558,23 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                 const ImVec2 POS_MAX(POS_MIN.x + PUPOP_ICON_SIZE.x, POS_MIN.y + PUPOP_ICON_SIZE.y);
                 ImGui::GetWindowDrawList()->AddImageRounded(gui.app_selector.user_apps_icon[title_id], POS_MIN, POS_MAX, ImVec2(0, 0), ImVec2(1, 1), IM_COL32_WHITE, PUPOP_ICON_SIZE.x * SCALE.x, ImDrawFlags_RoundCornersAll);
             }
-            ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.6f);
             ImGui::SetCursorPosY(ICON_MARGIN + PUPOP_ICON_SIZE.y + (4.f * SCALE.y));
             TextColoredCentered(GUI_COLOR_TEXT, APP_INDEX->stitle.c_str());
-            ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.4f);
             ImGui::SetCursorPosY((WINDOW_SIZE.y / 2) + 10);
             TextColoredCentered(GUI_COLOR_TEXT, context_dialog.c_str(), 54.f * SCALE.x);
             if (context_dialog == lang.deleting["app_delete"])
                 SetTooltipEx(lang.deleting["app_delete_description"].c_str());
-            ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.4f);
             ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2) - (BUTTON_SIZE.x + (20.f * SCALE.x)), WINDOW_SIZE.y - BUTTON_SIZE.y - (24.0f * SCALE.y)));
-            if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+            if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
                 context_dialog.clear();
             }
             ImGui::SameLine();
             ImGui::SetCursorPosX((WINDOW_SIZE.x / 2.f) + (20.f * SCALE.x));
         }
-        if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross))) {
+        if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross))) {
             if (context_dialog == lang.deleting["app_delete"])
                 delete_app(gui, emuenv, app_path);
             if (context_dialog == lang.deleting["addcont_delete"])
@@ -596,9 +596,9 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
         ImGui::SetNextWindowPos(ImVec2(emuenv.logical_viewport_pos.x, emuenv.logical_viewport_pos.y), ImGuiCond_Always);
         ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
         ImGui::Begin("##information", &gui.vita_area.app_information, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
-        ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.5f);
         ImGui::SetCursorPos(ImVec2(10.0f * SCALE.x, 10.0f * SCALE.y));
-        if (ImGui::Button("X", ImVec2(40.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+        if (ImGui::Button("X", ImVec2(40.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
             gui.vita_area.app_information = false;
             gui.vita_area.information_bar = true;
         }

--- a/vita3k/gui/src/archive_install_dialog.cpp
+++ b/vita3k/gui/src/archive_install_dialog.cpp
@@ -99,7 +99,7 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f * SCALE.x);
     ImGui::BeginChild("##archive_Install_child", WINDOW_SIZE, ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     const auto POS_BUTTON = (ImGui::GetWindowWidth() / 2.f) - (BUTTON_SIZE.x / 2.f) + (10.f * SCALE.x);
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     TextColoredCentered(GUI_COLOR_TEXT_MENUBAR, title.c_str());
     ImGui::Spacing();
     ImGui::Separator();

--- a/vita3k/gui/src/common_dialog.cpp
+++ b/vita3k/gui/src/common_dialog.cpp
@@ -627,7 +627,7 @@ static void draw_savedata_dialog(GuiState &gui, EmuEnvState &emuenv, float FONT_
 }
 
 void draw_common_dialog(GuiState &gui, EmuEnvState &emuenv) {
-    ImGui::PushFont(gui.vita_font[emuenv.current_font_level]);
+    ImGui::PushFont(gui.vita_font);
     const auto RES_SCALE = ImVec2(emuenv.gui_scale.x, emuenv.gui_scale.y);
     const auto SCALE = ImVec2(RES_SCALE.x * emuenv.manual_dpi_scale, RES_SCALE.y * emuenv.manual_dpi_scale);
     if (emuenv.common_dialog.status == SCE_COMMON_DIALOG_STATUS_RUNNING) {

--- a/vita3k/gui/src/compile_shaders.cpp
+++ b/vita3k/gui/src/compile_shaders.cpp
@@ -33,13 +33,13 @@ void draw_pre_compiling_shaders_progress(GuiState &gui, EmuEnvState &emuenv, con
     const auto WINDOW_SIZE = ImVec2(616.f * SCALE.x, 236.f * SCALE.y);
     const auto ICON_SIZE_SCALE = ImVec2(96.f * SCALE.x, 96.f * SCALE.y);
 
-    ImGui::PushFont(gui.vita_font[emuenv.current_font_level]);
+    ImGui::PushFont(gui.vita_font);
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(WINDOW_SIZE);
     ImGui::SetNextWindowBgAlpha(0.9f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.f);
     ImGui::Begin("##shaders_pre_compile", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::SetWindowFontScale(1.1f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.1f);
 
     // Check if icon exist
     if (gui.app_selector.user_apps_icon.contains(emuenv.io.app_path)) {

--- a/vita3k/gui/src/content_manager.cpp
+++ b/vita3k/gui/src/content_manager.cpp
@@ -267,7 +267,7 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
     else
         draw_list->AddRectFilled(VIEWPORT_POS, VIEWPORT_POS_MAX, IM_COL32(53.f, 54.f, 70.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
 
-    ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.5f);
 
     auto &lang = gui.lang.content_manager;
     auto &application = lang.application;
@@ -300,9 +300,9 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
 
             // Free Space
             const auto scal_font = 19.2f / ImGui::GetFontSize();
-            draw_list->AddText(gui.vita_font[emuenv.current_font_level], 19.2f * SCALE.x, ImVec2((VIEWPORT_POS.x + VIEWPORT_SIZE.x - ((ImGui::CalcTextSize(lang.main["free_space"].c_str()).x * scal_font)) * SCALE.x) - (15.f * SCALE.x), VIEWPORT_POS.y + (42.f * SCALE.y)),
+            draw_list->AddText(gui.vita_font, 19.2f * SCALE.x, ImVec2((VIEWPORT_POS.x + VIEWPORT_SIZE.x - ((ImGui::CalcTextSize(lang.main["free_space"].c_str()).x * scal_font)) * SCALE.x) - (15.f * SCALE.x), VIEWPORT_POS.y + (42.f * SCALE.y)),
                 IM_COL32_WHITE, lang.main["free_space"].c_str());
-            draw_list->AddText(gui.vita_font[emuenv.current_font_level], 19.2f * SCALE.x, ImVec2((VIEWPORT_POS.x + VIEWPORT_SIZE.x - ((ImGui::CalcTextSize(space["free"].c_str()).x * scal_font)) * SCALE.x) - (15.f * SCALE.x), VIEWPORT_POS.y + (68.f * SCALE.y)),
+            draw_list->AddText(gui.vita_font, 19.2f * SCALE.x, ImVec2((VIEWPORT_POS.x + VIEWPORT_SIZE.x - ((ImGui::CalcTextSize(space["free"].c_str()).x * scal_font)) * SCALE.x) - (15.f * SCALE.x), VIEWPORT_POS.y + (68.f * SCALE.y)),
                 IM_COL32_WHITE, space["free"].c_str());
         }
         ImGui::SetCursorPosY(64.0f * SCALE.y);
@@ -384,7 +384,7 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f * SCALE.x);
             ImGui::BeginChild("##app_delete_child", POPUP_SIZE, ImGuiChildFlags_Borders, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
             ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f * SCALE.x);
-            ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.6f);
             ImGui::SetCursorPos(ImVec2(52.f * SCALE.x, 80.f * SCALE.y));
             ImGui::PushTextWrapPos(POPUP_SIZE.x);
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", menu == "app" ? application["delete"].c_str() : saved_data["delete"].c_str());
@@ -392,11 +392,11 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::SetCursorPos(ImVec2(106.f * SCALE.x, ImGui::GetCursorPosY() + (76.f * SCALE.y)));
             ImGui::TextColored(GUI_COLOR_TEXT, "%s %s", gui.lang.game_data["data_delete"].c_str(), size_selected_contents.c_str());
             ImGui::SetCursorPos(ImVec2((POPUP_SIZE.x / 2) - (BUTTON_SIZE.x + (10.f * SCALE.x)), POPUP_SIZE.y - BUTTON_SIZE.y - (22.0f * SCALE.y)));
-            if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+            if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
                 popup = false;
             }
             ImGui::SameLine(0, 20.f * SCALE.x);
-            if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross))) {
+            if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross))) {
                 content_delete = true;
                 popup = false;
             }
@@ -559,12 +559,12 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
 
     ImGui::EndChild();
 
-    ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.2f);
     ImGui::SetCursorPos(ImVec2(10.f * SCALE.x, WINDOW_SIZE.y - (56.f * SCALE.y)));
     const auto is_empty = ((menu == "app") && gui.app_selector.user_apps.empty()) || ((menu == "save") && save_data_list.empty());
     if (menu.empty() || (menu == "info") || is_empty) {
         // Back
-        if (ImGui::Button("<<", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+        if (ImGui::Button("<<", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
             if (!menu.empty()) {
                 if (menu == "info") {
                     menu = "app";
@@ -575,20 +575,20 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
                 close_system_app(gui, emuenv);
         }
     } else {
-        ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.5f);
 
         // Draw the bottom band
         draw_list->AddRectFilled(ImVec2(VIEWPORT_POS.x, VIEWPORT_POS.y + (482.f * SCALE.y)), VIEWPORT_POS_MAX, IM_COL32(39.f, 42.f, 49.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
 
         // Cancel
-        if (ImGui::Button(common["cancel"].c_str(), ImVec2(202.f * SCALE.x, 44.f * SCALE.y)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+        if (ImGui::Button(common["cancel"].c_str(), ImVec2(202.f * SCALE.x, 44.f * SCALE.y)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
             if (!menu.empty()) {
                 menu.clear();
                 contents_selected.clear();
             }
         }
         const auto state = std::any_of(std::begin(contents_selected), std::end(contents_selected), [&](const auto &c) { return !c.second; });
-        ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.2f);
         ImGui::SetCursorPos(ImVec2(WINDOW_SIZE.x - (450.f * SCALE.x), WINDOW_SIZE.y - (56.f * SCALE.y)));
         if (ImGui::Button(state ? common["select_all"].c_str() : lang.main["clear_all"].c_str(), ImVec2(224.f * SCALE.x, 44.f * SCALE.y))) {
             for (auto &content : contents_selected) {
@@ -600,7 +600,7 @@ void draw_content_manager(GuiState &gui, EmuEnvState &emuenv) {
         }
         const auto is_enable = std::any_of(std::begin(contents_selected), std::end(contents_selected), [&](const auto &cs) { return cs.second; });
         ImGui::SameLine();
-        ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.5f);
         ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.5f, 0.5f));
         if (is_enable ? ImGui::Button(common["delete"].c_str(), ImVec2(202.f * SCALE.x, 44.f * SCALE.y)) && get_size_selected_contents(gui, emuenv) : ImGui::Selectable(common["delete"].c_str(), false, ImGuiSelectableFlags_Disabled, ImVec2(194.f * SCALE.x, 36.f * SCALE.y)))
             popup = true;

--- a/vita3k/gui/src/controllers_dialog.cpp
+++ b/vita3k/gui/src/controllers_dialog.cpp
@@ -220,7 +220,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
 
     ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f)), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin("##controllers", &gui.controls_menu.controllers_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["title"].c_str());
     ImGui::Spacing();
     ImGui::Separator();
@@ -274,7 +274,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::SetNextWindowSize(ImVec2(VIEWPORT_SIZE.x / 1.4f, 0.f), ImGuiCond_Always);
                     ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f)), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
                     ImGui::Begin("##rebind_controls", &rebinds_is_open, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
-                    ImGui::SetWindowFontScale(RES_SCALE.x);
+                    ImGui::SetWindowFontScale(1.f);
                     TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["rebind_controls"].c_str());
                     ImGui::Spacing();
                     ImGui::Separator();

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -121,7 +121,7 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowSize(ImVec2(0, height));
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f, ImGui::GetIO().DisplaySize.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin("##controls", &gui.controls_menu.controls_dialog, ImGuiWindowFlags_NoTitleBar);
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     TextColoredCentered(GUI_COLOR_TEXT_TITLE, gui.lang.main_menubar.controls["title"].c_str());
     ImGui::Spacing();
     ImGui::Separator();

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -78,7 +78,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     if (!finished_installing) {
         ImGui::OpenPopup("firmware_installation");
         if (ImGui::BeginPopupModal("firmware_installation", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration)) {
-            ImGui::SetWindowFontScale(RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.f);
             TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["firmware_installation"].c_str());
             ImGui::Spacing();
             ImGui::Separator();
@@ -97,7 +97,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     } else {
         ImGui::OpenPopup("firmware_installation");
         if (ImGui::BeginPopupModal("firmware_installation", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration)) {
-            ImGui::SetWindowFontScale(RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.f);
             const auto POS_BUTTON = (WINDOW_SIZE.x / 2.f) - (BUTTON_SIZE.x / 2.f) + (10.f * SCALE.x);
             TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["successed_install_firmware"].c_str());
             ImGui::Spacing();

--- a/vita3k/gui/src/home_screen.cpp
+++ b/vita3k/gui/src/home_screen.cpp
@@ -243,7 +243,7 @@ void draw_app_close(GuiState &gui, EmuEnvState &emuenv) {
 
     const auto ICON_SIZE = ImVec2(64.f * SCALE.x, 64.f * SCALE.y);
 
-    ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.4f);
     ImGui::SetCursorPos(ImVec2(50.f * SCALE.x, 108.f * SCALE.y));
     ImGui::TextColored(GUI_COLOR_TEXT, "%s", gui.lang.game_data["app_close"].c_str());
     if (gui.app_selector.user_apps_icon.contains(emuenv.io.app_path)) {
@@ -594,7 +594,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
 
     auto &lang = gui.lang.home_screen;
 
-    ImGui::SetWindowFontScale(0.9f * VIEWPORT_RES_SCALE.x);
+    ImGui::SetWindowFontScale(0.9f);
 
     // Sort Apps list when is not sorted
     if (!gui.app_selector.is_app_list_sorted)
@@ -675,7 +675,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
             app_compat_state = ALL_COMPAT_STATE;
         }
         if (ImGui::BeginMenu(lang["by_region"].c_str())) {
-            ImGui::SetWindowFontScale(1.1f * VIEWPORT_RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.1f);
             if (ImGui::MenuItem(lang["usa"].c_str(), nullptr, app_region == USA))
                 app_region = USA;
             if (ImGui::MenuItem(lang["europe"].c_str(), nullptr, app_region == EURO))
@@ -687,7 +687,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu(lang["by_type"].c_str())) {
-            ImGui::SetWindowFontScale(1.1f * VIEWPORT_RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.1f);
             if (ImGui::MenuItem(lang["commercial"].c_str(), nullptr, app_region == COMMERCIAL))
                 app_region = COMMERCIAL;
             if (ImGui::MenuItem(lang["homebrew"].c_str(), nullptr, app_region == HOMEBREW))
@@ -695,7 +695,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu(lang["by_compatibility_state"].c_str())) {
-            ImGui::SetWindowFontScale(1.1f * VIEWPORT_RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.1f);
             if (ImGui::MenuItem(lang["all"].c_str(), nullptr, app_compat_state == ALL_COMPAT_STATE))
                 app_compat_state = ALL_COMPAT_STATE;
             auto &lang_compat = gui.lang.compatibility.states;
@@ -964,7 +964,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
             ImVec2(ARROW_UP_CENTER.x + (20.f * VIEWPORT_SCALE.x), ARROW_UP_CENTER.y + (16.f * VIEWPORT_SCALE.y)), ARROW_COLOR);
         ImGui::SetCursorPos(ImVec2(ARROW_SELECT_WIDTH_POS, ARROW_UP_HEIGHT_POS - SELECTABLE_SIZE.y));
         if (ImGui::Selectable("##upp", false, ImGuiSelectableFlags_None, SELECTABLE_SIZE)
-            || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_up)))) {
+            || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_up)))) {
             gui.is_nav_button = false;
             scroll_type = 1;
         }
@@ -979,7 +979,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
             ImVec2(ARROW_CENTER.x + (16.f * VIEWPORT_SCALE.x), ARROW_CENTER.y),
             ImVec2(ARROW_CENTER.x - (16.f * VIEWPORT_SCALE.x), ARROW_CENTER.y + (20.f * VIEWPORT_SCALE.y)), ARROW_COLOR);
         ImGui::SetCursorPos(ImVec2(ARROW_SELECT_WIDTH_POS, ARROW_CENTER_HEIGHT_POS - SELECTABLE_SIZE.y));
-        if (!gui.vita_area.app_close && (ImGui::Selectable("##right", false, ImGuiSelectableFlags_None, SELECTABLE_SIZE) || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyReleased(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_r1))))) {
+        if (!gui.vita_area.app_close && (ImGui::Selectable("##right", false, ImGuiSelectableFlags_None, SELECTABLE_SIZE) || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyReleased(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_r1))))) {
             last_time["start"] = 0;
             ++gui.live_area_app_current_open;
             gui.vita_area.home_screen = false;
@@ -997,7 +997,7 @@ void draw_home_screen(GuiState &gui, EmuEnvState &emuenv) {
             ImVec2(ARROW_DOWN_CENTER.x - (20.f * VIEWPORT_SCALE.x), ARROW_DOWN_CENTER.y - (16.f * VIEWPORT_SCALE.y)), ARROW_COLOR);
         ImGui::SetCursorPos(ImVec2(ARROW_SELECT_WIDTH_POS, ARROW_DOWN_HEIGHT_POS - SELECTABLE_SIZE.y));
         if (ImGui::Selectable("##down", false, ImGuiSelectableFlags_None, SELECTABLE_SIZE)
-            || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_down)))) {
+            || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_down)))) {
             gui.is_nav_button = false;
             scroll_type = -1;
         }

--- a/vita3k/gui/src/ime.cpp
+++ b/vita3k/gui/src/ime.cpp
@@ -297,7 +297,7 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f * SCALE.x);
     ImGui::PushStyleColor(ImGuiCol_Button, GUI_COLOR_TEXT);
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_BLACK);
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     if (numeric_pad) {
         ImGui::SetCursorPosX(MARGE_BORDER);
         ImGui::PushStyleVar(ImGuiStyleVar_GrabMinSize, 62.f * SCALE.y);
@@ -361,7 +361,7 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
         ImGui::SetCursorPos(ImVec2(MARGE_BORDER, key_row_pos[3] * SCALE.y));
         ImGui::PushStyleColor(ImGuiCol_Button, IME_BUTTON_BG);
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
-        if (ImGui::Button("Shift", BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_l2))) {
+        if (ImGui::Button("Shift", BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_l2))) {
             if (ime.edit_text.caretIndex == 0)
                 ime.caps_level = ime.caps_level == YES ? NO : ++ime.caps_level;
             else
@@ -378,7 +378,7 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
         ImGui::SameLine(0, SPACE);
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
         ImGui::PushStyleColor(ImGuiCol_Button, IME_BUTTON_BG);
-        if (ImGui::Button("<", PUNCT_BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_l1))) {
+        if (ImGui::Button("<", PUNCT_BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_l1))) {
             ime.edit_text.editIndex = ime.edit_text.caretIndex;
             if (ime.edit_text.caretIndex)
                 --ime.edit_text.caretIndex;
@@ -392,7 +392,7 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
                 ime.caps_level = YES;
         }
         ImGui::SameLine(0, SPACE_BUTTON_SIZE.x + (SPACE * 2.f));
-        if (ImGui::Button(">", PUNCT_BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_r1))) {
+        if (ImGui::Button(">", PUNCT_BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_r1))) {
             ime.edit_text.editIndex = ime.edit_text.caretIndex;
             if (ime.edit_text.caretIndex < ime.str.length())
                 ++ime.edit_text.caretIndex;
@@ -432,7 +432,7 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
     ImGui::SetCursorPos(ImVec2(BUTTON_POS_X, key_row_pos[3] * SCALE.y));
     ImGui::PushStyleColor(ImGuiCol_Button, IME_BUTTON_BG);
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT);
-    if ((ImGui::Button("Backspace", BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_square))) && ime.edit_text.caretIndex) {
+    if ((ImGui::Button("Backspace", BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_square))) && ime.edit_text.caretIndex) {
         ime.str.erase(ime.edit_text.caretIndex - 1, 1);
         ime.edit_text.editIndex = ime.edit_text.caretIndex;
         --ime.edit_text.caretIndex;
@@ -449,7 +449,7 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
     ImGui::PopStyleColor(2);
     ImGui::PushStyleColor(ImGuiCol_Button, GUI_COLOR_TEXT_BLACK);
     ImGui::SetCursorPos(ImVec2(MARGE_BORDER, LAST_ROW_KEY_POS));
-    if (ImGui::Button("V", ImVec2(44.f * SCALE.x, KEY_BUTTON_SIZE.y)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle)))
+    if (ImGui::Button("V", ImVec2(44.f * SCALE.x, KEY_BUTTON_SIZE.y)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle)))
         ime.event_id = SCE_IME_EVENT_PRESS_CLOSE;
     ImGui::PopStyleColor();
     ImGui::SameLine(0, 18.f);
@@ -472,12 +472,12 @@ void draw_ime(Ime &ime, EmuEnvState &emuenv) {
         }
     }
     ImGui::SetCursorPos(SPACE_BUTTON_POS);
-    if (ImGui::Button(space_str.c_str(), SPACE_BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_triangle)))
+    if (ImGui::Button(space_str.c_str(), SPACE_BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_triangle)))
         update_ponct(ime, u" ");
     ImGui::PopStyleColor();
     ImGui::SetCursorPos(ImVec2(ENTER_BUTTON_POS_X, LAST_ROW_KEY_POS));
     ImGui::PushStyleColor(ImGuiCol_Button, GUI_PROGRESS_BAR);
-    if (ImGui::Button(ime.enter_label.c_str(), ENTER_BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_r2)))
+    if (ImGui::Button(ime.enter_label.c_str(), ENTER_BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_r2)))
         ime.event_id = SCE_IME_EVENT_PRESS_ENTER;
     ImGui::PopStyleColor();
 

--- a/vita3k/gui/src/imgui_impl_sdl.cpp
+++ b/vita3k/gui/src/imgui_impl_sdl.cpp
@@ -159,6 +159,117 @@ static ImGuiKey ImGui_ImplSDL3_KeycodeToImGuiKey(SDL_Keycode keycode) {
     }
 }
 
+IMGUI_API ImGuiKey ImGui_ImplSdl_ScancodeToImGuiKey(int scancode) {
+    switch (scancode) {
+    case SDL_SCANCODE_TAB: return ImGuiKey_Tab;
+    case SDL_SCANCODE_LEFT: return ImGuiKey_LeftArrow;
+    case SDL_SCANCODE_RIGHT: return ImGuiKey_RightArrow;
+    case SDL_SCANCODE_UP: return ImGuiKey_UpArrow;
+    case SDL_SCANCODE_DOWN: return ImGuiKey_DownArrow;
+    case SDL_SCANCODE_PAGEUP: return ImGuiKey_PageUp;
+    case SDL_SCANCODE_PAGEDOWN: return ImGuiKey_PageDown;
+    case SDL_SCANCODE_HOME: return ImGuiKey_Home;
+    case SDL_SCANCODE_END: return ImGuiKey_End;
+    case SDL_SCANCODE_INSERT: return ImGuiKey_Insert;
+    case SDL_SCANCODE_DELETE: return ImGuiKey_Delete;
+    case SDL_SCANCODE_BACKSPACE: return ImGuiKey_Backspace;
+    case SDL_SCANCODE_SPACE: return ImGuiKey_Space;
+    case SDL_SCANCODE_RETURN: return ImGuiKey_Enter;
+    case SDL_SCANCODE_ESCAPE: return ImGuiKey_Escape;
+    case SDL_SCANCODE_APOSTROPHE: return ImGuiKey_Apostrophe;
+    case SDL_SCANCODE_COMMA: return ImGuiKey_Comma;
+    case SDL_SCANCODE_MINUS: return ImGuiKey_Minus;
+    case SDL_SCANCODE_PERIOD: return ImGuiKey_Period;
+    case SDL_SCANCODE_SLASH: return ImGuiKey_Slash;
+    case SDL_SCANCODE_SEMICOLON: return ImGuiKey_Semicolon;
+    case SDL_SCANCODE_EQUALS: return ImGuiKey_Equal;
+    case SDL_SCANCODE_LEFTBRACKET: return ImGuiKey_LeftBracket;
+    case SDL_SCANCODE_BACKSLASH: return ImGuiKey_Backslash;
+    case SDL_SCANCODE_RIGHTBRACKET: return ImGuiKey_RightBracket;
+    case SDL_SCANCODE_GRAVE: return ImGuiKey_GraveAccent;
+    case SDL_SCANCODE_CAPSLOCK: return ImGuiKey_CapsLock;
+    case SDL_SCANCODE_SCROLLLOCK: return ImGuiKey_ScrollLock;
+    case SDL_SCANCODE_NUMLOCKCLEAR: return ImGuiKey_NumLock;
+    case SDL_SCANCODE_PRINTSCREEN: return ImGuiKey_PrintScreen;
+    case SDL_SCANCODE_PAUSE: return ImGuiKey_Pause;
+    case SDL_SCANCODE_KP_0: return ImGuiKey_Keypad0;
+    case SDL_SCANCODE_KP_1: return ImGuiKey_Keypad1;
+    case SDL_SCANCODE_KP_2: return ImGuiKey_Keypad2;
+    case SDL_SCANCODE_KP_3: return ImGuiKey_Keypad3;
+    case SDL_SCANCODE_KP_4: return ImGuiKey_Keypad4;
+    case SDL_SCANCODE_KP_5: return ImGuiKey_Keypad5;
+    case SDL_SCANCODE_KP_6: return ImGuiKey_Keypad6;
+    case SDL_SCANCODE_KP_7: return ImGuiKey_Keypad7;
+    case SDL_SCANCODE_KP_8: return ImGuiKey_Keypad8;
+    case SDL_SCANCODE_KP_9: return ImGuiKey_Keypad9;
+    case SDL_SCANCODE_KP_PERIOD: return ImGuiKey_KeypadDecimal;
+    case SDL_SCANCODE_KP_DIVIDE: return ImGuiKey_KeypadDivide;
+    case SDL_SCANCODE_KP_MULTIPLY: return ImGuiKey_KeypadMultiply;
+    case SDL_SCANCODE_KP_MINUS: return ImGuiKey_KeypadSubtract;
+    case SDL_SCANCODE_KP_PLUS: return ImGuiKey_KeypadAdd;
+    case SDL_SCANCODE_KP_ENTER: return ImGuiKey_KeypadEnter;
+    case SDL_SCANCODE_KP_EQUALS: return ImGuiKey_KeypadEqual;
+    case SDL_SCANCODE_LCTRL: return ImGuiKey_LeftCtrl;
+    case SDL_SCANCODE_LSHIFT: return ImGuiKey_LeftShift;
+    case SDL_SCANCODE_LALT: return ImGuiKey_LeftAlt;
+    case SDL_SCANCODE_LGUI: return ImGuiKey_LeftSuper;
+    case SDL_SCANCODE_RCTRL: return ImGuiKey_RightCtrl;
+    case SDL_SCANCODE_RSHIFT: return ImGuiKey_RightShift;
+    case SDL_SCANCODE_RALT: return ImGuiKey_RightAlt;
+    case SDL_SCANCODE_RGUI: return ImGuiKey_RightSuper;
+    case SDL_SCANCODE_APPLICATION: return ImGuiKey_Menu;
+    case SDL_SCANCODE_0: return ImGuiKey_0;
+    case SDL_SCANCODE_1: return ImGuiKey_1;
+    case SDL_SCANCODE_2: return ImGuiKey_2;
+    case SDL_SCANCODE_3: return ImGuiKey_3;
+    case SDL_SCANCODE_4: return ImGuiKey_4;
+    case SDL_SCANCODE_5: return ImGuiKey_5;
+    case SDL_SCANCODE_6: return ImGuiKey_6;
+    case SDL_SCANCODE_7: return ImGuiKey_7;
+    case SDL_SCANCODE_8: return ImGuiKey_8;
+    case SDL_SCANCODE_9: return ImGuiKey_9;
+    case SDL_SCANCODE_A: return ImGuiKey_A;
+    case SDL_SCANCODE_B: return ImGuiKey_B;
+    case SDL_SCANCODE_C: return ImGuiKey_C;
+    case SDL_SCANCODE_D: return ImGuiKey_D;
+    case SDL_SCANCODE_E: return ImGuiKey_E;
+    case SDL_SCANCODE_F: return ImGuiKey_F;
+    case SDL_SCANCODE_G: return ImGuiKey_G;
+    case SDL_SCANCODE_H: return ImGuiKey_H;
+    case SDL_SCANCODE_I: return ImGuiKey_I;
+    case SDL_SCANCODE_J: return ImGuiKey_J;
+    case SDL_SCANCODE_K: return ImGuiKey_K;
+    case SDL_SCANCODE_L: return ImGuiKey_L;
+    case SDL_SCANCODE_M: return ImGuiKey_M;
+    case SDL_SCANCODE_N: return ImGuiKey_N;
+    case SDL_SCANCODE_O: return ImGuiKey_O;
+    case SDL_SCANCODE_P: return ImGuiKey_P;
+    case SDL_SCANCODE_Q: return ImGuiKey_Q;
+    case SDL_SCANCODE_R: return ImGuiKey_R;
+    case SDL_SCANCODE_S: return ImGuiKey_S;
+    case SDL_SCANCODE_T: return ImGuiKey_T;
+    case SDL_SCANCODE_U: return ImGuiKey_U;
+    case SDL_SCANCODE_V: return ImGuiKey_V;
+    case SDL_SCANCODE_W: return ImGuiKey_W;
+    case SDL_SCANCODE_X: return ImGuiKey_X;
+    case SDL_SCANCODE_Y: return ImGuiKey_Y;
+    case SDL_SCANCODE_Z: return ImGuiKey_Z;
+    case SDL_SCANCODE_F1: return ImGuiKey_F1;
+    case SDL_SCANCODE_F2: return ImGuiKey_F2;
+    case SDL_SCANCODE_F3: return ImGuiKey_F3;
+    case SDL_SCANCODE_F4: return ImGuiKey_F4;
+    case SDL_SCANCODE_F5: return ImGuiKey_F5;
+    case SDL_SCANCODE_F6: return ImGuiKey_F6;
+    case SDL_SCANCODE_F7: return ImGuiKey_F7;
+    case SDL_SCANCODE_F8: return ImGuiKey_F8;
+    case SDL_SCANCODE_F9: return ImGuiKey_F9;
+    case SDL_SCANCODE_F10: return ImGuiKey_F10;
+    case SDL_SCANCODE_F11: return ImGuiKey_F11;
+    case SDL_SCANCODE_F12: return ImGuiKey_F12;
+    }
+    return ImGuiKey_None;
+}
+
 static void ImGui_ImplSDL3_UpdateKeyModifiers(SDL_Keymod sdl_key_mods) {
     ImGuiIO &io = ImGui::GetIO();
     io.AddKeyEvent(ImGuiMod_Ctrl, (sdl_key_mods & SDL_KMOD_CTRL) != 0);
@@ -478,6 +589,21 @@ IMGUI_API void ImGui_ImplSdl_RenderDrawData(ImGui_State *state) {
     }
 }
 
+IMGUI_API void ImGui_ImplSdl_UpdateTexture(ImGui_State *state, ImTextureData *tex) {
+    switch (state->renderer->current_backend) {
+    case renderer::Backend::OpenGL:
+        return ImGui_ImplSdlGL3_UpdateTexture(dynamic_cast<ImGui_GLState &>(*state), tex);
+
+    case renderer::Backend::Vulkan:
+        return ImGui_ImplSdlVulkan_UpdateTexture(dynamic_cast<ImGui_VulkanState &>(*state), tex);
+    }
+}
+
+IMGUI_API void ImGui_ImplSdl_GetDrawableSize(ImGui_State *state, int &width, int &height) {
+    // Does this even matter?
+    SDL_GetWindowSizeInPixels(state->window, &width, &height);
+}
+
 IMGUI_API ImTextureID ImGui_ImplSdl_CreateTexture(ImGui_State *state, void *data, int width, int height) {
     switch (state->renderer->current_backend) {
     case renderer::Backend::OpenGL:
@@ -544,11 +670,15 @@ void ImGui_Texture::init(ImGui_State *new_state, void *data, int width, int heig
 }
 
 ImGui_Texture::operator bool() const {
-    return texture_id != nullptr;
+    return texture_id != 0;
 }
 
 ImGui_Texture::operator ImTextureID() const {
     return texture_id;
+}
+
+ImGui_Texture::operator ImTextureRef() const {
+    return ImTextureRef(texture_id);
 }
 
 bool ImGui_Texture::operator==(const ImGui_Texture &texture) {
@@ -560,7 +690,7 @@ ImGui_Texture &ImGui_Texture::operator=(ImGui_Texture &&texture) noexcept {
     this->texture_id = texture.texture_id;
 
     texture.state = nullptr;
-    texture.texture_id = nullptr;
+    texture.texture_id = 0;
 
     return *this;
 }
@@ -573,7 +703,7 @@ ImGui_Texture::ImGui_Texture(ImGui_Texture &&texture) noexcept
     : state(texture.state)
     , texture_id(texture.texture_id) {
     texture.state = nullptr;
-    texture.texture_id = nullptr;
+    texture.texture_id = 0;
 }
 
 ImGui_Texture::~ImGui_Texture() {

--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -391,10 +391,10 @@ static void draw_notice_info(GuiState &gui, EmuEnvState &emuenv) {
             draw_list->AddImage(gui.theme_information_bar_notice[NoticeIcon::NEW], NOTICE_ICON_POS, NOTICE_ICON_POS_MAX);
         else
             draw_list->AddCircleFilled(ImVec2(VIEWPORT_WIDTH_POS_MAX - (24.f * SCALE.x), VIEWPORT_POS.y + (16.f * SCALE.y)), 60.f * SCALE.x, IM_COL32(11.f, 90.f, 252.f, 255.f));
-        const auto FONT_SCALE = 40.f * SCALE.x;
-        const auto NOTICE_COUNT_FONT_SCALE = FONT_SCALE / 40.f;
+        const auto FONT_SCALE = 40.f;
+        const auto NOTICE_COUNT_FONT_SCALE = 1.f;
         const auto NOTICE_COUNT_SIZE = ImGui::CalcTextSize(std::to_string(notice_info_count_new).c_str()).x * NOTICE_COUNT_FONT_SCALE;
-        draw_list->AddText(gui.vita_font[emuenv.current_font_level], FONT_SCALE, ImVec2(VIEWPORT_WIDTH_POS_MAX - (NOTICE_SIZE.x / 2.f) - (NOTICE_COUNT_SIZE / 2.f) + (12.f * SCALE.x), VIEWPORT_POS.y + (15.f * SCALE.y)), NOTICE_COLOR, std::to_string(notice_info_count_new).c_str());
+        draw_list->AddText(gui.vita_font, FONT_SCALE, ImVec2(VIEWPORT_WIDTH_POS_MAX - (NOTICE_SIZE.x / 2.f) - (NOTICE_COUNT_SIZE / 2.f) + (12.f * SCALE.x), VIEWPORT_POS.y + (15.f * SCALE.y)), NOTICE_COLOR, std::to_string(notice_info_count_new).c_str());
     } else {
         if (gui.theme_information_bar_notice.contains(NoticeIcon::NO))
             draw_list->AddImage(gui.theme_information_bar_notice[NoticeIcon::NO], NOTICE_ICON_POS, NOTICE_ICON_POS_MAX);
@@ -424,7 +424,7 @@ static void draw_notice_info(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::BeginChild("##notice_info_child", POPUP_SIZE, ImGuiChildFlags_Borders, ImGuiWindowFlags_NoSavedSettings);
         auto &lang = gui.lang.indicator;
         if (notice_info.empty()) {
-            ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.2f);
             const auto no_notif = lang["no_notif"].c_str();
             const auto calc_text = ImGui::CalcTextSize(no_notif);
             ImGui::SetCursorPos(ImVec2((POPUP_SIZE.x / 2.f) - (calc_text.x / 2.f), (POPUP_SIZE.y / 2.f) - (calc_text.y / 2.f)));
@@ -468,11 +468,11 @@ static void draw_notice_info(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::PopStyleColor(3);
                 ImGui::PopID();
                 ImGui::NextColumn();
-                ImGui::SetWindowFontScale(1.3f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.3f);
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (14.f * SCALE.y));
                 ImGui::TextColored(GUI_COLOR_TEXT, "%s", notice.name.c_str());
                 ImGui::Spacing();
-                ImGui::SetWindowFontScale(0.9f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(0.9f);
                 ImGui::TextColored(GUI_COLOR_TEXT, "%s", notice.msg.c_str());
                 const auto notice_time = get_notice_time(gui, emuenv, notice.time);
                 const auto notice_time_size = ImGui::CalcTextSize(notice_time.c_str());
@@ -490,10 +490,10 @@ static void draw_notice_info(GuiState &gui, EmuEnvState &emuenv) {
             const auto DELETE_POPUP_SIZE = ImVec2(756.0f * SCALE.x, 436.0f * SCALE.y);
             const auto BUTTON_SIZE = ImVec2(320.f * SCALE.x, 46.f * SCALE.y);
 
-            ImGui::SetWindowFontScale(1.f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.f);
             ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f * SCALE.x);
             ImGui::SetCursorPos(ImVec2(VIEWPORT_SIZE.x - (70.f * SCALE.x), VIEWPORT_SIZE.y - (52.f * SCALE.y)));
-            if (ImGui::Button("...", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_triangle)))
+            if (ImGui::Button("...", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_triangle)))
                 ImGui::OpenPopup("...");
             if (ImGui::BeginPopup("...", ImGuiWindowFlags_NoMove)) {
                 if (ImGui::Button(lang["delete_all"].c_str()))
@@ -502,16 +502,16 @@ static void draw_notice_info(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::SetNextWindowSize(DELETE_POPUP_SIZE, ImGuiCond_Always);
                 ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f) - (DELETE_POPUP_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f) - (DELETE_POPUP_SIZE.y / 2.f)));
                 if (ImGui::BeginPopupModal("Delete All", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
-                    ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+                    ImGui::SetWindowFontScale(1.4f);
                     auto &common = emuenv.common_dialog.lang.common;
                     ImGui::SetCursorPosY((DELETE_POPUP_SIZE.y / 2.f) - (46.f * SCALE.y));
                     TextColoredCentered(GUI_COLOR_TEXT, lang["notif_deleted"].c_str());
                     ImGui::SetCursorPos(ImVec2((DELETE_POPUP_SIZE.x / 2) - (BUTTON_SIZE.x + (20.f * SCALE.x)), DELETE_POPUP_SIZE.y - BUTTON_SIZE.y - (24.0f * SCALE.y)));
-                    if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+                    if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
                         ImGui::CloseCurrentPopup();
                     }
                     ImGui::SameLine(0.f, 20.f);
-                    if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross))) {
+                    if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross))) {
                         notice_info.clear();
                         for (auto &notice : gui.notice_info_icon)
                             notice.second = {};
@@ -613,9 +613,9 @@ void draw_information_bar(GuiState &gui, EmuEnvState &emuenv) {
     }
 
     constexpr auto PIX_FONT_SCALE = 19.2f / 24.f;
-    const auto DEFAULT_FONT_SCALE = ImGui::GetFontSize() / (19.2f * emuenv.manual_dpi_scale);
-    const auto CLOCK_DEFAULT_FONT_SCALE = (24.f * emuenv.manual_dpi_scale) * DEFAULT_FONT_SCALE;
-    const auto DAY_MOMENT_DEFAULT_FONT_SCALE = (18.f * emuenv.manual_dpi_scale) * DEFAULT_FONT_SCALE;
+    const auto DEFAULT_FONT_SCALE = ImGui::GetFontSize() / 19.2f;
+    const auto CLOCK_DEFAULT_FONT_SCALE = 24.f * DEFAULT_FONT_SCALE;
+    const auto DAY_MOMENT_DEFAULT_FONT_SCALE = 18.f * DEFAULT_FONT_SCALE;
     const auto CLOCK_FONT_SIZE_SCALE = CLOCK_DEFAULT_FONT_SCALE / ImGui::GetFontSize();
     const auto DAY_MOMENT_FONT_SIZE_SCALE = DAY_MOMENT_DEFAULT_FONT_SCALE / ImGui::GetFontSize();
 
@@ -627,17 +627,17 @@ void draw_information_bar(GuiState &gui, EmuEnvState &emuenv) {
 
     auto DATE_TIME = get_date_time(gui, emuenv, local);
     const auto CALC_CLOCK_SIZE = ImGui::CalcTextSize(DATE_TIME[DateTime::CLOCK].c_str());
-    const auto CLOCK_SIZE_SCALE = ImVec2((CALC_CLOCK_SIZE.x * CLOCK_FONT_SIZE_SCALE) * RES_SCALE.x, (CALC_CLOCK_SIZE.y * CLOCK_FONT_SIZE_SCALE * PIX_FONT_SCALE) * RES_SCALE.y);
+    const auto CLOCK_SIZE_SCALE = ImVec2(CALC_CLOCK_SIZE.x * CLOCK_FONT_SIZE_SCALE, CALC_CLOCK_SIZE.y * CLOCK_FONT_SIZE_SCALE * PIX_FONT_SCALE);
     const auto CALC_DAY_MOMENT_SIZE = ImGui::CalcTextSize(DATE_TIME[DateTime::DAY_MOMENT].c_str());
-    const auto DAY_MOMENT_SIZE_SCALE = emuenv.io.user_id.empty() || is_12_hour_format ? ImVec2((CALC_DAY_MOMENT_SIZE.x * DAY_MOMENT_FONT_SIZE_SCALE) * RES_SCALE.y, (CALC_DAY_MOMENT_SIZE.y * DAY_MOMENT_FONT_SIZE_SCALE * PIX_FONT_SCALE) * RES_SCALE.y) : ImVec2(0.f, 0.f);
+    const auto DAY_MOMENT_SIZE_SCALE = emuenv.io.user_id.empty() || is_12_hour_format ? ImVec2(CALC_DAY_MOMENT_SIZE.x * DAY_MOMENT_FONT_SIZE_SCALE, CALC_DAY_MOMENT_SIZE.y * DAY_MOMENT_FONT_SIZE_SCALE * PIX_FONT_SCALE) : ImVec2(0.f, 0.f);
 
     const ImVec2 CLOCK_POS(VIEWPORT_POS.x + INFO_BAR_SIZE.x - (64.f * SCALE.x) - CLOCK_SIZE_SCALE.x - DAY_MOMENT_SIZE_SCALE.x - is_notif_pos, VIEWPORT_POS.y + (INFO_BAR_SIZE.y / 2.f) - (CLOCK_SIZE_SCALE.y / 2.f));
     const auto DAY_MOMENT_POS = ImVec2(CLOCK_POS.x + CLOCK_SIZE_SCALE.x + (6.f * SCALE.x), CLOCK_POS.y + (CLOCK_SIZE_SCALE.y - DAY_MOMENT_SIZE_SCALE.y));
 
     // Draw clock
-    draw_list->AddText(gui.vita_font[emuenv.current_font_level], CLOCK_DEFAULT_FONT_SCALE * RES_SCALE.x, CLOCK_POS, is_theme_color ? indicator_color : DEFAULT_INDICATOR_COLOR, DATE_TIME[DateTime::CLOCK].c_str());
+    draw_list->AddText(gui.vita_font, CLOCK_DEFAULT_FONT_SCALE, CLOCK_POS, is_theme_color ? indicator_color : DEFAULT_INDICATOR_COLOR, DATE_TIME[DateTime::CLOCK].c_str());
     if (emuenv.io.user_id.empty() || is_12_hour_format)
-        draw_list->AddText(gui.vita_font[emuenv.current_font_level], DAY_MOMENT_DEFAULT_FONT_SCALE * RES_SCALE.x, DAY_MOMENT_POS, is_theme_color ? indicator_color : DEFAULT_INDICATOR_COLOR, DATE_TIME[DateTime::DAY_MOMENT].c_str());
+        draw_list->AddText(gui.vita_font, DAY_MOMENT_DEFAULT_FONT_SCALE, DAY_MOMENT_POS, is_theme_color ? indicator_color : DEFAULT_INDICATOR_COLOR, DATE_TIME[DateTime::DAY_MOMENT].c_str());
 
     // Set full size and position of battery
     const auto FULL_BATTERY_SIZE = 38.f * SCALE.x;

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -87,7 +87,7 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
     const auto FW_FONT_PATH{ emuenv.pref_path / "sa0" };
     const auto FW_FONT_INSTALLED = fs::exists(FW_FONT_PATH) && !fs::is_empty(FW_FONT_PATH);
 
-    ImGui::PushFont(gui.vita_font[emuenv.current_font_level]);
+    ImGui::PushFont(gui.vita_font);
     ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size, ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.f);
@@ -104,14 +104,14 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowBgAlpha(0.0f);
 
     ImGui::BeginChild("##window_box", WINDOW_SIZE, ImGuiChildFlags_Borders, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
-    ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.6f);
     const auto SELECT_COLOR = ImVec4(0.23f, 0.68f, 0.95f, 0.60f);
     const auto SELECT_COLOR_HOVERED = ImVec4(0.23f, 0.68f, 0.99f, 0.80f);
     const auto SELECT_COLOR_ACTIVE = ImVec4(0.23f, 0.68f, 1.f, 1.f);
 
     ImGui::SetCursorPosY((47 * SCALE.y) - (ImGui::GetFontSize() / 2.f));
     TextCentered(title_str.c_str());
-    ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.4f);
     ImGui::SetCursorPosY(94.f * SCALE.y);
     ImGui::Separator();
     switch (setup) {
@@ -197,7 +197,7 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         if (ImGui::Button(lang["install_firmware_file"].c_str(), BIG_BUTTON_SIZE))
             gui.file_menu.firmware_install_dialog = true;
         if (gui.file_menu.firmware_install_dialog) {
-            ImGui::SetWindowFontScale(RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.f);
             draw_firmware_install_dialog(gui, emuenv);
         }
         break;
@@ -229,7 +229,7 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::SetCursorPosY((WINDOW_SIZE.y / 2.f) - ImGui::GetFontSize());
         TextCentered(lang["completed_setup"].c_str());
         ImGui::SetCursorPos(BIG_BUTTON_POS);
-        if (ImGui::Button(common["ok"].c_str(), BIG_BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross))) {
+        if (ImGui::Button(common["ok"].c_str(), BIG_BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross))) {
             emuenv.cfg.initial_setup = true;
             config::serialize_config(emuenv.cfg, emuenv.config_path);
         }
@@ -241,14 +241,14 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::EndChild();
     ImGui::PopStyleVar(2);
     ImGui::PopStyleColor();
-    ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.5f);
 
     // Draw Button
     ImGui::SetCursorPos(BUTTON_POS);
-    if ((setup > SELECT_LANGUAGE) && ImGui::Button(lang["back"].c_str(), BUTTON_SIZE) || (setup > SELECT_LANGUAGE) && ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle)))
+    if ((setup > SELECT_LANGUAGE) && ImGui::Button(lang["back"].c_str(), BUTTON_SIZE) || (setup > SELECT_LANGUAGE) && ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle)))
         setup = (InitialSetup)(setup - 1);
     ImGui::SetCursorPos(ImVec2(display_size.x - BUTTON_SIZE.x - BUTTON_POS.x, BUTTON_POS.y));
-    if ((setup < FINISHED) && ImGui::Button(lang["next"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross))) {
+    if ((setup < FINISHED) && ImGui::Button(lang["next"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross))) {
         setup = (InitialSetup)(setup + 1);
         config::serialize_config(emuenv.cfg, emuenv.config_path);
     }

--- a/vita3k/gui/src/license_install_dialog.cpp
+++ b/vita3k/gui/src/license_install_dialog.cpp
@@ -53,7 +53,7 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowSize(display_size);
     ImGui::Begin("##license_install", &gui.file_menu.license_install_dialog, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f * SCALE.x);
     ImGui::BeginChild("##license_install_child", ImVec2(616.f * SCALE.x, 264.f * SCALE.y), ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     const auto POS_BUTTON = (ImGui::GetWindowWidth() / 2.f) - (BUTTON_SIZE.x / 2.f) + (10.f * SCALE.x);

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -870,7 +870,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
                 }
 
                 const auto size_text_scale = str_tag.size != 0 ? str_tag.size / 19.2f : 1.f;
-                ImGui::SetWindowFontScale(size_text_scale * RES_SCALE.x);
+                ImGui::SetWindowFontScale(size_text_scale);
 
                 // Calculate text pixel size
                 ImVec2 calc_text_size;
@@ -1038,12 +1038,12 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
                 if (liveitem[app_path][frame.id]["text"]["word-wrap"].second != "off")
                     ImGui::PopTextWrapPos();
                 ImGui::EndChild();
-                ImGui::SetWindowFontScale(RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.f);
             }
         }
     }
 
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     const auto default_font_scale = (25.f * emuenv.manual_dpi_scale) * (ImGui::GetFontSize() / (19.2f * emuenv.manual_dpi_scale));
     const auto font_size_scale = default_font_scale / ImGui::GetFontSize();
 
@@ -1087,7 +1087,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PushID(app_path.c_str());
     const ImVec2 BUTTON_POS_MIN(WINDOW_POS.x + POS_BUTTON.x, WINDOW_POS.y + POS_BUTTON.y);
     window_draw_list->AddRectFilled(BUTTON_POS_MIN, ImVec2(BUTTON_POS_MIN.x + START_BUTTON_SIZE.x, BUTTON_POS_MIN.y + START_BUTTON_SIZE.y), IM_COL32(20, 168, 222, 255), 10.0f * SCALE.x, ImDrawFlags_RoundCornersAll);
-    window_draw_list->AddText(gui.vita_font[emuenv.current_font_level], default_font_scale, POS_START, IM_COL32(255, 255, 255, 255), BUTTON_STR.c_str());
+    window_draw_list->AddText(gui.vita_font, default_font_scale, POS_START, IM_COL32(255, 255, 255, 255), BUTTON_STR.c_str());
     ImGui::SetCursorPos(SELECT_POS);
     if (ImGui::Selectable("##gate", gui.is_nav_button && (live_area_type_selected == GATE), ImGuiSelectableFlags_None, SELECT_SIZE))
         pre_run_app(gui, emuenv, app_path);
@@ -1108,7 +1108,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
         const auto POS_STR_SEARCH = ImVec2(SEARCH_WIDGET_POS_MIN.x + ((widget_scal_size.x / 2.f) - (SEARCH_SCAL_SIZE.x / 2.f)),
             SEARCH_WIDGET_POS_MIN.y + ((widget_scal_size.x / 2.f) - (SEARCH_SCAL_SIZE.y / 2.f)));
         window_draw_list->AddRectFilled(SEARCH_WIDGET_POS_MIN, ImVec2(SEARCH_WIDGET_POS_MIN.x + widget_scal_size.x, SEARCH_WIDGET_POS_MIN.y + widget_scal_size.y), IM_COL32(10, 169, 246, 255), 12.0f * SCALE.x, ImDrawFlags_RoundCornersAll);
-        window_draw_list->AddText(gui.vita_font[emuenv.current_font_level], 23.0f * SCALE.x, POS_STR_SEARCH, IM_COL32(255, 255, 255, 255), SEARCH_STR);
+        window_draw_list->AddText(gui.vita_font, 23.0f * SCALE.x, POS_STR_SEARCH, IM_COL32(255, 255, 255, 255), SEARCH_STR);
         ImGui::SetCursorPos(pos_scal_search);
         if (ImGui::Selectable("##Search", gui.is_nav_button && (live_area_type_selected == SEARCH), ImGuiSelectableFlags_None, widget_scal_size))
             open_search(get_app_index(gui, app_path)->title);
@@ -1123,7 +1123,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
             const auto MANUAL_STR_POS = ImVec2(MANUAL_WIDGET_POS_MIN.x + ((widget_scal_size.x / 2.f) - (MANUAL_STR_SCAL_SIZE.x / 2.f)),
                 MANUAL_WIDGET_POS_MIN.y + ((widget_scal_size.x / 2.f) - (MANUAL_STR_SCAL_SIZE.y / 2.f)));
             window_draw_list->AddRectFilled(MANUAL_WIDGET_POS_MIN, ImVec2(MANUAL_WIDGET_POS_MIN.x + widget_scal_size.x, MANUAL_WIDGET_POS_MIN.y + widget_scal_size.y), IM_COL32(202, 0, 106, 255), 12.0f * SCALE.x, ImDrawFlags_RoundCornersAll);
-            window_draw_list->AddText(gui.vita_font[emuenv.current_font_level], 23.0f * SCALE.x, MANUAL_STR_POS, IM_COL32(255, 255, 255, 255), MANUAL_STR);
+            window_draw_list->AddText(gui.vita_font, 23.0f * SCALE.x, MANUAL_STR_POS, IM_COL32(255, 255, 255, 255), MANUAL_STR);
             ImGui::SetCursorPos(pos_scal_manual);
             if (ImGui::Selectable("##manual", gui.is_nav_button && (live_area_type_selected == MANUAL), ImGuiSelectableFlags_None, widget_scal_size))
                 open_manual(gui, emuenv, app_path);
@@ -1138,7 +1138,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
         const auto UPDATE_STR_POS = ImVec2(UPDATE_WIDGET_POS_MIN.x + ((widget_scal_size.x / 2.f) - (UPDATE_STR_SCAL_SIZE.x / 2.f)),
             UPDATE_WIDGET_POS_MIN.y + ((widget_scal_size.x / 2.f) - (UPDATE_STR_SCAL_SIZE.y / 2.f)));
         window_draw_list->AddRectFilled(UPDATE_WIDGET_POS_MIN, ImVec2(UPDATE_WIDGET_POS_MIN.x + widget_scal_size.x, UPDATE_WIDGET_POS_MIN.y + widget_scal_size.y), IM_COL32(3, 187, 250, 255), 12.0f * SCALE.x, ImDrawFlags_RoundCornersAll);
-        window_draw_list->AddText(gui.vita_font[emuenv.current_font_level], 23.0f * SCALE.x, UPDATE_STR_POS, IM_COL32(255, 255, 255, 255), UPDATE_STR);
+        window_draw_list->AddText(gui.vita_font, 23.0f * SCALE.x, UPDATE_STR_POS, IM_COL32(255, 255, 255, 255), UPDATE_STR);
         ImGui::SetCursorPos(pos_scal_update);
         if (ImGui::Selectable("##update", ImGuiSelectableFlags_None, false, widget_scal_size))
             update_app(gui, emuenv, app_path);
@@ -1200,7 +1200,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
 
             ImGui::Spacing();
             ImGui::SetCursorPosX(ImGui::GetWindowWidth() / 2.f - (BUTTON_SIZE.x / 2.f));
-            if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross)))
+            if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross)))
                 ImGui::CloseCurrentPopup();
 
             ImGui::EndPopup();

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -78,7 +78,7 @@ static void draw_emulation_menu(GuiState &gui, EmuEnvState &emuenv) {
     if (ImGui::BeginMenu(lang["title"].c_str())) {
         const auto app_list_is_empty = gui.time_apps[emuenv.io.user_id].empty();
         ImGui::SetNextWindowSize(ImVec2(!app_list_is_empty ? 480.f * SCALE.x : 0.f, 0.f));
-        ImGui::SetWindowFontScale(RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.f);
         if (ImGui::BeginMenu(lang["last_apps_used"].c_str())) {
             if (!app_list_is_empty) {
                 for (size_t i = 0; i < std::min<size_t>(8, gui.time_apps[emuenv.io.user_id].size()); i++) {
@@ -153,7 +153,7 @@ void draw_main_menu_bar(GuiState &gui, EmuEnvState &emuenv) {
     if (ImGui::BeginMainMenuBar()) {
         const ImVec2 RES_SCALE(emuenv.gui_scale.x, emuenv.gui_scale.y);
 
-        ImGui::SetWindowFontScale(RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.f);
         ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
 
         draw_file_menu(gui, emuenv);

--- a/vita3k/gui/src/manual.cpp
+++ b/vita3k/gui/src/manual.cpp
@@ -205,9 +205,9 @@ void draw_manual(GuiState &gui, EmuEnvState &emuenv) {
 
         // Set scroll with mouse wheel or keyboard up/down keys
         const auto wheel_counter = ImGui::GetIO().MouseWheel;
-        if ((wheel_counter == 1.f) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_up)))
+        if ((wheel_counter == 1.f) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_up)))
             scroll -= std::min(40.f * SCALE.y, scroll);
-        else if ((wheel_counter == -1.f) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_down)))
+        else if ((wheel_counter == -1.f) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_down)))
             scroll += std::min(40.f * SCALE.y, max_scroll.at(current_page) - scroll);
 
         // Set scroll y position
@@ -231,7 +231,7 @@ void draw_manual(GuiState &gui, EmuEnvState &emuenv) {
     }
 
     // Set window font scale for buttons
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
 
     // Hide button when right click is pressed on mouse
     if (!ImGui::IsAnyItemHovered() && ImGui::IsMouseClicked(0))
@@ -239,7 +239,7 @@ void draw_manual(GuiState &gui, EmuEnvState &emuenv) {
 
     // Draw esc button
     ImGui::SetCursorPos(ImVec2(5.0f * SCALE.x, 10.0f * SCALE.y));
-    if ((!hidden_button && ImGui::Button("Esc", BUTTON_SIZE)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_psbutton)))
+    if ((!hidden_button && ImGui::Button("Esc", BUTTON_SIZE)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_psbutton)))
         gui::close_system_app(gui, emuenv);
 
     const auto BUTTON_POS = ImVec2(10.f * SCALE.x, display_size.y - (10.f * SCALE.y) - BUTTON_SIZE.y);
@@ -247,7 +247,7 @@ void draw_manual(GuiState &gui, EmuEnvState &emuenv) {
     // Draw left button
     if (current_page > 0) {
         ImGui::SetCursorPos(BUTTON_POS);
-        if ((!hidden_button && ImGui::Button("<", BUTTON_SIZE)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_left)))
+        if ((!hidden_button && ImGui::Button("<", BUTTON_SIZE)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_left)))
             change_page(emuenv, current_page - 1);
     }
 
@@ -280,13 +280,13 @@ void draw_manual(GuiState &gui, EmuEnvState &emuenv) {
     }
 
     ImGui::SetCursorPos(ImVec2(display_size.x - BUTTON_POS.x - (BUTTON_SIZE.x * 2.f) - (36.f * SCALE.x), BUTTON_POS.y));
-    if ((!hidden_button && ImGui::Button("Book", BUTTON_SIZE)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_right)))
+    if ((!hidden_button && ImGui::Button("Book", BUTTON_SIZE)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_right)))
         is_book_mode = !is_book_mode;
 
     // Draw right button
     if (current_page < max_pages_index) {
         ImGui::SetCursorPos(ImVec2(display_size.x - BUTTON_POS.x - BUTTON_SIZE.x, BUTTON_POS.y));
-        if ((!hidden_button && ImGui::Button(">", BUTTON_SIZE)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_right)))
+        if ((!hidden_button && ImGui::Button(">", BUTTON_SIZE)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_right)))
             change_page(emuenv, current_page + 1);
     }
     ImGui::EndChild();

--- a/vita3k/gui/src/perf_overlay.cpp
+++ b/vita3k/gui/src/perf_overlay.cpp
@@ -72,7 +72,7 @@ void draw_perf_overlay(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 5.f * SCALE.x);
     ImGui::BeginChild("#perf_stats", WINDOW_SIZE, ImGuiChildFlags_Borders, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
 
-    ImGui::SetWindowFontScale(0.7f * RES_SCALE.y);
+    ImGui::SetWindowFontScale(0.7f);
 
     ImGui::Text("%s", FPS_TEXT.c_str());
     if (emuenv.cfg.performance_overlay_detail >= PerformanceOverlayDetail::MEDIUM) {

--- a/vita3k/gui/src/pkg_install_dialog.cpp
+++ b/vita3k/gui/src/pkg_install_dialog.cpp
@@ -97,7 +97,7 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(emuenv.logical_viewport_pos.x + (display_size.x / 2.f) - (WINDOW_SIZE.x / 2), emuenv.logical_viewport_pos.y + (display_size.y / 2.f) - (WINDOW_SIZE.y / 2.f)), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE);
     if (ImGui::BeginPopupModal("install", &gui.file_menu.pkg_install_dialog, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration)) {
-        ImGui::SetWindowFontScale(RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.f);
         const auto POS_BUTTON = (WINDOW_SIZE.x / 2.f) - (BUTTON_SIZE.x / 2.f) + (10.f * SCALE.x);
         TextColoredCentered(GUI_COLOR_TEXT_TITLE, title.c_str());
         ImGui::Spacing();

--- a/vita3k/gui/src/private.h
+++ b/vita3k/gui/src/private.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <gui/imgui_impl_sdl.h>
 #include <gui/state.h>
 
 #include <emuenv/state.h>

--- a/vita3k/gui/src/reinstall.cpp
+++ b/vita3k/gui/src/reinstall.cpp
@@ -29,7 +29,7 @@ void draw_reinstall_dialog(GenericDialogState *status, GuiState &gui, EmuEnvStat
     auto &info = gui.lang.app_context.info;
     auto &common = emuenv.common_dialog.lang.common;
 
-    ImGui::PushFont(gui.vita_font[emuenv.current_font_level]);
+    ImGui::PushFont(gui.vita_font);
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 2.f, ImGui::GetIO().DisplaySize.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(0, 0));
     ImGui::Begin(lang["reinstall_content"].c_str());

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -272,7 +272,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
     else
         draw_list->AddRectFilled(VIEWPORT_POS, BG_POS_MAX, IM_COL32(36.f, 120.f, 12.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
 
-    ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.6f);
     const auto title_size_str = ImGui::CalcTextSize(title.c_str(), 0, false, SIZE_LIST.x);
     ImGui::PushTextWrapPos(((WINDOW_SIZE.x - SIZE_LIST.x) / 2.f) + SIZE_LIST.x);
     ImGui::SetCursorPos(ImVec2((WINDOW_SIZE.x / 2.f) - (title_size_str.x / 2.f), (35.f * SCALE.y) - (title_size_str.y / 2.f)));
@@ -288,13 +288,13 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
     if (settings_menu == SettingsMenu::THEME_BACKGROUND) {
         // Search Bar
         if ((menu == Menu::THEME) && selected.empty()) {
-            ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.2f);
             const auto search_size = ImGui::CalcTextSize(common["search"].c_str());
             ImGui::SetCursorPos(ImVec2(WINDOW_SIZE.x - (220.f * SCALE.x) - search_size.x, (35.f * SCALE.y) - (search_size.y / 2.f)));
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", common["search"].c_str());
             ImGui::SameLine();
             search_bar.Draw("##search_bar", 200 * SCALE.x);
-            ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.6f);
 
             // Draw Scroll Arrow
             const auto ARROW_SIZE = ImVec2(50.f * SCALE.x, 60.f * SCALE.y);
@@ -314,8 +314,8 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     ImVec2(ARROW_UPP_CENTER.x + (20.f * SCALE.x), ARROW_UPP_CENTER.y + (16.f * SCALE.y)), ARROW_COLOR);
                 ImGui::SetCursorPos(ImVec2(ARROW_SELECT_WIDTH_POS, ARROW_UP_HEIGHT_POS - ARROW_SIZE.y));
                 if ((ImGui::Selectable("##upp", false, ImGuiSelectableFlags_None, ARROW_SIZE))
-                    || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_up)))
-                    || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_up)))
+                    || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_up)))
+                    || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_up)))
                     set_scroll_pos = current_scroll_pos - (340 * SCALE.y);
             }
             if (current_scroll_pos < max_scroll_pos) {
@@ -327,8 +327,8 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     ImVec2(ARROW_DOWN_CENTER.x - (20.f * SCALE.x), ARROW_DOWN_CENTER.y - (16.f * SCALE.y)), ARROW_COLOR);
                 ImGui::SetCursorPos(ImVec2(ARROW_SELECT_WIDTH_POS, ARROW_DOWN_HEIGHT_POS - ARROW_SIZE.y));
                 if ((ImGui::Selectable("##down", false, ImGuiSelectableFlags_None, ARROW_SIZE))
-                    || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_leftstick_down)))
-                    || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_down)))
+                    || (!ImGui::GetIO().WantTextInput && ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_leftstick_down)))
+                    || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_down)))
                     set_scroll_pos = current_scroll_pos + (340 * SCALE.y);
             }
         }
@@ -464,7 +464,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     }
                     ImGui::SetWindowFontScale(1.2f);
                     ImGui::SetCursorPos(ImVec2((SIZE_LIST.x / 2.f) - (BUTTON_SIZE.x / 2.f), (SIZE_LIST.y - 82.f) - BUTTON_SIZE.y));
-                    if ((selected != gui.users[emuenv.io.user_id].theme_id) && (ImGui::Button(select, BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross)))) {
+                    if ((selected != gui.users[emuenv.io.user_id].theme_id) && (ImGui::Button(select, BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross)))) {
                         gui.users[emuenv.io.user_id].start_path.clear();
                         if (init_theme(gui, emuenv, selected)) {
                             gui.users[emuenv.io.user_id].theme_id = selected;
@@ -487,7 +487,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.f * SCALE.x);
                     ImGui::BeginChild("##delete_theme_popup", POPUP_SIZE, ImGuiChildFlags_Borders, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
                     ImGui::SetCursorPos(ImVec2(48.f * SCALE.x, 28.f * SCALE.y));
-                    ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+                    ImGui::SetWindowFontScale(1.6f);
                     ImGui::Image(gui.themes_preview[selected][PACKAGE], SIZE_MINI_PACKAGE);
                     ImGui::SameLine(0, 22.f * SCALE.x);
                     const auto CALC_TITLE = ImGui::CalcTextSize(themes_info[selected].title.c_str(), nullptr, false, POPUP_SIZE.x - SIZE_MINI_PACKAGE.x - (70.f * SCALE.x)).y / 2.f;
@@ -496,10 +496,10 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::SetCursorPosY(POPUP_SIZE.y / 2.f);
                     TextColoredCentered(GUI_COLOR_TEXT, theme.main["delete"].c_str());
                     ImGui::SetCursorPos(ImVec2((POPUP_SIZE.x / 2.f) - BUTTON_SIZE.x - (20.f * SCALE.x), POPUP_SIZE.y - BUTTON_SIZE.y - (22.f * SCALE.y)));
-                    if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle)))
+                    if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle)))
                         popup = Popup::UNDEFINED;
                     ImGui::SameLine(0, 40.f * SCALE.x);
-                    if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross))) {
+                    if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross))) {
                         if (selected == gui.users[emuenv.io.user_id].theme_id) {
                             gui.users[emuenv.io.user_id].theme_id = "default";
                             gui.users[emuenv.io.user_id].start_path.clear();
@@ -645,7 +645,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                         ImGui::Image(gui.themes_preview[gui.users[emuenv.io.user_id].theme_id][LOCK], SIZE_PREVIEW);
                     }
                     ImGui::SetCursorPos(SELECT_BUTTON_POS);
-                    if ((gui.users[emuenv.io.user_id].start_type != "theme") && (ImGui::Button(select, BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross)))) {
+                    if ((gui.users[emuenv.io.user_id].start_type != "theme") && (ImGui::Button(select, BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross)))) {
                         gui.users[emuenv.io.user_id].start_path.clear();
                         gui.users[emuenv.io.user_id].start_type = "theme";
                         init_theme_start_background(gui, emuenv, gui.users[emuenv.io.user_id].theme_id);
@@ -672,7 +672,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                         ImGui::Image(gui.themes_preview["default"][LOCK], SIZE_PREVIEW);
                     }
                     ImGui::SetCursorPos(SELECT_BUTTON_POS);
-                    if ((gui.users[emuenv.io.user_id].start_type != "default") && (ImGui::Button(select, BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross)))) {
+                    if ((gui.users[emuenv.io.user_id].start_type != "default") && (ImGui::Button(select, BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross)))) {
                         gui.users[emuenv.io.user_id].start_path.clear();
                         init_theme_start_background(gui, emuenv, "default");
                         gui.users[emuenv.io.user_id].start_type = "default";
@@ -769,7 +769,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
             ImGui::Columns(2, nullptr, false);
             ImGui::SetColumnWidth(0, 30.f * SCALE.x);
-            ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.4f);
             if (menu == Menu::DATE_FORMAT) {
                 const auto get_date_format_sting = [&](SceSystemParamDateFormat date_format) {
                     std::string date_format_str;
@@ -883,7 +883,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
                 ImGui::Columns(2, nullptr, false);
                 ImGui::SetColumnWidth(0, 30.f * SCALE.x);
-                ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.4f);
                 for (const auto &sys_lang : LIST_SYS_LANG) {
                     ImGui::PushID(sys_lang.first);
                     const auto is_current_lang = emuenv.cfg.sys_lang == sys_lang.first;
@@ -1020,9 +1020,9 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PopStyleVar();
 
     // Back
-    ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.2f);
     ImGui::SetCursorPos(ImVec2(6.f * SCALE.x, WINDOW_SIZE.y - (52.f * SCALE.y)));
-    if (ImGui::Button("<<", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+    if (ImGui::Button("<<", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
         if (settings_menu != SettingsMenu::SELECT) {
             if (menu != Menu::UNDEFINED) {
                 if (!selected.empty()) {
@@ -1047,7 +1047,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
 
     if ((settings_menu == SettingsMenu::THEME_BACKGROUND) && !selected.empty() && (selected != "default")) {
         ImGui::SetCursorPos(ImVec2(WINDOW_SIZE.x - (70.f * SCALE.x), WINDOW_SIZE.y - (52.f * SCALE.y)));
-        if (((popup != Popup::INFORMATION) && ImGui::Button("...", ImVec2(64.f * SCALE.x, 40.f * SCALE.y))) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_triangle)))
+        if (((popup != Popup::INFORMATION) && ImGui::Button("...", ImVec2(64.f * SCALE.x, 40.f * SCALE.y))) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_triangle)))
             ImGui::OpenPopup("...");
         if (ImGui::BeginPopup("...")) {
             if (ImGui::MenuItem(theme.information["title"].c_str()))

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -505,7 +505,7 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
     // Reference here is intentional
     auto &show_settings_dialog = is_custom_config ? gui.configuration_menu.custom_settings_dialog : gui.configuration_menu.settings_dialog;
     ImGui::Begin("##settings", &show_settings_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings);
-    ImGui::SetWindowFontScale(0.7f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(0.7f);
     const auto settings_str = lang.main_window["title"];
     TextColoredCentered(GUI_COLOR_TEXT_TITLE, (is_custom_config ? fmt::format("{}: {} [{}]", settings_str, get_app_index(gui, emuenv.app_path)->title, emuenv.app_path) : settings_str).c_str());
     ImGui::Spacing();

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -457,10 +457,10 @@ void draw_start_screen(GuiState &gui, EmuEnvState &emuenv) {
 
     SAFE_LOCALTIME(&tt, &local);
 
-    ImGui::PushFont(gui.vita_font[emuenv.current_font_level]);
-    const auto DEFAULT_FONT_SCALE = ImGui::GetFontSize() / (19.2f * SCALE.x);
+    ImGui::PushFont(gui.vita_font);
+    const auto DEFAULT_FONT_SCALE = ImGui::GetFontSize() / 19.2f;
     const auto SCAL_PIX_DATE_FONT = 34.f / 28.f;
-    const auto DATE_FONT_SIZE = (34.f * SCALE.x) * DEFAULT_FONT_SCALE;
+    const auto DATE_FONT_SIZE = 34.f * DEFAULT_FONT_SCALE;
     const auto SCAL_DATE_FONT_SIZE = DATE_FONT_SIZE / ImGui::GetFontSize();
 
     auto DATE_TIME = get_date_time(gui, emuenv, local);
@@ -468,35 +468,35 @@ void draw_start_screen(GuiState &gui, EmuEnvState &emuenv) {
     const auto CALC_DATE_SIZE = ImGui::CalcTextSize(DATE_STR.c_str());
     const auto DATE_INIT_SCALE = ImVec2(start_param.date_pos.x * SCALE.x, start_param.date_pos.y * SCALE.y);
     const auto DATE_SIZE = ImVec2(CALC_DATE_SIZE.x * SCAL_DATE_FONT_SIZE, CALC_DATE_SIZE.y * SCAL_DATE_FONT_SIZE * SCAL_PIX_DATE_FONT);
-    const auto DATE_POS = ImVec2(WINDOW_POS_MAX.x - (start_param.date_layout == DateLayout::RIGHT_DOWN ? DATE_INIT_SCALE.x + (DATE_SIZE.x * RES_SCALE.x) : DATE_INIT_SCALE.x), WINDOW_POS_MAX.y - DATE_INIT_SCALE.y);
-    draw_list->AddText(gui.vita_font[emuenv.current_font_level], DATE_FONT_SIZE * RES_SCALE.x, DATE_POS, start_param.date_color, DATE_STR.c_str());
+    const auto DATE_POS = ImVec2(WINDOW_POS_MAX.x - (start_param.date_layout == DateLayout::RIGHT_DOWN ? DATE_INIT_SCALE.x + DATE_SIZE.x : DATE_INIT_SCALE.x), WINDOW_POS_MAX.y - DATE_INIT_SCALE.y);
+    draw_list->AddText(gui.vita_font, DATE_FONT_SIZE, DATE_POS, start_param.date_color, DATE_STR.c_str());
     ImGui::PopFont();
 
-    ImGui::PushFont(gui.large_font[emuenv.current_font_level]);
-    const auto DEFAULT_LARGE_FONT_SCALE = ImGui::GetFontSize() / (116.f * SCALE.y);
-    const auto LARGE_FONT_SIZE = (116.f * SCALE.y) * DEFAULT_FONT_SCALE;
-    const auto PIX_LARGE_FONT_SCALE = (96.f * SCALE.y) / ImGui::GetFontSize();
+    ImGui::PushFont(gui.large_font);
+    const auto DEFAULT_LARGE_FONT_SCALE = ImGui::GetFontSize() / 116.f;
+    const auto LARGE_FONT_SIZE = 116.f * DEFAULT_LARGE_FONT_SCALE;
+    const auto PIX_LARGE_FONT_SCALE = 96.f / ImGui::GetFontSize();
 
     const auto &CLOCK_STR = DATE_TIME[DateTime::CLOCK];
     const auto CALC_CLOCK_SIZE = ImGui::CalcTextSize(CLOCK_STR.c_str());
-    const auto CLOCK_SIZE = ImVec2(CALC_CLOCK_SIZE.x * RES_SCALE.x, CALC_CLOCK_SIZE.y * PIX_LARGE_FONT_SCALE);
+    const auto CLOCK_SIZE = ImVec2(CALC_CLOCK_SIZE.x, CALC_CLOCK_SIZE.y * PIX_LARGE_FONT_SCALE);
 
     const auto &DAY_MOMENT_STR = DATE_TIME[DateTime::DAY_MOMENT];
     const auto CALC_DAY_MOMENT_SIZE = ImGui::CalcTextSize(DAY_MOMENT_STR.c_str());
-    const auto DAY_MOMENT_LARGE_FONT_SIZE = (56.f * SCALE.x) * DEFAULT_LARGE_FONT_SCALE;
+    const auto DAY_MOMENT_LARGE_FONT_SIZE = 56.f * DEFAULT_LARGE_FONT_SCALE;
     const auto LARGE_FONT_DAY_MOMENT_SCALE = DAY_MOMENT_LARGE_FONT_SIZE / ImGui::GetFontSize();
-    const auto DAY_MOMENT_SIZE = is_12_hour_format ? ImVec2((CALC_DAY_MOMENT_SIZE.x * LARGE_FONT_DAY_MOMENT_SCALE) * RES_SCALE.x, (CALC_DAY_MOMENT_SIZE.y * LARGE_FONT_DAY_MOMENT_SCALE) * PIX_LARGE_FONT_SCALE) : ImVec2(0.f, 0.f);
+    const auto DAY_MOMENT_SIZE = is_12_hour_format ? ImVec2(CALC_DAY_MOMENT_SIZE.x * LARGE_FONT_DAY_MOMENT_SCALE, CALC_DAY_MOMENT_SIZE.y * LARGE_FONT_DAY_MOMENT_SCALE * PIX_LARGE_FONT_SCALE) : ImVec2(0.f, 0.f);
 
     auto CLOCK_POS = ImVec2(WINDOW_POS_MAX.x - (start_param.clock_pos.x * SCALE.x), WINDOW_POS_MAX.y - (start_param.clock_pos.y * SCALE.y));
     if (start_param.date_layout == DateLayout::RIGHT_DOWN)
         CLOCK_POS.x -= CLOCK_SIZE.x + DAY_MOMENT_SIZE.x;
     else if (string_utils::stoi_def(DATE_TIME[DateTime::HOUR], 0, "hour") < 10)
-        CLOCK_POS.x += ImGui::CalcTextSize("0").x * RES_SCALE.x;
+        CLOCK_POS.x += ImGui::CalcTextSize("0").x;
 
-    draw_list->AddText(gui.large_font[emuenv.current_font_level], LARGE_FONT_SIZE * RES_SCALE.y, CLOCK_POS, start_param.date_color, CLOCK_STR.c_str());
+    draw_list->AddText(gui.large_font, LARGE_FONT_SIZE, CLOCK_POS, start_param.date_color, CLOCK_STR.c_str());
     if (is_12_hour_format) {
-        const auto DAY_MOMENT_POS = ImVec2(CLOCK_POS.x + CLOCK_SIZE.x + (6.f * SCALE.x), CLOCK_POS.y + (CLOCK_SIZE.y - DAY_MOMENT_SIZE.y));
-        draw_list->AddText(gui.large_font[emuenv.current_font_level], DAY_MOMENT_LARGE_FONT_SIZE * RES_SCALE.y, DAY_MOMENT_POS, start_param.date_color, DAY_MOMENT_STR.c_str());
+        const auto DAY_MOMENT_POS = ImVec2(CLOCK_POS.x + CLOCK_SIZE.x + (6.f * SCALE.x), CLOCK_POS.y + (CLOCK_SIZE.y - DAY_MOMENT_SIZE.y) * ImGui::GetStyle().FontScaleMain);
+        draw_list->AddText(gui.large_font, DAY_MOMENT_LARGE_FONT_SIZE, DAY_MOMENT_POS, start_param.date_color, DAY_MOMENT_STR.c_str());
     }
     ImGui::PopFont();
 

--- a/vita3k/gui/src/trophy_collection.cpp
+++ b/vita3k/gui/src/trophy_collection.cpp
@@ -456,7 +456,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
     const auto hidden_trophy_str = gui.lang.common.main["hidden_trophy"].c_str();
 
     if (group_id_selected.empty()) {
-        ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.4f);
         if (!np_com_id_list.empty() && np_com_id_selected.empty()) {
             ImGui::SetCursorPos(ImVec2(VIEWPORT_POS.x + (10.f * SCALE.x), VIEWPORT_POS.y + (27.f * SCALE.y) - (ImGui::CalcTextSize(common["search"].c_str()).y / 2.f)));
             ImGui::TextColored(GUI_COLOR_TEXT, "%s", common["search"].c_str());
@@ -474,7 +474,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
 
     // Trophy Collection
     if (np_com_id_list.empty()) {
-        ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.6f);
         ImGui::SetCursorPosY(140.f * SCALE.y);
         ImGui::TextWrapped("%s", lang["no_trophies"].c_str());
     } else {
@@ -501,23 +501,23 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::Image(gui.trophy_np_com_id_list_icons[delete_np_com_id]["000"], SIZE_ICON_LIST);
                 }
                 const auto PADDING = (20.f * SCALE.x);
-                ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.5f);
                 const auto CALC_TITLE = ImGui::CalcTextSize(np_com_id_info[delete_np_com_id].name["000"].c_str(), nullptr, false, POPUP_SIZE.x - SIZE_ICON_LIST.x - ICON_POS.x - PADDING).y / 2.f;
                 ImGui::SetCursorPos(ImVec2(ICON_POS.x + SIZE_ICON_LIST.x + PADDING, ICON_POS.y + (SIZE_ICON_LIST.y / 2.f) - CALC_TITLE));
                 ImGui::PushTextWrapPos(POPUP_SIZE.x - PADDING);
                 ImGui::TextColored(GUI_COLOR_TEXT, "%s", np_com_id_info[delete_np_com_id].name["000"].c_str());
                 ImGui::PopTextWrapPos();
-                ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.2f);
                 const auto delete_str = lang["trophy_deleted"].c_str();
                 ImGui::SetCursorPos(ImVec2(POPUP_SIZE.x / 2 - ImGui::CalcTextSize(delete_str, 0, false, POPUP_SIZE.x - (108.f * SCALE.x)).x / 2, (POPUP_SIZE.y / 2) + 10));
                 ImGui::PushTextWrapPos(POPUP_SIZE.x - (54.f * SCALE.x));
                 ImGui::TextColored(GUI_COLOR_TEXT, "%s", delete_str);
                 ImGui::PopTextWrapPos();
                 ImGui::SetCursorPos(ImVec2((POPUP_SIZE.x / 2) - (BUTTON_SIZE.x + (20.f * SCALE.x)), POPUP_SIZE.y - BUTTON_SIZE.y - (22.0f * SCALE.y)));
-                if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle)))
+                if (ImGui::Button(common["cancel"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle)))
                     delete_np_com_id.clear();
                 ImGui::SameLine(0, 20.f * SCALE.x);
-                if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross))) {
+                if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross))) {
                     fs::remove_all(TROPHY_PATH / "conf" / delete_np_com_id);
                     fs::remove_all(TROPHY_PATH / "data" / delete_np_com_id);
                     const auto np_com_id_index = std::find_if(np_com_id_list.begin(), np_com_id_list.end(), [&](const NPComIdSort &np_com) {
@@ -546,7 +546,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 if (gui.trophy_np_com_id_list_icons[np_com.id].contains("000"))
                     ImGui::Image(gui.trophy_np_com_id_list_icons[np_com.id]["000"], SIZE_ICON_LIST);
                 ImGui::NextColumn();
-                ImGui::SetWindowFontScale(1.3f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.3f);
                 ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.2f));
                 const auto Title_POS = ImGui::GetCursorPosY();
                 if (ImGui::Selectable(np_com.name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, SIZE_ICON_LIST.y))) {
@@ -568,7 +568,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 }
 
                 ImGui::SetCursorPosY(Title_POS + (50.f * SCALE.y));
-                ImGui::SetWindowFontScale(1.f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.f);
                 ImGui::PushStyleColor(ImGuiCol_PlotHistogram, GUI_PROGRESS_BAR);
                 ImGui::ProgressBar(np_com.progress / 100.f, ImVec2(200 * SCALE.x, 15.f * SCALE.y), "");
                 ImGui::PopStyleColor();
@@ -576,7 +576,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() - (6.f * SCALE.y));
                 ImGui::TextColored(GUI_COLOR_TEXT, "%s", std::to_string(np_com.progress).append("%").c_str());
                 ImGui::NextColumn();
-                ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.4f);
                 ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
                 ImGui::Selectable(np_com_id_info[np_com.id].unlocked_type_count["global"]["general"].c_str(), false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, SIZE_ICON_LIST.y));
                 ImGui::PopID();
@@ -590,7 +590,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 if (gui.trophy_np_com_id_list_icons[np_com_id_selected].contains("000"))
                     ImGui::Image(gui.trophy_np_com_id_list_icons[np_com_id_selected]["000"], SIZE_ICON_LIST);
                 ImGui::SameLine();
-                ImGui::SetWindowFontScale(1.3f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.3f);
                 ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
                 if (ImGui::Selectable(np_com_id_info[np_com_id_selected].name["000"].c_str(), false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0.f, SIZE_ICON_LIST.y))) {
                     group_id_selected = "global";
@@ -620,7 +620,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::PopID();
                     ImGui::PopStyleVar();
                     ImGui::SetCursorPosY(Title_POS + (50.f * SCALE.y));
-                    ImGui::SetWindowFontScale(1.f * RES_SCALE.x);
+                    ImGui::SetWindowFontScale(1.f);
                     ImGui::PushStyleColor(ImGuiCol_PlotHistogram, GUI_PROGRESS_BAR);
                     ImGui::ProgressBar(np_com_id_info[np_com_id_selected].progress[group_id] / 100.f, ImVec2(200 * SCALE.x, 15.f * SCALE.y), "");
                     ImGui::PopStyleColor();
@@ -629,7 +629,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::TextColored(GUI_COLOR_TEXT, "%s", std::to_string(np_com_id_info[np_com_id_selected].progress[group_id]).append("%").c_str());
                     ImGui::NextColumn();
                     ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
-                    ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+                    ImGui::SetWindowFontScale(1.4f);
                     ImGui::Selectable(np_com_id_info[np_com_id_selected].unlocked_type_count[group_id]["general"].c_str(), false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, SIZE_ICON_LIST.y));
                     ImGui::SameLine(0.f, 25.f * SCALE.x);
                     ImGui::Selectable(">", false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0, SIZE_ICON_LIST.y));
@@ -638,7 +638,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 }
                 // Detail of Np Com ID
             } else if (detail_np_com_id) {
-                ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.5f);
                 if (gui.trophy_np_com_id_list_icons[np_com_id_selected].contains(group_id_selected == "global" ? "000" : group_id_selected))
                     ImGui::Image(gui.trophy_np_com_id_list_icons[np_com_id_selected][group_id_selected == "global" ? "000" : group_id_selected], SIZE_ICON_LIST);
                 const auto CALC_NAME = ImGui::CalcTextSize(np_com_id_info[np_com_id_selected].name[group_id_selected == "global" ? "000" : group_id_selected].c_str(), nullptr, false, SIZE_INFO.x - SIZE_ICON_LIST.x - 48.f).y / 2.f;
@@ -679,7 +679,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 if (gui.trophy_np_com_id_list_icons[np_com_id_selected].contains(group_id_selected))
                     ImGui::Image(gui.trophy_np_com_id_list_icons[np_com_id_selected][group_id_selected], SIZE_ICON_LIST);
                 ImGui::SameLine();
-                ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.6f);
                 ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
                 if (ImGui::Selectable(np_com_id_info[np_com_id_selected].name[group_id_selected].c_str(), false, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0.f, SIZE_ICON_LIST.y)))
                     detail_np_com_id = true;
@@ -690,7 +690,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::SetColumnWidth(2, 40.f * SCALE.x);
                 for (const auto &trophy : trophy_list) {
                     ImGui::NextColumn();
-                    ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+                    ImGui::SetWindowFontScale(1.2f);
                     if (trophy_info[trophy.id].earned)
                         ImGui::Image(gui.trophy_list[trophy.id], SIZE_TROPHY_LIST);
                     else {
@@ -715,7 +715,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                     ImGui::PopStyleVar();
                     if (!hidden_trophy || show_hidden_trophy) {
                         ImGui::SetCursorPosY(name_pos + (40.f * SCALE.y));
-                        ImGui::SetWindowFontScale(1.0f * RES_SCALE.x);
+                        ImGui::SetWindowFontScale(1.0f);
                         ImGui::Text("%s", trophy_info[trophy.id].detail.c_str());
                     }
                     ImGui::NextColumn();
@@ -723,7 +723,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::Columns(1);
             } else {
                 // Detail Trophy
-                ImGui::SetWindowFontScale(1.5f * RES_SCALE.x);
+                ImGui::SetWindowFontScale(1.5f);
                 if (trophy_info[trophy_id_selected].earned)
                     ImGui::Image(gui.trophy_list[trophy_id_selected], SIZE_TROPHY_LIST);
                 else {
@@ -765,11 +765,11 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::EndChild();
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f * SCALE.x);
-    ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.2f);
 
     // Back
     ImGui::SetCursorPos(ImVec2(8.f * SCALE.x, WINDOW_SIZE.y - (52.f * SCALE.y)));
-    if (ImGui::Button("<<", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+    if (ImGui::Button("<<", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
         if (!np_com_id_selected.empty()) {
             if (detail_np_com_id) {
                 detail_np_com_id = false;
@@ -799,7 +799,7 @@ void draw_trophy_collection(GuiState &gui, EmuEnvState &emuenv) {
     // Sort
     if (trophy_id_selected.empty() && !detail_np_com_id && (np_com_id_selected.empty() || !group_id_selected.empty())) {
         ImGui::SetCursorPos(ImVec2(WINDOW_SIZE.x - (70.f * SCALE.x), WINDOW_SIZE.y - (52.f * SCALE.y)));
-        if (ImGui::Button("...", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_triangle)))
+        if (ImGui::Button("...", ImVec2(64.f * SCALE.x, 40.f * SCALE.y)) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_triangle)))
             ImGui::OpenPopup("...");
         if (ImGui::BeginPopup("...", ImGuiWindowFlags_NoMove)) {
             ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["sort"].c_str());

--- a/vita3k/gui/src/trophy_unlocked.cpp
+++ b/vita3k/gui/src/trophy_unlocked.cpp
@@ -107,10 +107,10 @@ static void draw_trophy_unlocked(GuiState &gui, EmuEnvState &emuenv, NpTrophyUnl
         break;
     }
 
-    ImGui::SetWindowFontScale(1.f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     ImGui::SetCursorPosY(TROPHY_WINDOW_MARGIN_PADDING);
     ImGui::TextColored(ImVec4(0.24f, 0.24f, 0.24f, 1.0f), "(%s) %s", trophy_kind_s.c_str(), callback_data.trophy_name.c_str());
-    ImGui::SetWindowFontScale(0.8f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(0.8f);
     ImGui::TextColored(ImVec4(0.24f, 0.24f, 0.24f, 1.0f), "%s", gui.lang.indicator["trophy_earned"].c_str());
     ImGui::End();
     ImGui::PopStyleColor();

--- a/vita3k/gui/src/user_management.cpp
+++ b/vita3k/gui/src/user_management.cpp
@@ -502,7 +502,7 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
     const auto LARGE_AVATAR_SIZE = get_avatar_size(LARGE, SCALE);
     const auto USER_NAME_BG_SIZE = ImVec2(MED_AVATAR_SIZE.x, 60.f * SCALE.y);
 
-    ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.4f);
     const auto calc_title = ImGui::CalcTextSize(title.c_str()).y / 2.f;
     ImGui::SetCursorPos(ImVec2(54.f * SCALE.x, (32.f * SCALE.y) - calc_title));
     ImGui::TextColored(GUI_COLOR_TEXT, "%s", title.c_str());
@@ -795,7 +795,7 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
             if (gui.is_nav_button)
                 delete_flags |= ImGuiWindowFlags_NoMouseInputs;
             ImGui::BeginChild("##delete_user_child", CHILD_DELETE_USER_SIZE, ImGuiChildFlags_None, delete_flags);
-            ImGui::SetWindowFontScale(RES_SCALE.x);
+            ImGui::SetWindowFontScale(1.f);
             ImGui::Columns(2, nullptr, false);
             ImGui::SetColumnWidth(0, SMALL_AVATAR_SIZE.x + (10.f * SCALE.x));
             ImGui::Separator();
@@ -867,7 +867,7 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv) {
 
     ImGui::SetCursorPosY(WINDOW_SIZE.y - POS_SEPARATOR);
     ImGui::Separator();
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     const auto USER_ALREADY_INIT = !gui.users.empty() && !emuenv.io.user_id.empty() && (emuenv.cfg.user_id == emuenv.io.user_id);
     if ((menu == SELECT && USER_ALREADY_INIT) || ((menu != SELECT) && (menu != CONFIRM) && del_menu.empty())) {
         ImGui::SetCursorPos(ImVec2(54.f * SCALE.x, ImGui::GetCursorPosY() + (10.f * SCALE.y)));

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -310,13 +310,13 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
     else
         ImGui::GetBackgroundDrawList()->AddRectFilled(WINDOW_POS, display_size, IM_COL32(36.f, 120.f, 12.f, 255.f), 0.f, ImDrawFlags_RoundCornersAll);
 
-    ImGui::SetWindowFontScale(1.6f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.6f);
     ImGui::SetCursorPosY(44.f * SCALE.y);
     TextCentered(lang["title"].c_str());
     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (6.f * SCALE.y));
     ImGui::Separator();
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f * SCALE.x);
-    ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.4f);
     switch (state) {
     case NOT_COMPLETE_UPDATE:
         ImGui::SetCursorPosY((display_size.y / 2.f) - ImGui::GetFontSize());
@@ -336,7 +336,7 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
     }
     case DESCRIPTION: {
         ImGui::Spacing();
-        ImGui::SetWindowFontScale(1.4f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.4f);
         TextCentered(fmt::format(fmt::runtime(lang["new_features"]), git_version).c_str());
         ImGui::Spacing();
         ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, 136.0f * SCALE.y), ImGuiCond_Always, ImVec2(0.5f, 0.f));
@@ -388,12 +388,12 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
 
         break;
     case DOWNLOAD: {
-        ImGui::SetWindowFontScale(1.25f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.25f);
         ImGui::SetCursorPos(ImVec2(102.f * SCALE.x, ImGui::GetCursorPosY() + (44 * SCALE.y)));
         ImGui::PushTextWrapPos(WINDOW_POS.x + (858.f * SCALE.x));
         ImGui::Text("%s", lang["downloading"].c_str());
         ImGui::PopTextWrapPos();
-        ImGui::SetWindowFontScale(1.04f * RES_SCALE.x);
+        ImGui::SetWindowFontScale(1.04f);
         const auto remaining_str = get_remaining_str(gui.lang, remaining);
         ImGui::SetCursorPos(ImVec2(display_size.x - (90 * SCALE.x) - (ImGui::CalcTextSize(remaining_str.c_str()).x), display_size.y - (196.f * SCALE.y) - ImGui::GetFontSize()));
         ImGui::Text("%s", remaining_str.c_str());
@@ -411,11 +411,11 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
         break;
     }
 
-    ImGui::SetWindowFontScale(1.2f * RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.2f);
     ImGui::SetCursorPosY(display_size.y - BUTTON_SIZE.y - (20.f * SCALE.y));
     ImGui::Separator();
     ImGui::SetCursorPos(ImVec2(WINDOW_POS.x + (10.f * SCALE.x), (display_size.y - BUTTON_SIZE.y - (12.f * SCALE.y))));
-    if (ImGui::Button((state < DESCRIPTION) || (state == DOWNLOAD) ? common["cancel"].c_str() : lang["back"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_cross))) {
+    if (ImGui::Button((state < DESCRIPTION) || (state == DOWNLOAD) ? common["cancel"].c_str() : lang["back"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_cross))) {
         if (state < DESCRIPTION) {
             if (thread_running)
                 cancel_thread = true;
@@ -430,7 +430,7 @@ void draw_vita3k_update(GuiState &gui, EmuEnvState &emuenv) {
 
     if (state > NO_UPDATE && state < DOWNLOAD) {
         ImGui::SetCursorPos(ImVec2(display_size.x - WINDOW_POS.x - BUTTON_SIZE.x - (10.f * SCALE.x), (display_size.y - BUTTON_SIZE.y - (12.f * SCALE.y))));
-        if (ImGui::Button(state < UPDATE_VITA3K ? lang["next"].c_str() : lang["update"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(static_cast<ImGuiKey>(emuenv.cfg.keyboard_button_circle))) {
+        if (ImGui::Button(state < UPDATE_VITA3K ? lang["next"].c_str() : lang["update"].c_str(), BUTTON_SIZE) || ImGui::IsKeyPressed(ImGui_ImplSdl_ScancodeToImGuiKey(emuenv.cfg.keyboard_button_circle))) {
             state = (Vita3kUpdate)(state + 1);
             if (state == DOWNLOAD)
                 download_update(emuenv.base_path.string());

--- a/vita3k/gui/src/welcome_dialog.cpp
+++ b/vita3k/gui/src/welcome_dialog.cpp
@@ -36,7 +36,7 @@ void draw_welcome_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::PushStyleColor(ImGuiCol_Text, GUI_COLOR_TEXT_MENUBAR);
     ImGui::Begin("##welcome", &gui.help_menu.welcome_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::SetWindowFontScale(RES_SCALE.x);
+    ImGui::SetWindowFontScale(1.f);
     TextColoredCentered(GUI_COLOR_TEXT_TITLE, lang["title"].c_str());
     ImGui::Spacing();
     ImGui::Separator();

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -445,7 +445,7 @@ int main(int argc, char *argv[]) {
         gui::draw_vita_area(gui, emuenv);
 
         if (emuenv.cfg.performance_overlay && !emuenv.kernel.is_threads_paused() && (emuenv.common_dialog.status != SCE_COMMON_DIALOG_STATUS_RUNNING)) {
-            ImGui::PushFont(gui.vita_font[emuenv.current_font_level]);
+            ImGui::PushFont(gui.vita_font);
             gui::draw_perf_overlay(gui, emuenv);
             ImGui::PopFont();
         }


### PR DESCRIPTION
This PR implements the Dynamic Font Rendering feature introduced in ImGui 1.20. We can now dynamically render various fonts at different resolutions without the long initial loading time. This improvement is particularly significant when using CJK fonts, which previously required substantial time to bake all glyphs at startup.

### Concerns about Stability

Due to my limited expertise in graphics APIs, I cannot guarantee the stability of this PR. While I've closely followed the imgui modifications for implementation, I have significant doubts about whether `imgui_impl_sdl_vulkan` has been correctly ported, as Vulkan is outside my area of expertise.

### Testing Status

The logic in other parts should be ok. I've tested on Windows and Linux environments, and within my testing scope, no issues were found. However, I haven't been able to test on multi-monitor systems, and so on. Further testing by multiple people in various scenarios is needed.

### Credits

The modifications to `imgui_impl_sdl_gl3` and `imgui_impl_sdl_vulkan` are heavily based on the upstream changes to `imgui_impl_opengl3` and `imgui_impl_vulkan` by the ImGui maintainers.

Reference
- https://github.com/ocornut/imgui/commit/abe294bfd0bfff325bbaa000f2d688085f1d4696 
- https://github.com/ocornut/imgui/commit/dbb91a574f35e24697754f6344455fd43b97d46d 