### PR TITLE
modules/SceAppUtil: refactor and fix sceAppUtilSaveDataGetQuota.

### DIFF
--- a/vita3k/io/include/io/vfs.h
+++ b/vita3k/io/include/io/vfs.h
@@ -24,15 +24,9 @@ class VitaIoDevice;
 
 namespace vfs {
 
-struct SpaceInfo {
-    unsigned long long max_capacity;
-    unsigned long long used;
-    unsigned long long free;
-};
-
 using FileBuffer = std::vector<SceUInt8>;
 
 bool read_file(VitaIoDevice device, FileBuffer &buf, const fs::path &pref_path, const fs::path &vfs_file_path);
 bool read_app_file(FileBuffer &buf, const fs::path &pref_path, const std::string &app_path, const fs::path &vfs_file_path);
-SpaceInfo get_space_info(const VitaIoDevice device, const std::string &vfs_path, const fs::path &pref_path);
+SceSize get_directory_used_size(const VitaIoDevice device, const std::string &vfs_path, const fs::path &pref_path);
 } // namespace vfs

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -73,13 +73,16 @@ bool read_app_file(FileBuffer &buf, const fs::path &pref_path, const std::string
     return read_file(VitaIoDevice::ux0, buf, pref_path, fs::path("app") / app_path / vfs_file_path);
 }
 
-SpaceInfo get_space_info(const VitaIoDevice device, const std::string &vfs_path, const fs::path &pref_path) {
-    SpaceInfo space_info;
+SceSize get_directory_used_size(const VitaIoDevice device, const std::string &vfs_path, const fs::path &pref_path) {
     const auto emuenv_path = device::construct_emulated_path(device, vfs_path, pref_path);
-    space_info.max_capacity = fs::space(emuenv_path).capacity;
-    space_info.free = fs::space(emuenv_path).available;
-    space_info.used = fs::space(emuenv_path).capacity - space_info.free;
-    return space_info;
+
+    SceSize total_size = 0;
+    for (const auto &entry : fs::recursive_directory_iterator(emuenv_path)) {
+        if (fs::is_regular_file(entry.path()))
+            total_size += fs::file_size(entry.path());
+    }
+
+    return total_size;
 }
 
 } // namespace vfs


### PR DESCRIPTION
# About
- modules/SceAppUtil: refactor and fix sceAppUtilSaveDataGetQuota.
Using SFO value to set SAVEDATA_MAX_SIZE quota.
Calculate used save data size from all save files.
Prevent "not enough space" block on game boot.

Get improve boot of djmax game, but block after in other things