### PR TITLE
vita3k: Fix deadlock on SDL_EVENT_QUIT

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -699,6 +699,7 @@ bool handle_events(EmuEnvState &emuenv, GuiState &gui) {
             emuenv.kernel.exit_delete_all_threads();
             emuenv.gxm.display_queue.abort();
             emuenv.display.abort = true;
+            emuenv.renderer->notification_ready.notify_all();
             if (emuenv.display.vblank_thread) {
                 emuenv.display.vblank_thread->join();
             }

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2792,7 +2792,7 @@ EXPORT(int, sceGxmNotificationWait, const SceGxmNotification *notification) {
 
     std::unique_lock<std::mutex> lock(emuenv.renderer->notification_mutex);
     if (*value != target_value) {
-        emuenv.renderer->notification_ready.wait(lock, [&]() { return *value == target_value; });
+        emuenv.renderer->notification_ready.wait(lock, [&]() { return *value == target_value || emuenv.display.abort.load(); });
     }
 
     return 0;


### PR DESCRIPTION
When closing Vita3k via a window manager while a game is running, there was a shutdown deadlock instead of clean exit.

Two fixed issues:

- CPU: `sceGxmNotificationWait` could block indefinitely; make it aware of abort and notify on quit
- GPU (Vulkan): `gpu_request_wait_thread` could block indefinitely; abort `request_queue` and join the thread in `preclose_action`.

Fixes #3767.