### PR TITLE
gui/main menubar: Fix crash on exit by using SDL quit event.

### DIFF
--- a/vita3k/gui/src/information_bar.cpp
+++ b/vita3k/gui/src/information_bar.cpp
@@ -685,7 +685,7 @@ void draw_information_bar(GuiState &gui, EmuEnvState &emuenv) {
         draw_list->AddRectFilled(BATTERY_BASE_MIN_POS, BATTERY_BASE_MAX_POS, BATTERY_COLOR);
     draw_list->AddRectFilled(ImVec2(BATTERY_MAX_POS.x - battery_size, BATTERY_HEIGHT_MIN_POS), BATTERY_MAX_POS, BATTERY_COLOR, 2.f * SCALE.x, ImDrawFlags_RoundCornersAll);
 
-    if (emuenv.display.imgui_render && !gui.vita_area.start_screen && !gui.vita_area.live_area_screen && !gui.vita_area.user_management && !gui.help_menu.vita3k_update && get_sys_apps_state(gui) && (ImGui::IsWindowHovered(ImGuiHoveredFlags_None) || ImGui::IsItemClicked(0)))
+    if (emuenv.display.imgui_render && !gui.vita_area.start_screen && !gui.vita_area.live_area_screen && !gui.vita_area.user_management && !gui.configuration_menu.settings_dialog && !gui.configuration_menu.custom_settings_dialog && !gui.help_menu.vita3k_update && get_sys_apps_state(gui) && (ImGui::IsWindowHovered(ImGuiHoveredFlags_None) || ImGui::IsItemClicked(0)))
         gui.vita_area.information_bar = false;
 
     ImGui::End();

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -19,6 +19,8 @@
 #include <gui/functions.h>
 #include <io/state.h>
 
+#include <SDL3/SDL_events.h>
+
 #include "private.h"
 
 namespace gui {
@@ -48,8 +50,12 @@ static void draw_file_menu(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::MenuItem(lang["install_zip"].c_str(), nullptr, &gui.file_menu.archive_install_dialog);
         ImGui::MenuItem(lang["install_license"].c_str(), nullptr, &gui.file_menu.license_install_dialog);
         ImGui::Separator();
-        if (ImGui::MenuItem(lang["exit"].c_str()))
-            exit(0);
+        if (ImGui::MenuItem(lang["exit"].c_str())) {
+            SDL_Event quit_event{
+                .type = SDL_EVENT_QUIT
+            };
+            SDL_PushEvent(&quit_event);
+        }
         ImGui::EndMenu();
     }
 }


### PR DESCRIPTION
# About
- gui/main menubar: Fix crash on exit by using SDL quit event.
using exit(0) skip the event loop, preventing the normal shutdown sequence.
- gui/information bar: No disable it when setting dialog is open.