### PR TITLE
cpu: Move exclusive monitor entirely into Dynarmic backend

### DIFF
--- a/vita3k/cpu/include/cpu/common.h
+++ b/vita3k/cpu/include/cpu/common.h
@@ -21,6 +21,7 @@
 #include <mem/util.h> // Address.
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -37,12 +38,12 @@ typedef std::function<void(CPUState &cpu, uint32_t, Address)> CallSVC;
 typedef std::function<Address(Address)> GetWatchMemoryAddr;
 typedef std::unique_ptr<CPUState, std::function<void(CPUState *)>> CPUStatePtr;
 typedef std::unique_ptr<CPUInterface> CPUInterfacePtr;
-typedef void *ExclusiveMonitorPtr;
+
+inline constexpr std::size_t MAX_CORE_COUNT = 150;
 
 struct CPUProtocolBase {
     virtual void call_svc(CPUState &cpu, uint32_t svc, Address pc, ThreadState &thread) = 0;
     virtual Address get_watch_memory_addr(Address addr) = 0;
-    virtual ExclusiveMonitorPtr get_exclusive_monitor() = 0;
     virtual ~CPUProtocolBase() = default;
 };
 

--- a/vita3k/cpu/include/cpu/functions.h
+++ b/vita3k/cpu/include/cpu/functions.h
@@ -58,9 +58,7 @@ void write_cpsr(CPUState &state, uint32_t value);
 uint32_t stack_alloc(CPUState &state, size_t size);
 uint32_t stack_free(CPUState &state, size_t size);
 
-ExclusiveMonitorPtr new_exclusive_monitor(int max_num_cores);
-void free_exclusive_monitor(ExclusiveMonitorPtr monitor);
-void clear_exclusive(ExclusiveMonitorPtr monitor, std::size_t core_num);
+void clear_exclusive(CPUState &state);
 
 // Debugging helpers
 std::string disassemble(CPUState &state, uint64_t at, bool thumb, uint16_t *insn_size = nullptr);

