### PR TITLE
gui/lang: Some updates.

### DIFF
--- a/lang/system/da.xml
+++ b/lang/system/da.xml
@@ -269,6 +269,9 @@ Dit Vita3K-system er klart!</completed_setup>
 	</live_area>
 	
 	<settings name="Indstillinger">
+		<sound_display name="Lyd og display">
+			<system_music>Systemmusik</system_music>
+		</sound_display>
 		<theme_background name="Tema og baggrund">
 			<default>Standard</default>
 			<theme name="Tema">
@@ -326,6 +329,8 @@ Dit Vita3K-system er klart!</completed_setup>
 	</settings>
 
 	<settings_dialog name="Indstillinger">
+		<camera name="Kamera">
+		</camera>
 		<system name="System">
 		</system>
 		<network name="Netværk">

--- a/lang/system/de.xml
+++ b/lang/system/de.xml
@@ -279,6 +279,9 @@ Tippe auf 'Zugriff gewähren', um fortzufahren.</storage_file_permissions>
 	</live_area>
 
 	<settings name="Einstellungen">
+		<sound_display name="Sound und Anzeige">
+			<system_music>Systemmusik</system_music>
+		</sound_display>
 		<theme_background name="Design und Hintergrund">
 			<default>Standard</default>
 			<theme name="Design">
@@ -337,6 +340,8 @@ Tippe auf 'Zugriff gewähren', um fortzufahren.</storage_file_permissions>
 	</settings>
 
 	<settings_dialog name="Einstellungen">
+		<camera name="Kamera">
+		</camera>
 		<system name="System">
 		</system>
 		<network name="Netzwerk">

--- a/lang/system/en-gb.xml
+++ b/lang/system/en-gb.xml
@@ -4,7 +4,7 @@
 	<main_menubar>
 		<file name="File">
 			<open_pref_path>Open Pref Path</open_pref_path>
-			<open_patch_path>Open Patch Path</open_patch_path>
+			<open_patches_path>Open Patch Path</open_patches_path>
 			<open_textures_path>Open Textures Path</open_textures_path>
 			<install_firmware>Install Firmware</install_firmware>
 			<install_pkg>Install .pkg</install_pkg>
@@ -90,6 +90,7 @@ depending on its size and your hardware.</delete_app_description>
 			<delete_license>Do you want to delete this license?</delete_license>
 		</delete>
 		<other name="Other">
+			<decrypt_all_self>Decrypt all SELF</decrypt_all_self>
 			<reset_last_time_played>Reset Last Time Played</reset_last_time_played>
 		</other>
 		<update_history>Update History</update_history>
@@ -325,6 +326,7 @@ Connect a controller that is compatible with SDL3.</not_connected>
 	<controls>
 		<button>Button</button>
 		<mapped_button>Mapped button</mapped_button>
+		<mapped_button_alt>Alternate mapped button</mapped_button_alt>
 		<left_stick_up>Left stick up</left_stick_up>
 		<left_stick_down>Left stick down</left_stick_down>
 		<left_stick_right>Left stick right</left_stick_right>
@@ -383,7 +385,6 @@ Connect a controller that is compatible with SDL3.</not_connected>
 			</info>
 			<load name="Load">
 				<cancel_loading>Do you want to cancel loading?</cancel_loading>
-				<could_not_load>Could not load the file.</could_not_load>
 				<no_saved_data>There is no saved data.</no_saved_data>
 				<load_complete>Loading complete.</load_complete>
 				<loading>Loading...</loading>
@@ -474,6 +475,7 @@ If disabled, right click on an application to open it.</live_area_screen_descrip
 		<apps_list_grid_description>Check the box to set the app list to grid mode like of PS Vita.</apps_list_grid_description>
 		<icon_size>App Icon Size</icon_size>
 		<select_icon_size>Select your preferred icon size.</select_icon_size>
+		<system_music_description>This option can be changed later in the system Settings app.</system_music_description>
 		<completed>Completed.</completed>
 		<next>Next</next>
 	</initial_setup>
@@ -495,6 +497,8 @@ and also for Asian regional font support. (Generally Recommended)</firmware_font
 			<enter_zrif>Enter zRIF</enter_zrif>
 			<enter_zrif_key>Enter zRIF key</enter_zrif_key>
 			<input_zrif>Please input your zRIF here</input_zrif>
+			<inputmethod_paste_zrif>Use the input method clipboard to copy and paste.
+Keyboard: Ctrl + C to copy, Ctrl + V to paste.</inputmethod_paste_zrif>
 			<copy_paste_zrif>Ctrl + C to copy, Ctrl + V to paste.</copy_paste_zrif>
 			<delete_pkg>Delete the pkg file?</delete_pkg>
 			<delete_bin_rif>Delete the work.bin/rif file?</delete_bin_rif>
@@ -734,6 +738,14 @@ and not all GPUs are compatible with this.</spirv_shader_description>
 			<bgm_volume>Bgm Volume</bgm_volume>
 			<bgm_volume_description>Adjusts the background music volume percentage of the theme.</bgm_volume_description>
 		</audio>
+		<camera name="Camera">
+			<front_camera>Front Camera</front_camera>
+			<back_camera>Back Camera</back_camera>
+			<image_not_set>Image not set</image_not_set>
+			<set_image>Set image</set_image>
+			<solid_color>Solid Color</solid_color>
+			<static_image>Static Image</static_image>
+		</camera>
 		<system name="System">
 			<select_enter_button>Enter button assignment
 Select your 'Enter' button.</select_enter_button>

