### PR TITLE
motion: Add device motion support and fix elapsed timestamp handling.

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -795,7 +795,10 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             handle_touchpad_event(event.gtouchpad);
             break;
         case SDL_EVENT_GAMEPAD_SENSOR_UPDATE:
-            handle_motion_event(emuenv, event.gsensor);
+            handle_motion_event(emuenv, event.gsensor.sensor, event.gsensor);
+            break;
+        case SDL_EVENT_SENSOR_UPDATE:
+            handle_motion_event(emuenv, SDL_GetSensorTypeForID(event.sensor.which), event.sensor);
             break;
         case SDL_EVENT_GAMEPAD_ADDED:
         case SDL_EVENT_GAMEPAD_REMOVED:

--- a/vita3k/modules/SceDriverUser/SceMotion.cpp
+++ b/vita3k/modules/SceDriverUser/SceMotion.cpp
@@ -82,7 +82,7 @@ EXPORT(int, sceMotionGetSensorState, SceMotionSensorState *sensorState, int numR
         return RET_ERROR(SCE_MOTION_ERROR_NULL_PARAMETER);
     }
 
-    if (emuenv.ctrl.has_motion_support && !emuenv.cfg.disable_motion) {
+    if ((emuenv.ctrl.has_motion_support || emuenv.motion.has_device_motion_support) && !emuenv.cfg.disable_motion) {
         std::lock_guard<std::mutex> guard(emuenv.motion.mutex);
         sensorState->accelerometer = get_acceleration(emuenv.motion);
         sensorState->gyro = get_gyroscope(emuenv.motion);
@@ -119,7 +119,7 @@ EXPORT(int, sceMotionGetState, SceMotionState *motionState) {
         return RET_ERROR(SCE_MOTION_ERROR_NULL_PARAMETER);
     }
 
-    if (emuenv.ctrl.has_motion_support && !emuenv.cfg.disable_motion) {
+    if ((emuenv.ctrl.has_motion_support || emuenv.motion.has_device_motion_support) && !emuenv.cfg.disable_motion) {
         std::lock_guard<std::mutex> guard(emuenv.motion.mutex);
         motionState->timestamp = emuenv.motion.last_accel_timestamp;
 
@@ -263,7 +263,7 @@ EXPORT(int, sceMotionStartSampling) {
         return SCE_MOTION_ERROR_ALREADY_SAMPLING;
     }
 
-    emuenv.motion.is_sampling = true;
+    emuenv.motion.start_sensor_sampling();
     return SCE_MOTION_OK;
 }
 
@@ -278,7 +278,7 @@ EXPORT(int, sceMotionStopSampling) {
         return SCE_MOTION_ERROR_NOT_SAMPLING;
     }
 
-    emuenv.motion.is_sampling = false;
+    emuenv.motion.stop_sensor_sampling();
     return SCE_MOTION_OK;
 }
 

--- a/vita3k/motion/include/motion/event_handler.h
+++ b/vita3k/motion/include/motion/event_handler.h
@@ -19,4 +19,5 @@
 
 #include <SDL3/SDL_events.h>
 #include <emuenv/state.h>
-void handle_motion_event(EmuEnvState &emuenv, const SDL_GamepadSensorEvent &sensor);
+void handle_motion_event(EmuEnvState &emuenv, int32_t sensor_type, const SDL_GamepadSensorEvent &sensor);
+void handle_motion_event(EmuEnvState &emuenv, int32_t sensor_type, const SDL_SensorEvent &sensor);

--- a/vita3k/motion/include/motion/state.h
+++ b/vita3k/motion/include/motion/state.h
@@ -28,5 +28,10 @@ struct MotionState {
     uint64_t last_gyro_timestamp = 0;
     uint64_t last_accel_timestamp = 0;
 
+    bool has_device_motion_support = false;
     bool is_sampling = false;
+
+    void init();
+    void stop_sensor_sampling();
+    void start_sensor_sampling();
 };

--- a/vita3k/motion/src/motion.cpp
+++ b/vita3k/motion/src/motion.cpp
@@ -21,8 +21,151 @@
 
 #include <ctrl/state.h>
 
+#include <util/log.h>
+
 #include <SDL3/SDL_gamepad.h>
+#include <SDL3/SDL_sensor.h>
+
 #include <numbers>
+
+enum DeviceRotation : int32_t {
+    ROTATION_UNKNOWN = -1,
+    ROTATION_0,
+    ROTATION_90,
+    ROTATION_180,
+    ROTATION_270
+};
+
+#ifdef __ANDROID__
+
+#include <SDL3/SDL_system.h>
+
+#include <jni.h>
+
+static DeviceRotation device_native_rotation = ROTATION_UNKNOWN;
+
+static void init_device_orientation() {
+    JNIEnv *env = reinterpret_cast<JNIEnv *>(SDL_GetAndroidJNIEnv());
+    jobject activity = reinterpret_cast<jobject>(SDL_GetAndroidActivity());
+    jclass clazz(env->GetObjectClass(activity));
+
+    jmethodID method_id = env->GetMethodID(clazz, "getNativeDisplayRotation", "()I");
+
+    device_native_rotation = static_cast<DeviceRotation>(env->CallIntMethod(activity, method_id));
+
+    // clean up the local references.
+    env->DeleteLocalRef(activity);
+    env->DeleteLocalRef(clazz);
+}
+#else
+constexpr DeviceRotation device_native_rotation = ROTATION_0;
+#endif
+
+static uint32_t device_accel_id = 0;
+static uint32_t device_gyro_id = 0;
+
+static void detect_device_motion_support(MotionState &state) {
+    device_accel_id = 0;
+    device_gyro_id = 0;
+
+    int num_sensors;
+    auto sensors_id = SDL_GetSensors(&num_sensors);
+    if (!sensors_id || (num_sensors <= 0)) {
+        state.has_device_motion_support = false;
+        return;
+    }
+
+    for (int idx = 0; idx < num_sensors; idx++) {
+        switch (SDL_GetSensorTypeForID(sensors_id[idx])) {
+        case SDL_SENSOR_ACCEL:
+            device_accel_id = sensors_id[idx];
+            break;
+        case SDL_SENSOR_GYRO:
+            device_gyro_id = sensors_id[idx];
+            break;
+        default:
+            break;
+        }
+
+        if ((device_accel_id != 0) && (device_gyro_id != 0))
+            break;
+    }
+
+    SDL_free(sensors_id);
+
+    state.has_device_motion_support = ((device_accel_id != 0) && (device_gyro_id != 0));
+
+#ifdef __ANDROID__
+    init_device_orientation();
+#endif
+}
+
+static std::string device_rotation_to_string(DeviceRotation rotation) {
+    switch (rotation) {
+    case ROTATION_0:
+        return "ROTATION_0";
+    case ROTATION_90:
+        return "ROTATION_90";
+    case ROTATION_180:
+        return "ROTATION_180";
+    case ROTATION_270:
+        return "ROTATION_270";
+    default:
+        return "UNKNOWN_ROTATION";
+    }
+}
+
+void MotionState::init() {
+    detect_device_motion_support(*this);
+
+    if (has_device_motion_support)
+        LOG_INFO("Device has a built-in accelerometer and gyroscope (native display rotation: {}).", device_rotation_to_string(device_native_rotation));
+}
+
+struct SDL_SensorDeleter {
+    void operator()(SDL_Sensor *s) const { SDL_CloseSensor(s); }
+};
+
+using SDL_SensorPtr = std::unique_ptr<SDL_Sensor, SDL_SensorDeleter>;
+
+static SDL_SensorPtr device_accel;
+static SDL_SensorPtr device_gyro;
+
+void MotionState::stop_sensor_sampling() {
+    is_sampling = false;
+    if (!has_device_motion_support)
+        return;
+
+    device_accel.reset();
+    device_gyro.reset();
+}
+
+void MotionState::start_sensor_sampling() {
+    is_sampling = true;
+    if (!has_device_motion_support)
+        return;
+
+    const auto open_sensor = [](SDL_SensorPtr &sensor, uint32_t sensor_id, const char *name) {
+        if (sensor_id == 0) {
+            LOG_ERROR("No {} sensor ID available to open.", name);
+            return false;
+        }
+
+        SDL_Sensor *raw_sensor = SDL_OpenSensor(sensor_id);
+        if (!raw_sensor) {
+            LOG_ERROR("Failed to open {} sensor with ID {}: {}", name, sensor_id, SDL_GetError());
+            return false;
+        }
+
+        sensor.reset(raw_sensor);
+        return true;
+    };
+
+    if (!open_sensor(device_accel, device_accel_id, "accelerometer") || !open_sensor(device_gyro, device_gyro_id, "gyroscope")) {
+        has_device_motion_support = false;
+        stop_sensor_sampling();
+    }
+}
 
 SceFVector3 get_acceleration(const MotionState &state) {
     Util::Vec3f accelerometer = state.motion_data.GetAcceleration();
@@ -86,49 +229,84 @@ SceFVector3 get_basic_orientation(const MotionState &state) {
     return state.motion_data.GetBasicOrientation();
 }
 
-void handle_motion_event(EmuEnvState &emuenv, const SDL_GamepadSensorEvent &sensor) {
+constexpr uint64_t to_microseconds(uint64_t ns) {
+    return ns / 1000;
+}
+
+static uint64_t last_updated_gyro_timestamp = 0;
+static uint64_t last_updated_accel_timestamp = 0;
+
+template <typename SensorEvent>
+static void handle_motion_event(EmuEnvState &emuenv, int32_t sensor_type, const SensorEvent &sensor) {
     if (!emuenv.motion.is_sampling)
         return;
 
-    if (!emuenv.ctrl.has_motion_support)
+    if (!emuenv.ctrl.has_motion_support && !emuenv.motion.has_device_motion_support)
         return;
 
-    if (sensor.sensor == SDL_SENSOR_ACCEL) {
-        Util::Vec3f accel{
-            sensor.data[0],
-            sensor.data[1],
-            sensor.data[2],
-        };
-        accel /= -SDL_STANDARD_GRAVITY;
-        std::swap(accel.y, accel.z);
-        accel.y *= -1;
-        emuenv.motion.motion_data.SetAcceleration(accel);
-        emuenv.motion.motion_data.UpdateOrientation(sensor.sensor_timestamp - emuenv.motion.last_accel_timestamp);
-        emuenv.motion.motion_data.UpdateBasicOrientation();
-        emuenv.motion.last_accel_timestamp = sensor.sensor_timestamp;
+    const auto get_processed_sensor_data = [&]() {
+        Util::Vec3f data = { sensor.data[0], sensor.data[1], sensor.data[2] };
+        const auto from_gamepad = sensor.type == SDL_EVENT_GAMEPAD_SENSOR_UPDATE;
+        if (!from_gamepad) {
+            switch (device_native_rotation) {
+            case ROTATION_90: // portrait -> landscape left
+                std::tie(data.x, data.y, data.z) = std::make_tuple(-data.y, data.x, data.z);
+                break;
+            case ROTATION_180: // upside-down
+                data.x *= -1.f;
+                data.y *= -1.f;
+                break;
+            case ROTATION_270: // portrait -> landscape right
+                std::tie(data.x, data.y, data.z) = std::make_tuple(data.y, -data.x, data.z);
+                break;
+            default: // ROTATION_0 or unknown: no transform
+                break;
+            }
+        } else
+            std::tie(data.x, data.y, data.z) = std::make_tuple(data.x, -data.z, data.y);
+
+        return data;
+    };
+
+    const uint64_t sensor_timestamp = (sensor.sensor_timestamp > 0)
+        ? to_microseconds(sensor.sensor_timestamp) // convert ns -> us
+        : std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+
+    auto sensor_data = get_processed_sensor_data();
+
+    if (sensor_type == SDL_SENSOR_ACCEL) {
+        sensor_data /= -SDL_STANDARD_GRAVITY;
+        emuenv.motion.motion_data.SetAcceleration(sensor_data);
+        last_updated_accel_timestamp = sensor_timestamp;
         emuenv.motion.last_counter++;
-    } else if (sensor.sensor == SDL_SENSOR_GYRO) {
-        Util::Vec3f gyro{
-            sensor.data[0],
-            sensor.data[1],
-            sensor.data[2],
-        };
-        gyro /= 2.f * std::numbers::pi_v<float>;
-        std::swap(gyro.y, gyro.z);
-        gyro.y *= -1;
-        emuenv.motion.motion_data.SetGyroscope(gyro);
-        emuenv.motion.motion_data.UpdateRotation(sensor.sensor_timestamp - emuenv.motion.last_gyro_timestamp);
-        emuenv.motion.last_gyro_timestamp = sensor.sensor_timestamp;
-        emuenv.motion.last_counter++;
+    } else if (sensor_type == SDL_SENSOR_GYRO) {
+        sensor_data /= 2.f * std::numbers::pi_v<float>;
+        emuenv.motion.motion_data.SetGyroscope(sensor_data);
+        last_updated_gyro_timestamp = sensor_timestamp;
     }
+}
+
+void handle_motion_event(EmuEnvState &emuenv, int32_t sensor_type, const SDL_SensorEvent &sensor) {
+    handle_motion_event<SDL_SensorEvent>(emuenv, sensor_type, sensor);
+}
+
+void handle_motion_event(EmuEnvState &emuenv, int32_t sensor_type, const SDL_GamepadSensorEvent &sensor) {
+    handle_motion_event<SDL_GamepadSensorEvent>(emuenv, sensor_type, sensor);
 }
 
 void refresh_motion(MotionState &state, CtrlState &ctrl_state) {
     if (!state.is_sampling)
         return;
 
-    if (!ctrl_state.has_motion_support)
+    if (!ctrl_state.has_motion_support && !state.has_device_motion_support)
         return;
+
+    state.motion_data.UpdateOrientation(last_updated_accel_timestamp - state.last_accel_timestamp);
+    state.motion_data.UpdateBasicOrientation();
+    state.motion_data.UpdateRotation(last_updated_gyro_timestamp - state.last_gyro_timestamp);
+
+    state.last_accel_timestamp = last_updated_accel_timestamp;
+    state.last_gyro_timestamp = last_updated_gyro_timestamp;
 
     state.last_counter++;
 }


### PR DESCRIPTION
# About
 - motion: Add device motion support and fix elapsed timestamp handling.
Move Update(Orientation/Rotation) to refresh_motion to update once per refresh instead of per sensor event.
Fix elapsed time using sensor timestamps (ns -> us), with fallback when timestamp is 0.
Add support for device motion (accelerometer and gyroscope) and handle all native device rotations.

Fix regression caused by moving to sdl3 with using event #3600