### PR TITLE
modules/SceNet: Implement Getpeername and fix accept return P2P sock.

### DIFF
--- a/vita3k/modules/SceNet/SceNet.cpp
+++ b/vita3k/modules/SceNet/SceNet.cpp
@@ -322,16 +322,17 @@ EXPORT(int, sceNetGetStatisticsInfo) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceNetGetpeername) {
-    TRACY_FUNC(sceNetGetpeername);
-    return UNIMPLEMENTED();
+EXPORT(int, sceNetGetpeername, int sid, SceNetSockaddr *addr, unsigned int *addrlen) {
+    TRACY_FUNC(sceNetGetpeername, sid, addr, addrlen);
+    auto sock = lock_and_find(sid, emuenv.net.socks, emuenv.kernel.mutex);
+    RET_NET_ERRNO(sock ? sock->get_peer_address(addr, addrlen) : SCE_NET_ERROR_EBADF);
 }
 
-EXPORT(int, sceNetGetsockname, int sid, SceNetSockaddr *name, unsigned int *namelen) {
-    TRACY_FUNC(sceNetGetsockname, sid, name, namelen);
+EXPORT(int, sceNetGetsockname, int sid, SceNetSockaddr *addr, unsigned int *addrlen) {
+    TRACY_FUNC(sceNetGetsockname, sid, addr, addrlen);
     auto sock = lock_and_find(sid, emuenv.net.socks, emuenv.kernel.mutex);
 
-    RET_NET_ERRNO(sock ? sock->get_socket_address(name, namelen) : SCE_NET_ERROR_EBADF);
+    RET_NET_ERRNO(sock ? sock->get_socket_address(addr, addrlen) : SCE_NET_ERROR_EBADF);
 }
 
 EXPORT(int, sceNetGetsockopt, int sid, int level, int optname, void *optval, unsigned int *optlen) {


### PR DESCRIPTION
# About
- modules/SceNet: Implement Getpeername and fix accept return P2P sock.
Implement get peer address for both socket.
refactor, improve and rename variable of get socket address.
convert PosixSocket to P2PSocket when is created by one P2PSocket.

# Result
- fix join room of it and get now perfectly playable in adhoc
<img width="3820" height="1146" alt="image" src="https://github.com/user-attachments/assets/333d3d18-4007-4f88-b2ab-382482bfd803" />
- fix found and join room
<img width="3820" height="1138" alt="image" src="https://github.com/user-attachments/assets/3a3f8dc3-de92-436a-b876-9e80241fa097" />
