### PR TITLE
Audio improvements: safer shutdown, pacing, and per-thread config filtering

### DIFF
--- a/vita3k/audio/include/audio/impl/cubeb_audio.h
+++ b/vita3k/audio/include/audio/impl/cubeb_audio.h
@@ -19,6 +19,7 @@
 
 #include "../state.h"
 
+#include <atomic>
 #include <condition_variable>
 
 #include <cubeb/cubeb.h>
@@ -28,17 +29,23 @@ struct AudioBuffer {
     int buffer_position;
 };
 
-struct CubebAudioOutPort : AudioOutPort {
-    cubeb_stream *out_stream = nullptr;
+struct CubebAudioSharedState {
     cubeb_stream_params spec;
-    // sync variables used to wait for the buffer to be ready
+    int len_bytes = 0;
     std::mutex mutex;
     std::condition_variable cond_var;
-    // buffer filled with audio data to pass to cubeb
     std::vector<AudioBuffer> audio_buffers;
-    // position of the next audio buffer to put audio
     int next_audio_buffer = 0;
     int nb_buffers_ready = 0;
+    std::atomic<bool> shutting_down = false;
+    std::atomic<int> active_callbacks = 0;
+    std::mutex shutdown_mutex;
+    std::condition_variable shutdown_cond_var;
+};
+
+struct CubebAudioOutPort : AudioOutPort {
+    cubeb_stream *out_stream = nullptr;
+    std::shared_ptr<CubebAudioSharedState> callback_state;
 
     // use the destructor to destroy the cubeb stream
     ~CubebAudioOutPort();

--- a/vita3k/audio/include/audio/state.h
+++ b/vita3k/audio/include/audio/state.h
@@ -46,6 +46,15 @@ struct AudioOutPort {
     int len = 0;
     int freq = 0;
     int mode = 0;
+
+    struct TidConfig {
+        int len = 0;
+        int freq = 0;
+        int mode = 0;
+    };
+
+    // Per-thread output configuration profile used for silent mismatch filtering.
+    std::map<SceUID, TidConfig> tid_configs;
 };
 
 typedef std::shared_ptr<AudioOutPort> AudioOutPortPtr;

--- a/vita3k/audio/src/audio.cpp
+++ b/vita3k/audio/src/audio.cpp
@@ -66,21 +66,9 @@ AudioOutPortPtr AudioState::open_port(int nb_channels, int freq, int nb_sample) 
 void AudioState::audio_output(AudioOutPort &out_port, const void *buffer) {
     adapter->audio_output(out_port, buffer);
 
-    uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    uint64_t diff = now - out_port.last_output;
-    uint64_t to_wait = out_port.len_microseconds - diff;
-    if (diff < out_port.len_microseconds && to_wait > 1000) {
-        // This is what we should be waiting to be perfectly accurate
-        // However, doing so would cause the host audio buffer to often lack samples to output
-        // This is because the PS Vita and the host audio parameters do not match exactly
-        // So instead only wait 50% of the time
-        // also don't sleep for less than 0.5 ms
-        to_wait /= 2;
-        std::this_thread::sleep_for(std::chrono::microseconds(to_wait));
-        out_port.last_output = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    } else {
-        out_port.last_output = now;
-    }
+    // Backend adapters already pace output according to their own queue depth.
+    // Sleeping again here over-throttles short buffers and can starve movie audio.
+    out_port.last_output = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 void AudioState::set_volume(AudioOutPort &out_port, float volume) {

--- a/vita3k/audio/src/impl/cubeb_audio.cpp
+++ b/vita3k/audio/src/impl/cubeb_audio.cpp
@@ -18,39 +18,57 @@
 #include "audio/impl/cubeb_audio.h"
 #include "util/log.h"
 
+#include <cstring>
+
 static long impl_cubeb_audio_callback(cubeb_stream *stream, void *user_data, const void *input, void *output, long nframes) {
     assert(user_data != nullptr);
     assert(stream != nullptr);
-    CubebAudioOutPort *port = static_cast<CubebAudioOutPort *>(user_data);
+    CubebAudioSharedState *state = static_cast<CubebAudioSharedState *>(user_data);
     uint8_t *output_buffer = static_cast<uint8_t *>(output);
 
+    memset(output_buffer, 0, nframes * state->spec.channels * sizeof(uint16_t));
+
+    state->active_callbacks.fetch_add(1, std::memory_order_acq_rel);
+    const auto finish_callback = [&]() {
+        if (state->active_callbacks.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            std::lock_guard<std::mutex> lock(state->shutdown_mutex);
+            state->shutdown_cond_var.notify_all();
+        }
+    };
+
+    if (state->shutting_down.load(std::memory_order_acquire)) {
+        finish_callback();
+        return nframes;
+    }
+
     int bytes_given = 0;
-    const int bytes_to_give = nframes * port->spec.channels * sizeof(uint16_t);
+    const int bytes_to_give = nframes * state->spec.channels * sizeof(uint16_t);
     while (bytes_given < bytes_to_give) {
-        if (port->nb_buffers_ready == 0) {
+        if (state->nb_buffers_ready == 0) {
             // no data available, should we wait for it or return nothing?
             // return nothing for now
             break;
         }
 
-        AudioBuffer &audio_buffer = port->audio_buffers[port->next_audio_buffer];
+        AudioBuffer &audio_buffer = state->audio_buffers[state->next_audio_buffer];
         // compute the number of bytes we can copy from this buffer to the output
-        const int bytes_to_copy = std::min(bytes_to_give - bytes_given, port->len_bytes - audio_buffer.buffer_position);
+        const int bytes_to_copy = std::min(bytes_to_give - bytes_given, state->len_bytes - audio_buffer.buffer_position);
         memcpy(&output_buffer[bytes_given], &audio_buffer.buffer[audio_buffer.buffer_position], bytes_to_copy);
         audio_buffer.buffer_position += bytes_to_copy;
 
-        if (audio_buffer.buffer_position == port->len_bytes) {
+        if (audio_buffer.buffer_position == state->len_bytes) {
             // if we are done with this buffer, tell it
-            std::unique_lock<std::mutex> lock(port->mutex);
-            port->next_audio_buffer = (port->next_audio_buffer + 1) % port->audio_buffers.size();
-            port->nb_buffers_ready--;
+            std::unique_lock<std::mutex> lock(state->mutex);
+            state->next_audio_buffer = (state->next_audio_buffer + 1) % state->audio_buffers.size();
+            state->nb_buffers_ready--;
             lock.unlock();
-            port->cond_var.notify_one();
+            state->cond_var.notify_one();
         }
 
         bytes_given += bytes_to_copy;
     }
 
+    finish_callback();
     return nframes;
 }
 
@@ -59,9 +77,21 @@ static void impl_cubeb_state_callback(cubeb_stream *stm, void *user, cubeb_state
 }
 
 CubebAudioOutPort::~CubebAudioOutPort() {
+    if (callback_state) {
+        callback_state->shutting_down.store(true, std::memory_order_release);
+    }
+
     if (out_stream) {
         cubeb_stream_stop(out_stream);
         cubeb_stream_destroy(out_stream);
+        out_stream = nullptr;
+    }
+
+    if (callback_state) {
+        std::unique_lock<std::mutex> lock(callback_state->shutdown_mutex);
+        callback_state->shutdown_cond_var.wait(lock, [&]() {
+            return callback_state->active_callbacks.load(std::memory_order_acquire) == 0;
+        });
     }
 }
 
@@ -84,7 +114,8 @@ bool CubebAudioAdapter::init() {
 
 AudioOutPortPtr CubebAudioAdapter::open_port(int nb_channels, int freq, int nb_sample) {
     std::shared_ptr<CubebAudioOutPort> port = std::make_shared<CubebAudioOutPort>();
-    port->spec = {
+    port->callback_state = std::make_shared<CubebAudioSharedState>();
+    port->callback_state->spec = {
         // all the ps vita samples are signed 16 bits low edian
         .format = CUBEB_SAMPLE_S16LE,
         .rate = static_cast<uint32_t>(freq),
@@ -95,21 +126,22 @@ AudioOutPortPtr CubebAudioAdapter::open_port(int nb_channels, int freq, int nb_s
     };
 
     uint32_t latency;
-    cubeb_get_min_latency(cubeb_ctx, &port->spec, &latency);
+    cubeb_get_min_latency(cubeb_ctx, &port->callback_state->spec, &latency);
 
     if (cubeb_stream_init(cubeb_ctx, &port->out_stream, "Vita3K audio out", nullptr, nullptr, nullptr,
-            &port->spec, latency, impl_cubeb_audio_callback, impl_cubeb_state_callback, port.get())
+            &port->callback_state->spec, latency, impl_cubeb_audio_callback, impl_cubeb_state_callback, port->callback_state.get())
         != CUBEB_OK) {
         LOG_ERROR("Could not initialize cubeb stream");
         return nullptr;
     }
 
     port->len_bytes = nb_sample * nb_channels * sizeof(uint16_t);
+    port->callback_state->len_bytes = port->len_bytes;
 
     // allocate enough buffers to be able to satisfy a callback (+1 to make sure one buffer can be ready)
     const int nb_buffers = (latency + nb_sample - 1) / nb_sample + 1;
-    port->audio_buffers.resize(nb_buffers);
-    for (AudioBuffer &audio_buffer : port->audio_buffers) {
+    port->callback_state->audio_buffers.resize(nb_buffers);
+    for (AudioBuffer &audio_buffer : port->callback_state->audio_buffers) {
         // initialize all the buffers
         audio_buffer.buffer.resize(port->len_bytes);
         audio_buffer.buffer_position = 0;
@@ -121,24 +153,25 @@ AudioOutPortPtr CubebAudioAdapter::open_port(int nb_channels, int freq, int nb_s
 
 void CubebAudioAdapter::audio_output(AudioOutPort &out_port, const void *buffer) {
     CubebAudioOutPort &port = static_cast<CubebAudioOutPort &>(out_port);
+    CubebAudioSharedState &state = *port.callback_state;
 
-    std::unique_lock<std::mutex> lock(port.mutex);
-    if (port.nb_buffers_ready == port.audio_buffers.size()) {
-        port.cond_var.wait(lock);
+    std::unique_lock<std::mutex> lock(state.mutex);
+    if (state.nb_buffers_ready == state.audio_buffers.size()) {
+        state.cond_var.wait(lock);
     }
 
-    assert(port.nb_buffers_ready < port.audio_buffers.size());
+    assert(state.nb_buffers_ready < state.audio_buffers.size());
     if (buffer) {
         // the buffer can be empty to drain the port
-        int next_buffer_pos = (port.next_audio_buffer + port.nb_buffers_ready) % port.audio_buffers.size();
+        int next_buffer_pos = (state.next_audio_buffer + state.nb_buffers_ready) % state.audio_buffers.size();
         // we could unlock the lock here and re-lock it right after, but will this be faster?
-        memcpy(port.audio_buffers[next_buffer_pos].buffer.data(), buffer, port.len_bytes);
-        port.audio_buffers[next_buffer_pos].buffer_position = 0;
-        port.nb_buffers_ready++;
+        memcpy(state.audio_buffers[next_buffer_pos].buffer.data(), buffer, port.len_bytes);
+        state.audio_buffers[next_buffer_pos].buffer_position = 0;
+        state.nb_buffers_ready++;
     }
 
     lock.unlock();
-    port.cond_var.notify_one();
+    state.cond_var.notify_one();
 }
 
 void CubebAudioAdapter::set_volume(AudioOutPort &out_port, float volume) {

--- a/vita3k/audio/src/impl/sdl_audio.cpp
+++ b/vita3k/audio/src/impl/sdl_audio.cpp
@@ -20,6 +20,8 @@
 #include <SDL3/SDL_audio.h>
 #include <SDL3/SDL_hints.h>
 
+#include <algorithm>
+
 #define SDL_CHECK_EXT(condition, ret)                         \
     do {                                                      \
         if (!(condition)) {                                   \
@@ -32,8 +34,17 @@
 #define SDL_CHECK_VOID(f_call) SDL_CHECK_EXT(f_call, )
 #define SDL_CHECK_NEG(f_call) SDL_CHECK_EXT((f_call) >= 0, {})
 
-static int get_threshold_samples(const int device_buffer_samples) {
-    return 4 * device_buffer_samples;
+static int get_stream_buffer_samples(const SDL_AudioSpec &spec, const AudioOutPort &out_port) {
+    return out_port.len_bytes / SDL_AUDIO_FRAMESIZE(spec);
+}
+
+static int get_threshold_samples(const int device_buffer_samples, const int stream_buffer_samples) {
+#ifdef __ANDROID__
+    // Android's audio latency is higher than other platforms, so increase prebuffering to reduce underruns.
+    return std::max(stream_buffer_samples, 4 * device_buffer_samples);
+#else
+    return std::max(stream_buffer_samples, device_buffer_samples);
+#endif
 }
 
 void SDLCALL SDLAudioAdapter::thread_wakeup_callback(void *userdata, SDL_AudioStream *stream, int additional_amount, int total_amount) {
@@ -41,7 +52,8 @@ void SDLCALL SDLAudioAdapter::thread_wakeup_callback(void *userdata, SDL_AudioSt
     assert(stream != nullptr);
     SDLAudioOutPort *port = static_cast<SDLAudioOutPort *>(userdata);
     const int samples_available = port->adapter.get_rest_sample(*port);
-    if (samples_available < get_threshold_samples(port->adapter.device_buffer_samples) || additional_amount > 0) {
+    const int stream_buffer_samples = get_stream_buffer_samples(port->adapter.dst_spec, *port);
+    if (samples_available < get_threshold_samples(port->adapter.device_buffer_samples, stream_buffer_samples)) {
         port->cond_var.notify_one();
     }
 }
@@ -94,12 +106,13 @@ AudioOutPortPtr SDLAudioAdapter::open_port(int nb_channels, int freq, int nb_sam
 void SDLAudioAdapter::audio_output(AudioOutPort &out_port, const void *buffer) {
     //  Put audio to the port's stream and see how much is left to play.
     SDLAudioOutPort &port = static_cast<SDLAudioOutPort &>(out_port);
+    const int stream_buffer_samples = get_stream_buffer_samples(dst_spec, out_port);
     // If there's lots of audio left to play, stop this thread.
     // The audio callback will wake it up later when it's running out of data.
     const int samples_available = get_rest_sample(port);
-    if (samples_available > get_threshold_samples(device_buffer_samples)) {
+    if (samples_available >= get_threshold_samples(device_buffer_samples, stream_buffer_samples)) {
         std::unique_lock<std::mutex> lock(port.mutex);
-        port.cond_var.wait_for(lock, std::chrono::microseconds(port.len_microseconds * 2));
+        port.cond_var.wait_for(lock, std::chrono::microseconds(port.len_microseconds));
     }
     SDL_CHECK_VOID(SDL_PutAudioStreamData(port.stream.get(), buffer, out_port.len_bytes));
 }

--- a/vita3k/modules/SceAudio/SceAudio.cpp
+++ b/vita3k/modules/SceAudio/SceAudio.cpp
@@ -146,8 +146,21 @@ EXPORT(int, sceAudioOutGetAdopt, SceAudioOutPortType type) {
 }
 
 EXPORT(int, sceAudioOutGetConfig, int port, SceAudioOutConfigType type) {
-    TRACY_FUNC(sceAudioOutGetConfig, type);
-    return UNIMPLEMENTED();
+    TRACY_FUNC(sceAudioOutGetConfig, port, type);
+    const AudioOutPortPtr prt = lock_and_find(port, emuenv.audio.out_ports, emuenv.audio.mutex);
+    if (!prt) {
+        return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_PORT);
+    }
+    switch (type) {
+    case SCE_AUDIO_OUT_CONFIG_TYPE_LEN:
+        return prt->len;
+    case SCE_AUDIO_OUT_CONFIG_TYPE_FREQ:
+        return prt->freq;
+    case SCE_AUDIO_OUT_CONFIG_TYPE_MODE:
+        return prt->mode;
+    default:
+        return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_CONF_TYPE);
+    }
 }
 
 EXPORT(int, sceAudioOutGetPortVolume_forUser) {
@@ -201,7 +214,7 @@ EXPORT(int, sceAudioOutOutput, int port, const void *buf) {
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_PORT);
     }
 
-    auto [cfg_it, inserted] = prt->tid_configs.try_emplace(thread_id, AudioOutPort::TidConfig { prt->len, prt->freq, prt->mode });
+    auto [cfg_it, inserted] = prt->tid_configs.try_emplace(thread_id, AudioOutPort::TidConfig{ prt->len, prt->freq, prt->mode });
     const bool config_match = (cfg_it->second.len == prt->len) && (cfg_it->second.freq == prt->freq) && (cfg_it->second.mode == prt->mode);
 
     (void)inserted;

--- a/vita3k/modules/SceAudio/SceAudio.cpp
+++ b/vita3k/modules/SceAudio/SceAudio.cpp
@@ -21,6 +21,7 @@
 #include <kernel/state.h>
 #include <kernel/thread/thread_state.h>
 #include <util/lock_and_find.h>
+#include <util/log.h>
 #include <util/tracy.h>
 
 TRACY_MODULE_NAME(SceAudio);
@@ -170,16 +171,21 @@ EXPORT(int, sceAudioOutOpenPort, SceAudioOutPortType type, int len, int freq, Sc
     }
 
     const int channels = (mode == SCE_AUDIO_OUT_MODE_MONO) ? 1 : 2;
+    const int type_value = static_cast<int>(type);
+    const int mode_value = static_cast<int>(mode);
 
     AudioOutPortPtr port = emuenv.audio.open_port(channels, freq, len);
-    if (!port)
+    if (!port) {
+        LOG_WARN("sceAudioOutOpenPort failed type={} len={} freq={} mode={} backend={}", type_value, len, freq, mode_value, emuenv.audio.audio_backend);
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_NOT_OPENED);
+    }
 
     // Save the port configuration
     port->type = type;
     port->len = len;
     port->freq = freq;
     port->mode = mode;
+    port->tid_configs[thread_id] = { len, freq, mode };
 
     const std::lock_guard<std::mutex> lock(emuenv.audio.mutex);
     const int port_id = emuenv.audio.next_port_id++;
@@ -195,11 +201,22 @@ EXPORT(int, sceAudioOutOutput, int port, const void *buf) {
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_PORT);
     }
 
+    auto [cfg_it, inserted] = prt->tid_configs.try_emplace(thread_id, AudioOutPort::TidConfig { prt->len, prt->freq, prt->mode });
+    const bool config_match = (cfg_it->second.len == prt->len) && (cfg_it->second.freq == prt->freq) && (cfg_it->second.mode == prt->mode);
+
+    (void)inserted;
+
     // Empty "buf" variable is valid. It mean wait until sound output is completed.
     // Because this function always returns when all sound is out, then on empty buf it returns immediately.
     // Return value is the number of samples (value of 0 or greater) registered to the audio driver for normal termination.
     if (!buf)
         return 0;
+
+    // Experimental behavior: if this thread's historical config does not match
+    // the current port config, silently drop its data without signaling an error.
+    if (!config_match) {
+        return prt->len;
+    }
 
     const ThreadStatePtr thread = emuenv.kernel.get_thread(thread_id);
     if (!thread) {
@@ -219,7 +236,9 @@ EXPORT(int, sceAudioOutGetRestSample, int port) {
     if (!prt) {
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_PORT);
     }
-    int samples_available = emuenv.audio.get_rest_sample(*prt);
+
+    const int raw_samples_available = emuenv.audio.get_rest_sample(*prt);
+    int samples_available = raw_samples_available;
     if (prt->type == SCE_AUDIO_OUT_PORT_TYPE_MAIN) {
         samples_available = std::clamp(samples_available, 0, prt->len);
     } else {
@@ -229,6 +248,7 @@ EXPORT(int, sceAudioOutGetRestSample, int port) {
         else
             samples_available = prt->len;
     }
+
     return samples_available;
 }
 
@@ -272,36 +292,46 @@ EXPORT(int, sceAudioOutSetConfig, int port, int len, int freq, int mode) {
     if (len == 0)
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_SIZE);
 
-    if ((mode >= 0) && (mode != SCE_AUDIO_OUT_MODE_MONO) && (mode != SCE_AUDIO_OUT_MODE_STEREO))
+    const bool keep_mode = (mode < 0) || (mode == 0xFF);
+    if (!keep_mode && (mode != SCE_AUDIO_OUT_MODE_MONO) && (mode != SCE_AUDIO_OUT_MODE_STEREO)) {
+        LOG_WARN("sceAudioOutSetConfig invalid mode={} port={} len={} freq={}", mode, port, len, freq);
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_FORMAT);
+    }
 
-    AudioOutPortPtr prt = lock_and_find(port, emuenv.audio.out_ports, emuenv.audio.mutex);
-    if (!prt)
+    AudioOutPortPtr current_port = lock_and_find(port, emuenv.audio.out_ports, emuenv.audio.mutex);
+    if (!current_port)
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_PORT);
 
-    if ((freq >= 0) && (prt->type == SCE_AUDIO_OUT_PORT_TYPE_MAIN) && (freq != 48000))
+    if ((freq >= 0) && (current_port->type == SCE_AUDIO_OUT_PORT_TYPE_MAIN) && (freq != 48000))
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_SAMPLE_FREQ);
 
-    const auto set_len = len > 0 ? len : prt->len;
-    const auto set_freq = freq >= 0 ? freq : prt->freq;
-    const auto set_mode = mode >= 0 ? mode : prt->mode;
+    const auto set_len = len > 0 ? len : current_port->len;
+    const auto set_freq = freq >= 0 ? freq : current_port->freq;
+    const auto set_mode = keep_mode ? current_port->mode : mode;
 
-    if ((set_len == prt->len) && (set_freq == prt->freq) && (set_mode == prt->mode))
+    // Only close/reopen if parameters actually changed
+    if ((set_len == current_port->len) && (set_freq == current_port->freq) && (set_mode == current_port->mode)) {
         return 0;
+    }
 
     if (CALL_EXPORT(sceAudioOutReleasePort, port) != 0)
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_INVALID_PORT);
 
     const auto channels = (set_mode == SCE_AUDIO_OUT_MODE_MONO) ? 1 : 2;
 
-    prt = emuenv.audio.open_port(channels, set_freq, set_len);
+    AudioOutPortPtr prt = emuenv.audio.open_port(channels, set_freq, set_len);
     if (!prt)
         return RET_ERROR(SCE_AUDIO_OUT_ERROR_NOT_OPENED);
 
     // Save the port configuration
+    prt->type = current_port->type;
     prt->freq = set_freq;
     prt->len = set_len;
     prt->mode = set_mode;
+    prt->left_channel_volume = current_port->left_channel_volume;
+    prt->right_channel_volume = current_port->right_channel_volume;
+    prt->tid_configs = current_port->tid_configs;
+    emuenv.audio.set_volume(*prt, current_port->volume);
 
     const std::lock_guard<std::mutex> lock(emuenv.audio.mutex);
     emuenv.audio.out_ports.emplace(port, prt);

--- a/vita3k/threads/include/threads/queue.h
+++ b/vita3k/threads/include/threads/queue.h
@@ -41,7 +41,7 @@ public:
                 }
             } else {
                 if (queue_.empty()) {
-                    condempty_.wait_for(mlock, std::chrono::microseconds(ms));
+                    condempty_.wait_for(mlock, std::chrono::milliseconds(ms));
                 }
             }
             if (aborted || queue_.empty()) {
@@ -63,7 +63,7 @@ public:
                 }
             } else {
                 if (queue_.empty()) {
-                    condempty_.wait_for(mlock, std::chrono::microseconds(ms));
+                    condempty_.wait_for(mlock, std::chrono::milliseconds(ms));
                 }
             }
             if (aborted || queue_.empty()) {


### PR DESCRIPTION
## Summary

Audio improvements covering shutdown safety, streaming pacing, and per-thread configuration mismatch filtering.

### Changes

1. **cubeb: Safe shutdown via CubebAudioSharedState**
   - Extract callback-accessed state into a separate shared_ptr-owned struct
   - Destructor signals shutdown and waits for all in-flight callbacks
   - Prevents use-after-free crashes during rapid stream destruction

2. **SceAudio: Per-thread TidConfig mismatch filtering**
   - Track per-thread audio config (len/freq/mode) in AudioOutPort::tid_configs
   - Silently drop audio from threads using stale configurations
   - Preserves type and volume settings during port reconfiguration

3. **Fix movie audio pacing and queue timing**
   - Use get_stream_buffer_samples() to compute threshold for prebuffering
   - Platform-specific prebuffering (higher on Android, standard on other platforms)
   - Fix SDL3 wait timeout to not double the microseconds on some platforms