### PR TITLE
Fix crackling audio with SDL3 audio backend in certain games

### DIFF
--- a/vita3k/audio/src/audio.cpp
+++ b/vita3k/audio/src/audio.cpp
@@ -69,6 +69,8 @@ AudioOutPortPtr AudioState::open_port(int nb_channels, int freq, int nb_sample) 
 }
 
 void AudioState::audio_output(ThreadState &thread, AudioOutPort &out_port, const void *buffer) {
+    if (!buffer)
+        return;
     adapter->audio_output(thread, out_port, buffer);
 
     uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();


### PR DESCRIPTION
First commit helps with massive log spam, probably enough to slow the game down.

Second commit skips pacing sleep in audio thread for SDL3 audio backend.

Fixes #3798.