### PR TITLE
gui/app context menu: Add support for creating app shortcuts.

### DIFF
--- a/lang/system/en-gb.xml
+++ b/lang/system/en-gb.xml
@@ -59,6 +59,7 @@
 		<copy_app_info>Copy App info</copy_app_info>
 		<name_and_id>Name and Title ID</name_and_id>
 		<app_summary>App Summary</app_summary>
+		<create_shortcut>Create Shortcut</create_shortcut>
 		<custom_config>Custom Config</custom_config>
 		<create>Create</create>
 		<edit>Edit</edit>

--- a/lang/system/en.xml
+++ b/lang/system/en.xml
@@ -59,6 +59,7 @@
 		<copy_app_info>Copy App info</copy_app_info>
 		<name_and_id>Name and Title ID</name_and_id>
 		<app_summary>App Summary</app_summary>
+		<create_shortcut>Create Shortcut</create_shortcut>
 		<custom_config>Custom Config</custom_config>
 		<create>Create</create>
 		<edit>Edit</edit>

--- a/lang/system/fr.xml
+++ b/lang/system/fr.xml
@@ -42,10 +42,11 @@
 		<copy_vita3k_summary>Copier le résumé de Vita3K</copy_vita3k_summary>
 		<open_state_report>Ouvrir le rapport d'état</open_state_report>
 		<create_state_report>Créer le rapport d'état</create_state_report>
-		<update_database>Mettre à jour la base de donnée</update_database>
+		<update_database>Mettre à jour la base de données</update_database>
 		<copy_app_info>Copier l'info de l'App</copy_app_info>
 		<name_and_id>Nom et ID du Titre</name_and_id>
-		<app_summary>App Summary</app_summary>
+		<app_summary>Résumé de l'App</app_summary>
+		<create_shortcut>Créer un raccourci</create_shortcut>
 		<custom_config>Config personnalisée</custom_config>
 		<create>Créer</create>
 		<edit>Editer</edit>

