### PR TITLE
android: Support 16 KB page sizes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ android {
 		externalNativeBuild {
 			cmake {
 				abiFilters.addAll( 'arm64-v8a' )
+				arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON" // required until NDK r28
 			}
 		}
 	}


### PR DESCRIPTION
- Fix #3740.
- NDK r27 is the latest LTS version now (2026/01), so i didn't update NDK to r28 or higher.