### PR TITLE
mem&util/log: Bugfixes for log utils

### DIFF
--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -583,7 +583,7 @@ static void signal_handler(int sig, siginfo_t *info, void *uct) noexcept {
         }
     }
 
-    LOG_CRITICAL("Unhandled access to {}", log_hex(*reinterpret_cast<uint64_t *>(&info->si_addr)));
+    LOG_CRITICAL("Unhandled access to 0x{:X}", reinterpret_cast<uintptr_t>(info->si_addr));
     raise(SIGTRAP);
     return;
 }

--- a/vita3k/util/include/util/log.h
+++ b/vita3k/util/include/util/log.h
@@ -36,11 +36,7 @@
 #define LOG_ERROR SPDLOG_ERROR
 #define LOG_CRITICAL SPDLOG_CRITICAL
 
-#define LOG_IF(log_function, flag, ...) \
-    do {                                \
-        if (flag)                       \
-            log_function(__VA_ARGS__);  \
-    } while (0)
+#define LOG_IF(log_function, flag, ...) ((flag) ? log_function(__VA_ARGS__) : static_cast<void>(0))
 
 #define LOG_TRACE_IF(flag, ...) LOG_IF(LOG_TRACE, flag, __VA_ARGS__)
 #define LOG_DEBUG_IF(flag, ...) LOG_IF(LOG_DEBUG, flag, __VA_ARGS__)

--- a/vita3k/util/src/logging.cpp
+++ b/vita3k/util/src/logging.cpp
@@ -78,7 +78,12 @@ ExitCode init(const Root &root_paths, bool use_stdout) {
     static std::terminate_handler old_terminate = nullptr;
     old_terminate = std::set_terminate([]() {
         try {
-            std::rethrow_exception(std::current_exception());
+            auto eptr = std::current_exception();
+            if (eptr) {
+                std::rethrow_exception(eptr);
+            } else {
+                LOG_CRITICAL("Unhandled 'std::terminate()' call");
+            }
         } catch (const std::exception &e) {
             LOG_CRITICAL("Unhandled C++ exception. {}", e.what());
         } catch (...) {


### PR DESCRIPTION
- Avoid dereferencing the address of `si_addr` after converting it to `uint64_t *`.

`si_addr` has the type `void *` and should be cast directly to `uintptr_t`, even though we currently only have 64-bit builds.

---

- Prohibit to use initialization expressions when using `LOG_XXX_IF`.

Consider the following code:
```cpp
// Expands to:
// do {
//     if (int a = 1234; a > 0)
//         LOG_DEBUG("test");
// } while (0);
LOG_DEBUG_IF(int a = 1234; a > 0, "test");
```
or
```cpp
// Expands to:
// do {
//     if (int b = 5678)
//         LOG_DEBUG("test");
// } while (0);
LOG_DEBUG_IF(int b = 5678, "test");
```
Both are valid C++ code, because C++ allows variables to be declared within `if` conditions; however, declaring variables within the parameters of function-like macros looks very strange.

---

- Handle null exception pointer in terminate handler.