--- a/lang/system/en.xml
+++ b/lang/system/en.xml
@@ -4,7 +4,7 @@
 	<main_menubar>
 		<file name="File">
 			<open_pref_path>Open Pref Path</open_pref_path>
-			<open_patch_path>Open Patch Path</open_patch_path>
+			<open_patches_path>Open Patch Path</open_patches_path>
 			<open_textures_path>Open Textures Path</open_textures_path>
 			<install_firmware>Install Firmware</install_firmware>
 			<install_pkg>Install .pkg</install_pkg>
@@ -90,6 +90,7 @@ depending on its size and your hardware.</delete_app_description>
 			<delete_license>Do you want to delete this license?</delete_license>
 		</delete>
 		<other name="Other">
+			<decrypt_all_self>Decrypt all SELF</decrypt_all_self>
 			<reset_last_time_played>Reset Last Time Played</reset_last_time_played>
 		</other>
 		<update_history>Update History</update_history>
@@ -395,7 +396,7 @@ Connect a controller that is compatible with SDL3.</not_connected>
 There is not enough free space on the memory card. To save your progress in the application, you must create at least {} of free space.
 
 To create the free space, press PS button to pause this application, and then delete other applications or content.</could_not_save>
-				<not_free_space>There is not enough free space on the memory card. 
+				<not_free_space>There is not enough free space on the memory card.
 To continue using the application, you must create at least {} of free space.
 
 Press the PS button to pause this application, and then delete other applications or content.</not_free_space>
@@ -474,6 +475,7 @@ If disabled, right click on an application to open it.</live_area_screen_descrip
 		<apps_list_grid_description>Check the box to set the app list to grid mode like of PS Vita.</apps_list_grid_description>
 		<icon_size>App Icon Size</icon_size>
 		<select_icon_size>Select your preferred icon size.</select_icon_size>
+		<system_music_description>This option can be changed later in the system Settings app.</system_music_description>
 		<completed>Completed.</completed>
 		<next>Next</next>
 	</initial_setup>
@@ -495,6 +497,8 @@ and also for Asian regional font support. (Generally Recommended)</firmware_font
 			<enter_zrif>Enter zRIF</enter_zrif>
 			<enter_zrif_key>Enter zRIF key</enter_zrif_key>
 			<input_zrif>Please input your zRIF here</input_zrif>
+			<inputmethod_paste_zrif>Use the input method clipboard to copy and paste.
+Keyboard: Ctrl + C to copy, Ctrl + V to paste.</inputmethod_paste_zrif>
 			<copy_paste_zrif>Ctrl + C to copy, Ctrl + V to paste.</copy_paste_zrif>
 			<delete_pkg>Delete the pkg file?</delete_pkg>
 			<delete_bin_rif>Delete the work.bin/rif file?</delete_bin_rif>

--- a/lang/system/es.xml
+++ b/lang/system/es.xml
@@ -290,6 +290,9 @@ Toca 'Conceder Acceso' para continuar.</storage_file_permissions>
 	</live_area>
 
 	<settings name="Ajustes">
+		<sound_display name="Sonido y pantalla">
+			<system_music>Música del sistema</system_music>
+		</sound_display>
 		<theme_background name="Tema y Fondo">
 			<default>Predeterminado</default>
 			<theme name="Tema">
@@ -347,6 +350,8 @@ Toca 'Conceder Acceso' para continuar.</storage_file_permissions>
 	</settings>
 
 	<settings_dialog name="Ajustes">
+		<camera name="Cámara">
+		</camera>
 		<system name="Sistema">
 		</system>
 		<network name="Red">

--- a/lang/system/fi.xml
+++ b/lang/system/fi.xml
@@ -273,6 +273,9 @@ Napauta 'Myönnä Käyttöoikeus' jatkaaksesi.</storage_file_permissions>
 	</live_area>
 
 	<settings name="Asetukset">
+		<sound_display name="Ääni ja näyttö">
+			<system_music>Järjestelmän musiikki</system_music>
+		</sound_display>
 		<theme_background name="Teema ja tausta">
 			<default>Oletus</default>
 			<theme name="Teema">
@@ -330,6 +333,8 @@ Napauta 'Myönnä Käyttöoikeus' jatkaaksesi.</storage_file_permissions>
 	</settings>
 
 	<settings_dialog name="Asetukset">
+		<camera name="Kamera">
+		</camera>
 		<system name="Järjestelmä">
 		</system>
 		<network name="Verkko">

--- a/lang/system/fr.xml
+++ b/lang/system/fr.xml
@@ -438,6 +438,8 @@ Appuyez sur 'Autoriser l'accès' pour continuer.</storage_file_permissions>
 	</settings>
 
 	<settings_dialog name="Paramètres">
+		<camera name="Appareil photo">
+		</camera>
 		<system name="Système">
 		</system>
 		<network name="Réseau">

--- a/lang/system/it.xml
+++ b/lang/system/it.xml
@@ -291,6 +291,9 @@ Tocca 'Concedi Accesso' per continuare.</storage_file_permissions>
 	</live_area>
 
 	<settings name="Impostazioni">
