### PR TITLE
Codec/h264: protect send with mutex to avoid flush race.

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <queue>
 #include <string>
 
@@ -69,6 +70,8 @@ enum class DecoderQuery {
 
 struct DecoderState {
     AVCodecContext *context{};
+
+    std::mutex codec_mutex;
 
     virtual uint32_t get(DecoderQuery query);
 

--- a/vita3k/codec/src/decoder.cpp
+++ b/vita3k/codec/src/decoder.cpp
@@ -32,7 +32,9 @@ uint32_t DecoderState::get_es_size() {
 }
 
 void DecoderState::flush() {
-    avcodec_flush_buffers(context);
+    std::lock_guard<std::mutex> lock(codec_mutex);
+    if (context)
+        avcodec_flush_buffers(context);
 }
 
 DecoderState::~DecoderState() {

--- a/vita3k/codec/src/h264.cpp
+++ b/vita3k/codec/src/h264.cpp
@@ -67,6 +67,8 @@ uint32_t H264DecoderState::get(DecoderQuery query) {
 }
 
 bool H264DecoderState::send(const uint8_t *data, uint32_t size) {
+    std::lock_guard<std::mutex> lock(codec_mutex);
+
     int error = 0;
 
     std::vector<uint8_t> au_frame(size + AV_INPUT_BUFFER_PADDING_SIZE);


### PR DESCRIPTION
# About
- Codec/h264: protect send with mutex to avoid flush race.
fix crash when send is called concurrently with flush.

# Result
- Fix random crash in H264 send on Gintama.
The game calls flush right after decode, which could cause a race condition.
Protect send with a mutex to avoid concurrent access with flush.