--- a/vita3k/gui/CMakeLists.txt
+++ b/vita3k/gui/CMakeLists.txt
@@ -1,6 +1,4 @@
-add_library(
-	gui
-	STATIC
+set(GUI_SOURCES
 	include/gui/functions.h
 	include/gui/imgui_impl_sdl_gl3.h
 	include/gui/imgui_impl_sdl_state.h
@@ -49,7 +47,26 @@ add_library(
 	src/welcome_dialog.cpp
 )
 
+# Add macOS-specific Objective-C++ files
+if(APPLE)
+	list(APPEND GUI_SOURCES
+		include/gui/macos_helper.h
+		src/macos_helper.mm
+	)
+endif()
+
+add_library(gui STATIC ${GUI_SOURCES})
+
 target_include_directories(gui PUBLIC include ${CMAKE_SOURCE_DIR}/vita3k)
 target_link_libraries(gui PUBLIC app compat config dialog emuenv ime imgui lang regmgr np)
 target_link_libraries(gui PRIVATE audio cppcommon ctrl kernel miniz psvpfsparser pugixml::pugixml stb renderer packages SDL3::SDL3 touch vkutil host::dialog concurrentqueue)
 target_link_libraries(gui PUBLIC tracy)
+
+# Link macOS frameworks for Objective-C++ code
+if(APPLE)
+	target_link_libraries(gui PRIVATE
+		"-framework Foundation"
+		"-framework ImageIO"
+		"-framework UniformTypeIdentifiers"
+	)
+endif()

--- a/vita3k/gui/include/gui/macos_helper.h
+++ b/vita3k/gui/include/gui/macos_helper.h
@@ -1,0 +1,25 @@
+// Vita3K emulator project
+// Copyright (C) 2025 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+namespace gui {
+bool png_to_icns(const fs::path &png_path, const fs::path &icns_path);
+fs::path get_desktop_path();
+bool create_launcher(const fs::path &exe_path, const fs::path &macOS_path, const std::string &app_path);
+bool create_info_plist(const fs::path &contents_path, const std::string &app_name, const std::string &title_id);
+} // namespace gui

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -28,6 +28,7 @@
 
 #include <util/log.h>
 #include <util/safe_time.h>
+#include <util/string_utils.h>
 
 #include <SDL3/SDL_cpuinfo.h>
 #include <SDL3/SDL_misc.h>
@@ -38,7 +39,378 @@
 #include <pugixml.hpp>
 #include <regex>
 
+#ifdef _WIN32
+#include <shlobj.h>
+#include <shobjidl.h>
+
+#include <stb_image.h>
+
+static bool png_to_ico(const fs::path &png, const fs::path &ico) {
+    int w, h, n;
+    unsigned char *data = stbi_load(png.string().c_str(), &w, &h, &n, 4);
+    if (!data) {
+        LOG_ERROR("Failed to load PNG '{}'", png.string());
+        return false;
+    }
+
+    fs::ofstream i(ico, std::ios::binary);
+    if (!i.good()) {
+        stbi_image_free(data);
+        return false;
+    }
+
+    const uint16_t reserved = 0, type = 1, count = 1;
+    const uint8_t width = (w >= 256) ? 0 : w;
+    const uint8_t height = (h >= 256) ? 0 : h;
+    const uint8_t colors = 0, reserved2 = 0;
+    const uint16_t planes = 1, bpp = 32;
+    const uint32_t imageOffset = 6 + 16;
+    const uint32_t imageSize = 40 + (w * h * 4) + (((w + 31) / 32) * 4 * h);
+
+    // ICO header
+    i.write((char *)&reserved, 2);
+    i.write((char *)&type, 2);
+    i.write((char *)&count, 2);
+    i.put(width);
+    i.put(height);
+    i.put(colors);
+    i.put(reserved2);
+    i.write((char *)&planes, 2);
+    i.write((char *)&bpp, 2);
+    i.write((char *)&imageSize, 4);
+    i.write((char *)&imageOffset, 4);
+
+    // BITMAPINFOHEADER
+    const uint32_t headerSize = 40;
+    const int32_t w32 = w, h32 = h * 2;
+    const uint16_t planes2 = 1, bitcount = 32;
+    const uint32_t compression = 0, imgSize = w * h * 4;
+    const uint32_t zero = 0;
+
+    i.write((char *)&headerSize, 4);
+    i.write((char *)&w32, 4);
+    i.write((char *)&h32, 4);
+    i.write((char *)&planes2, 2);
+    i.write((char *)&bitcount, 2);
+    i.write((char *)&compression, 4);
+    i.write((char *)&imgSize, 4);
+    i.write((char *)&zero, 4);
+    i.write((char *)&zero, 4);
+    i.write((char *)&zero, 4);
+    i.write((char *)&zero, 4);
+
+    // Pixel data (bottom-up, BGRA)
+    for (int y = h - 1; y >= 0; --y) {
+        for (int x = 0; x < w; ++x) {
+            const uint8_t *px = &data[(y * w + x) * 4];
+            const uint8_t bgra[4] = { px[2], px[1], px[0], px[3] };
+            i.write((char *)bgra, 4);
+        }
+    }
+
+    // AND mask
+    const size_t andSize = (static_cast<size_t>(w + 31) / 32) * 4 * static_cast<size_t>(h);
+    const std::vector<uint8_t> zeros(andSize, 0);
+    i.write((char *)zeros.data(), zeros.size());
+
+    stbi_image_free(data);
+    return true;
+}
+#elif defined(__ANDROID__)
+#include <SDL3/SDL_system.h>
+#include <jni.h>
+#elif defined(__linux__)
+static fs::path get_desktop_path() {
+    static fs::path desktop_path = []() -> fs::path {
+        // get XDG_DESKTOP_DIR variable environment
+        const char *xdg = std::getenv("XDG_DESKTOP_DIR");
+        if (xdg && fs::exists(xdg))
+            return fs::path(xdg);
+
+        // Try fallback ~/Desktop
+        const char *home = std::getenv("HOME");
+        if (home) {
+            fs::path d = fs::path(home) / "Desktop";
+            if (fs::exists(d))
+                return d;
+        }
+
+        return {};
+    }();
+
+    return desktop_path;
+}
+#elif defined(__APPLE__)
+#include <gui/macos_helper.h>
+#include <mach-o/dyld.h>
+#endif
+
+static fs::path get_exe_path() {
+    static fs::path cached;
+    if (!cached.empty())
+        return cached;
+
+#ifdef _WIN32
+    wchar_t exe_path[MAX_PATH];
+    if (GetModuleFileNameW(NULL, exe_path, MAX_PATH))
+        cached = exe_path;
+    else {
+        LOG_ERROR("Failed to get executable path");
+        return fs::path();
+    }
+#elif defined(__APPLE__)
+    char exe_path[PATH_MAX];
+    uint32_t size = sizeof(exe_path);
+
+    if (_NSGetExecutablePath(exe_path, &size) != 0) {
+        LOG_ERROR("Failed to get executable path");
+        return fs::path();
+    }
+
+    // Resolving the path (important)
+    char resolved[PATH_MAX];
+    if (realpath(exe_path, resolved) != nullptr)
+        cached = resolved;
+    else
+        cached = exe_path; // fallback
+#else // Linux / Others
+    char exe_path[PATH_MAX];
+    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+    if (len != -1) {
+        exe_path[len] = '\0';
+        cached = exe_path;
+    } else {
+        LOG_ERROR("Failed to get executable path");
+        return fs::path();
+    }
+#endif
+
+    return cached;
+}
+
 namespace gui {
+
+static void create_app_icon(EmuEnvState &emuenv, const fs::path &app_path) {
+    // Get title ID and icon path
+    const std::string title_id = app_path.stem().string();
+    const fs::path png_path = emuenv.pref_path / "ux0/app" / app_path / "sce_sys" / "icon0.png";
+
+    if (!fs::exists(png_path))
+        return; // skip, will use exe icon
+
+    // Create icons directory if not exist
+    const fs::path icon_dir = emuenv.cache_path / "icons";
+    fs::create_directories(icon_dir);
+
+    // Create icon in appropriate format
+    fs::path icon_path = icon_dir / title_id;
+#ifdef _WIN32
+    icon_path += ".ico";
+    if (!png_to_ico(png_path, icon_path))
+#elif defined(__linux__)
+    icon_path += ".png";
+    if (!fs::copy_file(png_path, icon_path, fs::copy_options::overwrite_existing))
+#elif defined(__APPLE__)
+    icon_path += ".icns";
+    if (!png_to_icns(png_path, icon_path))
+#endif
+        LOG_ERROR("Failed to create icon for app '{}", title_id);
+}
+
+static bool has_shortcut_support() {
+#if defined(__linux__) && !defined(__ANDROID__)
+    static bool is_supported = []() -> bool {
+        // Not supported if running in an AppImage
+        if (std::getenv("APPIMAGE") != nullptr)
+            return false;
+
+        // Get the desktop path
+        const fs::path desktop = get_desktop_path();
+
+        // Desktop should not be empty
+        if (desktop.empty())
+            return false;
+
+        // Desktop should not be empty or equal to home directory
+        const char *home_cstr = std::getenv("HOME");
+        if ((home_cstr != nullptr) && (desktop == fs::path(home_cstr)))
+            return false;
+
+        return true;
+    }();
+
+    return is_supported;
+#else
+    return true;
+#endif
+}
+
+static void create_shortcut(EmuEnvState &emuenv, const std::string &app_path, const std::string &app_name) {
+    const fs::path exe_path = get_exe_path();
+    fs::path icon_path = emuenv.cache_path / "icons" / fs::path(app_path).stem();
+#ifdef _WIN32
+    // Initialize COM library
+    HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr) && hr != S_FALSE && hr != RPC_E_CHANGED_MODE) {
+        LOG_ERROR("COM initialization failed: {:#X}", hr);
+        return;
+    }
+
+    // Create IShellLink instance
+    IShellLinkW *psl = nullptr;
+    hr = CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER,
+        IID_IShellLinkW, (void **)&psl);
+    if (FAILED(hr) || !psl) {
+        LOG_ERROR("Failed to create IShellLink instance: {:#X}", hr);
+        if (hr != S_FALSE)
+            CoUninitialize();
+        return;
+    }
+
+    // Set executable path, arguments and working directory
+    psl->SetPath(exe_path.wstring().c_str());
+    const std::wstring args = L"-r " + std::wstring(app_path.begin(), app_path.end());
+    psl->SetArguments(args.c_str());
+    psl->SetWorkingDirectory(exe_path.parent_path().wstring().c_str());
+
+    // Set icon location
+    icon_path += ".ico";
+    if (fs::exists(icon_path))
+        psl->SetIconLocation(icon_path.wstring().c_str(), 0);
+    else
+        psl->SetIconLocation(exe_path.wstring().c_str(), 0);
+
+    // Get desktop folder path
+    wchar_t desktop[MAX_PATH];
+    hr = SHGetFolderPathW(NULL, CSIDL_DESKTOPDIRECTORY, NULL, 0, desktop);
+    if (FAILED(hr)) {
+        LOG_ERROR("Failed to get desktop path: {:#X}", hr);
+        psl->Release();
+        if (hr != S_FALSE)
+            CoUninitialize();
+        return;
+    }
+    const fs::path shortcut = fs::path(desktop) / (app_name + ".lnk");
+
+    // Get IPersistFile interface to save shortcut
+    IPersistFile *ppf = nullptr;
+    hr = psl->QueryInterface(IID_IPersistFile, (void **)&ppf);
+    if (FAILED(hr) || !ppf) {
+        LOG_ERROR("QueryInterface for IPersistFile failed: {:#X}", hr);
+        psl->Release();
+        if (hr != S_FALSE)
+            CoUninitialize();
+        return;
+    }
+
+    // Save the shortcut file
+    hr = ppf->Save(shortcut.wstring().c_str(), TRUE);
+    if (FAILED(hr))
+        LOG_ERROR("Failed to save shortcut '{}': {:#X}", shortcut.string(), hr);
+    else
+        LOG_INFO("Shortcut created successfully at '{}'", shortcut.string());
+
+    // Release interfaces and uninitialize COM if needed
+    ppf->Release();
+    psl->Release();
+    if (hr != S_FALSE)
+        CoUninitialize();
+#elif defined(__ANDROID__)
+    // retrieve the JNI environment.
+    JNIEnv *env = reinterpret_cast<JNIEnv *>(SDL_GetAndroidJNIEnv());
+
+    // retrieve the Java instance of the SDLActivity
+    jobject activity = reinterpret_cast<jobject>(SDL_GetAndroidActivity());
+
+    // find the Java class of the activity. It should be SDLActivity or a subclass of it.
+    jclass clazz(env->GetObjectClass(activity));
+
+    // find the identifier of the method to call
+    jmethodID method_id = env->GetMethodID(clazz, "createShortcut", "(Ljava/lang/String;Ljava/lang/String;)Z");
+    jstring j_app_path = env->NewStringUTF(app_path.data());
+    jstring j_app_name = env->NewStringUTF(app_name.data());
+
+    jboolean result = env->CallBooleanMethod(activity, method_id, j_app_path, j_app_name);
+
+    // clean up the local references.
+    env->DeleteLocalRef(j_app_name);
+    env->DeleteLocalRef(j_app_path);
+    env->DeleteLocalRef(activity);
+    env->DeleteLocalRef(clazz);
+
+    if (result)
+        SDL_ShowAndroidToast("Shortcut successfully created!", 0, -1, 0, 0);
+    else
+        SDL_ShowAndroidToast("Failed to create shortcut.", 1, -1, 0, 0);
+#elif defined(__linux__)
+    // Linux: create a .desktop file on desktop
+    const fs::path desktop_path = get_desktop_path();
+    const fs::path shortcut = desktop_path / (app_name + ".desktop");
+    fs::ofstream f(shortcut);
+    if (!f.is_open()) {
+        LOG_ERROR("Failed to create shortcut '{}'", shortcut.string());
+        return;
+    }
+
+    icon_path += ".png";
+    f << "[Desktop Entry]\n"
+         "Type=Application\n"
+         "Name="
+      << app_name << "\n"
+                     "Exec="
+      << exe_path.string() << " -r " << app_path << "\n"
+                                                    "Icon="
+      << (fs::exists(icon_path) ? icon_path.string() : exe_path.string()) << "\n"
+                                                                             "Categories=Game;Emulator;X-None;\n";
+
+    f.close();
+    fs::permissions(shortcut, fs::perms::owner_exe | fs::perms::owner_read | fs::perms::owner_write);
+    LOG_INFO("Linux shortcut created successfully at '{}'", shortcut.string());
+#elif defined(__APPLE__)
+    const auto desktop = get_desktop_path();
+
+    if (desktop.empty()) {
+        LOG_ERROR("Failed to retrieve desktop path");
+        return;
+    }
+
+    const fs::path app_bundle = desktop / (app_name + ".app");
+    const fs::path contents_dir = app_bundle / "Contents";
+    const fs::path macos_dir = contents_dir / "MacOS";
+    const fs::path resources_dir = contents_dir / "Resources";
+
+    // Check whether shortcut is already exist and remove existing one
+    if (fs::exists(app_bundle))
+        fs::remove_all(app_bundle);
+
+    // Create necessary directories
+    fs::create_directories(macos_dir);
+    fs::create_directories(resources_dir);
+
+    // Create launcher script
+    if (!create_launcher(get_exe_path(), macos_dir, app_path)) {
+        LOG_ERROR("Failed to create launcher script");
+        fs::remove_all(app_bundle);
+        return;
+    }
+
+    // Create info.plist
+    if (!create_info_plist(contents_dir, app_name, app_path)) {
+        LOG_ERROR("Failed to create info.plist");
+        fs::remove_all(app_bundle);
+        return;
+    }
+
+    // Copy icns
+    icon_path += ".icns";
+    if (fs::exists(icon_path))
+        fs::copy_file(icon_path, resources_dir / "icon.icns", fs::copy_options::overwrite_existing);
+    else
+        fs::copy_file(emuenv.base_path / "Vita3K.icns", resources_dir / "icon.icns", fs::copy_options::overwrite_existing);
+
+    LOG_INFO("macOS app bundle shortcut created successfully at '{}'", app_bundle.string());
+#endif
+}
 
 static std::map<double, std::string> update_history_infos;
 