--- a/vita3k/cpu/include/cpu/impl/dynarmic_cpu.h
+++ b/vita3k/cpu/include/cpu/impl/dynarmic_cpu.h
@@ -35,7 +35,6 @@ class DynarmicCPU : public CPUInterface {
     std::unique_ptr<Dynarmic::A32::Jit> jit;
     std::unique_ptr<ArmDynarmicCallback> cb;
     std::shared_ptr<ArmDynarmicCP15> cp15;
-    Dynarmic::ExclusiveMonitor *monitor;
 
     std::size_t core_id = 0;
 
@@ -49,7 +48,7 @@ class DynarmicCPU : public CPUInterface {
     std::unique_ptr<Dynarmic::A32::Jit> make_jit();
 
 public:
-    DynarmicCPU(CPUState *state, std::size_t processor_id, Dynarmic::ExclusiveMonitor *monitor, bool cpu_opt);
+    DynarmicCPU(CPUState *state, std::size_t processor_id, bool cpu_opt);
     ~DynarmicCPU() override;
     int run() override;
     void stop() override;
@@ -91,6 +90,9 @@ public:
     bool get_log_code() override;
     bool get_log_mem() override;
 
+    void clear_exclusive() override;
     std::size_t processor_id() const override;
     void invalidate_jit_cache(Address start, size_t length) override;
+
+    static Dynarmic::ExclusiveMonitor shared_monitor;
 };

--- a/vita3k/cpu/include/cpu/impl/interface.h
+++ b/vita3k/cpu/include/cpu/impl/interface.h
@@ -66,6 +66,8 @@ struct CPUInterface {
     virtual bool get_log_code() = 0;
     virtual bool get_log_mem() = 0;
 
+    virtual void clear_exclusive() = 0;
+
     virtual std::size_t processor_id() const {
         return 0;
     }

--- a/vita3k/cpu/src/cpu.cpp
+++ b/vita3k/cpu/src/cpu.cpp
@@ -56,8 +56,7 @@ CPUStatePtr init_cpu(bool cpu_opt, SceUID thread_id, std::size_t processor_id, M
         return CPUStatePtr();
     }
 
-    Dynarmic::ExclusiveMonitor *monitor = static_cast<Dynarmic::ExclusiveMonitor *>(protocol->get_exclusive_monitor());
-    state->cpu = std::make_unique<DynarmicCPU>(state.get(), processor_id, monitor, cpu_opt);
+    state->cpu = std::make_unique<DynarmicCPU>(state.get(), processor_id, cpu_opt);
 
     return state;
 }
@@ -164,6 +163,10 @@ bool get_log_code(CPUState &state) {
 
 bool get_log_mem(CPUState &state) {
     return state.cpu->get_log_mem();
+}
+
+void clear_exclusive(CPUState &state) {
+    state.cpu->clear_exclusive();
 }
 
 std::size_t get_processor_id(CPUState &state) {

--- a/vita3k/cpu/src/dynarmic_cpu.cpp
+++ b/vita3k/cpu/src/dynarmic_cpu.cpp
@@ -298,6 +298,8 @@ public:
     }
 };
 
+Dynarmic::ExclusiveMonitor DynarmicCPU::shared_monitor(MAX_CORE_COUNT);
+
 std::unique_ptr<Dynarmic::A32::Jit> DynarmicCPU::make_jit() {
     Dynarmic::A32::UserConfig config{};
     config.arch_version = Dynarmic::A32::ArchVersion::v7;
@@ -310,7 +312,7 @@ std::unique_ptr<Dynarmic::A32::Jit> DynarmicCPU::make_jit() {
     }
     config.hook_hint_instructions = true;
     config.enable_cycle_counting = false;
-    config.global_monitor = monitor;
+    config.global_monitor = &shared_monitor;
     config.coprocessors[15] = cp15;
     config.processor_id = core_id;
     config.optimizations = cpu_opt ? Dynarmic::all_safe_optimizations : Dynarmic::no_optimizations;
@@ -319,11 +321,10 @@ std::unique_ptr<Dynarmic::A32::Jit> DynarmicCPU::make_jit() {
     return std::make_unique<Dynarmic::A32::Jit>(config);
 }
 
-DynarmicCPU::DynarmicCPU(CPUState *state, std::size_t processor_id, Dynarmic::ExclusiveMonitor *monitor, bool cpu_opt)
+DynarmicCPU::DynarmicCPU(CPUState *state, std::size_t processor_id, bool cpu_opt)
     : parent(state)
     , cb(std::make_unique<ArmDynarmicCallback>(*state, *this))
     , cp15(std::make_shared<ArmDynarmicCP15>())
-    , monitor(monitor)
     , core_id(processor_id)
     , cpu_opt(cpu_opt) {
     jit = make_jit();
@@ -488,17 +489,6 @@ void DynarmicCPU::invalidate_jit_cache(Address start, size_t length) {
     jit->InvalidateCacheRange(start, length);
 }
 
-// TODO: proper abstraction
-ExclusiveMonitorPtr new_exclusive_monitor(int max_num_cores) {
-    return new Dynarmic::ExclusiveMonitor(max_num_cores);
-}
-
-void free_exclusive_monitor(ExclusiveMonitorPtr monitor) {
-    Dynarmic::ExclusiveMonitor *monitor_ = static_cast<Dynarmic::ExclusiveMonitor *>(monitor);
-    delete monitor_;
-}
-
-void clear_exclusive(ExclusiveMonitorPtr monitor, std::size_t core_num) {
-    Dynarmic::ExclusiveMonitor *monitor_ = static_cast<Dynarmic::ExclusiveMonitor *>(monitor);
-    monitor_->ClearProcessor(core_num);
+void DynarmicCPU::clear_exclusive() {
+    shared_monitor.ClearProcessor(core_id);
 }

--- a/vita3k/kernel/include/kernel/cpu_protocol.h
+++ b/vita3k/kernel/include/kernel/cpu_protocol.h
@@ -29,7 +29,6 @@ struct CPUProtocol : public CPUProtocolBase {
     ~CPUProtocol() override = default;
     void call_svc(CPUState &cpu, uint32_t svc, Address pc, ThreadState &thread) override;
     Address get_watch_memory_addr(Address addr) override;
-    ExclusiveMonitorPtr get_exclusive_monitor() override;
 
 private:
     CallImportFunc call_import;

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -135,7 +135,6 @@ struct KernelState {
     bool cpu_opt;
     CorenumAllocator corenum_allocator;
     CPUProtocolPtr cpu_protocol;
-    ExclusiveMonitorPtr exclusive_monitor;
 
     ObjectStore obj_store;
 

--- a/vita3k/kernel/src/cpu_protocol.cpp
+++ b/vita3k/kernel/src/cpu_protocol.cpp
@@ -56,13 +56,9 @@ void CPUProtocol::call_svc(CPUState &cpu, uint32_t svc, Address pc, ThreadState 
     call_import(cpu, nid, thread.id);
 
     // ARM recommends clearing exclusive state inside interrupt handler
-    clear_exclusive(kernel->exclusive_monitor, get_processor_id(cpu));
+    clear_exclusive(cpu);
 }
 
 Address CPUProtocol::get_watch_memory_addr(Address addr) {
     return kernel->debugger.get_watch_memory_addr(addr);
-}
-
-ExclusiveMonitorPtr CPUProtocol::get_exclusive_monitor() {
-    return kernel->exclusive_monitor;
 }

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -19,6 +19,7 @@
 #include <tracy/Tracy.hpp>
 #endif
 
+#include <cpu/common.h>
 #include <kernel/state.h>
 
 #include <kernel/thread/thread_state.h>
@@ -83,10 +84,7 @@ KernelState::KernelState()
 }
 
 bool KernelState::init(MemState &mem, const CallImportFunc &call_import, bool cpu_opt) {
-    constexpr std::size_t MAX_CORE_COUNT = 150;
-
     corenum_allocator.set_max_core_count(MAX_CORE_COUNT);
-    exclusive_monitor = new_exclusive_monitor(MAX_CORE_COUNT);
     start_tick = rtc_get_ticks(rtc_base_ticks());
     base_tick = { rtc_base_ticks() };
     cpu_protocol = std::make_unique<CPUProtocol>(*this, mem, call_import);


### PR DESCRIPTION
The exclusive monitor is a Dynarmic implementation detail for emulating ARM LDREX/STREX in software, it shouldn't be exposed to the kernel or protocol layers.

The shared monitor is now a static member of DynarmicCPU. All DynarmicCPU instances reference it via their processor_id slot.