### PR TITLE
ci: Add macOS ARM64 build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -35,11 +35,13 @@ jobs:
             cache_path: ~/.ccache
             extra_cmake_args: -DLINUXDEPLOY_COMMAND=/usr/local/bin/linuxdeploy-x86_64.AppImage
             cmake_preset: linux-ninja-clang-appimage
+
           - os: ubuntu-24.04-arm
             arch: aarch64
             cache_path: ~/.ccache
             extra_cmake_args: -DLINUXDEPLOY_COMMAND=/usr/local/bin/linuxdeploy-aarch64.AppImage
             cmake_preset: linux-ninja-clang-appimage
+
           - os: windows-latest
             cache_path: |
                 C:\vcpkg\installed
@@ -47,10 +49,19 @@ jobs:
                 C:\Users\runneradmin\AppData\Local\ccache
             extra_cmake_args: -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
             cmake_preset: windows-ninja
-          - os: macos-latest
+
+          - os: macos-intel
+            runs_on: macos-latest
             cache_path: ~/Library/Caches/ccache
             extra_cmake_args: -DCMAKE_OSX_ARCHITECTURES="x86_64" -DFORCE_BUILD_OPENSSL_MAC=ON -DVITA3K_FORCE_CUSTOM_BOOST=ON
             cmake_preset: macos-ninja
+
+          - os: macos-arm64
+            runs_on: macos-latest
+            cache_path: ~/Library/Caches/ccache
+            extra_cmake_args: -DCMAKE_OSX_ARCHITECTURES="arm64" -DFORCE_BUILD_OPENSSL_MAC=ON -DVITA3K_FORCE_CUSTOM_BOOST=ON
+            cmake_preset: macos-ninja
+
           - os: android
             runs_on: ubuntu-latest
 
@@ -66,7 +77,7 @@ jobs:
           brew install ccache create-dmg
           echo "$(brew --prefix ccache)/libexec" >> $GITHUB_PATH
           ccache --set-config=compiler_check=content
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
 
       - name: Set up build environment (Linux)
         run: |
@@ -190,7 +201,7 @@ jobs:
             vita3k-${{ env.GIT_SHORT_SHA }}-${{ matrix.os }}.dmg \
             Vita3K.app
           rm -rf Vita3K.app
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
 
       - name: Prepare Linux AppImage artifact
         run: |
