### PR TITLE
mem: split host/guest page sizes to support 16kib page devices

### DIFF
--- a/vita3k/cpu/src/dynarmic_cpu.cpp
+++ b/vita3k/cpu/src/dynarmic_cpu.cpp
@@ -130,11 +130,11 @@ public:
     template <typename T>
     T MemoryRead(Dynarmic::A32::VAddr addr) {
         Ptr<T> ptr{ addr };
-        if (!ptr || !ptr.valid(*parent->mem) || ptr.address() < parent->mem->page_size) {
+        if (!ptr || !ptr.valid(*parent->mem) || ptr.address() < parent->mem->host_page_size) {
             LOG_ERROR("Invalid read of uint{}_t at address: 0x{:x}\n{}", sizeof(T) * 8, addr, this->cpu->save_context().description());
 
             auto pc = this->cpu->get_pc();
-            if (pc < parent->mem->page_size)
+            if (pc < parent->mem->host_page_size)
                 LOG_CRITICAL("PC is 0x{:x}", pc);
             else
                 LOG_ERROR("Executing: {}", disassemble(*parent, pc, nullptr));
@@ -167,11 +167,11 @@ public:
     template <typename T>
     void MemoryWrite(Dynarmic::A32::VAddr addr, T value) {
         Ptr<T> ptr{ addr };
-        if (!ptr || !ptr.valid(*parent->mem) || ptr.address() < parent->mem->page_size) {
+        if (!ptr || !ptr.valid(*parent->mem) || ptr.address() < parent->mem->host_page_size) {
             LOG_ERROR("Invalid write of uint{}_t at addr: 0x{:x}, val = 0x{:x}\n{}", sizeof(T) * 8, addr, value, this->cpu->save_context().description());
 
             auto pc = this->cpu->get_pc();
-            if (pc < parent->mem->page_size)
+            if (pc < parent->mem->host_page_size)
                 LOG_CRITICAL("PC is 0x{:x}", pc);
             else
                 LOG_ERROR("Executing: {}", disassemble(*parent, pc, nullptr));
@@ -203,11 +203,11 @@ public:
     template <typename T>
     bool MemoryWriteExclusive(Dynarmic::A32::VAddr addr, T value, T expected) {
         Ptr<T> ptr{ addr };
-        if (!ptr || !ptr.valid(*parent->mem) || ptr.address() < parent->mem->page_size) {
+        if (!ptr || !ptr.valid(*parent->mem) || ptr.address() < parent->mem->host_page_size) {
             LOG_ERROR("Invalid exclusive write of uint{}_t at addr: 0x{:x}, val = 0x{:x}, expected = 0x{:x}\n{}", sizeof(T) * 8, addr, value, expected, this->cpu->save_context().description());
 
             auto pc = this->cpu->get_pc();
-            if (pc < parent->mem->page_size)
+            if (pc < parent->mem->host_page_size)
                 LOG_CRITICAL("PC is 0x{:x}", pc);
             else
                 LOG_ERROR("Executing: {}", disassemble(*parent, pc, nullptr));

--- a/vita3k/gdbstub/src/gdb.cpp
+++ b/vita3k/gdbstub/src/gdb.cpp
@@ -340,7 +340,7 @@ static bool check_memory_region(Address address, Address length, MemState &mem) 
 
     Address it = address;
     bool valid = true;
-    for (; it < address + length; it += mem.page_size) {
+    for (; it < address + length; it += mem.host_page_size) {
         if (!is_valid_addr(mem, it)) {
             valid = false;
             break;

--- a/vita3k/io/src/state_functions.cpp
+++ b/vita3k/io/src/state_functions.cpp
@@ -26,6 +26,16 @@
 
 #include <io/state.h>
 
+static const uint32_t page_size = []() -> uint32_t {
+#ifdef _WIN32
+    SYSTEM_INFO system_info = {};
+    GetSystemInfo(&system_info);
+    return system_info.dwPageSize;
+#else
+    return static_cast<uint32_t>(sysconf(_SC_PAGESIZE));
+#endif
+}();
+
 SceOff FileStats::read(void *input_data, const int element_size, const SceSize element_count) const {
     if (!wrapped_file)
         return -1;
@@ -38,7 +48,7 @@ SceOff FileStats::read(void *input_data, const int element_size, const SceSize e
     // so set 1 byte to 0 in all pages to trigger all possible pagefaults in this range
     // todo: call a mem function to check this instead
     volatile uint8_t *input_addr = reinterpret_cast<volatile uint8_t *>(input_data);
-    for (int i = 0; i < element_size * element_count; i += 0x1000)
+    for (int i = 0; i < element_size * element_count; i += page_size)
         input_addr[i] = 0;
     input_addr[element_size * element_count - 1] = 0;
 

--- a/vita3k/mem/include/mem/state.h
+++ b/vita3k/mem/include/mem/state.h
@@ -66,7 +66,7 @@ struct MemState {
     std::mutex generation_mutex;
     std::mutex protect_mutex;
 
-    uint32_t page_size = 0;
+    uint32_t host_page_size = 0;
     Memory memory;
     AllocPageTable alloc_table;
     BitmapAllocator allocator;

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -66,14 +66,12 @@ bool init(MemState &state, const bool use_page_table) {
 #ifdef _WIN32
     SYSTEM_INFO system_info = {};
     GetSystemInfo(&system_info);
-    state.page_size = system_info.dwPageSize;
+    state.host_page_size = system_info.dwPageSize;
 #else
-    state.page_size = static_cast<int>(sysconf(_SC_PAGESIZE));
+    state.host_page_size = static_cast<int>(sysconf(_SC_PAGESIZE));
 #endif
-    state.page_size = std::max(STANDARD_PAGE_SIZE, state.page_size);
 
-    assert(state.page_size >= 4096); // Limit imposed by Unicorn.
-    assert(!use_page_table || state.page_size == KiB(4));
+    assert(state.host_page_size >= 4096); // Limit imposed by Unicorn.
 
     void *preferred_address = reinterpret_cast<void *>(1ULL << 34);
 
@@ -102,7 +100,7 @@ bool init(MemState &state, const bool use_page_table) {
     }
 #endif
 
-    const size_t table_length = TOTAL_MEM_SIZE / state.page_size;
+    const size_t table_length = TOTAL_MEM_SIZE / STANDARD_PAGE_SIZE;
     state.alloc_table = AllocPageTable(new AllocMemPage[table_length]);
     memset(state.alloc_table.get(), 0, sizeof(AllocMemPage) * table_length);
 
@@ -113,14 +111,14 @@ bool init(MemState &state, const bool use_page_table) {
     };
     register_access_violation_handler(handler);
 
-    const Address null_address = alloc_inner(state, 0, 1, "null", true);
+    const Address null_address = alloc_inner(state, 0, state.host_page_size / STANDARD_PAGE_SIZE, "null", true);
     assert(null_address == 0);
 #ifdef _WIN32
     DWORD old_protect = 0;
-    const BOOL ret = VirtualProtect(state.memory.get(), state.page_size, PAGE_NOACCESS, &old_protect);
+    const BOOL ret = VirtualProtect(state.memory.get(), state.host_page_size, PAGE_NOACCESS, &old_protect);
     LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", get_error_msg());
-#elif !defined(__ANDROID__)
-    const int ret = mprotect(state.memory.get(), state.page_size, PROT_NONE);
+#else
+    const int ret = mprotect(state.memory.get(), state.host_page_size, PROT_NONE);
     LOG_CRITICAL_IF(ret == -1, "mprotect failed: {}", get_error_msg());
 #endif
 
@@ -146,13 +144,13 @@ static void delete_memory(uint8_t *memory) {
 }
 
 bool is_valid_addr(const MemState &state, Address addr) {
-    const uint32_t page_num = addr / state.page_size;
+    const uint32_t page_num = addr / STANDARD_PAGE_SIZE;
     return addr && state.allocator.free_slot_count(page_num, page_num + 1) == 0;
 }
 
 bool is_valid_addr_range(const MemState &state, Address start, Address end) {
-    const uint32_t start_page = start / state.page_size;
-    const uint32_t end_page = (end + state.page_size - 1) / state.page_size;
+    const uint32_t start_page = start / STANDARD_PAGE_SIZE;
+    const uint32_t end_page = (end + STANDARD_PAGE_SIZE - 1) / STANDARD_PAGE_SIZE;
     return state.allocator.free_slot_count(start_page, end_page) == 0;
 }
 
@@ -169,19 +167,23 @@ static Address alloc_inner(MemState &state, uint32_t start_page, uint32_t page_c
             return 0;
     }
 
-    const uint32_t size = page_count * state.page_size;
-    const Address addr = page_num * state.page_size;
-    uint8_t *const memory = &state.memory[addr];
+    const uint32_t size = page_count * STANDARD_PAGE_SIZE;
+    const Address addr = page_num * STANDARD_PAGE_SIZE;
+
+    const Address commit_start = align_down(addr, state.host_page_size);
+    const Address commit_end = align(addr + size, state.host_page_size);
+    const uint32_t commit_size = commit_end - commit_start;
+    uint8_t *const commit_ptr = &state.memory[commit_start];
 
     // Make memory chunk available to access
 #ifdef _WIN32
-    const void *const ret = VirtualAlloc(memory, size, MEM_COMMIT, PAGE_READWRITE);
+    const void *const ret = VirtualAlloc(commit_ptr, commit_size, MEM_COMMIT, PAGE_READWRITE);
     LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", get_error_msg());
 #else
-    const int ret = mprotect(memory, size, PROT_READ | PROT_WRITE);
+    const int ret = mprotect(commit_ptr, commit_size, PROT_READ | PROT_WRITE);
     LOG_CRITICAL_IF(ret == -1, "mprotect failed: {}", get_error_msg());
 #endif
-    std::memset(memory, 0, size);
+    std::memset(&state.memory[addr], 0, size);
 
     AllocMemPage &page = state.alloc_table[page_num];
     assert(!page.allocated);
@@ -200,11 +202,11 @@ Address alloc_aligned(MemState &state, uint32_t size, const char *name, unsigned
         return alloc(state, size, name, start_addr);
     const std::lock_guard<std::mutex> lock(state.generation_mutex);
     size += alignment;
-    const uint32_t page_count = align(size, state.page_size) / state.page_size;
-    const Address addr = alloc_inner(state, start_addr / state.page_size, page_count, name, false);
+    const uint32_t page_count = align(size, STANDARD_PAGE_SIZE) / STANDARD_PAGE_SIZE;
+    const Address addr = alloc_inner(state, start_addr / STANDARD_PAGE_SIZE, page_count, name, false);
     const Address align_addr = align(addr, alignment);
-    const uint32_t page_num = addr / state.page_size;
-    const uint32_t align_page_num = align_addr / state.page_size;
+    const uint32_t page_num = addr / STANDARD_PAGE_SIZE;
+    const uint32_t align_page_num = align_addr / STANDARD_PAGE_SIZE;
 
     if (page_num != align_page_num) {
         AllocMemPage &page = state.alloc_table[page_num];
@@ -220,8 +222,8 @@ Address alloc_aligned(MemState &state, uint32_t size, const char *name, unsigned
 }
 
 static void align_to_page(MemState &state, Address &addr, Address &size) {
-    const Address end = align(addr + size, state.page_size);
-    addr = align_down(addr, state.page_size);
+    const Address end = align(addr + size, STANDARD_PAGE_SIZE);
+    addr = align_down(addr, STANDARD_PAGE_SIZE);
     size = end - addr;
 }
 
@@ -231,12 +233,18 @@ void unprotect_inner(MemState &state, Address addr, uint32_t size) {
     }
     uint8_t *addr_ptr = state.use_page_table ? state.page_table[addr / KiB(4)] : state.memory.get();
 
+    uint8_t *target = &addr_ptr[addr];
+    uint8_t *aligned_start = reinterpret_cast<uint8_t *>(
+        align_down(reinterpret_cast<uintptr_t>(target), state.host_page_size));
+    uint8_t *aligned_end = reinterpret_cast<uint8_t *>(align(reinterpret_cast<uintptr_t>(target + size), state.host_page_size));
+    size_t aligned_size = aligned_end - aligned_start;
+
 #ifdef _WIN32
     DWORD old_protect = 0;
-    const BOOL ret = VirtualProtect(&addr_ptr[addr], size - 1, PAGE_READWRITE, &old_protect);
+    const BOOL ret = VirtualProtect(aligned_start, aligned_size, PAGE_READWRITE, &old_protect);
     LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", get_error_msg());
 #else
-    const int ret = mprotect(&addr_ptr[addr], size, PROT_READ | PROT_WRITE);
+    const int ret = mprotect(aligned_start, aligned_size, PROT_READ | PROT_WRITE);
     LOG_CRITICAL_IF(ret == -1, "mprotect failed: {}", get_error_msg());
 #endif
 }
@@ -244,12 +252,18 @@ void unprotect_inner(MemState &state, Address addr, uint32_t size) {
 void protect_inner(MemState &state, Address addr, uint32_t size, const MemPerm perm) {
     uint8_t *addr_ptr = state.use_page_table ? state.page_table[addr / KiB(4)] : state.memory.get();
 
+    uint8_t *target = &addr_ptr[addr];
+    uint8_t *aligned_start = reinterpret_cast<uint8_t *>(
+        align_down(reinterpret_cast<uintptr_t>(target), state.host_page_size));
+    uint8_t *aligned_end = reinterpret_cast<uint8_t *>(align(reinterpret_cast<uintptr_t>(target + size), state.host_page_size));
+    size_t aligned_size = aligned_end - aligned_start;
+
 #ifdef _WIN32
     DWORD old_protect = 0;
-    const BOOL ret = VirtualProtect(&addr_ptr[addr], size - 1, (perm == MemPerm::None) ? PAGE_NOACCESS : ((perm == MemPerm::ReadOnly) ? PAGE_READONLY : PAGE_READWRITE), &old_protect);
+    const BOOL ret = VirtualProtect(aligned_start, aligned_size, (perm == MemPerm::None) ? PAGE_NOACCESS : ((perm == MemPerm::ReadOnly) ? PAGE_READONLY : PAGE_READWRITE), &old_protect);
     LOG_CRITICAL_IF(!ret, "VirtualAlloc failed: {}", get_error_msg());
 #else
-    const int ret = mprotect(&addr_ptr[addr], size, (perm == MemPerm::None) ? PROT_NONE : ((perm == MemPerm::ReadOnly) ? PROT_READ : (PROT_READ | PROT_WRITE)));
+    const int ret = mprotect(aligned_start, aligned_size, (perm == MemPerm::None) ? PROT_NONE : ((perm == MemPerm::ReadOnly) ? PROT_READ : (PROT_READ | PROT_WRITE)));
     LOG_CRITICAL_IF(ret == -1, "mprotect failed: {}", get_error_msg());
 #endif
 }
@@ -287,7 +301,7 @@ bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcep
     auto it = state.protect_tree.lower_bound(vaddr);
     if (it == state.protect_tree.end()) {
         // HACK: keep going
-        unprotect_inner(state, align_down(vaddr, state.page_size), state.page_size);
+        unprotect_inner(state, align_down(vaddr, state.host_page_size), state.host_page_size);
         LOG_CRITICAL("Unhandled write protected region was valid. Address=0x{:X}", vaddr);
         return true;
     }
@@ -295,7 +309,7 @@ bool handle_access_violation(MemState &state, uint8_t *addr, bool write) noexcep
     ProtectSegmentInfo &info = it->second;
     if (vaddr < it->first || vaddr >= it->first + info.size) {
         // HACK: keep going
-        unprotect_inner(state, align_down(vaddr, state.page_size), state.page_size);
+        unprotect_inner(state, align_down(vaddr, state.host_page_size), state.host_page_size);
         LOG_CRITICAL("Unhandled write protected region was valid. Address=0x{:X}", vaddr);
         return true;
     }
@@ -441,24 +455,24 @@ void remove_external_mapping(MemState &mem, uint8_t *addr_ptr, uint32_t size) {
 
 Address alloc(MemState &state, uint32_t size, const char *name, Address start_addr) {
     const std::lock_guard<std::mutex> lock(state.generation_mutex);
-    const uint32_t page_count = align(size, state.page_size) / state.page_size;
-    const Address addr = alloc_inner(state, start_addr / state.page_size, page_count, name, false);
+    const uint32_t page_count = align(size, STANDARD_PAGE_SIZE) / STANDARD_PAGE_SIZE;
+    const Address addr = alloc_inner(state, start_addr / STANDARD_PAGE_SIZE, page_count, name, false);
     return addr;
 }
 
 Address alloc_at(MemState &state, Address address, uint32_t size, const char *name) {
     const std::lock_guard<std::mutex> lock(state.generation_mutex);
-    const uint32_t wanted_page = address / state.page_size;
-    size += address % state.page_size;
-    const uint32_t page_count = align(size, state.page_size) / state.page_size;
+    const uint32_t wanted_page = address / STANDARD_PAGE_SIZE;
+    size += address % STANDARD_PAGE_SIZE;
+    const uint32_t page_count = align(size, STANDARD_PAGE_SIZE) / STANDARD_PAGE_SIZE;
     alloc_inner(state, wanted_page, page_count, name, true);
     return address;
 }
 
 Address try_alloc_at(MemState &state, Address address, uint32_t size, const char *name) {
-    const uint32_t wanted_page = address / state.page_size;
-    size += address % state.page_size;
-    const uint32_t page_count = align(size, state.page_size) / state.page_size;
+    const uint32_t wanted_page = address / STANDARD_PAGE_SIZE;
+    size += address % STANDARD_PAGE_SIZE;
+    const uint32_t page_count = align(size, STANDARD_PAGE_SIZE) / STANDARD_PAGE_SIZE;
     if (state.allocator.free_slot_count(wanted_page, wanted_page + page_count) != page_count) {
         return 0;
     }
@@ -475,7 +489,7 @@ Block alloc_block(MemState &mem, uint32_t size, const char *name, Address start_
 
 void free(MemState &state, Address address) {
     const std::lock_guard<std::mutex> lock(state.generation_mutex);
-    const uint32_t page_num = address / state.page_size;
+    const uint32_t page_num = address / STANDARD_PAGE_SIZE;
     assert(page_num >= 0);
 
     AllocMemPage &page = state.alloc_table[page_num];
@@ -490,26 +504,59 @@ void free(MemState &state, Address address) {
     }
 
     assert(!state.use_page_table || state.page_table[address / KiB(4)] == state.memory.get());
-    uint8_t *const memory = &state.memory[page_num * state.page_size];
+    const Address region_start = page_num * STANDARD_PAGE_SIZE;
+    const Address region_end = region_start + page.size * STANDARD_PAGE_SIZE;
 
+    Address host_page = align_down(region_start, state.host_page_size);
+    Address batch_start = 0;
+    uint32_t batch_size = 0;
+
+    while (host_page < region_end) {
+        Address host_page_end = host_page + state.host_page_size;
+        uint32_t first_guest = host_page / STANDARD_PAGE_SIZE;
+        uint32_t last_guest = host_page_end / STANDARD_PAGE_SIZE;
+
+        if (state.allocator.free_slot_count(first_guest, last_guest) == (last_guest - first_guest)) {
+            if (batch_size == 0)
+                batch_start = host_page;
+            batch_size += state.host_page_size;
+        } else if (batch_size > 0) {
+            uint8_t *memory = &state.memory[batch_start];
 #ifdef _WIN32
-    const BOOL ret = VirtualFree(memory, page.size * state.page_size, MEM_DECOMMIT);
-    LOG_CRITICAL_IF(!ret, "VirtualFree failed: {}", get_error_msg());
+            const BOOL ret = VirtualFree(memory, batch_size, MEM_DECOMMIT);
+            LOG_CRITICAL_IF(!ret, "VirtualFree failed: {}", get_error_msg());
 #else
-    int ret = mprotect(memory, page.size * state.page_size, PROT_NONE);
-    LOG_CRITICAL_IF(ret == -1, "mprotect failed: {}", get_error_msg());
-    ret = madvise(memory, page.size * state.page_size, MADV_DONTNEED);
-    LOG_CRITICAL_IF(ret == -1, "madvise failed: {}", get_error_msg());
+            int ret = mprotect(memory, batch_size, PROT_NONE);
+            LOG_CRITICAL_IF(ret == -1, "mprotect failed: {}", get_error_msg());
+            ret = madvise(memory, batch_size, MADV_DONTNEED);
+            LOG_CRITICAL_IF(ret == -1, "madvise failed: {}", get_error_msg());
 #endif
+            batch_size = 0;
+        }
+        host_page = host_page_end;
+    }
+
+    if (batch_size > 0) {
+        uint8_t *memory = &state.memory[batch_start];
+#ifdef _WIN32
+        const BOOL ret = VirtualFree(memory, batch_size, MEM_DECOMMIT);
+        LOG_CRITICAL_IF(!ret, "VirtualFree failed: {}", get_error_msg());
+#else
+        int ret = mprotect(memory, batch_size, PROT_NONE);
+        LOG_CRITICAL_IF(ret == -1, "mprotect failed: {}", get_error_msg());
+        ret = madvise(memory, batch_size, MADV_DONTNEED);
+        LOG_CRITICAL_IF(ret == -1, "madvise failed: {}", get_error_msg());
+#endif
+    }
 }
 
 uint32_t mem_available(MemState &state) {
-    return state.allocator.free_slot_count(0, state.allocator.max_offset) * state.page_size;
+    return state.allocator.free_slot_count(0, state.allocator.max_offset) * STANDARD_PAGE_SIZE;
 }
 
 const char *mem_name(Address address, MemState &state) {
     if (PAGE_NAME_TRACKING) {
-        return state.page_name_map.find(address / state.page_size)->second.c_str();
+        return state.page_name_map.find(address / STANDARD_PAGE_SIZE)->second.c_str();
     }
     return "";
 }

--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -5470,7 +5470,7 @@ EXPORT(int, sceGxmUnmapMemory, Ptr<void> base) {
     // we don't run into issues later
     // TODO: call a mem function to invalidate the range instead
     uint8_t *addr_start = base.cast<uint8_t>().get(emuenv.mem);
-    for (volatile uint8_t *addr = addr_start; addr < addr_start + ite->second.size; addr += emuenv.mem.page_size) {
+    for (volatile uint8_t *addr = addr_start; addr < addr_start + ite->second.size; addr += emuenv.mem.host_page_size) {
         // this should cause a read and a write
         *addr = *addr;
     }

--- a/vita3k/renderer/src/texture/cache.cpp
+++ b/vita3k/renderer/src/texture/cache.cpp
@@ -677,11 +677,11 @@ void TextureCache::cache_and_bind_texture(const SceGxmTexture &gxm_texture, MemS
         // This works under the assumption that once this big enough texture decided to modify. It will have to modify either all of its data,
         // or replace with an entire new texture.
         bool should_use_hash = true;
-        if (use_protect && info->texture_size >= mem.page_size * 4) {
-            range_protect_begin = align(gxm_texture.data_addr << 2, mem.page_size);
-            range_protect_end = align_down((gxm_texture.data_addr << 2) + info->texture_size, mem.page_size);
+        if (use_protect && info->texture_size >= mem.host_page_size * 4) {
+            range_protect_begin = align(gxm_texture.data_addr << 2, mem.host_page_size);
+            range_protect_end = align_down((gxm_texture.data_addr << 2) + info->texture_size, mem.host_page_size);
 
-            if (range_protect_end - range_protect_begin >= mem.page_size * 4) {
+            if (range_protect_end - range_protect_begin >= mem.host_page_size * 4) {
                 should_use_hash = false;
             }
         }
@@ -708,8 +708,8 @@ void TextureCache::cache_and_bind_texture(const SceGxmTexture &gxm_texture, MemS
 
             upload = previous_hash != info->hash;
         } else {
-            range_protect_begin = align(gxm_texture.data_addr << 2, mem.page_size);
-            range_protect_end = align_down((gxm_texture.data_addr << 2) + info->texture_size, mem.page_size);
+            range_protect_begin = align(gxm_texture.data_addr << 2, mem.host_page_size);
+            range_protect_end = align_down((gxm_texture.data_addr << 2) + info->texture_size, mem.host_page_size);
             upload = info->dirty;
         }
     }


### PR DESCRIPTION
In regards to #2843 and #3860. 

Align OS calls to respect the host's page size instead of hardcoding 4KiB, everything else that needs to work with guest page size keeps working as it did before. 