### PR TITLE
vita3k/config: Changed the BGM disabled by default

### DIFF
--- a/vita3k/gui/include/gui/state.h
+++ b/vita3k/gui/include/gui/state.h
@@ -186,7 +186,7 @@ struct User {
     std::string avatar = "default";
     gui::SortType sort_apps_type = gui::TITLE;
     gui::SortState sort_apps_state = gui::ASCENDANT;
-    bool system_music = true;
+    bool system_music = false;
     std::string theme_id = "default";
     bool use_theme_bg = true;
     std::string start_type = "default";

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -328,9 +328,9 @@ int main(int argc, char *argv[]) {
         gui::pre_init(gui, emuenv);
         gui::init_bgm_player(emuenv.cfg.bgm_volume);
         if (!emuenv.cfg.initial_setup) {
-            emuenv.cfg.system_music.emplace(true);
+            emuenv.cfg.system_music.emplace(false);
             if (gui::init_bgm(gui, emuenv))
-                gui::switch_bgm_state(false);
+                gui::switch_bgm_state(true);
             while (!emuenv.cfg.initial_setup) {
                 wait_for_frame_done();
                 if (handle_events(emuenv, gui)) {


### PR DESCRIPTION
As [macdu said](https://github.com/Vita3K/Vita3K/pull/3411#issuecomment-2439723570), this should clearly be disabled by default.
Also, there's a bug where it clacking sound if the at9 file path is invalid, which is extremely frustrating.
