### PR TITLE
modules/SceCommonDialog: Handle null title/text ptrs in ImeDialogInit.

### DIFF
--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -186,8 +186,10 @@ EXPORT(int, sceImeDialogInit, const Ptr<SceImeDialogParam> param) {
 
     SceImeDialogParam *p = param.get(emuenv.mem);
 
-    std::u16string title = p->title.cast<char16_t>().get(emuenv.mem);
-    std::u16string text = p->initialText.cast<char16_t>().get(emuenv.mem);
+    const auto title_data = p->title.cast<char16_t>().get(emuenv.mem);
+    std::u16string title = title_data ? title_data : u"";
+    const auto text_data = p->initialText.cast<char16_t>().get(emuenv.mem);
+    std::u16string text = text_data ? text_data : u"";
 
     emuenv.common_dialog.status = SCE_COMMON_DIALOG_STATUS_RUNNING;
     emuenv.common_dialog.type = IME_DIALOG;


### PR DESCRIPTION
# About
- modules/SceCommonDialog: Handle null title/text ptrs in ImeDialogInit.
Avoid crash when title or initialText is missing by falling back to empty strings.

# Result
- Fix crash reported by user in Danganronpa 1-2 Reload, when the game calls ImeDialog to enter a password.
Likely affects other versions of Danganronpa 2 as well.
<img width="1924" height="1148" alt="image" src="https://github.com/user-attachments/assets/2a7a2fc4-700a-41e1-88e5-f3020019103d" />
