### PR TITLE
debugger/kernel: remove unused trampoline machinery

### DIFF
--- a/vita3k/kernel/include/kernel/debugger.h
+++ b/vita3k/kernel/include/kernel/debugger.h
@@ -22,22 +22,7 @@
 
 #include <map>
 
-constexpr uint32_t TRAMPOLINE_JUMPER_SVC = 0x54;
-constexpr uint32_t TRAMPOLINE_HANDLER_SVC = 0x53;
-
 struct KernelState;
-
-typedef std::function<bool(CPUState &cpu, MemState &mem, Address lr)> TrampolineCallback;
-
-struct Trampoline {
-    bool thumb_mode;
-    uint32_t original;
-    Block trampoline_code;
-    Address trampoline_addr;
-    Address addr;
-    Address lr;
-    TrampolineCallback callback;
-};
 
 struct Breakpoint {
     bool thumb_mode;
@@ -51,7 +36,6 @@ struct WatchMemory {
 
 typedef std::map<Address, WatchMemory> WatchMemoryAddrs;
 typedef std::map<Address, Breakpoint> Breakpoints;
-typedef std::map<Address, std::unique_ptr<Trampoline>> Trampolines;
 
 struct Debugger {
     Debugger() = delete;
@@ -70,9 +54,6 @@ struct Debugger {
     void remove_watch_memory_addr(KernelState &state, Address addr);
     void add_breakpoint(MemState &mem, uint32_t addr, bool thumb_mode);
     void remove_breakpoint(MemState &mem, uint32_t addr);
-    void add_trampoline(MemState &mem, uint32_t addr, bool thumb_mode, const TrampolineCallback &callback);
-    Trampoline *get_trampoline(Address addr);
-    void remove_trampoline(MemState &mem, uint32_t addr);
     Address get_watch_memory_addr(Address addr);
     void update_watches();
 
@@ -81,5 +62,4 @@ private:
     KernelState &parent;
     WatchMemoryAddrs watch_memory_addrs;
     Breakpoints breakpoints;
-    Trampolines trampolines;
 };

--- a/vita3k/kernel/src/cpu_protocol.cpp
+++ b/vita3k/kernel/src/cpu_protocol.cpp
@@ -27,29 +27,6 @@ CPUProtocol::CPUProtocol(KernelState &kernel, MemState &mem, const CallImportFun
 }
 
 void CPUProtocol::call_svc(CPUState &cpu, uint32_t svc, Address pc, ThreadState &thread) {
-    // Handle trampoline
-    // 1. Handle trampoline jumper
-    // to save the space we use interrupt to implement jumper
-    // as thumb instructions require total three instructions to jump to any pc without limitations
-    if (svc == TRAMPOLINE_JUMPER_SVC) {
-        // find thumb16 trampoline
-        Trampoline *tr = kernel->debugger.get_trampoline(pc - 2);
-        // find thumb32 or arm trampoline
-        if (!tr)
-            tr = kernel->debugger.get_trampoline(pc - 4);
-        write_pc(cpu, tr->trampoline_addr);
-        return;
-    }
-
-    // 2. Call trampoline callback
-    // this interrupt is made inside trampoline body
-    if (svc == TRAMPOLINE_HANDLER_SVC) {
-        Trampoline *tr = *Ptr<Trampoline *>(pc).get(*mem);
-        tr->callback(cpu, *mem, tr->lr);
-        return;
-    }
-
-    // This is usual service call
     uint32_t nid = *Ptr<uint32_t>(pc + 4).get(*mem);
     // TODO: just supply ThreadStatePtr to call_import
     // the only benefit of using thread_id instead--namely less locking-- has been gone for long

--- a/vita3k/kernel/src/debugger.cpp
+++ b/vita3k/kernel/src/debugger.cpp
@@ -17,14 +17,9 @@
 
 #include <kernel/debugger.h>
 #include <kernel/state.h>
-#include <util/align.h>
 
 constexpr unsigned char THUMB_BREAKPOINT[2] = { 0x00, 0xBE };
 constexpr unsigned char ARM_BREAKPOINT[4] = { 0x70, 0x00, 0x20, 0xE1 };
-
-inline static bool is_thumb16(uint32_t inst) {
-    return (inst & 0xF8000000) < 0xE8000000;
-}
 
 void Debugger::add_breakpoint(MemState &mem, uint32_t addr, bool thumb_mode) {
     const auto lock = std::lock_guard(mutex);
@@ -47,73 +42,6 @@ void Debugger::remove_breakpoint(MemState &mem, uint32_t addr) {
         auto last = breakpoints[addr];
         std::memcpy(Ptr<uint8_t>(addr).get(mem), &last.data, last.thumb_mode ? sizeof(THUMB_BREAKPOINT) : sizeof(ARM_BREAKPOINT));
         breakpoints.erase(addr);
-        parent.invalidate_jit_cache(addr, 4);
-    }
-}
-
-void Debugger::add_trampoline(MemState &mem, uint32_t addr, bool thumb_mode, const TrampolineCallback &callback) {
-    const auto swap_inst = [](uint32_t inst) {
-        return (inst << 16) | ((inst >> 16) & 0xFFFF);
-    };
-
-    std::unique_ptr<Trampoline> tr = std::make_unique<Trampoline>();
-    tr->addr = addr;
-    tr->thumb_mode = thumb_mode;
-    tr->callback = callback;
-    tr->trampoline_code = alloc_block(mem, 0x60, "trampoline");
-
-    const Address trampoline_addr = align(tr->trampoline_code.get(), 4);
-    tr->trampoline_addr = trampoline_addr;
-    if (thumb_mode)
-        tr->trampoline_addr |= 1;
-
-    // Insert trampoline jumper and back up
-    uint32_t *inst = Ptr<uint32_t>(addr).get(mem);
-    tr->original = *inst;
-    uint32_t back_inst;
-    if (thumb_mode && is_thumb16(swap_inst(*inst))) {
-        *inst = (tr->original & 0xFFFF0000) | 0xDF54; // SVC 0x54
-        tr->lr = tr->addr + 2;
-        tr->lr |= 1;
-        back_inst = 0xBF000000 | (tr->original & 0xFFFF);
-    } else if (thumb_mode) {
-        *inst = 0xDF54BF00; // SVC 0x54
-        tr->lr = tr->addr + 4;
-        tr->lr |= 1;
-        back_inst = tr->original;
-    } else { // ARM
-        *inst = 0xEF000054; // SVC 0x54
-        tr->lr = tr->addr + 4;
-        back_inst = tr->original;
-    }
-
-    // Create trampoline body
-    uint32_t *trampoline_insts = Ptr<uint32_t>(trampoline_addr).get(mem);
-    trampoline_insts[0] = back_inst; // original instruction; if thumb16 it's nop + original thumb16 instruction
-    trampoline_insts[1] = thumb_mode ? 0xDF53BF00 : 0xEF000053; // SVC 0x53
-    Trampoline **trampoline_host_ptr = Ptr<Trampoline *>(trampoline_addr + 8).get(mem); // interrupt handler will read this
-    *trampoline_host_ptr = tr.get();
-
-    std::lock_guard<std::mutex> lock(mutex);
-    trampolines.emplace(addr, std::move(tr));
-    parent.invalidate_jit_cache(addr, 4);
-}
-
-Trampoline *Debugger::get_trampoline(Address addr) {
-    const auto lock = std::lock_guard(mutex);
-    const auto it = trampolines.find(addr);
-    if (it == trampolines.end())
-        return nullptr;
-    return it->second.get();
-}
-
-void Debugger::remove_trampoline(MemState &mem, uint32_t addr) {
-    std::lock_guard<std::mutex> lock(mutex);
-    const auto it = trampolines.find(addr);
-    if (it != trampolines.end()) {
-        uint32_t *insts = Ptr<uint32_t>(addr).get(mem);
-        insts[0] = it->second->original;
-        trampolines.erase(it);
         parent.invalidate_jit_cache(addr, 4);
     }
 }


### PR DESCRIPTION
The Debugger trampoline API (`Trampoline` struct, `TrampolineCallback`, `add_trampoline` / `get_trampoline` / `remove_trampoline`, `TRAMPOLINE_JUMPER_SVC` and `TRAMPOLINE_HANDLER_SVC`, plus the two SVC-dispatch branches in `CPUProtocol::call_svc`) has never had a caller.