### PR TITLE
gui/bgm_player: Move init_bgm_player call out of pre_init.

### DIFF
--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -829,7 +829,6 @@ void pre_init(GuiState &gui, EmuEnvState &emuenv) {
 
     init_style(emuenv);
     init_font(gui, emuenv);
-    gui::init_bgm_player(emuenv.cfg.bgm_volume);
     lang::init_lang(gui.lang, emuenv);
 
     bool result = ImGui_ImplSdl_CreateDeviceObjects(gui.imgui_state.get());

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -305,6 +305,7 @@ int main(int argc, char *argv[]) {
     GuiState gui;
     if (!cfg.console) {
         gui::pre_init(gui, emuenv);
+        gui::init_bgm_player(emuenv.cfg.bgm_volume);
         if (!emuenv.cfg.initial_setup) {
             if (gui::init_bgm(emuenv, { "pd0", "data/systembgm/initialsetup.at9" }))
                 gui::switch_bgm_state(false);


### PR DESCRIPTION
# About
- gui/bgm_player: Move init_bgm_player call out of pre_init.
Avoids early audio initialization on Windows.
Fixes a timing issue where Cubeb was being initialized before SDL/WASAPI were fully ready.