### PR TITLE
modules/SceNet: Implement sceNetGetMacAddress for macOS

### DIFF
--- a/vita3k/modules/CMakeLists.txt
+++ b/vita3k/modules/CMakeLists.txt
@@ -210,8 +210,19 @@ set(SOURCE_LIST
 	SceWlanBt/SceWlan.cpp
 )
 
+if(APPLE)
+    list(APPEND SOURCE_LIST
+        SceNet/macos_net_helper.h
+        SceNet/macos_net_helper.cpp
+    )
+endif()
+
 add_library(modules STATIC ${SOURCE_LIST})
 target_include_directories(modules PUBLIC include)
 target_link_libraries(modules PRIVATE audio codec ctrl dialog display dlmalloc gui gxm kernel mem motion net ngs np ssl packages patch printf renderer rtc SDL3::SDL3 touch xxHash::xxhash)
 target_link_libraries(modules PUBLIC module)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_LIST})
+
+if(APPLE)
+    target_link_libraries(modules PUBLIC "-framework SystemConfiguration")
+endif()

--- a/vita3k/modules/SceNet/SceNet.cpp
+++ b/vita3k/modules/SceNet/SceNet.cpp
@@ -28,6 +28,11 @@
 #include <cstdio>
 #include <thread>
 
+#ifdef __APPLE__
+#include "macos_net_helper.h"
+#include <net/if.h>
+#endif
+
 #include <util/tracy.h>
 TRACY_MODULE_NAME(SceNet);
 
@@ -362,8 +367,22 @@ EXPORT(int, sceNetGetMacAddress, SceNetEtherAddr *addr, int flags) {
         };
         memcpy(addr->data, magicMac, 6);
     }
+#elif defined(__APPLE__)
+    char hint[IFNAMSIZ] = {};
+    get_primary_interface_name(hint, sizeof(hint));
+
+    if (!get_mac_address(hint, addr->data)) {
+        uint8_t magicMac[6] = {
+            0x02, // LAA
+            0x41, // 'A'
+            0x50, // 'P'
+            0x50, // 'P'
+            0x4C, // 'L'
+            0x45, // 'E'
+        };
+        memcpy(addr->data, magicMac, 6);
+    }
 #else
-    // TODO: Implement the function for macOS
     return UNIMPLEMENTED();
 #endif
     return 0;

--- a/vita3k/modules/SceNet/macos_net_helper.cpp
+++ b/vita3k/modules/SceNet/macos_net_helper.cpp
@@ -1,0 +1,103 @@
+// Vita3K emulator project
+// Copyright (C) 2026 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "macos_net_helper.h"
+
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <cstring>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+
+// Check if interface is physical (en*)
+bool is_physical_interface(const char *name) {
+    return name && strncmp(name, "en", 2) == 0;
+}
+
+// Get the primary network interface name using SystemConfiguration
+bool get_primary_interface_name(char *dest, size_t bufferSize) {
+    bool success = false;
+    auto size = static_cast<CFIndex>(bufferSize);
+
+    if (size < 0) [[unlikely]] // Overflow from size_t to CFIndex (practically unreachable)
+        return false;
+
+    auto store = SCDynamicStoreCreate(nullptr, CFSTR("Vita3K"), nullptr, nullptr);
+    if (!store)
+        return false;
+
+    // Try IPv4 first
+    auto dict = static_cast<CFDictionaryRef>(SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv4")));
+    if (dict) {
+        auto iface = static_cast<CFStringRef>(CFDictionaryGetValue(dict, CFSTR("PrimaryInterface")));
+        if (iface && CFStringGetCString(iface, dest, size, kCFStringEncodingUTF8)) {
+            success = true;
+        }
+        CFRelease(dict);
+    }
+
+    // Fallback to IPv6
+    if (!success) {
+        dict = static_cast<CFDictionaryRef>(SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv6")));
+        if (dict) {
+            auto iface = static_cast<CFStringRef>(CFDictionaryGetValue(dict, CFSTR("PrimaryInterface")));
+            if (iface && CFStringGetCString(iface, dest, size, kCFStringEncodingUTF8)) {
+                success = true;
+            }
+            CFRelease(dict);
+        }
+    }
+
+    CFRelease(store);
+    return success;
+}
+
+// Get MAC address from a physical interface
+// If hint is a physical interface, use it; otherwise find first active en*
+bool get_mac_address(const char *hint, uint8_t mac[6]) {
+    struct ifaddrs *iflist = nullptr;
+    if (getifaddrs(&iflist) != 0)
+        return false;
+
+    const char *target = is_physical_interface(hint) ? hint : nullptr;
+    bool success = false;
+
+    for (struct ifaddrs *cur = iflist; cur; cur = cur->ifa_next) {
+        if (!cur->ifa_addr || !cur->ifa_name)
+            continue;
+        if (!(cur->ifa_flags & IFF_UP) || (cur->ifa_flags & IFF_LOOPBACK))
+            continue;
+        if (cur->ifa_addr->sa_family != AF_LINK)
+            continue;
+        if (!is_physical_interface(cur->ifa_name))
+            continue;
+
+        // If we have a target, only match that; otherwise take first
+        if (target && strcmp(cur->ifa_name, target) != 0)
+            continue;
+
+        auto sdl = reinterpret_cast<struct sockaddr_dl *>(cur->ifa_addr);
+        if (sdl->sdl_alen == 6) {
+            memcpy(mac, LLADDR(sdl), 6);
+            success = true;
+            break;
+        }
+    }
+
+    freeifaddrs(iflist);
+    return success;
+}

--- a/vita3k/modules/SceNet/macos_net_helper.h
+++ b/vita3k/modules/SceNet/macos_net_helper.h
@@ -1,0 +1,24 @@
+// Vita3K emulator project
+// Copyright (C) 2026 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+bool get_primary_interface_name(char *dest, size_t bufferSize);
+bool get_mac_address(const char *hint, uint8_t mac[6]);


### PR DESCRIPTION
Implements the macOS version of sceNetGetMacAddress.
Uses SystemConfiguration framework to get the primary network interface, then retrieves its MAC address via getifaddrs(). If the primary interface is a VPN or tunnel (utun, ppp, etc.), it falls back to the first active physical interface (en*). If no adapters are found, uses a magic MAC (02:41:50:50:4C:45, which spells "APPLE") as fallback, similar to the Linux implementation.