### PR TITLE
util/log: Fix 'LOG_IF' and 'LOG_ONCE'

### DIFF
--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -23,6 +23,7 @@
 #include <util/exit_code.h>
 #include <util/fs.h>
 
+#include <atomic>
 #include <type_traits>
 
 #define LOG_TRACE SPDLOG_TRACE
@@ -45,13 +46,11 @@
 #define LOG_ERROR_IF(flag, ...) LOG_IF(LOG_ERROR, flag, __VA_ARGS__)
 #define LOG_CRITICAL_IF(flag, ...) LOG_IF(LOG_CRITICAL, flag, __VA_ARGS__)
 
-#define LOG_ONCE(log_function, ...)     \
-    do {                                \
-        static bool has_logged = false; \
-        if (!has_logged) {              \
-            has_logged = true;          \
-            log_function(__VA_ARGS__);  \
-        }                               \
+#define LOG_ONCE(log_function, ...)         \
+    do {                                    \
+        static std::atomic_flag has_logged; \
+        if (!has_logged.test_and_set())     \
+            log_function(__VA_ARGS__);      \
     } while (0)
 
 #define LOG_TRACE_ONCE(...) LOG_ONCE(LOG_TRACE, __VA_ARGS__)


### PR DESCRIPTION
- Wrap if statement in macro with do-while loop to avoid dangling 'else'.
- Make `LOG_ONCE` atomic to avoid race conditions.

---

For `LOG_IF`, consider the following code:
```cpp
if (flag1)
    LOG_INFO_IF(flag2, "flag2 == true");
else
    // statement-false
```
When `flag1 == false`, _statement-false_ will never be executed.