### PR TITLE
config: Add option to enable/disable font scaling.

### DIFF
--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -185,7 +185,7 @@ enum ScreenshotFormat {
     code(int, "keyboard-take-screenshot-alt", 0, keyboard_take_screenshot_alt)                          \
     code(int, "keyboard-pinch-modifier-alt", 0, keyboard_pinch_modifier_alt)                            \
     code(int, "keyboard-alternate-pinch-in-alt", 0, keyboard_alternate_pinch_in_alt)                    \
-    code(int, "keyboard-alternate-pinch-out-alt", 0, keyboard_alternate_pinch_out_alt)                 \
+    code(int, "keyboard-alternate-pinch-out-alt", 0, keyboard_alternate_pinch_out_alt)                  \
     code(std::string, "user-id", std::string{}, user_id)                                                \
     code(bool, "user-auto-connect", false, auto_user_login)                                             \
     code(std::string, "user-lang", std::string{}, user_lang)                                            \
@@ -194,6 +194,7 @@ enum ScreenshotFormat {
     code(bool, "check-for-updates", true, check_for_updates)                                            \
     code(int, "file-loading-delay", 0, file_loading_delay)                                              \
     code(bool, "asia-font-support", false, asia_font_support)                                           \
+    code(bool, "font-scaling", true, font_scaling)                                                     \
     code(bool, "shader-cache", true, shader_cache)                                                      \
     code(bool, "spirv-shader", false, spirv_shader)                                                     \
     code(bool, "fps-hack", false, fps_hack)                                                             \

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -208,7 +208,8 @@ static void init_font(GuiState &gui, EmuEnvState &emuenv) {
     int max_texture_size = emuenv.renderer->get_max_2d_texture_width();
     io.Fonts->TexDesiredWidth = max_texture_size;
 
-    for (int font_scale_count = std::size(FontScaleCandidates); font_scale_count > 0; font_scale_count--) {
+    const auto FONT_SCALE_COUNT = emuenv.cfg.font_scaling ? std::size(FontScaleCandidates) : 1;
+    for (int font_scale_count = FONT_SCALE_COUNT; font_scale_count > 0; font_scale_count--) {
         for (int i = 0; i < font_scale_count; i++) {
             float scale = FontScaleCandidates[i];
 

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -260,6 +260,9 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::Checkbox(lang["show_live_area_screen"].c_str(), &emuenv.cfg.show_live_area_screen);
         SetTooltipEx(lang["live_area_screen_description"].c_str());
         ImGui::Spacing();
+        ImGui::Checkbox("Font Scaling", &emuenv.cfg.font_scaling);
+        SetTooltipEx("Enable or disable font scaling in the GUI.\nThis option increases memory usage.");
+        ImGui::SameLine();
         ImGui::Checkbox(lang["apps_list_grid"].c_str(), &emuenv.cfg.apps_list_grid);
         SetTooltipEx(lang["apps_list_grid_description"].c_str());
         if (!emuenv.cfg.apps_list_grid) {

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -1372,6 +1372,9 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 open_path("https://bit.ly/2P2rb0r");
             SetTooltipEx(lang.gui["firmware_font_package_description"].c_str());
         }
+        ImGui::SameLine();
+        ImGui::Checkbox("Font Scaling", &emuenv.cfg.font_scaling);
+        SetTooltipEx("Enable or disable font scaling in the GUI.\nThis option increases memory usage.\nRestart required for changes to take effect.");
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -330,6 +330,7 @@ int main(int argc, char *argv[]) {
         bgm_player::init_bgm_player(emuenv.cfg.bgm_volume);
         if (!emuenv.cfg.initial_setup) {
             emuenv.cfg.system_music.emplace(false);
+            const auto current_font_scaling_state = emuenv.cfg.font_scaling;
             if (bgm_player::init_bgm(emuenv.pref_path, true))
                 bgm_player::switch_bgm_state(true);
             while (!emuenv.cfg.initial_setup) {
@@ -342,7 +343,7 @@ int main(int argc, char *argv[]) {
                 } else
                     return QuitRequested;
             }
-            if (!gui.fw_font)
+            if (!gui.fw_font || (emuenv.cfg.font_scaling != current_font_scaling_state))
                 gui::load_fonts(gui, emuenv, true);
         }
         gui::init(gui, emuenv);


### PR DESCRIPTION
# About
- config: Add option to enable/disable font scaling.
Introduced a font scaling checkbox in the initial setup, with automatic font reload on completion.
Added the checkbox to the settings dialog as well, applying the change requires a restart.