### PR TITLE
script & gui/vita3k_update: Revert & bugfixes

### DIFF
--- a/vita3k/gui/src/vita3k_update.cpp
+++ b/vita3k/gui/src/vita3k_update.cpp
@@ -209,9 +209,10 @@ static void download_update(const fs::path &base_path) {
 #endif
 #elif defined(__APPLE__)
 #ifdef __aarch64__
-        download_continuous_link += "macos-arm64-latest.zip";
+        // download_continuous_link += "macos-arm64-latest.dmg"; // unstable
+        download_continuous_link += "macos-latest.dmg";
 #else
-        download_continuous_link += "macos-latest.zip";
+        download_continuous_link += "macos-latest.dmg";
 #endif
 #elif defined(__ANDROID__)
         download_continuous_link += "android-latest.apk";

--- a/vita3k/script/update-linux.sh
+++ b/vita3k/script/update-linux.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 echo ============================================================
 echo ====================== Vita3K Updater ======================
 echo ============================================================
@@ -20,23 +20,23 @@ case "$arch" in
 esac
 
 # Download if not present
-if [ ! -e "$zip_name" ]; then
+if [ ! -e "vita3k-latest.zip" ]; then
     echo Checking for Vita3K updates...
     echo Attempting to download and extract the latest Vita3K version in progress...
-    curl -L "https://github.com/Vita3K/Vita3K/releases/download/continuous/$zip_name" -o "./$zip_name"
+    curl -L "https://github.com/Vita3K/Vita3K/releases/download/continuous/$zip_name" -o "./vita3k-latest.zip"
 else
     boot=1
 fi
 
 echo Installing update ...
-unzip -q -o "./$zip_name"
+unzip -q -o "./vita3k-latest.zip"
 
 # Restore execution permissions
 chmod +x ./Vita3K
 chmod +x ./update-vita3k.sh
 
 # Remove the zip after extraction
-rm -f "./$zip_name"
+rm -f "./vita3k-latest.zip"
 
 echo Vita3K updated successfully!
 

--- a/vita3k/script/update-macos.sh
+++ b/vita3k/script/update-macos.sh
@@ -4,7 +4,8 @@ APP_PATH="$(dirname "$0")/../../.."
 ARCH=$(uname -m)
 
 if [ "$ARCH" = "arm64" ]; then
-  DMG_NAME=macos-arm64-latest.dmg
+  # DMG_NAME=macos-arm64-latest.dmg # unstable
+  DMG_NAME=macos-latest.dmg
 else
   DMG_NAME=macos-latest.dmg
 fi


### PR DESCRIPTION
- Revert the macOS update link to x64 build because the ARM64 build is unstable.
- Fix using `.zip` suffix for macOS download.
- Use bash to fix error `read: arg count` in `update-linux.sh` (<https://unix.stackexchange.com/questions/581409>).
- Fix the zip name in `update-linux.sh` differing from that in GUI.