### PR TITLE
renderer: Improve transfer operation flow

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -5435,6 +5435,7 @@ EXPORT(int, sceGxmTransferFill, uint32_t fillColor, SceGxmTransferFormat destFor
 EXPORT(int, sceGxmTransferFinish) {
     TRACY_FUNC(sceGxmTransferFinish);
     // same as sceGxmFinish
+    renderer::wait_for_transfer_ops(*emuenv.renderer);
     renderer::finish(*emuenv.renderer, nullptr);
 
     return 0;

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -85,6 +85,9 @@ void draw(State &state, Context *ctx, SceGxmPrimitiveType prim_type, SceGxmIndex
 void transfer_copy(State &state, uint32_t colorKeyValue, uint32_t colorKeyMask, SceGxmTransferColorKeyMode colorKeyMode, const SceGxmTransferImage *images, SceGxmTransferType srcType, SceGxmTransferType destType);
 void transfer_downscale(State &state, const SceGxmTransferImage *src, const SceGxmTransferImage *dest);
 void transfer_fill(State &state, uint32_t fillColor, const SceGxmTransferImage *dest);
+void start_transfer_op(State &state);
+void finish_transfer_op(State &state);
+void wait_for_transfer_ops(State &state);
 void sync_surface_data(State &state, Context *ctx, const SceGxmNotification vertex_notification, const SceGxmNotification fragment_notification);
 
 bool create_context(State &state, std::unique_ptr<Context> &context);

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -22,6 +22,7 @@
 #include <renderer/types.h>
 #include <threads/queue.h>
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <string_view>
@@ -79,6 +80,10 @@ struct State {
 
     std::condition_variable notification_ready;
     std::mutex notification_mutex;
+
+    std::atomic<uint32_t> pending_transfer_ops{ 0 };
+    std::condition_variable transfer_ops_done;
+    std::mutex transfer_ops_mutex;
 
     std::vector<ShadersHash> shaders_cache_hashs;
     std::string shader_version;


### PR DESCRIPTION
# About
- renderer: Improve transfer operation flow
Fix crash when app runs transfer finish during an operation.


# Result
- fix one game crashing when it start transferdownscaling and call transfer finish just after, causing crash on ptr get unmaped