+		<sound_display name="Audio e schermo">
+			<system_music>Musica di sistema</system_music>
+		</sound_display>
 		<theme_background name="Tema e Sfondo">
 			<default>Predefinita</default>
 			<theme name="Tema">
@@ -348,6 +351,8 @@ Tocca 'Concedi Accesso' per continuare.</storage_file_permissions>
 	</settings>
 
 	<settings_dialog name="Impostazioni">
+		<camera name="Fotocamera">
+		</camera>
 		<system name="Sistema">
 		</system>
 		<network name="Rete">

--- a/lang/system/ja.xml
+++ b/lang/system/ja.xml
@@ -488,6 +488,9 @@ GUIでのアジア地域のフォントサポートに必須です。
 	</live_area>
 
 	<settings name="設定">
+		<sound_display name="サウンド&ディスプレイ">
+			<system_music>システムのミュージック</system_music>
+		</sound_display>
 		<theme_background name="テーマ&背景">
 			<default>デフォルト</default>
 			<theme name="テーマ">
@@ -606,6 +609,8 @@ GUIでのアジア地域のフォントサポートに必須です。
 			<enable_ngs_support>NGSサポートを有効にする</enable_ngs_support>
 			<ngs_description>NGSオーディオライブラリのサポートを無効にするには、チェックボックスを外します。</ngs_description>
 		</audio>
+		<camera name="カメラ">
+		</camera>
 		<system name="システム">
 			<select_enter_button>決定ボタンの割り当て
 「決定」ボタンを選択してください。</select_enter_button>

--- a/lang/system/ko.xml
+++ b/lang/system/ko.xml
@@ -306,6 +306,9 @@ Vita3K를 즐기러 GOGO!</completed_setup>
 	</live_area>
 
 	<settings name="설정">
+		<sound_display name="사운드 & 디스플레이">
+			<system_music>시스템 음악</system_music>
+		</sound_display>
 		<theme_background name="테마 & 배경">
 			<default>오리지널</default>
 			<theme name="테마">
@@ -363,6 +366,8 @@ Vita3K를 즐기러 GOGO!</completed_setup>
 	</settings>
 
 	<settings_dialog name="설정">
+		<camera name="카메라">
+		</camera>
 		<system name="시스템">
 		</system>
 		<network name="네트워크">

--- a/lang/system/nl.xml
+++ b/lang/system/nl.xml
@@ -289,6 +289,9 @@ Je Vita3K-systeem is gereed!</completed_setup>
 	</live_area>
 
 	<settings name="Instellingen">
+		<sound_display name="Geluid en weergave">
+			<system_music>Systeemmuziek</system_music>
+		</sound_display>
 		<theme_background name="Thema en achtergrond">
 			<default>Standaard</default>
 			<theme name="Thema">
@@ -346,6 +349,8 @@ Je Vita3K-systeem is gereed!</completed_setup>
 	</settings>
 
 	<settings_dialog name="Instellingen">
+		<camera name="Camera">
+		</camera>
 		<system name="Systeem">
 		</system>
 		<network name="Netwerk">

--- a/lang/system/no.xml
+++ b/lang/system/no.xml
@@ -269,6 +269,9 @@ Vita3K-systemet ditt er klart!</completed_setup>
 	</live_area>
 	
 	<settings name="Innstillinger">
+		<sound_display name="Lyd og visning">
+			<system_music>Systemmusikk</system_music>
+		</sound_display>
 		<theme_background name="Tema og bakgrunn">
 			<default>Standard</default>
 			<theme name="Tema">
@@ -326,6 +329,8 @@ Vita3K-systemet ditt er klart!</completed_setup>
 	</settings>
 
 	<settings_dialog name="Innstillinger">
+		<camera name="Kamera">
+		</camera>
 		<system name="System">
 		</system>
 		<network name="Nettverk">

--- a/lang/system/pl.xml
+++ b/lang/system/pl.xml
@@ -550,6 +550,9 @@ Sprawdź plik vita3k.log, aby zobaczyć szczegóły na konsoli.
 	</performance_overlay>
 	
 	<settings name="Ustawienia">
+		<sound_display name="Dźwięk i ekran">
+			<system_music>Muzyka w systemie</system_music>
+		</sound_display>
 		<theme_background name="Motyw i tło">
 			<default>Domyślnie</default>
 			<theme name="Motyw">
@@ -690,6 +693,8 @@ W innych grach może to nie mieć żadnego efektu lub spowodować, że będą dz
 			<enable_ngs_support>Włącz wsparcie dla NGS</enable_ngs_support>
 			<ngs_description>Odznacz, aby wyłączyć wsparcie dla zaawansowanej biblioteki dzwięków NGS.</ngs_description>
 		</audio>
+		<camera name="Kamera">
+		</camera>
 		<system name="System">
 			<select_enter_button>Przypisanie przycisku potwierdzenia
 Wybierz swój przycisk potwierdzenia.</select_enter_button>

--- a/lang/system/pt-br.xml
+++ b/lang/system/pt-br.xml
@@ -346,6 +346,9 @@ durante o uso do aplicativo</show_hide>
 	</live_area>
 
 	<settings name="Configurações">
+		<sound_display name="Som e imagem">
+			<system_music>Música do sistema</system_music>
+		</sound_display>
 		<theme_background name="Tema e fundo">
 			<default>Padrão</default>
 			<theme name="Tema">
