### PR TITLE
ngs/player: fix ADPCM frame alignment and buffering.

### DIFF
--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -788,6 +788,10 @@ EXPORT(SceInt32, sceNgsVoiceInit, ngs::Voice *voice, const SceNgsVoicePreset *pr
     if (init_flags & SCE_NGS_VOICE_INIT_PRESET) {
         if (!preset) {
             STUBBED("Default preset not implemented");
+            for (size_t i = 0; i < voice->rack->modules.size(); i++) {
+                if (voice->rack->modules[i])
+                    voice->rack->modules[i]->set_default_preset(emuenv.mem, voice->datas[i]);
+            }
         } else if (!voice->set_preset(emuenv.mem, preset)) {
             return RET_ERROR(SCE_NGS_ERROR);
         }

--- a/vita3k/ngs/include/ngs/modules/player.h
+++ b/vita3k/ngs/include/ngs/modules/player.h
@@ -49,6 +49,8 @@ struct SceNgsPlayerStates {
     SceInt32 samples_generated_total = 0;
     SceInt32 total_bytes_consumed = 0;
 
+    std::vector<uint8_t> adpcm_buffer;
+
     // INTERNAL
     int8_t current_loop_count = 0;
     uint32_t decoded_samples_pending = 0;
@@ -89,6 +91,7 @@ private:
     std::unique_ptr<PCMDecoderState> decoder;
 
 public:
+    void set_default_preset(const MemState &mem, ModuleData &data) override;
     bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) override;
     uint32_t module_id() const override { return 0x5CE6; }
     void on_state_change(const MemState &mem, ModuleData &v, const VoiceState previous) override;

--- a/vita3k/ngs/include/ngs/system.h
+++ b/vita3k/ngs/include/ngs/system.h
@@ -113,6 +113,7 @@ class Module {
 public:
     virtual ~Module() = default;
 
+    virtual void set_default_preset(const MemState &mem, ModuleData &data) {}
     virtual bool process(KernelState &kern, const MemState &mem, const SceUID thread_id, ModuleData &data, std::unique_lock<std::recursive_mutex> &scheduler_lock, std::unique_lock<std::mutex> &voice_lock) = 0;
     virtual uint32_t module_id() const { return 0; }
     virtual uint32_t get_buffer_parameter_size() const = 0;


### PR DESCRIPTION
# About
- ngs/player: fix ADPCM frame alignment and buffering.
Implement proper ADPCM frame alignment by buffering incoming data and only forwarding complete 16/32‑byte HEVAG frames to the decoder. This prevents partial-frame processing and ensures stable playback.
Add a minimal default preset stub for PlayerModule. When a voice is initialized with an empty preset, the module now resets its internal PlayerState structure to a clean state.

# Result
- Fix batman audio explosed.