### PR TITLE
modules/SceCommonDialog: Clamp slot_list_size in SaveDataDialog.

### DIFF
--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -1106,9 +1106,9 @@ EXPORT(int, sceSaveDataDialogContinue, const SceSaveDataDialogParam *p) {
         emuenv.common_dialog.savedata.mode_to_display = SCE_SAVEDATA_DIALOG_MODE_LIST;
         list_param = p->listParam.get(emuenv.mem);
         if (list_param->slotListSize > 0)
-            emuenv.common_dialog.savedata.slot_list_size = list_param->slotListSize;
-        slot_list.resize(list_param->slotListSize);
-        for (std::uint32_t i = 0; i < list_param->slotListSize; i++) {
+            emuenv.common_dialog.savedata.slot_list_size = std::min(list_param->slotListSize, emuenv.common_dialog.savedata.slot_list_size);
+        slot_list.resize(emuenv.common_dialog.savedata.slot_list_size);
+        for (std::uint32_t i = 0; i < emuenv.common_dialog.savedata.slot_list_size; i++) {
             slot_list[i] = list_param->slotList.get(emuenv.mem)[i];
             emuenv.common_dialog.savedata.slot_id[i] = slot_list[i].id;
             emuenv.common_dialog.savedata.list_empty_param[i] = slot_list[i].emptyParam.get(emuenv.mem);
@@ -1241,7 +1241,7 @@ EXPORT(int, sceSaveDataDialogInit, const SceSaveDataDialogParam *p) {
         break;
     case SCE_SAVEDATA_DIALOG_MODE_LIST:
         list_param = p->listParam.get(emuenv.mem);
-        emuenv.common_dialog.savedata.slot_list_size = list_param->slotListSize;
+        emuenv.common_dialog.savedata.slot_list_size = std::min(list_param->slotListSize, (uint32_t)SCE_SAVEDATA_DIALOG_SLOTLIST_MAXSIZE);
         emuenv.common_dialog.savedata.list_style = list_param->itemStyle;
 
         slot_list.resize(list_param->slotListSize);


### PR DESCRIPTION
# About
- modules/SceCommonDialog: Clamp slot_list_size in SaveDataDialog.
Clamp slot_list_size in Continue to not exceed the value set by Init, preventing vector overflow crash.
Clamp slot_list_size in Init to SLOTLIST_MAXSIZE (256) to respect SDK maximum.

- Fix crash in Sly Cooper: Thieves in Time when returning to Save List.
When selecting a save slot and cancelling the dialog, Continue would try to display the list
with a slotListSize of 32, exceeding the 31 slots set in Init, causing a vector overflow.
This clamps slot_list_size to prevent the crash.