@@ -409,6 +412,8 @@ fundo</add_background>
 	</settings>
 
 	<settings_dialog name="Configurações">
+		<camera name="Câmera">
+		</camera>
 		<system name="Sistema">
 		</system>
 		<network name="Rede">

--- a/lang/system/pt.xml
+++ b/lang/system/pt.xml
@@ -272,6 +272,9 @@ O seu sistema Vita3K está pronto!</completed_setup>
 	</live_area>
 
 	<settings name="Definições">
+		<sound_display name="Som e apresentação">
+			<system_music>Música do sistema</system_music>
+		</sound_display>
 		<theme_background name="Tema e fundo">
 			<default>Predefinição</default>
 			<theme name="Tema">
@@ -329,6 +332,8 @@ O seu sistema Vita3K está pronto!</completed_setup>
 	</settings>
 
 	<settings_dialog name="Definições">
+		<camera name="Câmara">
+		</camera>
 		<system name="Sistema">
 		</system>
 		<network name="Rede">

--- a/lang/system/ru.xml
+++ b/lang/system/ru.xml
@@ -529,6 +529,9 @@
 	</performance_overlay>
 
 	<settings name="Настройки">
+		<sound_display name="Звук и изображение">
+			<system_music>Фоновая музыка системы</system_music>
+		</sound_display>
 		<theme_background name="Тема и Фон">
 			<default>По умолчанию</default>
 			<theme name="Тема">

--- a/lang/system/sv.xml
+++ b/lang/system/sv.xml
@@ -273,6 +273,9 @@ Tryck på 'Ge Åtkomst' för att fortsätta.</storage_file_permissions>
 	</live_area>
 	
 	<settings name="Inställningar">
+		<sound_display name="Ljud och bildskärm">
+			<system_music>Systemmusik</system_music>
+		</sound_display>
 		<theme_background name="Tema och bakgrund">
 			<default>Standardinställning</default>
 			<theme name="Tema">
@@ -331,6 +334,8 @@ Tryck på 'Ge Åtkomst' för att fortsätta.</storage_file_permissions>
 	</settings>
 
 	<settings_dialog name="Inställningar">
+		<camera name="Kamera">
+		</camera>
 		<system name="System">
 		</system>
 		<network name="Nätverk">

--- a/lang/system/tr.xml
+++ b/lang/system/tr.xml
@@ -279,6 +279,9 @@ Devam etmek için 'Erişim Ver' düğmesine dokunun.</storage_file_permissions>
 	</live_area>
 
 	<settings name="Ayarlar">
+		<sound_display name="Ses & Görüntü">
+			<system_music>Sistem Müziği</system_music>
+		</sound_display>
 		<theme_background name="Tema & Arkaplan">
 			<default>Varsayılan</default>
 			<theme name="Tema">
@@ -336,6 +339,8 @@ Devam etmek için 'Erişim Ver' düğmesine dokunun.</storage_file_permissions>
 	</settings>
 
 	<settings_dialog name="Ayarlar">
+		<camera name="Kamera">
+		</camera>
 		<system name="Sistem">
 		</system>
 		<network name="Ağ">

--- a/lang/system/zh-s.xml
+++ b/lang/system/zh-s.xml
@@ -4,7 +4,7 @@
 	<main_menubar>
 		<file name="文件">
 			<open_pref_path>打开存放路径</open_pref_path>
-			<open_patch_path>打开补丁路径</open_patch_path>
+			<open_patches_path>打开补丁路径</open_patches_path>
 			<open_textures_path>打开纹理路径</open_textures_path>
 			<install_firmware>安装固件</install_firmware>
 			<install_pkg>安装pkg</install_pkg>
@@ -90,6 +90,7 @@
 			<delete_license>要删除此授权吗？</delete_license>
 		</delete>
 		<other name="其他">
+			<decrypt_all_self>解密全部SELF</decrypt_all_self>
 			<reset_last_time_played>重置最近游玩时间</reset_last_time_played>
 		</other>
 		<update_history>更新历史记录</update_history>
@@ -324,6 +325,7 @@
 	<controls>
 		<button>按键</button>
 		<mapped_button>映射按键</mapped_button>
+		<mapped_button_alt>备用映射按键</mapped_button_alt>
 		<left_stick_up>左摇杆上</left_stick_up>
 		<left_stick_down>左摇杆下</left_stick_down>
 		<left_stick_right>左摇杆右</left_stick_right>
@@ -472,6 +474,7 @@
 		<apps_list_grid_description>勾选此项将应用程序列表设置为像PS Vita一样的网格模式。</apps_list_grid_description>
 		<icon_size>应用程序图标大小</icon_size>
 		<select_icon_size>选择您喜欢的图标大小。</select_icon_size>
+		<system_music_description>此项可以稍后在系统设定应用程序中更改。</system_music_description>
 		<completed>已完成。</completed>
 		<next>继续</next>
 	</initial_setup>
@@ -492,6 +495,8 @@
 			<enter_zrif>输入zRIF</enter_zrif>
 			<enter_zrif_key>输入zRIF密钥</enter_zrif_key>
 			<input_zrif>请在此处输入您的zRIF</input_zrif>
+			<inputmethod_paste_zrif>使用输入法剪贴板复制粘贴。
+键盘：Ctrl+C复制，Ctrl+V粘贴。</inputmethod_paste_zrif>
 			<copy_paste_zrif>Ctrl+C复制，Ctrl+V粘贴。</copy_paste_zrif>
 			<delete_pkg>删除pkg文件？</delete_pkg>
 			<delete_bin_rif>删除work.bin/rif文件？</delete_bin_rif>
