### PR TITLE
ngs: Calling sceNgsVoiceResume on a non-paused voice is a no-op

### DIFF
--- a/vita3k/modules/SceNgsUser/SceNgs.cpp
+++ b/vita3k/modules/SceNgsUser/SceNgs.cpp
@@ -962,7 +962,7 @@ EXPORT(int, sceNgsVoiceResume, ngs::Voice *voice) {
     }
 
     if (!voice->is_paused)
-        return RET_ERROR(SCE_NGS_ERROR_INVALID_STATE);
+        return SCE_NGS_OK;
 
     if (!voice->rack->system->voice_scheduler.resume(emuenv.mem, voice)) {
         return RET_ERROR(SCE_NGS_ERROR);


### PR DESCRIPTION
Currently calling `sceNgsVoiceResume` on a non-paused voice will return a `SCE_NGS_ERROR_INVALID_STATE`  error, but based on my own RE of `sceNgsVoiceResume` and `sceNgsVoiceResumeInternal` I'm confident it is actually a no-op.

This simple change brings games from Dramatic Create (a VN Porter) like [Monobeno -pure smile-](https://github.com/Vita3K/compatibility/issues/1019) and [Orfleurs: Koufuku no Hanataba](https://github.com/Vita3K/compatibility/issues/1948) from `Menu` to `Ingame +`. The main issue remaining is quite a few graphical glitches during transitions and the like.