### PR TITLE
util/tracy: Prevent crash caused by exceeding Tracy module limit.

### DIFF
--- a/vita3k/util/src/tracy.cpp
+++ b/vita3k/util/src/tracy.cpp
@@ -27,7 +27,7 @@
 
 namespace tracy_module_utils {
 
-constexpr int max_modules = 64; // If not enough increase to 64*n
+constexpr int max_modules = 128; // If not enough increase to 64*n
 typedef std::bitset<max_modules> tracy_module_flags;
 typedef std::vector<std::string> tracy_module_names;
 


### PR DESCRIPTION
# About
- util/tracy: Prevent crash caused by exceeding Tracy module limit.
The number of loaded modules already exceeds Tracy's limit. Any subsequent call to a Tracy-instrumented module function results in an out-of-bounds crash.