### PR TITLE
host/dialog/filesystem android: Cleanup file picker path handling.

### DIFF
--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -171,7 +171,7 @@ if(WIN32)
 	target_sources(vita3k PRIVATE util/src/vc_runtime_checker.cpp)
 endif()
 
-target_link_libraries(vita3k PRIVATE app config cppcommon ctrl display gdbstub gui gxm host_dialog io miniz modules motion packages patch renderer shader touch util)
+target_link_libraries(vita3k PRIVATE app config cppcommon ctrl display gdbstub gui gxm io miniz modules motion packages patch renderer shader touch util)
 if(USE_DISCORD_RICH_PRESENCE)
 	target_link_libraries(vita3k PRIVATE discord-rpc)
 endif()

--- a/vita3k/app/src/app.cpp
+++ b/vita3k/app/src/app.cpp
@@ -102,7 +102,7 @@ void add_custom_driver(EmuEnvState &emuenv) {
 
     fs::create_directories(driver_path);
 
-    std::unique_ptr<FILE, int (*)(FILE *)> zip_file(host::dialog::filesystem::resolve_host_handle(file_path), fclose);
+    std::unique_ptr<FILE, int (*)(FILE *)> zip_file(FOPEN(file_path.c_str(), "rb"), fclose);
     std::string driver_so = "";
 
     mz_zip_archive zip;

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -45,9 +45,6 @@ void browse_users_management(GuiState &gui, EmuEnvState &emuenv, const uint32_t 
 void close_and_run_new_app(EmuEnvState &emuenv, const std::string &app_path);
 void close_live_area_app(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path);
 void close_system_app(GuiState &gui, EmuEnvState &emuenv);
-#ifdef __ANDROID__
-bool copy_file_from_host(const fs::path &src, const fs::path &dst);
-#endif
 void delete_app(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path);
 void erase_app_notice(GuiState &gui, const std::string &title_id);
 void get_app_info(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path);

--- a/vita3k/host/dialog/include/host/dialog/filesystem.h
+++ b/vita3k/host/dialog/include/host/dialog/filesystem.h
@@ -102,11 +102,6 @@ Result open_file(fs::path &resulting_path, const std::vector<FileFilter> &file_f
 Result pick_folder(fs::path &resulting_path, const fs::path &default_path = "");
 
 /**
- * @brief Open a File* handle when given a path that was obtained using open_file
- */
-FILE *resolve_host_handle(const fs::path &path);
-
-/**
  * @brief Get a string describing the last dialog error
  *
  * @return A string in English describing the last dialog error

--- a/vita3k/host/dialog/src/filesystem_nfd.cpp
+++ b/vita3k/host/dialog/src/filesystem_nfd.cpp
@@ -203,14 +203,4 @@ std::string get_error() {
     return error;
 }
 
-FILE *resolve_host_handle(const fs::path &path) {
-    FILE *result;
-#ifdef _WIN32
-    _wfopen_s(&result, path.c_str(), L"rb");
-#else
-    result = fopen(path.c_str(), "rb");
-#endif
-    return result;
-}
-
 } // namespace host::dialog::filesystem

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -29,7 +29,6 @@
 #include <display/state.h>
 #include <gui/functions.h>
 #include <gxm/state.h>
-#include <host/dialog/filesystem.h>
 #include <io/functions.h>
 #include <io/vfs.h>
 #include <kernel/state.h>
@@ -269,12 +268,12 @@ static std::vector<std::string> get_archive_contents_path(const ZipPtr &zip) {
 }
 
 std::vector<ContentInfo> install_archive(EmuEnvState &emuenv, GuiState *gui, const fs::path &archive_path, const std::function<void(ArchiveContents)> &progress_callback) {
-    FILE *vpk_fp = host::dialog::filesystem::resolve_host_handle(archive_path);
-
+    FILE *vpk_fp = FOPEN(archive_path.c_str(), "rb");
     if (!vpk_fp) {
-        LOG_CRITICAL("Failed to load archive file in path: {}", archive_path.generic_path().string());
+        LOG_CRITICAL("Failed to load archive file in path: {}", fs_utils::path_to_utf8(archive_path));
         return {};
     }
+
     const ZipPtr zip(new mz_zip_archive, delete_zip);
     std::memset(zip.get(), 0, sizeof(*zip));
 

--- a/vita3k/motion/src/motion.cpp
+++ b/vita3k/motion/src/motion.cpp
@@ -278,7 +278,6 @@ static void handle_motion_event(EmuEnvState &emuenv, int32_t sensor_type, const 
         sensor_data /= -SDL_STANDARD_GRAVITY;
         emuenv.motion.motion_data.SetAcceleration(sensor_data);
         last_updated_accel_timestamp = sensor_timestamp;
-        emuenv.motion.last_counter++;
     } else if (sensor_type == SDL_SENSOR_GYRO) {
         sensor_data /= 2.f * std::numbers::pi_v<float>;
         emuenv.motion.motion_data.SetGyroscope(sensor_data);

--- a/vita3k/packages/CMakeLists.txt
+++ b/vita3k/packages/CMakeLists.txt
@@ -14,4 +14,4 @@ add_library(packages STATIC
 )
 target_include_directories(packages PUBLIC include)
 target_link_libraries(packages PUBLIC emuenv util)
-target_link_libraries(packages PRIVATE config crypto emuenv FAT16 host_dialog io miniz psvpfsparser vita-toolchain)
+target_link_libraries(packages PRIVATE config crypto emuenv FAT16 io miniz psvpfsparser vita-toolchain)

--- a/vita3k/packages/src/pkg.cpp
+++ b/vita3k/packages/src/pkg.cpp
@@ -30,7 +30,7 @@
 
 #include <config/state.h>
 #include <emuenv/state.h>
-#include <host/dialog/filesystem.h>
+
 #include <packages/functions.h>
 #include <packages/license.h>
 #include <packages/pkg.h>
@@ -77,9 +77,9 @@ bool decrypt_install_nonpdrm(EmuEnvState &emuenv, const fs::path &drmlicpath, co
 }
 
 bool install_pkg(const fs::path &pkg_path, EmuEnvState &emuenv, std::string &p_zRIF, const std::function<void(float)> &progress_callback) {
-    FILE *infile = host::dialog::filesystem::resolve_host_handle(pkg_path);
+    FILE *infile = FOPEN(pkg_path.c_str(), "rb");
     if (!infile) {
-        LOG_CRITICAL("Failed to load pkg file in path: {}", pkg_path.generic_path().string());
+        LOG_CRITICAL("Failed to load pkg file in path: {}", fs_utils::path_to_utf8(pkg_path));
         return false;
     }
 

--- a/vita3k/packages/src/pup.cpp
+++ b/vita3k/packages/src/pup.cpp
@@ -23,7 +23,6 @@
  * contain firmware updates
  */
 
-#include <host/dialog/filesystem.h>
 #include <openssl/evp.h>
 #include <packages/exfat.h>
 #include <packages/sce_types.h>
@@ -108,7 +107,12 @@ static std::string make_filename(unsigned char *hdr, int64_t filetype) {
 static void extract_pup_files(const fs::path &pup, const fs::path &output) {
     constexpr int SCEUF_HEADER_SIZE = 0x80;
     constexpr int SCEUF_FILEREC_SIZE = 0x20;
-    FILE *infile = host::dialog::filesystem::resolve_host_handle(pup);
+    FILE *infile = FOPEN(pup.c_str(), "rb");
+    if (!infile) {
+        LOG_CRITICAL("Failed to load pup file in path: {}", fs_utils::path_to_utf8(pup));
+        return;
+    }
+
     char header[SCEUF_HEADER_SIZE];
     fread(header, SCEUF_HEADER_SIZE, 1, infile);
 


### PR DESCRIPTION
# About
- host/dialog/filesystem android: Cleanup file picker path handling.
- Resolve real filesystem paths directly from the Android file picker.
- Remove all SAF fallback logic, temporary file copies, and FD-based handling.
- Drop file-descriptor mapping entirely.
- Unify file opening with desktop by using FOPEN().
- Simplify JNI: filedialogReturn now returns only a UTF-8 path.
- Add permission request on Android 11+ to ensure picker paths remain accessible.