@@ -574,6 +579,9 @@
 	</performance_overlay>
 
 	<settings name="设定">
+		<sound_display name="声音& 显示器">
+			<system_music>系统音乐</system_music>
+		</sound_display>
 		<theme_background name="主题&背景">
 			<default>原始</default>
 			<theme name="主题">
@@ -728,6 +736,14 @@
 			<bgm_volume>背景音乐音量</bgm_volume>
 			<bgm_volume_description>调整主题背景音乐的音量百分比。</bgm_volume_description>
 		</audio>
+		<camera name="相机">
+			<front_camera>前置摄像头</front_camera>
+			<back_camera>后置摄像头</back_camera>
+			<image_not_set>图像未设置</image_not_set>
+			<set_image>设置图像</set_image>
+			<solid_color>纯色</solid_color>
+			<static_image>静态图像</static_image>
+		</camera>
 		<system name="系统">
 			<select_enter_button>确认按键分配
 请选择您的“确认”按键。</select_enter_button>

--- a/lang/system/zh-t.xml
+++ b/lang/system/zh-t.xml
@@ -4,7 +4,7 @@
 	<main_menubar>
 		<file name="檔案">
 			<open_pref_path>開啟存放路徑</open_pref_path>
-			<open_patch_path>開啟補丁路徑</open_patch_path>
+			<open_patches_path>開啟補丁路徑</open_patches_path>
 			<open_textures_path>開啟紋理路徑</open_textures_path>
 			<install_firmware>安裝韌體</install_firmware>
 			<install_pkg>安裝pkg</install_pkg>
@@ -89,7 +89,8 @@
 			<delete_addcont>確定要刪除此追加內容嗎？</delete_addcont>
 			<delete_license>確定要刪除此授權嗎？</delete_license>
 		</delete>
-		<other name="其他">
+		<other name="其它">
+			<decrypt_all_self>解密全部SELF</decrypt_all_self>
 			<reset_last_time_played>重設上次遊玩時間</reset_last_time_played>
 		</other>
 		<update_history>更新履歷</update_history>
@@ -324,6 +325,7 @@
 	<controls>
 		<button>按鈕</button>
 		<mapped_button>按鍵對應</mapped_button>
+		<mapped_button_alt>備用按鍵對應</mapped_button_alt>
 		<left_stick_up>左操作桿上</left_stick_up>
 		<left_stick_down>左操作桿下</left_stick_down>
 		<left_stick_right>左操作桿右</left_stick_right>
@@ -472,6 +474,7 @@
 		<apps_list_grid_description>勾選此項將應用程式列表設定為像PS Vita一樣的網格模式。</apps_list_grid_description>
 		<icon_size>應用程式圖標大小</icon_size>
 		<select_icon_size>選擇您喜歡的圖標大小。</select_icon_size>
+		<system_music_description>此項可以稍後在系統設定应用程式中變更。</system_music_description>
 		<completed>已完成。</completed>
 		<next>繼續</next>
 	</initial_setup>
@@ -492,6 +495,8 @@
 			<enter_zrif>輸入zRIF</enter_zrif>
 			<enter_zrif_key>輸入zRIF金鑰</enter_zrif_key>
 			<input_zrif>請在此處輸入您的zRIF</input_zrif>
+			<inputmethod_paste_zrif>使用輸入法剪貼板複製貼上。
+鍵盤：Ctrl+C複製，Ctrl+V貼上。</inputmethod_paste_zrif>
 			<copy_paste_zrif>Ctrl+C複製，Ctrl+V貼上。</copy_paste_zrif>
 			<delete_pkg>刪除pkg檔案？</delete_pkg>
 			<delete_bin_rif>刪除work.bin/rif檔案？</delete_bin_rif>
@@ -574,6 +579,9 @@
 	</performance_overlay>
 
 	<settings name="設定">
+		<sound_display name="聲音&顯示器">
+			<system_music>系統音樂</system_music>
+		</sound_display>
 		<theme_background name="主題&背景">
 			<default>原音</default>
 			<theme name="主題">
@@ -703,8 +711,8 @@
 			<external_host>外部主機</external_host>
 			<page_table>頁表</page_table>
 			<native_buffer>原生緩衝</native_buffer>
-			<mapping_method>內存映射方式</mapping_method>
-			<mapping_method_description>內存映射提高了性能，減少內存使用量，並修復了許多圖形問題。
+			<mapping_method>記憶體對映方式</mapping_method>
+			<mapping_method_description>記憶體對映提高了性能，減少記憶體使用量，並修復了許多圖形問題。
 但是它在某些GPU上可能不穩定。</mapping_method_description>
 			<turbo_mode>啟用睿頻模式</turbo_mode>
 			<turbo_mode_description>提供了一種方法提來强制GPU以允許的最高時鐘頻率運行（溫控仍然適用）。</turbo_mode_description>
@@ -728,6 +736,14 @@
 			<bgm_volume>背景音樂音量</bgm_volume>
 			<bgm_volume_description>調整主題背景音樂的音量百分比。</bgm_volume_description>
 		</audio>
