### PR TITLE
replace SYSTEM_UI_FLAG_* with WindowInsetsControllerCompat as the for…

### DIFF
--- a/android/src/main/java/org/vita3k/emulator/Emulator.java
+++ b/android/src/main/java/org/vita3k/emulator/Emulator.java
@@ -17,6 +17,9 @@ import android.view.Surface;
 import android.view.ViewGroup;
 import android.view.View;
 import android.widget.Toast;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import androidx.annotation.Keep;
 import androidx.core.content.FileProvider;
@@ -336,13 +339,11 @@ public class Emulator extends SDLActivity
     public native void filedialogReturn(String result_path);
 
     private void hideSystemBars() {
-        getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                        | View.SYSTEM_UI_FLAG_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                        | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-        );
+        WindowInsetsControllerCompat controller =
+                WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        controller.hide(WindowInsetsCompat.Type.systemBars());
+        controller.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
     }
 }


### PR DESCRIPTION
Replace SYSTEM_UI_FLAG_* with WindowInsetsControllerCompat as the former is deprecated and ignored in certain UI race conditions.

Fix for this issue #3893

When Vita3k is launched externally via launchers like ES-DE on Android 11+ it could encounter certain race condition where SYSTEM_UI_FLAG_* is ignored in favor of the newer Android's default UI API, causing navigation bars to not hide itself. SYSTEM_UI_FLAG_* were deprecated since Android 11, and WindowInsetsControllerCompat is backward compatible which should work all the way back to [API 21 (Android 5+).](https://developer.android.com/reference/androidx/core/view/WindowInsetsControllerCompat)