### PR TITLE
gui/bgm_player: Wake up before join in destructor

### DIFF
--- a/vita3k/gui/src/bgm_player.cpp
+++ b/vita3k/gui/src/bgm_player.cpp
@@ -241,6 +241,9 @@ void destroy_bgm_player() {
         at9_stream.stop_requested = true;
     }
 
+    // Wake up the playback thread if it's waiting on init_cv
+    at9_stream.init_cv.notify_one();
+
     // Wait for the playback handle thread to finish
     if (playback_handle_thread.joinable())
         playback_handle_thread.join();


### PR DESCRIPTION
While testing #3758 on Steam Deck I noticed that it doesn't shut down cleanly from `SDL_EVENT_QUIT`, which I recently fixed in #3767.

Looking at the backtrace:

```
Thread 1 (Thread 0x7fb22807a400 (LWP 25302)):
#0  __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
#1  0x00007fb2287cfdd3 in __internal_syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=<optimized out>, a5=a5@entry=0, a6=a6@entry=4294967295, nr=202) at cancellation.c:49
#2  0x00007fb2287d045c in __futex_abstimed_wait_common64 (private=128, futex_word=0x7fb20dfe2990, expected=<optimized out>, op=<optimized out>, abstime=0x0, cancel=true) at futex-internal.c:57
#3  __futex_abstimed_wait_common (futex_word=futex_word@entry=0x7fb20dfe2990, expected=<optimized out>, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=128, cancel=cancel@entry=true) at futex-internal.c:87
#4  0x00007fb2287d04bf in __GI___futex_abstimed_wait_cancelable64 (futex_word=futex_word@entry=0x7fb20dfe2990, expected=<optimized out>, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=128) at futex-internal.c:139
#5  0x00007fb2287d5394 in __pthread_clockjoin_ex (threadid=140402715666112, thread_return=0x0, clockid=0, abstime=0x0, block=<optimized out>) at pthread_join_common.c:108
#6  0x0000559c011065f4 in std::thread::join() ()
#7  0x0000559c012a4b90 in gui::destroy_bgm_player() ()
#8  0x0000559c0119f17f in handle_events(EmuEnvState&, GuiState&) ()
#9  0x0000559c01164b1f in main ()
```

So `destroy_bgm_player` is waiting for the playback thread to wake up. Let's wake it up before joining the thread.