@@ -266,11 +277,15 @@ jobs:
             if [[ $dir == *-android ]]; then
               echo "Processing $dir (Android)"
               cp $dir/*.apk artifacts-master/android-latest.apk
-              cp $dir/*.apk artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}_android.apk
-            elif [[ $dir == *-macos-latest ]]; then
-              echo "Processing $dir (macOS)"
+              cp $dir/*.apk artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-android.apk
+            elif [[ $dir == *-macos-intel ]]; then
+              echo "Processing $dir (macOS Intel)"
               cp $dir/*.dmg artifacts-master/macos-latest.dmg
-              cp $dir/*.dmg artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}_macos.dmg
+              cp $dir/*.dmg artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-macos.dmg
+            elif [[ $dir == *-macos-arm64 ]]; then
+              echo "Processing $dir (macOS ARM64)"
+              cp $dir/*.dmg artifacts-master/macos-arm64-latest.dmg
+              cp $dir/*.dmg artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-macos-arm64.dmg
             elif [[ $dir == *-ubuntu-latest-appimage ]]; then
               echo "Processing $dir (x86_64 AppImage)"
               cp $dir/*.AppImage* artifacts-master/
@@ -282,15 +297,15 @@ jobs:
             elif [[ $dir == *-ubuntu-latest ]]; then
               echo "Processing $dir (Ubuntu x86_64)"
               (cd $dir && zip -r ../artifacts-master/ubuntu-latest.zip *)
-              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}_ubuntu-x86_64.7z $dir
+              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-ubuntu-x86_64.7z $dir
             elif [[ $dir == *-ubuntu-24.04-arm ]]; then
               echo "Processing $dir (Ubuntu ARM64)"
               (cd $dir && zip -r ../artifacts-master/ubuntu-aarch64-latest.zip *)
-              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}_ubuntu-aarch64.7z $dir
+              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-ubuntu-aarch64.7z $dir
             elif [[ $dir == *-windows-latest ]]; then
-              echo "Processing $dir (Windows)"
+              echo "Processing $dir (Windows x86_64)"
               (cd $dir && zip -r ../artifacts-master/windows-latest.zip *)
-              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}_windows.7z $dir
+              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-windows.7z $dir
             fi
           done
           echo "=== artifacts-master ==="

--- a/appimage/build_updater.sh
+++ b/appimage/build_updater.sh
@@ -7,14 +7,14 @@
 # Detect architecture
 ARCH=$(uname -m)
 
-if [ "$ARCH" = "x86_64" ]; then
-    APPIMAGE_NAME="Vita3K-x86_64.AppImage"
-elif [ "$ARCH" = "aarch64" ]; then
-    APPIMAGE_NAME="Vita3K-aarch64.AppImage"
-else
-    echo "Unsupported architecture: $ARCH"
-    exit 1
-fi
+case "$ARCH" in
+    x86_64|amd64) APPIMAGE_NAME="Vita3K-x86_64.AppImage" ;;
+    aarch64|arm64) APPIMAGE_NAME="Vita3K-aarch64.AppImage" ;;
+    *)
+      echo "Unsupported architecture: $ARCH"
+      exit 1
+      ;;
+esac
 
 echo "Executing linuxdeploy with cmdline: LDAI_VERBOSE=1 UPDATE_INFORMATION=\"gh-releases-zsync|Vita3K|Vita3K|latest|${APPIMAGE_NAME}.zsync\" $@"
 

--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -204,14 +204,18 @@ static void download_update(const fs::path &base_path) {
 #ifdef _WIN32
         download_continuous_link += "windows-latest.zip";
 #elif defined(__APPLE__)
-        download_continuous_link += "macos-latest.dmg";
+#ifdef __aarch64__
+        download_continuous_link += "macos-arm64-latest.zip";
+#else
+        download_continuous_link += "macos-latest.zip";
+#endif
 #elif defined(__ANDROID__)
         download_continuous_link += "android-latest.apk";
 #elif defined(__linux__)
-#if defined(__x86_64__)
-        download_continuous_link += "/ubuntu-latest.zip";
-#elif defined(__aarch64__)
-        download_continuous_link += "/ubuntu-aarch64-latest.zip";
+#ifdef __aarch64__
+        download_continuous_link += "ubuntu-aarch64-latest.zip";
+#else
+        download_continuous_link += "ubuntu-latest.zip";
 #endif
 #endif
 

--- a/vita3k/script/update-linux.sh
+++ b/vita3k/script/update-linux.sh
@@ -11,9 +11,12 @@ boot=0
 # determine architecture for correct zip
 arch="$(uname -m)"
 case "$arch" in
-    x86_64) zip_name="ubuntu-latest.zip" ;;
+    x86_64|amd64) zip_name="ubuntu-latest.zip" ;;
     aarch64|arm64) zip_name="ubuntu-aarch64-latest.zip" ;;
-    *) zip_name="vita3k-latest.zip" ;;
+    *)
+      echo "Unsupported architecture: $arch"
+      exit 1
+      ;;
 esac
 
 # Download if not present

--- a/vita3k/script/update-macos.sh
+++ b/vita3k/script/update-macos.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
 DIR="$(dirname "$0")"
 APP_PATH="$(dirname "$0")/../../.."
+ARCH=$(uname -m)
+
+if [ "$ARCH" = "arm64" ]; then
+  DMG_NAME=macos-arm64-latest.dmg
+else
+  DMG_NAME=macos-latest.dmg
+fi
 
 if [ ! -e "$DIR"/vita3k-latest.dmg ]; then
-	curl -L https://github.com/Vita3K/Vita3K/releases/download/continuous/macos-latest.dmg -o "$DIR"/vita3k-latest.dmg
+	curl -L https://github.com/Vita3K/Vita3K/releases/download/continuous/$DMG_NAME -o "$DIR"/vita3k-latest.dmg
 fi
 
 hdiutil attach "$DIR"/vita3k-latest.dmg


### PR DESCRIPTION
- Optimize Linux build & update.
- Rename artifacts for store repo.
- Considering binary size, I did not build the universal binary (and I'm not sure if this would extend compilation time).