### PR TITLE
kernel/thread: Fix data race regression in run_loop inner loop

### DIFF
--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -257,13 +257,9 @@ bool ThreadState::run_loop() {
                 }
             }
 
-            // Run the cpu
+            // Run the cpu — lock is NOT held on entry, HELD on exit
             while (true) {
                 lock.lock();
-                if (to_do != ThreadToDo::run && to_do != ThreadToDo::step)
-                    break;
-                if (res != 0 || call_level != run_level || hit_breakpoint(*cpu))
-                    break;
                 const bool do_step = (to_do == ThreadToDo::step);
                 if (do_step)
                     to_do = ThreadToDo::suspend;
@@ -278,6 +274,11 @@ bool ThreadState::run_loop() {
                 if (cpu->svc_called) {
                     cpu->protocol->call_svc(*cpu, cpu->svc, read_pc(*cpu), *this);
                 }
+
+                lock.lock();
+                if (to_do != ThreadToDo::run || res != 0 || call_level != run_level || hit_breakpoint(*cpu))
+                    break;
+                lock.unlock();
             }
 
             // Handle errors
@@ -414,7 +415,10 @@ Address ThreadState::stack_top() const {
 
 void ThreadState::suspend() {
     assert(to_do == ThreadToDo::run);
-    to_do = ThreadToDo::suspend;
+    {
+        const std::lock_guard<std::mutex> lock(mutex);
+        to_do = ThreadToDo::suspend;
+    }
     stop(*cpu);
 }
 


### PR DESCRIPTION
The previous fix (a93e009a) changed the inner do-while loop into a
while-at-top loop, checking exit conditions before the first
execution. But those conditions (res, hit_breakpoint, etc.) only
make sense after execution — checking them first caused the loop
to break immediately without executing any guest code (0 fps).

Restore do-while semantics: always execute at least once, then
check the loop condition under the mutex. The to_do read at the
top of each iteration (step vs run decision) and the exit
condition at the bottom are both protected by the mutex.

Also fix suspend() to hold the mutex before modifying to_do,
matching what resume() and exit_delete() already do.