### PR TITLE
modules/SceNetCtl: Fix IP/netmask in InetGetInfo by copy string.

### DIFF
--- a/vita3k/modules/SceNetCtl/SceNetCtl.cpp
+++ b/vita3k/modules/SceNetCtl/SceNetCtl.cpp
@@ -577,10 +577,12 @@ EXPORT(int, sceNetCtlInetGetInfo, int code, SceNetCtlInfo *info) {
         // STUBBED("code SCE_NETCTL_INFO_GET_RSSI_PERCENTAGE return 100%");
         break;
     case SCE_NETCTL_INFO_GET_IP_ADDRESS:
-        inet_pton(AF_INET, addr.addr.c_str(), &info->ip_address);
+        std::strncpy(info->ip_address, addr.addr.c_str(), sizeof(info->ip_address) - 1);
+        info->ip_address[sizeof(info->ip_address) - 1] = '\0';
         break;
     case SCE_NETCTL_INFO_GET_NETMASK:
-        inet_pton(AF_INET, addr.netMask.c_str(), &info->netmask);
+        std::strncpy(info->netmask, addr.netMask.c_str(), sizeof(info->netmask) - 1);
+        info->netmask[sizeof(info->netmask) - 1] = '\0';
         break;
     default:
         switch (code) {


### PR DESCRIPTION
# About
- modules/SceNetCtl: Fix IP/netmask in InetGetInfo by copy string.
info->(ip_address/netmask) correctly hold the complete IP/netmask strings.

# Result
- Fix some game in adhoc mode.
<img width="3809" height="1130" alt="image" src="https://github.com/user-attachments/assets/cffa31d5-7ef8-497f-8316-11f68a078a19" />
<img width="3817" height="1139" alt="image" src="https://github.com/user-attachments/assets/2de3dcd1-9a89-41d6-83c5-de7edf60cdf4" />