+		<camera name="相機">
+			<front_camera>前置攝像頭</front_camera>
+			<back_camera>後置攝像頭</back_camera>
+			<image_not_set>圖像未設定</image_not_set>
+			<set_image>設定圖像</set_image>
+			<solid_color>純色</solid_color>
+			<static_image>靜態圖像</static_image>
+		</camera>
 		<system name="系統">
 			<select_enter_button>確認按鈕分配
 請選擇您的“確認”按鈕。</select_enter_button>

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -594,12 +594,12 @@ void delete_app(GuiState &gui, EmuEnvState &emuenv, const std::string &app_path)
         const auto SAVE_DATA_PATH{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "savedata" / APP_INDEX->savedata };
         if (fs::exists(SAVE_DATA_PATH))
             fs::remove_all(SAVE_DATA_PATH);
-        const auto PATCH_PATH{ emuenv.shared_path / "patch" / title_id };
+        const auto PATCHES_PATH{ emuenv.shared_path / "patch" / title_id };
+        if (fs::exists(PATCHES_PATH))
+            fs::remove_all(PATCHES_PATH);
+        const auto PATCH_PATH{ emuenv.pref_path / "ux0/patch" / title_id };
         if (fs::exists(PATCH_PATH))
             fs::remove_all(PATCH_PATH);
-        const auto ORIGIN_PATCH_PATH{ emuenv.pref_path / "ux0/patch" / title_id };
-        if (fs::exists(ORIGIN_PATCH_PATH))
-            fs::remove_all(ORIGIN_PATCH_PATH);
         const auto ADDCONT_PATH{ emuenv.pref_path / "ux0/addcont" / APP_INDEX->addcont };
         if (fs::exists(ADDCONT_PATH))
             fs::remove_all(ADDCONT_PATH);
@@ -673,7 +673,7 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
     const auto APP_PATH{ emuenv.pref_path / "ux0/app" / app_path };
     const auto CUSTOM_CONFIG_PATH{ emuenv.config_path / "config" / fmt::format("config_{}.xml", app_path) };
     const auto SAVE_DATA_PATH{ emuenv.pref_path / "ux0/user" / emuenv.io.user_id / "savedata" / APP_INDEX->savedata };
-    const auto PATCH_PATH{ emuenv.shared_path / "patch" / title_id };
+    const auto PATCHES_PATH{ emuenv.shared_path / "patch" / title_id };
     const auto ADDCONT_PATH{ emuenv.pref_path / "ux0/addcont" / APP_INDEX->addcont };
     const auto LICENSE_PATH{ emuenv.pref_path / "ux0/license" / title_id };
     const auto MANUAL_PATH{ APP_PATH / "sce_sys/manual" };
@@ -852,8 +852,8 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                     open_path(APP_PATH.string());
                 if (fs::exists(SAVE_DATA_PATH) && ImGui::MenuItem(savedata_str["title"].c_str()))
                     open_path(SAVE_DATA_PATH.string());
-                if (fs::exists(PATCH_PATH) && ImGui::MenuItem(lang.path["patch"].c_str()))
-                    open_path(PATCH_PATH.string());
+                if (fs::exists(PATCHES_PATH) && ImGui::MenuItem(lang.path["patch"].c_str()))
+                    open_path(PATCHES_PATH.string());
                 if (fs::exists(ADDCONT_PATH) && ImGui::MenuItem(lang.path["addcont"].c_str()))
                     open_path(ADDCONT_PATH.string());
                 if (fs::exists(LICENSE_PATH) && ImGui::MenuItem(lang.path["license"].c_str()))
@@ -886,7 +886,7 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
                     context_dialog = lang.deleting["delete_app"];
                 if (fs::exists(SAVE_DATA_PATH) && ImGui::MenuItem(savedata_str["title"].c_str()))
                     context_dialog = delete_saved_data;
-                if (fs::exists(PATCH_PATH) && ImGui::MenuItem(lang.path["patch"].c_str()))
+                if (fs::exists(PATCHES_PATH) && ImGui::MenuItem(lang.path["patch"].c_str()))
                     context_dialog = lang.deleting["delete_patch"];
                 if (fs::exists(ADDCONT_PATH) && ImGui::MenuItem(lang.path["addcont"].c_str()))
                     context_dialog = lang.deleting["delete_addcont"];
