### PR TITLE
bgm player: Remove dependency of (Gui/EmuEnv)State.

### DIFF
--- a/vita3k/bgm_player/CMakeLists.txt
+++ b/vita3k/bgm_player/CMakeLists.txt
@@ -6,4 +6,4 @@ add_library(
 )
 
 target_include_directories(bgm_player PUBLIC include)
-target_link_libraries(bgm_player PUBLIC audio cubeb codec gui emuenv io)
+target_link_libraries(bgm_player PUBLIC audio cubeb codec io)

--- a/vita3k/bgm_player/include/bgm_player/functions.h
+++ b/vita3k/bgm_player/include/bgm_player/functions.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include <emuenv/state.h>
-#include <gui/state.h>
+#include <util/fs.h>
 
 namespace bgm_player {
 
 void destroy_bgm_player();
-bool init_bgm(GuiState &gui, EmuEnvState &emuenv);
+bool init_bgm(const fs::path &pref_path, const bool is_enable);
 void init_bgm_player(const float vol);
 void set_bgm_volume(const float vol);
 void set_current_bgm_path(const std::pair<std::string, std::string> &path);

--- a/vita3k/bgm_player/src/bgm_player.cpp
+++ b/vita3k/bgm_player/src/bgm_player.cpp
@@ -425,7 +425,7 @@ void set_current_bgm_path(const std::pair<std::string, std::string> &path) {
     current_path_bgm = path;
 }
 
-bool init_bgm(GuiState &gui, EmuEnvState &emuenv) {
+bool init_bgm(const fs::path &pref_path, const bool is_enable) {
     const auto device = VitaIoDevice::_from_string(current_path_bgm.first.c_str());
     const auto &path = current_path_bgm.second;
 
@@ -436,12 +436,12 @@ bool init_bgm(GuiState &gui, EmuEnvState &emuenv) {
     // Stop current Background Music
     stop_bgm();
 
-    if (!emuenv.io.user_id.empty() && !gui.users[emuenv.io.user_id].system_music)
+    if (!is_enable)
         return false;
 
     // Attempt to read the AT9 file from the specified path
     vfs::FileBuffer at9_buffer;
-    if (!vfs::read_file(device, at9_buffer, emuenv.pref_path, path)) {
+    if (!vfs::read_file(device, at9_buffer, pref_path, path)) {
         if (device == VitaIoDevice::pd0)
             LOG_WARN("Failed to read AT9 file from {}:{}, install Preinst Firmware for fix it", current_path_bgm.first, path);
         else

--- a/vita3k/gui/src/firmware_install_dialog.cpp
+++ b/vita3k/gui/src/firmware_install_dialog.cpp
@@ -131,7 +131,7 @@ void draw_firmware_install_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 if (emuenv.cfg.initial_setup)
                     init_theme(gui, emuenv, gui.users[emuenv.cfg.user_id].theme_id);
                 else {
-                    if (bgm_player::init_bgm(gui, emuenv))
+                    if (bgm_player::init_bgm(emuenv.pref_path, true))
                         bgm_player::switch_bgm_state(false);
                 }
                 fw_version.clear();

--- a/vita3k/gui/src/settings.cpp
+++ b/vita3k/gui/src/settings.cpp
@@ -384,7 +384,7 @@ void draw_settings(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ImVec4(0.62f, 0.75f, 0.62f, 0.8f));
         ImGui::SetCursorPos(ImVec2(SIZE_LIST.x - (106.f * SCALE.x), (SIZE_SELECT - (42.f * SCALE.y)) / 2.f));
         if (ImGui::Checkbox("##system_music", &gui.users[emuenv.io.user_id].system_music)) {
-            bgm_player::init_bgm(gui, emuenv);
+            bgm_player::init_bgm(emuenv.pref_path, gui.users[emuenv.io.user_id].system_music);
             save_user(gui, emuenv, emuenv.io.user_id);
         }
         ImGui::PopStyleColor(4);

--- a/vita3k/gui/src/themes.cpp
+++ b/vita3k/gui/src/themes.cpp
@@ -358,7 +358,7 @@ bool init_theme(GuiState &gui, EmuEnvState &emuenv, const std::string &content_i
 
     // Initialize the theme BGM with the path
     bgm_player::set_current_bgm_path(path_bgm);
-    bgm_player::init_bgm(gui, emuenv);
+    bgm_player::init_bgm(emuenv.pref_path, gui.users[emuenv.io.user_id].system_music);
 
     for (const auto &icon : theme_icon_name) {
         int32_t width = 0;

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -330,7 +330,7 @@ int main(int argc, char *argv[]) {
         bgm_player::init_bgm_player(emuenv.cfg.bgm_volume);
         if (!emuenv.cfg.initial_setup) {
             emuenv.cfg.system_music.emplace(false);
-            if (bgm_player::init_bgm(gui, emuenv))
+            if (bgm_player::init_bgm(emuenv.pref_path, true))
                 bgm_player::switch_bgm_state(true);
             while (!emuenv.cfg.initial_setup) {
                 wait_for_frame_done();


### PR DESCRIPTION
# About
- bgm player: Remove dependency of (Gui/EmuEnv)State.
Send only pref path and state of option.