@@ -435,6 +807,10 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                 }
                 ImGui::EndMenu();
             }
+            if (has_shortcut_support() && ImGui::MenuItem(lang.main["create_shortcut"].c_str())) {
+                create_app_icon(emuenv, app_path);
+                create_shortcut(emuenv, app_path, string_utils::remove_special_chars(APP_INDEX->title));
+            }
             if (ImGui::BeginMenu(lang.main["custom_config"].c_str())) {
                 if (!fs::exists(CUSTOM_CONFIG_PATH)) {
                     if (ImGui::MenuItem(lang.main["create"].c_str(), nullptr, &gui.configuration_menu.custom_settings_dialog))
@@ -447,6 +823,8 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                 }
                 ImGui::EndMenu();
             }
+
+#ifndef ANDROID
             if (ImGui::BeginMenu(lang.main["open_folder"].c_str())) {
                 if (ImGui::MenuItem(app_str["title"].c_str()))
                     open_path(APP_PATH.string());
@@ -466,6 +844,8 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                     open_path(IMPORT_TEXTURES_PATH.string());
                 ImGui::EndMenu();
             }
+#endif
+
             if (!emuenv.cfg.show_live_area_screen && ImGui::BeginMenu("Live Area")) {
                 if (ImGui::MenuItem("Live Area", nullptr, &gui.vita_area.live_area_screen))
                     open_live_area(gui, emuenv, app_path);

--- a/vita3k/gui/src/macos_helper.mm
+++ b/vita3k/gui/src/macos_helper.mm
@@ -1,0 +1,141 @@
+// Vita3K emulator project
+// Copyright (C) 2025 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <util/fs.h>
+
+#import <Foundation/Foundation.h>
+#import <ImageIO/ImageIO.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+namespace gui {
+
+// Convert PNG to ICNS using CGImageDestination
+bool png_to_icns(const fs::path &png_path, const fs::path &icns_path) {
+    @autoreleasepool {
+        NSString *pngPathStr = [NSString stringWithUTF8String:png_path.c_str()];
+        NSString *icnsPathStr = [NSString stringWithUTF8String:icns_path.c_str()];
+
+        NSURL *sourceURL = [NSURL fileURLWithPath:pngPathStr];
+        NSURL *destURL = [NSURL fileURLWithPath:icnsPathStr];
+
+        // Load source PNG image
+        CGImageSourceRef source = CGImageSourceCreateWithURL((__bridge CFURLRef)sourceURL, NULL);
+        if (!source) {
+            return false;
+        }
+
+        // Get CGImage from source
+        CGImageRef image = CGImageSourceCreateImageAtIndex(source, 0, NULL);
+        CFRelease(source);
+
+        if (!image) {
+            return false;
+        }
+
+        // Create ICNS destination
+        CGImageDestinationRef dest = CGImageDestinationCreateWithURL(
+            (__bridge CFURLRef)destURL,
+            (__bridge CFStringRef)UTTypeICNS.identifier,
+            1,
+            NULL
+        );
+
+        if (!dest) {
+            CGImageRelease(image);
+            return false;
+        }
+
+        // Add image and finalize
+        CGImageDestinationAddImage(dest, image, NULL);
+        bool success = CGImageDestinationFinalize(dest);
+
+        CFRelease(dest);
+        CGImageRelease(image);
+
+        return success;
+    }
+}
+
+fs::path get_desktop_path() {
+    @autoreleasepool {
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(
+            NSDesktopDirectory,
+            NSUserDomainMask,
+            YES
+        );
+
+        if ([paths count] > 0) { // Should have at least one value
+            NSString *desktopNSString = [paths objectAtIndex:0];
+            std::string desktopStdString = [desktopNSString UTF8String];
+            return fs::path(desktopStdString);
+        }
+        return fs::path();
+    }
+}
+
+// Create launcher script
+bool create_launcher(const fs::path &exe_path, const fs::path &macOS_path, const std::string &app_path) {
+    @autoreleasepool {
+        NSFileManager *fm = [NSFileManager defaultManager];
+
+        NSString *exePathStr = [NSString stringWithUTF8String:exe_path.c_str()];
+        NSString *macOSPath = [NSString stringWithUTF8String:macOS_path.c_str()];
+        NSString *appPathStr = [NSString stringWithUTF8String:app_path.c_str()];
+        NSString *launcherPath = [macOSPath stringByAppendingPathComponent:@"launcher"];
+
+        NSString *scriptContent = [NSString stringWithFormat:
+            @"#!/bin/bash\nexec \"%@\" -r \"%@\"\n",
+            exePathStr, appPathStr];
+
+        NSError *error = nil;
+        bool success = [scriptContent writeToFile:launcherPath
+                                       atomically:YES
+                                         encoding:NSUTF8StringEncoding
+                                            error:&error];
+
+        // Make launcher executable
+        [fm setAttributes:@{NSFilePosixPermissions: @0755}
+             ofItemAtPath:launcherPath
+                    error:nil];
+
+        return success;
+    }
+}
+
+// Create Info.plist
+bool create_info_plist(const fs::path &contents_path, const std::string &app_name, const std::string &app_path) {
+    @autoreleasepool {
+        NSString *contentsPath = [NSString stringWithUTF8String:contents_path.c_str()];
+        NSString *plistPath = [contentsPath stringByAppendingPathComponent:@"Info.plist"];
+        NSString *bundleID = [NSString stringWithFormat:@"org.vita3k.%s", app_path.c_str()];
+        NSString *appNameStr = [NSString stringWithUTF8String:app_name.c_str()];
+
+        NSDictionary *plistDict = @{
+            @"CFBundleExecutable": @"launcher",
+            @"CFBundleIconFile": @"icon.icns",
+            @"CFBundleIdentifier": bundleID,
+            @"CFBundleName": appNameStr,
+            @"CFBundleDisplayName": appNameStr,
+            @"LSMinimumSystemVersion": @"11",
+            @"LSMultipleInstancesProhibited": @YES
+        };
+
+        return [plistDict writeToFile:plistPath atomically:YES];
+    }
+}
+
+} // namespace gui

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -162,6 +162,7 @@ struct LangState {
             { "copy_app_info", "Copy App info" },
             { "name_and_id", "Name and Title ID" },
             { "app_summary", "App Summary" },
+            { "create_shortcut", "Create Shortcut" },
             { "custom_config", "Custom Config" },
             { "create", "Create" },
             { "edit", "Edit" },


### PR DESCRIPTION
# About
- gui/app_context_menu: Add support for creating app shortcuts.
Windows: Convert icon0.png to .ico, store in cache/icons and create .lnk shortcut.
MacOS: Create a desktop app bundle with launcher script and icon.
Linux: Copy icon0.png to cache/icons and create .desktop shortcut on desktop.
Android: Call Java createShortcut() via JNI.

Currenty tested and worked for windows, Mac, and android.
Android version writed by @Macdu and improved by me for sdl3 and external path for app
Mac version writed by @KhoraLee 