### PR TITLE
external: Update Android Vulkan validation layer to 1.4.341.0 SDK 

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -243,10 +243,12 @@ if(APPLE)
 elseif(ANDROID AND NOT (CMAKE_BUILD_TYPE STREQUAL "Release"))
 	# add validation layer
 	if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../android/prebuilt/${ANDROID_ABI}/libVkLayer_khronos_validation.so")
+		set(VALIDATION_BINARY "android-binaries-1.4.341.0")
+
 		# download it if not already done
 		if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/validation_layers.zip")
 			message(STATUS "Downloading validation layer...")
-			file(DOWNLOAD https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases/download/sdk-1.3.250.0/android-binaries-1.3.250.0.zip
+			file(DOWNLOAD https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases/download/vulkan-sdk-1.4.341.0/${VALIDATION_BINARY}.zip
 				"${CMAKE_BINARY_DIR}/external/validation_layers.zip" SHOW_PROGRESS)
 		endif()
 
@@ -256,7 +258,7 @@ elseif(ANDROID AND NOT (CMAKE_BUILD_TYPE STREQUAL "Release"))
 				WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/validation_layers")
 		endif()
 
-		file(COPY "${CMAKE_BINARY_DIR}/external/validation_layers/${ANDROID_ABI}" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/../android/prebuilt")
+		file(COPY "${CMAKE_BINARY_DIR}/external/validation_layers/${VALIDATION_BINARY}/${ANDROID_ABI}" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/../android/prebuilt")
 	endif()
 endif()
 


### PR DESCRIPTION
- To support Android 16 & 16 KB page sizes.
- The Android validation layer binary for 1.3.250.0 SDK were built with NDK v21.3.6528147 (very old).
- MoltenVK can be updated from v1.2.11 to v1.4.1, but it may raise minimum target for macOS, so I didn't change it.