### PR TITLE
modules/SceFiber: default to LLE

### DIFF
--- a/vita3k/module/src/load_module.cpp
+++ b/vita3k/module/src/load_module.cpp
@@ -184,7 +184,7 @@ bool is_lle_module(SceSysmoduleModuleId module_id, EmuEnvState &emuenv) {
 }
 
 static std::vector<std::string> init_auto_lle_module_names() {
-    std::vector<std::string> auto_lle_module_names = { "libc", "libSceFt2", "libpvf" };
+    std::vector<std::string> auto_lle_module_names = { "libc", "libSceFt2", "libpvf", "libfiber" };
     for (const auto module_id : auto_lle_modules) {
         for (const auto module : sysmodule_paths[module_id]) {
             auto_lle_module_names.emplace_back(module);


### PR DESCRIPTION
SceFiber depends on TLS's `TLS_SP_TOP`/`TLS_SP_BOTTOM` entries. Since they have been added and populated properly at thread creation, LLE SceFiber works (or should) out of the box without needing the current HLE implementation, which has some hacks and heap memory allocations that shouldn't be there.

This also removes all non-trivial manual CPU context/register manipulation from HLE modules, reducing the surface that would need special handling for native exec.