### PR TITLE
android: Add x86_64 ABI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -11,6 +11,7 @@ on:
 env:
   BUILD_CONFIG: Release
   SCCACHE_GHA_ENABLED: "true"
+  PACKAGES: boost-system boost-filesystem boost-program-options boost-icl boost-variant curl openssl zlib
 
 jobs:
   format-check:
@@ -72,7 +73,6 @@ jobs:
             cache_path: |
               /usr/local/share/vcpkg/installed
               /usr/local/share/vcpkg/packages
-            vcpkg_triplet: arm64-android
 
     steps:
       - uses: actions/checkout@v6
@@ -117,7 +117,7 @@ jobs:
 
       - name: Set up build environment (Windows)
         run: |
-          vcpkg install zlib boost-system boost-filesystem boost-program-options boost-icl boost-variant curl openssl --triplet=${{ matrix.vcpkg_triplet }}
+          vcpkg install ${{ env.PACKAGES }} --triplet=${{ matrix.vcpkg_triplet }}
         if: startsWith(matrix.os, 'windows') && !matrix.msys2_env
 
       - uses: ilammy/msvc-dev-cmd@v1
@@ -128,7 +128,8 @@ jobs:
       - name: Set up build environment (Android)
         run: |
           sudo apt-get install -y ninja-build
-          vcpkg install boost-system boost-filesystem boost-program-options boost-icl boost-variant openssl zlib --triplet=${{ matrix.vcpkg_triplet }}
+          vcpkg install ${{ env.PACKAGES }} --triplet=arm64-android
+          vcpkg install ${{ env.PACKAGES }} --triplet=x64-android
         if: matrix.os == 'android'
 
       - uses: hendrikmuhs/ccache-action@v1.2

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,9 +24,12 @@ android {
 		versionCode 21
 		versionName "0.2.1"
 
+		ndk {
+			abiFilters "arm64-v8a", "x86_64"
+		}
+
 		externalNativeBuild {
 			cmake {
-				abiFilters.addAll( 'arm64-v8a' )
 				arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON" // required until NDK r28
 			}
 		}

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -112,7 +112,12 @@ elseif (ARCHITECTURE STREQUAL "x86_64")
 endif ()
 
 if(ANDROID)
-	add_subdirectory(libadrenotools)
+	if(ARCHITECTURE STREQUAL "arm64")
+		add_subdirectory(libadrenotools)
+		add_definitions(-DUSE_ADRENO_TOOLS)
+	else()
+		add_library(adrenotools INTERFACE)
+	endif()
 endif()
 
 if(WIN32)

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -46,11 +46,14 @@
 
 #ifdef __ANDROID__
 #include <SDL3/SDL_system.h>
-#include <adrenotools/bcenabler.h>
-#include <adrenotools/driver.h>
 #include <dlfcn.h>
 #include <sys/mman.h>
 #include <util/float_to_half.h>
+
+#ifdef USE_ADRENO_TOOLS
+#include <adrenotools/bcenabler.h>
+#include <adrenotools/driver.h>
+#endif
 
 #include <android/hardware_buffer.h>
 
@@ -153,7 +156,7 @@ const static std::vector<const char *> required_device_extensions = {
 
 namespace renderer::vulkan {
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && defined(USE_ADRENO_TOOLS)
 // need to avoid patching bcn per custom driver more than once
 static bool patch_bcn_once(void *function_to_patch) {
     static std::unordered_set<void *> patched_functions;
@@ -386,7 +389,7 @@ bool VKState::create(std::unique_ptr<renderer::State> &state, const Config &conf
 
     // Create Instance
     {
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && defined(USE_ADRENO_TOOLS)
         PFN_vkGetInstanceProcAddr vk_get_instance_proc_addr = android_driver::resolve_vk_get_instance_proc_addr(config.current_config.custom_driver_name);
         if (!vk_get_instance_proc_addr)
             return false;
@@ -1784,10 +1787,12 @@ bool VKState::support_custom_drivers() {
 }
 
 void VKState::set_turbo_mode(bool set) {
+#ifdef USE_ADRENO_TOOLS
     if (!support_custom_drivers())
         return;
 
     adrenotools_set_turbo(set);
+#endif
 }
 #endif
 

--- a/vita3k/renderer/src/vulkan/screen_renderer.cpp
+++ b/vita3k/renderer/src/vulkan/screen_renderer.cpp
@@ -48,7 +48,7 @@ extern "C" void *get_metal_layer_from_view(void *nsview);
 static std::atomic<bool> has_surface{ false };
 
 extern "C" JNIEXPORT void JNICALL
-Java_org_vita3k_emulator_EmuSurface_setSurfaceStatus(JNIEnv *, jobject, bool surface_present) {
+Java_org_vita3k_emulator_EmuSurface_setSurfaceStatus(JNIEnv *, jobject, jboolean surface_present) {
     has_surface.store(surface_present, std::memory_order_release);
 }
 #endif

--- a/vita3k/util/src/android_driver.cpp
+++ b/vita3k/util/src/android_driver.cpp
@@ -6,10 +6,13 @@
 #include <util/log.h>
 
 #include <SDL3/SDL_system.h>
-#include <adrenotools/driver.h>
 #include <android/api-level.h>
 #include <dlfcn.h>
 #include <jni.h>
+
+#ifdef USE_ADRENO_TOOLS
+#include <adrenotools/driver.h>
+#endif
 
 #include <algorithm>
 #include <fstream>
@@ -408,6 +411,7 @@ bool is_custom_driver_loaded(const std::string &driver_name, uint32_t vendor_id,
 
 } // namespace android_driver
 
+#ifdef USE_ADRENO_TOOLS
 void *open_custom_vulkan_driver(const std::string &driver_name) {
     JNIEnv *env = reinterpret_cast<JNIEnv *>(SDL_GetAndroidJNIEnv());
     const auto files_dir = get_android_files_dir(env);
@@ -466,12 +470,12 @@ void *open_custom_vulkan_driver(const std::string &driver_name) {
 
     return vulkan_handle;
 }
+#endif
 
 namespace android_driver {
 
 PFN_vkGetInstanceProcAddr resolve_vk_get_instance_proc_addr(const std::string &driver_name) {
-    const PFN_vkGetInstanceProcAddr system_vk_get_instance_proc_addr = load_system_vk_get_instance_proc_addr();
-
+#ifdef USE_ADRENO_TOOLS
     if (!driver_name.empty()) {
         void *vulkan_handle = open_custom_vulkan_driver(driver_name);
         if (!vulkan_handle) {
@@ -485,8 +489,8 @@ PFN_vkGetInstanceProcAddr resolve_vk_get_instance_proc_addr(const std::string &d
             }
         }
     }
-
-    return system_vk_get_instance_proc_addr;
+#endif
+    return load_system_vk_get_instance_proc_addr();
 }
 
 } // namespace android_driver


### PR DESCRIPTION
- Disable adrenotools in Android x86_64 build to compile.
- Fix incorrect type for parameter of JNI function.