### PR TITLE
modules/SceCommonDialog: Fix 'check_save_file' crash on Linux

### DIFF
--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -825,10 +825,10 @@ static void check_save_file(const uint32_t index, EmuEnvState &emuenv, const cha
         auto empty_param = emuenv.common_dialog.savedata.list_empty_param[index];
         if (empty_param) {
             emuenv.common_dialog.savedata.title[index] = empty_param->title ? empty_param->title.get(emuenv.mem) : emuenv.common_dialog.lang.save_data.save["new_saved_data"];
-            const auto iconPath = empty_param->iconPath.get(emuenv.mem);
+            const char *iconPath = empty_param->iconPath.get(emuenv.mem);
             SceUChar8 *iconBuf = empty_param->iconBuf.cast<SceUChar8>().get(emuenv.mem);
             const auto iconBufSize = empty_param->iconBufSize;
-            if (iconPath) {
+            if (iconPath && (std::strlen(iconPath) > 0)) {
                 auto device = device::get_device(iconPath);
                 const auto thumbnail_path = translate_path(empty_param->iconPath.get(emuenv.mem), device, emuenv.io.device_paths);
                 vfs::read_file(VitaIoDevice::ux0, icon_buf_tmp, emuenv.pref_path, thumbnail_path);


### PR DESCRIPTION
- When `iconPath` is empty string, `vfs::read_file` will try to open dictory `ux0` as a binary file to read, which have no effect on Windows but crash on *nix (Linux/Android/...).
- `std::ifstream` can open a directory as file on *nix (but can not on Windows), and after that `std::ifstream::tellg()` return the max value that the return type can represent (strangely not fail), which leads to throwing an exception when buffer is being resized.