### PR TITLE
gui: Allow Android users to delete files after installation

### DIFF
--- a/vita3k/gui/src/archive_install_dialog.cpp
+++ b/vita3k/gui/src/archive_install_dialog.cpp
@@ -110,12 +110,10 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         if (ImGui::Button(lang["select_file"].c_str(), BUTTON_SIZE))
             type = Type::FILE;
         ImGui::Spacing();
-#ifndef __ANDROID__
         ImGui::SetCursorPosX(POS_BUTTON);
         if (ImGui::Button(lang["select_directory"].c_str(), BUTTON_SIZE))
             type = Type::DIRECTORY;
         ImGui::Spacing();
-#endif
         ImGui::Separator();
         ImGui::Spacing();
         ImGui::SetCursorPosX(POS_BUTTON);
@@ -269,9 +267,7 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::PopStyleVar();
             ImGui::Separator();
             ImGui::Spacing();
-#ifndef __ANDROID__
             ImGui::Checkbox(lang["delete_archive"].c_str(), &delete_archive_file);
-#endif
             ImGui::SetCursorPos(ImVec2(POS_BUTTON, WINDOW_SIZE.y - BUTTON_SIZE.y - (12.f * SCALE.y)));
             if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
                 for (const auto &archive : contents_archives) {

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -118,10 +118,8 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::Separator();
                 ImGui::Spacing();
             }
-#ifndef __ANDROID__
             ImGui::Checkbox(lang["delete_firmware"].c_str(), &delete_pup_file);
             ImGui::Spacing();
-#endif
             ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - (20.f * SCALE.y)));
             if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
                 if (delete_pup_file) {

--- a/vita3k/gui/src/license_install_dialog.cpp
+++ b/vita3k/gui/src/license_install_dialog.cpp
@@ -126,10 +126,8 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
-#ifndef __ANDROID__
         if (!license_path.empty())
             ImGui::Checkbox(license["delete_bin_rif"].c_str(), &delete_license_file);
-#endif
         ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - (20.f * SCALE.y)));
         if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
             if (delete_license_file) {

--- a/vita3k/gui/src/pkg_install_dialog.cpp
+++ b/vita3k/gui/src/pkg_install_dialog.cpp
@@ -184,12 +184,10 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();
-#ifndef __ANDROID__
             ImGui::Checkbox(lang["delete_pkg"].c_str(), &delete_pkg_file);
-            if (license_path != "")
+            if (!license_path.empty())
                 ImGui::Checkbox(lang["delete_bin_rif"].c_str(), &delete_license_file);
             ImGui::Spacing();
-#endif
             ImGui::SetCursorPos(ImVec2(POS_BUTTON, ImGui::GetWindowSize().y - BUTTON_SIZE.y - (20.f * SCALE.y)));
             if (ImGui::Button(common["ok"].c_str(), BUTTON_SIZE)) {
                 if (delete_pkg_file) {


### PR DESCRIPTION
- Allow Android users to select a directory for installing the archive files.
- There are no comments, so I don't know why Android users weren't allowed to do these before (they worked fine).