### PR TITLE
audio: Rewrite SDL backend to use ring buffer & callbacks

### DIFF
--- a/vita3k/audio/include/audio/impl/cubeb_audio.h
+++ b/vita3k/audio/include/audio/impl/cubeb_audio.h
@@ -23,11 +23,6 @@
 
 #include <cubeb/cubeb.h>
 
-struct AudioBuffer {
-    std::vector<uint8_t> buffer;
-    int buffer_position;
-};
-
 struct CubebAudioOutPort : AudioOutPort {
     cubeb_stream *out_stream = nullptr;
     cubeb_stream_params spec;

--- a/vita3k/audio/include/audio/state.h
+++ b/vita3k/audio/include/audio/state.h
@@ -30,6 +30,11 @@
 
 typedef std::function<void(SceUID)> ResumeAudioThread;
 
+struct AudioBuffer {
+    std::vector<uint8_t> buffer;
+    int buffer_position = 0;
+};
+
 struct AudioOutPort {
     // Channel range from 0 - 32768
     int left_channel_volume = SCE_AUDIO_VOLUME_0DB;
@@ -40,8 +45,6 @@ struct AudioOutPort {
     int len_bytes = 0;
     // number of microseconds a buffer lasts for
     uint64_t len_microseconds = 0;
-    // last time sceAudioOutOutput was called with this port (timestamp in microseconds)
-    uint64_t last_output = 0;
 
     // current config
     int type = 0;

--- a/vita3k/audio/src/audio.cpp
+++ b/vita3k/audio/src/audio.cpp
@@ -24,10 +24,6 @@
 
 #include <util/log.h>
 
-#include <algorithm>
-#include <cassert>
-#include <cstring>
-
 bool AudioState::init(const ResumeAudioThread &resume_thread, const std::string &adapter_name) {
     this->resume_thread = resume_thread;
 
@@ -70,22 +66,6 @@ AudioOutPortPtr AudioState::open_port(int nb_channels, int freq, int nb_sample) 
 
 void AudioState::audio_output(ThreadState &thread, AudioOutPort &out_port, const void *buffer) {
     adapter->audio_output(thread, out_port, buffer);
-
-    uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    uint64_t diff = now - out_port.last_output;
-    uint64_t to_wait = out_port.len_microseconds - diff;
-    if (diff < out_port.len_microseconds && to_wait > 1000) {
-        // This is what we should be waiting to be perfectly accurate
-        // However, doing so would cause the host audio buffer to often lack samples to output
-        // This is because the PS Vita and the host audio parameters do not match exactly
-        // So instead only wait 50% of the time
-        // also don't sleep for less than 0.5 ms
-        to_wait /= 2;
-        std::this_thread::sleep_for(std::chrono::microseconds(to_wait));
-        out_port.last_output = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    } else {
-        out_port.last_output = now;
-    }
 }
 
 void AudioState::set_volume(AudioOutPort &out_port, float volume) {

--- a/vita3k/audio/src/impl/sdl_audio.cpp
+++ b/vita3k/audio/src/impl/sdl_audio.cpp
@@ -20,6 +20,7 @@
 #include "kernel/thread/thread_state.h"
 
 #include <SDL3/SDL_audio.h>
+#include <SDL3/SDL_hints.h>
 
 #include "util/log.h"
 
@@ -35,19 +36,32 @@
 #define SDL_CHECK_VOID(f_call) SDL_CHECK_EXT(f_call, )
 #define SDL_CHECK_NEG(f_call) SDL_CHECK_EXT((f_call) >= 0, {})
 
-void SDLCALL SDLAudioAdapter::thread_wakeup_callback(void *userdata, SDL_AudioStream *stream, int additional_amount, int total_amount) {
+void SDLCALL SDLAudioAdapter::audio_callback(void *userdata, SDL_AudioStream *stream, int additional_amount, int total_amount) {
     assert(userdata != nullptr);
     assert(stream != nullptr);
+
+    if (additional_amount <= 0)
+        return;
+
     SDLAudioOutPort *port = static_cast<SDLAudioOutPort *>(userdata);
-    // Is there a thread waiting for playback to finish?
-    if (port->thread >= 0) {
-        const int samples_available = port->adapter.get_rest_sample(*port);
-        assert(samples_available >= 0);
-        // Running out of data?
-        if (samples_available < (4 * port->adapter.device_buffer_samples) + port->len) {
-            // Wake the thread up.
-            port->adapter.state.resume_thread(port->thread);
-            port->thread = -1;
+
+    // Copy data from ring buffer to SDL stream, just like in cubeb adapter.
+    while (additional_amount > 0 && port->nb_buffers_ready > 0) {
+        AudioBuffer &audio_buffer = port->audio_buffers[port->next_audio_buffer];
+        const int bytes_remaining = port->len_bytes - audio_buffer.buffer_position;
+        const int bytes_to_copy = std::min(additional_amount, bytes_remaining);
+
+        SDL_PutAudioStreamData(stream, &audio_buffer.buffer[audio_buffer.buffer_position], bytes_to_copy);
+        audio_buffer.buffer_position += bytes_to_copy;
+        additional_amount -= bytes_to_copy;
+
+        if (audio_buffer.buffer_position == port->len_bytes) {
+            // if we are done with this buffer, tell it
+            std::unique_lock<std::mutex> lock(port->mutex);
+            port->next_audio_buffer = (port->next_audio_buffer + 1) % port->audio_buffers.size();
+            port->nb_buffers_ready--;
+            lock.unlock();
+            port->cond_var.notify_one();
         }
     }
 }
@@ -62,6 +76,10 @@ SDLAudioAdapter::~SDLAudioAdapter() {
 }
 
 bool SDLAudioAdapter::init() {
+    // SDL3 default is 1024 sample frames for 48kHz audio, which is higher than cubeb.
+    // Request smaller device buffer for lower latency callbacks.
+    // 512 sample frames = 2048 bytes for stereo 16-bit, matching cubeb's callback size.
+    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, "512");
     device_id = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr);
     SDL_CHECK_EXT(device_id > 0, false);
     return true;
@@ -85,25 +103,46 @@ AudioOutPortPtr SDLAudioAdapter::open_port(int nb_channels, int freq, int nb_sam
     SDL_CHECK(stream);
     SDL_CHECK(SDL_BindAudioStream(device_id, stream.get()));
     auto port = std::make_shared<SDLAudioOutPort>(stream, *this);
-    SDL_CHECK(SDL_SetAudioStreamGetCallback(stream.get(), SDLAudioAdapter::thread_wakeup_callback, port.get()));
+    SDL_CHECK(SDL_SetAudioStreamGetCallback(stream.get(), SDLAudioAdapter::audio_callback, port.get()));
     port->channels = nb_channels;
     port->len_microseconds = (nb_sample * 1'000'000ULL) / freq;
     port->len_bytes = nb_sample * nb_channels * sizeof(int16_t);
+
+    // SDL3 has no equivalent to cubeb_get_min_latency(), so we calculate buffer count
+    // based on a target latency. 25ms matches cubeb's PulseAudio safe minimum.
+    const int target_latency_ms = 25;
+    const int target_latency_samples = target_latency_ms * freq / 1000;
+    const int nb_buffers = (target_latency_samples + nb_sample - 1) / nb_sample + 1;
+    port->audio_buffers.resize(nb_buffers);
+    for (AudioBuffer &audio_buffer : port->audio_buffers) {
+        // initialize all the buffers
+        audio_buffer.buffer.resize(port->len_bytes);
+        audio_buffer.buffer_position = 0;
+    }
+
     switch_state(false);
     return port;
 }
+
 void SDLAudioAdapter::audio_output(ThreadState &thread, AudioOutPort &out_port, const void *buffer) {
-    //  Put audio to the port's stream and see how much is left to play.
     SDLAudioOutPort &port = static_cast<SDLAudioOutPort &>(out_port);
-    SDL_CHECK_VOID(SDL_PutAudioStreamData(port.stream.get(), buffer, out_port.len_bytes));
-    const int samples_available = get_rest_sample(port);
-    // If there's lots of audio left to play, stop this thread.
-    // The audio callback will wake it up later when it's running out of data.
-    if (samples_available >= (4 * device_buffer_samples) + port.len) {
-        port.thread = thread.id;
-        std::unique_lock<std::mutex> mlock(thread.mutex);
+
+    std::unique_lock<std::mutex> lock(port.mutex);
+    if (port.nb_buffers_ready == port.audio_buffers.size()) {
+        // is it really useful to update the thread status?
         thread.update_status(ThreadStatus::wait);
-        thread.status_cond.wait(mlock, [&]() { return thread.status == ThreadStatus::run; });
+        port.cond_var.wait(lock);
+        thread.update_status(ThreadStatus::run);
+    }
+
+    assert(port.nb_buffers_ready < port.audio_buffers.size());
+    if (buffer) {
+        // the buffer can be empty to drain the port
+        const int next_buffer_pos = (port.next_audio_buffer + port.nb_buffers_ready) % port.audio_buffers.size();
+        // we could unlock the lock here and re-lock it right after, but will this be faster?
+        memcpy(port.audio_buffers[next_buffer_pos].buffer.data(), buffer, port.len_bytes);
+        port.audio_buffers[next_buffer_pos].buffer_position = 0;
+        port.nb_buffers_ready++;
     }
 }
 


### PR DESCRIPTION
Model the SDL audio backend after cubeb: push audio to ring buffer, block when full. Callback pulls from ring buffer and wakes the producer when a slot is freed.

I basically just copied what @Macdu did in the cubeb backend here verbatim. This way both audio backends resemble each other. In my testing after this change both audio backends keep the ring buffers full, gracefully blocking the thread until audio is consumed. No underruns either.

This is arguably a better fix for #3798, but it is way more work to test and review than #3799. Works for me on Linux & pipewire, but I have limited ability to test on other platforms...