### PR TITLE
android/java/Emulator: Hide system bars

### DIFF
--- a/android/src/main/java/org/vita3k/emulator/Emulator.java
+++ b/android/src/main/java/org/vita3k/emulator/Emulator.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Environment;
 import android.os.ParcelFileDescriptor;
 import android.provider.Settings;
@@ -14,6 +15,7 @@ import android.system.ErrnoException;
 import android.system.Os;
 import android.view.Surface;
 import android.view.ViewGroup;
+import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.Keep;
@@ -98,6 +100,26 @@ public class Emulator extends SDLActivity
             String game_id = intent.getAction().substring(7);
             if(!game_id.equals(currentGameId))
                 ProcessPhoenix.triggerRebirth(getContext(), intent);
+        }
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        hideSystemBars();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        hideSystemBars();
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus) {
+            hideSystemBars();
         }
     }
 
@@ -315,4 +337,15 @@ public class Emulator extends SDLActivity
     }
 
     public native void filedialogReturn(String result_path);
+
+    private void hideSystemBars() {
+        getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        );
+    }
 }


### PR DESCRIPTION
This change hides system bars (status and navigation) on Android by applying immersive UI flags during the activity lifecycle.

There is issue on Retroid Pocket Flip 2, which prevents the emulator to enter fullscreen automatically, resulting in a black bar at the top of the screen and hiding emulator's tool bar (see the screenshot).

<img width="1920" height="1080" alt="Screenshot_20260106-223433" src="https://github.com/user-attachments/assets/4cb4c528-b785-4e86-9cb5-eb69c10947f5" />

Fixes #3757.