@@ -904,7 +904,7 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
             }
 
             if (ImGui::BeginMenu(lang.other["title"].c_str())) {
-                if (ImGui::MenuItem("Decrypt all SELF")) {
+                if (ImGui::MenuItem(lang.other["decrypt_all_self"].c_str())) {
                     if (!emuenv.license.rif.contains(title_id))
                         get_license(emuenv, title_id, APP_INDEX->content_id);
                     decrypt_selfs(APP_PATH, emuenv.cache_path, emuenv.license.rif[title_id].key);
@@ -1000,7 +1000,7 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
             if (context_dialog == delete_saved_data)
                 fs::remove_all(SAVE_DATA_PATH);
             if (context_dialog == lang.deleting["delete_patch"])
-                fs::remove_all(PATCH_PATH);
+                fs::remove_all(PATCHES_PATH);
             if (context_dialog == lang.deleting["delete_addcont"])
                 fs::remove_all(ADDCONT_PATH);
             else if (context_dialog == lang.deleting["delete_license"])

--- a/vita3k/gui/src/archive_install_dialog.cpp
+++ b/vita3k/gui/src/archive_install_dialog.cpp
@@ -100,7 +100,7 @@ void draw_archive_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::BeginChild("##archive_Install_child", WINDOW_SIZE, ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings);
     const auto POS_BUTTON = (ImGui::GetWindowWidth() / 2.f) - (BUTTON_SIZE.x / 2.f) + (10.f * SCALE.x);
     ImGui::SetWindowFontScale(RES_SCALE.x);
-    TextColoredCentered(GUI_COLOR_TEXT_MENUBAR, title.c_str());
+    TextColoredCentered(GUI_COLOR_TEXT_TITLE, title.c_str());
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -270,7 +270,7 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Spacing();
         if (ImGui::Checkbox(gui.lang.settings.sound_display["system_music"].c_str(), &emuenv.cfg.system_music.value()))
             bgm_player::switch_bgm_state(!emuenv.cfg.system_music.value());
-        SetTooltipEx("This option can be changed later in the system Settings app.");
+        SetTooltipEx(lang["system_music_description"].c_str());
         if (emuenv.cfg.system_music.value()) {
             ImGui::Spacing();
             if (ImGui::SliderInt(gui.lang.settings_dialog.audio["bgm_volume"].c_str(), &emuenv.cfg.bgm_volume, 0, 100, "%d %%", ImGuiSliderFlags_AlwaysClamp))

--- a/vita3k/gui/src/license_install_dialog.cpp
+++ b/vita3k/gui/src/license_install_dialog.cpp
@@ -48,7 +48,7 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const auto RES_SCALE = ImVec2(emuenv.gui_scale.x, emuenv.gui_scale.y);
     const auto SCALE = ImVec2(RES_SCALE.x * emuenv.manual_dpi_scale, RES_SCALE.y * emuenv.manual_dpi_scale);
     const auto BUTTON_SIZE = ImVec2(180.f * SCALE.x, 45.f * SCALE.y);
-    const auto WINDOW_SIZE = ImVec2(616.f * SCALE.x, 264.f * SCALE.y);
+    const auto WINDOW_SIZE = ImVec2(616.f * SCALE.x, 240.f * SCALE.y);
 
     ImGui::SetNextWindowPos(ImVec2(emuenv.logical_viewport_pos.x, emuenv.logical_viewport_pos.y), ImGuiCond_Always);
     ImGui::SetNextWindowSize(display_size);
@@ -69,6 +69,7 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         title = license["select_license_type"];
         if (ImGui::Button(license["select_bin_rif"].c_str(), BUTTON_SIZE))
             state = State::LICENSE;
+        ImGui::Spacing();
         ImGui::SetCursorPosX(POS_BUTTON);
         if (ImGui::Button(license["enter_zrif"].c_str(), BUTTON_SIZE))
             state = State::ZRIF;
@@ -101,7 +102,11 @@ void draw_license_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::PushItemWidth(640.f * SCALE.x);
         ImGui::InputTextWithHint("##enter_zrif", license["input_zrif"].c_str(), &zRIF);
         ImGui::PopItemWidth();
+#ifdef __ANDROID__
+        SetTooltipEx(license["inputmethod_paste_zrif"].c_str());
+#else
         SetTooltipEx(license["copy_paste_zrif"].c_str());
+#endif
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -27,14 +27,14 @@ namespace gui {
 
 static void draw_file_menu(GuiState &gui, EmuEnvState &emuenv) {
     auto &lang = gui.lang.main_menubar.file;
-    const auto PATCH_PATH{ emuenv.shared_path / "patch" };
+    const auto PATCHES_PATH{ emuenv.shared_path / "patch" };
     const auto TEXTURES_PATH{ emuenv.shared_path / "textures" };
     if (ImGui::BeginMenu(lang["title"].c_str())) {
 #ifndef __ANDROID__
         if (ImGui::MenuItem(lang["open_pref_path"].c_str()))
             open_path(emuenv.pref_path.string());
-        if (ImGui::MenuItem(lang["open_patch_path"].c_str()))
-            open_path(PATCH_PATH.string());
+        if (ImGui::MenuItem(lang["open_patches_path"].c_str()))
+            open_path(PATCHES_PATH.string());
         if (ImGui::MenuItem(lang["open_textures_path"].c_str())) {
             if (!fs::exists(TEXTURES_PATH)) {
                 fs::create_directories(TEXTURES_PATH);
@@ -110,6 +110,7 @@ static void draw_emulation_menu(GuiState &gui, EmuEnvState &emuenv) {
     }
 }
 
+#ifndef __ANDROID__
 static void draw_debug_menu(GuiState &gui, DebugMenuState &state) {
     auto &lang = gui.lang.main_menubar.debug;
     if (ImGui::BeginMenu(lang["title"].c_str())) {
@@ -125,6 +126,7 @@ static void draw_debug_menu(GuiState &gui, DebugMenuState &state) {
         ImGui::EndMenu();
     }
 }
+#endif
 
 static void draw_config_menu(GuiState &gui, EmuEnvState &emuenv) {
     auto &lang = gui.lang.main_menubar.configuration;
@@ -171,7 +173,9 @@ void draw_main_menu_bar(GuiState &gui, EmuEnvState &emuenv) {
 
         draw_file_menu(gui, emuenv);
         draw_emulation_menu(gui, emuenv);
+#ifndef __ANDROID__
         draw_debug_menu(gui, gui.debug_menu);
+#endif
         draw_config_menu(gui, emuenv);
         draw_controls_menu(gui);
         draw_help_menu(gui);

--- a/vita3k/gui/src/pkg_install_dialog.cpp
+++ b/vita3k/gui/src/pkg_install_dialog.cpp
@@ -98,9 +98,10 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 display_size(emuenv.logical_viewport_size.x, emuenv.logical_viewport_size.y);
     const ImVec2 RES_SCALE(emuenv.gui_scale.x, emuenv.gui_scale.y);
     const ImVec2 SCALE(RES_SCALE.x * emuenv.manual_dpi_scale, RES_SCALE.y * emuenv.manual_dpi_scale);
-    const ImVec2 WINDOW_SIZE(616.f * SCALE.x, 264.f * SCALE.y);
     const ImVec2 BUTTON_SIZE(180.f * SCALE.x, 45.f * SCALE.y);
+    const ImVec2 WINDOW_SIZE(616.f * SCALE.x, 264.f * SCALE.y);
 
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 10.f * SCALE.x);
     ImGui::SetNextWindowPos(ImVec2(emuenv.logical_viewport_pos.x + (display_size.x / 2.f) - (WINDOW_SIZE.x / 2), emuenv.logical_viewport_pos.y + (display_size.y / 2.f) - (WINDOW_SIZE.y / 2.f)), ImGuiCond_Always);
     ImGui::SetNextWindowSize(WINDOW_SIZE);
     if (ImGui::BeginPopupModal("install", &gui.file_menu.pkg_install_dialog, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration)) {
@@ -116,6 +117,7 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             title = lang["select_license_type"];
             if (ImGui::Button(lang["select_bin_rif"].c_str(), BUTTON_SIZE))
                 state = State::LICENSE;
+            ImGui::Spacing();
             ImGui::SetCursorPosX(POS_BUTTON);
             if (ImGui::Button(lang["enter_zrif"].c_str(), BUTTON_SIZE))
                 state = State::ZRIF;
@@ -147,7 +149,11 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::PushItemWidth(640.f * SCALE.x);
             ImGui::InputTextWithHint("##enter_zrif", lang["input_zrif"].c_str(), &zRIF);
             ImGui::PopItemWidth();
+#ifdef __ANDROID__
+            SetTooltipEx(lang["inputmethod_paste_zrif"].c_str());
+#else
             SetTooltipEx(lang["copy_paste_zrif"].c_str());
+#endif
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();
@@ -241,6 +247,7 @@ void draw_pkg_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
             ImGui::PopStyleColor();
         }
         }
+        ImGui::PopStyleVar();
         ImGui::EndPopup();
     }
 }

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -357,6 +357,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.f, 0.5f));
         if (ImGui::Selectable(sound_display["title"].c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, SIZE_SELECT)))
             settings_menu = SettingsMenu::SOUND_DISPLAY;
+        ImGui::Separator();
         if (ImGui::Selectable(theme_background.main["title"].c_str(), false, ImGuiSelectableFlags_None, ImVec2(0.f, SIZE_SELECT))) {
             get_themes_list(gui, emuenv);
             settings_menu = SettingsMenu::THEME_BACKGROUND;

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -103,7 +103,7 @@ struct LangState {
         std::map<std::string, std::string> file = {
             { "title", "File" },
             { "open_pref_path", "Open Pref Path" },
-            { "open_patch_path", "Open Patch Path" },
+            { "open_patches_path", "Open Patch Path" },
             { "open_textures_path", "Open Textures Path" },
             { "install_firmware", "Install Firmware" },
             { "install_pkg", "Install .pkg" },
@@ -200,6 +200,7 @@ struct LangState {
         };
         std::map<std::string, std::string> other = {
             { "title", "Other" },
+            { "decrypt_all_self", "Decrypt all SELF" },
             { "reset_last_time_played", "Reset Last Time Played" }
         };
         std::map<std::string, std::string> info = {
@@ -395,6 +396,7 @@ struct LangState {
         { "apps_list_grid_description", "Check the box to set the app list to grid mode like of PS Vita." },
         { "icon_size", "App Icon Size" },
         { "select_icon_size", "Select your preferred icon size." },
+        { "system_music_description", "This option can be changed later in the system Settings app." },
         { "completed", "Completed." },
         { "next", "Next" }
     };
@@ -414,6 +416,7 @@ struct LangState {
             { "enter_zrif", "Enter zRIF" },
             { "enter_zrif_key", "Enter zRIF key" },
             { "input_zrif", "Please input your zRIF here" },
+            { "inputmethod_paste_zrif", "Use the input method clipboard to copy and paste.\nKeyboard: Ctrl + C to copy, Ctrl + V to paste." },
             { "copy_paste_zrif", "Ctrl + C to copy, Ctrl + V to paste." },
             { "delete_pkg", "Delete the pkg file?" },
             { "delete_bin_rif", "Delete the work.bin/rif file?" },


### PR DESCRIPTION
- gui/app_context_menu & main_menubar: Corrected the `patch_path` rename to `patches_path`, the `origin_patch_path` rename to `patch_path`.
- gui/pkg_install_dialog & license_install_dialog: Tiny adjust the dialog, added the `inputmethod_paste_zrif` description when paste the zrif key on Android.
- gui/settings: Fixed a missing separator.
- lang: Updated the translations.