### PR TITLE
renderer/vulkan: Drain VK wait thread queue in sceGxmFinish

### DIFF
--- a/vita3k/renderer/src/sync.cpp
+++ b/vita3k/renderer/src/sync.cpp
@@ -25,6 +25,7 @@
 #include <renderer/gl/functions.h>
 #include <renderer/vulkan/functions.h>
 #include <renderer/vulkan/state.h>
+#include <renderer/vulkan/types.h>
 
 #include <renderer/functions.h>
 #include <util/tracy.h>
@@ -95,9 +96,12 @@ void finish(State &state, Context *context) {
     // Add NOP then wait for it
     renderer::send_single_command(state, context, renderer::CommandOpcode::Nop, true, 1);
 
-    // Wait for the VK wait thread to drain pending notification writes.
+    // Wait for the VK wait thread to finish processing all pending requests.
+    // Push a dummy request then wait for the queue to drain, ensuring the last
+    // real request has been fully processed (not just dequeued).
     if (state.current_backend == Backend::Vulkan) {
-        auto &vk_state = reinterpret_cast<vulkan::VKState &>(state);
+        auto &vk_state = static_cast<vulkan::VKState &>(state);
+        vk_state.request_queue.push(vulkan::CallbackRequest{ nullptr });
         vk_state.request_queue.wait_empty();
     }
 }


### PR DESCRIPTION
`renderer::finish()` only waited for the renderer command thread (via Nop), but the VK wait thread that writes notification values after GPU fences runs asynchronously. This let `sceGxmFinish` return before notifications were fully written, so late writes could overwrite values the game already reset, causing deadlocks on scene transitions.

Fixes Sly Cooper: Thieves in Time (PCSF00270 / PCSA00097) black screen on Vulkan during scene transitions.

Tested on Linux x86, plays through intro and into Episode 1 with no issues.