### PR TITLE
renderer: Fix renderer finish on vulkan without memory mapping

### DIFF
--- a/vita3k/renderer/src/sync.cpp
+++ b/vita3k/renderer/src/sync.cpp
@@ -16,6 +16,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <chrono>
+#include <future>
 #include <renderer/commands.h>
 #include <renderer/driver_functions.h>
 #include <renderer/state.h>
@@ -97,12 +98,15 @@ void finish(State &state, Context *context) {
     renderer::send_single_command(state, context, renderer::CommandOpcode::Nop, true, 1);
 
     // Wait for the VK wait thread to finish processing all pending requests.
-    // Push a dummy request then wait for the queue to drain, ensuring the last
-    // real request has been fully processed (not just dequeued).
-    if (state.current_backend == Backend::Vulkan) {
+    // Push a callback request on the queue and wait for it to be treated
+    if (state.current_backend == Backend::Vulkan && state.features.enable_memory_mapping) {
         auto &vk_state = static_cast<vulkan::VKState &>(state);
-        vk_state.request_queue.push(vulkan::CallbackRequest{ nullptr });
-        vk_state.request_queue.wait_empty();
+        std::promise<void> promise;
+        auto callback = [&]() {
+            promise.set_value();
+        };
+        vk_state.request_queue.push(vulkan::CallbackRequest{ new vulkan::CallbackRequestFunction(callback) });
+        promise.get_future().wait();
     }
 }
 


### PR DESCRIPTION
The request queue is only used when memory mapping is enabled with Vulkan (otherwise it behaves like opengl). So correct this for the `renderer::finish` function.
I also modified this function to wait for the callback to be processed instead of the queue to be empty. This could prevent the guest thread from waiting arbitrarily long if another thread keeps submitting gpu loads (don't think it would ever happen but might as well handle this case).