### PR TITLE
mem: Add missing include for latest GCC/Clang

### DIFF
--- a/vita3k/mem/include/mem/atomic.h
+++ b/vita3k/mem/include/mem/atomic.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
used upstream instead of origin, mb but still should be merged fast