### PR TITLE
modules/SceLibKernel: Add an argument check to 'sceKernelUnlockLwMutex'

### DIFF
--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -1796,6 +1796,9 @@ EXPORT(int, sceKernelUnloadModule, SceUID uid, SceUInt32 flags, const void *pOpt
 
 EXPORT(int, sceKernelUnlockLwMutex, Ptr<SceKernelLwMutexWork> workarea, int unlock_count) {
     TRACY_FUNC(sceKernelUnlockLwMutex, workarea, unlock_count);
+    if (!workarea)
+        return RET_ERROR(SCE_KERNEL_ERROR_INVALID_ARGUMENT);
+
     const auto lwmutexid = workarea.get(emuenv.mem)->uid;
     return mutex_unlock(emuenv.kernel, export_name, thread_id, lwmutexid, unlock_count, SyncWeight::Light);
 }


### PR DESCRIPTION
- `sceKernelUnlockLwMutex` should be paired to `_sceKernelLockLwMutex`.
- The error was discovered during the testing of _下天の華 with 夢灯り 愛蔵版_ [PCSG00921].