### PR TITLE
kernel: extract abort dispatch into ThreadState::dispatch_abort

### DIFF
--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -121,6 +121,7 @@ struct ThreadState {
 
 private:
     void push_arguments(const std::vector<uint32_t> &args);
+    void dispatch_abort(CPUState &cpu);
 
     KernelState &kernel;
 

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -286,37 +286,8 @@ bool ThreadState::run_loop() {
                 }
 
                 // handle pending abort (exception handler from page fault)
-                if (cpu->abort_pending.exchange(false)) {
-                    const uint32_t fault_addr = cpu->abort_fault_addr.load();
-                    // DABT = type 0
-                    const Address handler = kernel.exception_handlers[0].load();
-                    if (handler) {
-                        // Build KuKernelAbortContext on guest stack for the handler to read.
-                        // Note: by the time we get here, the page has already been unprotected
-                        // by the protect_tree mechanism, and the CPU may have executed past
-                        // the faulting instruction. The handler is called as a notification;
-                        // we don't restore from AbortContext afterward.
-                        // { r0-r12, sp, lr, pc, FAR } = 17 uint32_t = 68 bytes
-                        const uint32_t ctx_size = 17 * 4;
-                        uint32_t sp_val = read_sp(*cpu);
-                        sp_val -= ctx_size;
-                        sp_val &= ~7u; // align to 8
-
-                        auto *ctx = Ptr<uint32_t>(sp_val).get(*cpu->mem);
-                        for (int i = 0; i < 13; i++)
-                            ctx[i] = read_reg(*cpu, i);
-                        ctx[13] = sp_val + ctx_size;
-                        ctx[14] = read_lr(*cpu);
-                        ctx[15] = read_pc(*cpu);
-                        ctx[16] = fault_addr;
-
-                        LOG_DEBUG("DABT handler=0x{:08X} FAR=0x{:08X} PC=0x{:08X} SP=0x{:08X} sp_val=0x{:08X}",
-                            handler, fault_addr, ctx[15], read_sp(*cpu), sp_val);
-
-                        // run_callback saves/restores full CPU context internally
-                        run_callback(handler, { sp_val });
-                    }
-                }
+                if (cpu->abort_pending.exchange(false))
+                    dispatch_abort(*cpu);
 
                 lock.lock();
                 if (to_do != ThreadToDo::run || res != 0 || call_level != run_level || hit_breakpoint(*cpu))
@@ -412,6 +383,38 @@ uint32_t ThreadState::run_callback(Address callback_address, const std::vector<u
     write_tpidruro(*cpu, previous_tpidruro);
 
     return returned_value;
+}
+
+void ThreadState::dispatch_abort(CPUState &cpu) {
+    const uint32_t fault_addr = cpu.abort_fault_addr.load();
+    // DABT = type 0
+    const Address handler = kernel.exception_handlers[0].load();
+    if (!handler)
+        return;
+
+    // Build KuKernelAbortContext on guest stack for the handler to read.
+    // Note: by the time we get here, the page has already been unprotected
+    // by the protect_tree mechanism, and the CPU may have executed past
+    // the faulting instruction. The handler is called as a notification;
+    // we don't restore from AbortContext afterward.
+    // { r0-r12, sp, lr, pc, FAR } = 17 uint32_t = 68 bytes
+    const uint32_t ctx_size = 17 * 4;
+    const uint32_t sp_orig = read_sp(cpu);
+    const uint32_t sp_aligned = align_down(sp_orig - ctx_size, 8);
+
+    auto *ctx = Ptr<uint32_t>(sp_aligned).get(*cpu.mem);
+    for (int i = 0; i < 13; i++)
+        ctx[i] = read_reg(cpu, i);
+    ctx[13] = sp_aligned + ctx_size;
+    ctx[14] = read_lr(cpu);
+    ctx[15] = read_pc(cpu);
+    ctx[16] = fault_addr;
+
+    LOG_DEBUG("DABT handler=0x{:08X} FAR=0x{:08X} PC=0x{:08X} SP=0x{:08X} sp_aligned=0x{:08X}",
+        handler, fault_addr, ctx[15], sp_orig, sp_aligned);
+
+    // run_callback saves/restores full CPU context internally
+    run_callback(handler, { sp_aligned });
 }
 
 uint32_t ThreadState::run_guest_function(Address callback_address, SceSize args, const Ptr<void> argp) {


### PR DESCRIPTION
Makes `ThreadState::run_loop` simpler to understand.