### PR TITLE
[TESTING NEEDED] kernel/thread: rework run_loop lifecycle (drop `ThreadToDo` + `something_to_do`)

### DIFF
--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -58,15 +58,6 @@ private:
     bool signaled = false;
 };
 
-// Internal
-enum class ThreadToDo {
-    remove,
-    run,
-    step,
-    suspend,
-    wait,
-};
-
 struct ThreadState {
     std::mutex mutex;
     std::string name;
@@ -104,7 +95,7 @@ struct ThreadState {
     void update_status(ThreadStatus status, std::optional<ThreadStatus> expected = std::nullopt);
     Address stack_top() const;
 
-    bool run_loop();
+    void run_loop();
     void raise_waiting_threads();
 
     // this function must be called from the thread itself (inside a svc call)
@@ -126,14 +117,17 @@ private:
     KernelState &kernel;
 
     CPUContext init_cpu_ctx;
-    ThreadToDo to_do = ThreadToDo::wait;
-    std::condition_variable something_to_do;
+    // sceKernelExitThread (or top-level guest function return): park at dormant, thread reusable via start() / run_guest_function().
+    bool exit_requested = false;
+    // sceKernelExitDeleteThread (or external kill): will return from top-level run_loop(), then host thread joins.
+    bool delete_requested = false;
+    // Set by suspend(), consumed in run_loop() to transition to ThreadStatus::suspend.
+    bool suspend_requested = false;
+    // Single stepping mode.
+    bool single_stepping = false;
 
-    // if looking at the thread stack, the number of times run_loop appear
-    // if the thread is dormant, call_level is 0
-    // most of the time the thread is running, call_level is 1
-    // if running a callback inside a callback (possible for exemple by allocating
-    // gxm callbacked memory inside a kernel callback), call_level is 2
+    // Number of active run_loop frames. The top-level host thread keeps one
+    // frame alive (run_loop()) while parked dormant; callbacks add nested frames.
     int call_level = 0;
 
     // when calling sceKernelStartThread

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -130,12 +130,11 @@ void ThreadState::raise_waiting_threads() {
 }
 
 int ThreadState::start(SceSize arglen, const Ptr<void> argp, bool run_entry_callback) {
-    if (status == ThreadStatus::run || call_level > 0)
-        return SCE_KERNEL_ERROR_RUNNING;
     std::unique_lock<std::mutex> thread_lock(mutex);
+    if (status != ThreadStatus::dormant)
+        return SCE_KERNEL_ERROR_RUNNING;
 
     run_start_callback = run_entry_callback;
-    call_level = 1;
     load_context(*cpu, init_cpu_ctx);
     write_pc(*cpu, entry_point);
     write_lr(*cpu, kernel.halt_instruction_pc);
@@ -151,14 +150,12 @@ int ThreadState::start(SceSize arglen, const Ptr<void> argp, bool run_entry_call
     }
 
     if (kernel.debugger.wait_for_debugger) {
-        to_do = ThreadToDo::suspend;
-        status = ThreadStatus::suspend;
         kernel.debugger.wait_for_debugger = false;
+        status = ThreadStatus::suspend;
     } else {
-        to_do = ThreadToDo::run;
         status = ThreadStatus::run;
     }
-    something_to_do.notify_one();
+    status_cond.notify_one();
 
     return SCE_KERNEL_OK;
 }
@@ -166,7 +163,7 @@ int ThreadState::start(SceSize arglen, const Ptr<void> argp, bool run_entry_call
 void ThreadState::exit(SceInt32 status) {
     std::lock_guard<std::mutex> guard(mutex);
     run_end_callback = true;
-    call_level = 0;
+    exit_requested = true;
     returned_value = static_cast<uint32_t>(status);
 }
 
@@ -174,25 +171,24 @@ void ThreadState::exit_delete(bool exit) {
     std::lock_guard<std::mutex> lock(mutex);
 
     run_end_callback = exit;
+    delete_requested = true;
 
-    const ThreadToDo last_to_do = to_do;
-    to_do = ThreadToDo::remove;
-    if (last_to_do == ThreadToDo::wait) {
-        something_to_do.notify_one();
-    } else {
+    if (status == ThreadStatus::run) {
         stop(*cpu);
+    } else if (status == ThreadStatus::wait) {
+        // wake threads blocked in a sync primitive so they can observe delete_requested
+        update_status(ThreadStatus::run);
+    } else {
+        // dormant or suspend: wake run_loop() so it can observe delete_requested
+        status_cond.notify_all();
     }
-
-    // Thread may enter a sync primitive wait after this runs, so always notify
-    update_status(ThreadStatus::run);
 
     // Wake if thread waiting on sceKernelWaitSignal
     signal.send();
 }
 
-bool ThreadState::run_loop() {
-    int res = 0;
-    int run_level = std::max(call_level, 1);
+void ThreadState::run_loop() {
+    bool guest_returned = false;
 
     // Set thread-local CPU state so signal handlers can access it.
     // The guard clears it on any exit so a recycled host thread never sees
@@ -203,6 +199,8 @@ bool ThreadState::run_loop() {
     } cpu_state_guard;
 
     std::unique_lock<std::mutex> lock(mutex);
+    ++call_level;
+    const bool top_level = call_level == 1;
 
     auto run_thread_end_callback = [&]() {
         if (!run_end_callback)
@@ -212,128 +210,100 @@ bool ThreadState::run_loop() {
         if (!kernel.thread_event_end)
             return;
 
-        ThreadToDo old_to_do = to_do;
-        int old_call_level = call_level;
-        uint32_t old_returned_value = returned_value;
-        to_do = ThreadToDo::run;
-        call_level = 1;
+        const ThreadStatus old_status = status;
+        const uint32_t old_returned_value = returned_value;
+        status = ThreadStatus::run;
 
         lock.unlock();
-        int ret = run_callback(kernel.thread_event_end.address(), { SCE_KERNEL_THREAD_EVENT_TYPE_END, static_cast<uint32_t>(id), 0, kernel.thread_event_end_arg });
+        const int ret = run_callback(kernel.thread_event_end.address(), { SCE_KERNEL_THREAD_EVENT_TYPE_END, static_cast<uint32_t>(id), 0, kernel.thread_event_end_arg });
         if (ret != 0)
-            LOG_WARN("Thread start event handler returned {}", log_hex(ret));
+            LOG_WARN("Thread end event handler returned {}", log_hex(ret));
         lock.lock();
 
-        to_do = old_to_do;
-        call_level = old_call_level;
+        status = old_status;
         returned_value = old_returned_value;
     };
 
     while (true) {
-        switch (to_do) {
-        case ThreadToDo::remove:
-            if (run_level == 1) {
+        // Check if this call-level is done (normal exit, guest return, or delete).
+        if (exit_requested || guest_returned || delete_requested) {
+            // Top-level fires the end callback and parks dormant
+            if (top_level && status != ThreadStatus::dormant) {
                 run_thread_end_callback();
                 update_status(ThreadStatus::dormant);
             }
-
-            return true;
-        case ThreadToDo::run:
-        case ThreadToDo::step:
-
-            if (call_level == 0) {
-                run_thread_end_callback();
-
-                // nothing to do
-                update_status(ThreadStatus::dormant);
-                to_do = ThreadToDo::wait;
+            // Return from nested levels to the top level (or completely if deleted)
+            if (!top_level || delete_requested)
                 break;
-            }
+            exit_requested = false;
+            guest_returned = false;
+            // Status is now dormant: we'll park until the next start() or exit_delete().
+        }
 
-            update_status(ThreadStatus::run);
+        // Park until we have something to do.
+        if (status != ThreadStatus::run) {
+            status_cond.wait(lock, [&] {
+                return status == ThreadStatus::run || delete_requested;
+            });
+            continue;
+        }
+
+        // Fire the thread-start event once per start.
+        if (run_start_callback) {
+            run_start_callback = false;
+            lock.unlock();
+            if (kernel.thread_event_start) {
+                const int ret = run_callback(kernel.thread_event_start.address(), { SCE_KERNEL_THREAD_EVENT_TYPE_START, static_cast<uint32_t>(id), 0, kernel.thread_event_start_arg });
+                if (ret != 0)
+                    LOG_WARN("Thread start event handler returned {}", log_hex(ret));
+            }
+            lock.lock();
+        }
+
+        // Active JIT loop. Lock held on entry and exit; unlocked only around run/step.
+        while (!delete_requested && !exit_requested && !guest_returned && status == ThreadStatus::run) {
+            const bool do_step = single_stepping;
+            if (do_step)
+                single_stepping = false;
 
             lock.unlock();
 
-            if (run_start_callback) {
-                run_start_callback = false;
+            // Single step or run
+            const int res = do_step ? step(*cpu) : run(*cpu);
 
-                if (kernel.thread_event_start) {
-                    int ret = run_callback(kernel.thread_event_start.address(), { SCE_KERNEL_THREAD_EVENT_TYPE_START, static_cast<uint32_t>(id), 0, kernel.thread_event_start_arg });
-                    if (ret != 0)
-                        LOG_WARN("Thread start event handler returned {}", log_hex(ret));
-                }
+            // handle svc call if this was what stopped the cpu
+            if (cpu->svc_called) {
+                const uint32_t nid = *Ptr<uint32_t>(read_pc(*cpu) + 4).get(mem);
+                kernel.call_import(*cpu, nid, id);
+                clear_exclusive(*cpu);
             }
 
-            // Run the cpu — lock is NOT held on entry, HELD on exit
-            while (true) {
-                lock.lock();
-                const bool do_step = (to_do == ThreadToDo::step);
-                if (do_step)
-                    to_do = ThreadToDo::suspend;
-                lock.unlock();
+            // handle pending abort (exception handler from page fault)
+            if (cpu->abort_pending.exchange(false))
+                dispatch_abort(*cpu);
 
-                if (do_step)
-                    res = step(*cpu);
-                else
-                    res = run(*cpu);
+            lock.lock();
 
-                // handle svc call if this was what stopped the cpu
-                if (cpu->svc_called) {
-                    const uint32_t nid = *Ptr<uint32_t>(read_pc(*cpu) + 4).get(mem);
-                    kernel.call_import(*cpu, nid, id);
-                    clear_exclusive(*cpu);
-                }
-
-                // handle pending abort (exception handler from page fault)
-                if (cpu->abort_pending.exchange(false))
-                    dispatch_abort(*cpu);
-
-                lock.lock();
-                if (to_do != ThreadToDo::run || res != 0 || call_level != run_level || hit_breakpoint(*cpu))
-                    break;
-                lock.unlock();
-            }
-
-            // Handle errors
-            if (to_do == ThreadToDo::remove)
-                continue;
-
-            if (res < 0) {
-                LOG_ERROR("Thread {} ({}) experienced a cpu error.", name, cpu->thread_id);
-                returned_value = 0xDEADDEAD;
-                call_level--;
-                if (call_level > 0)
-                    // only return if we are inside a callback
-                    return true;
-                break;
-            }
-
-            if (hit_breakpoint(*cpu) || to_do == ThreadToDo::suspend) {
+            if (do_step || suspend_requested || hit_breakpoint(*cpu)) {
+                suspend_requested = false;
                 update_status(ThreadStatus::suspend);
-                to_do = ThreadToDo::wait;
             }
 
-            if (call_level < run_level && run_level > 1)
-                // exit requested, exit this callback now
-                return true;
-
-            if (res) {
-                returned_value = read_reg(*cpu, 0);
-                call_level--;
-                if (call_level > 0)
-                    // only return if we are inside a callback
-                    return true;
+            // Guest function for this run_loop returned (or errored).
+            if (res != 0) {
+                if (res < 0) {
+                    LOG_ERROR("Thread {} ({}) experienced a cpu error.", name, cpu->thread_id);
+                    returned_value = 0xDEADDEAD;
+                } else {
+                    // Halt-sentinel (res = 1): guest function returned cleanly.
+                    returned_value = read_reg(*cpu, 0);
+                }
+                guest_returned = true;
             }
-            break;
-        case ThreadToDo::wait:
-            something_to_do.wait(lock);
-            break;
-        case ThreadToDo::suspend:
-            update_status(ThreadStatus::suspend);
-            something_to_do.wait(lock);
-            break;
         }
     }
+
+    --call_level;
 }
 
 void ThreadState::push_arguments(const std::vector<uint32_t> &args) {
@@ -351,17 +321,16 @@ void ThreadState::push_arguments(const std::vector<uint32_t> &args) {
 }
 
 uint32_t ThreadState::run_callback(Address callback_address, const std::vector<uint32_t> &args) {
+    std::unique_lock<std::mutex> thread_lock(mutex);
     if (call_level == 0) {
         LOG_ERROR("run_callback should not be called as the first thread entry");
         return 0;
     }
 
-    // first save the current context
+    // save the current context before overwriting PC/LR for the callback
     const CPUContext previous_ctx = save_context(*cpu);
     const uint32_t previous_tpidruro = read_tpidruro(*cpu);
 
-    std::unique_lock<std::mutex> thread_lock(mutex);
-    call_level++;
     // we shouldn't have to clean the context I believe
     write_pc(*cpu, callback_address);
     write_lr(*cpu, kernel.halt_instruction_pc);
@@ -423,11 +392,8 @@ uint32_t ThreadState::run_guest_function(Address callback_address, SceSize args,
 
     start(args, argp);
     {
-        // wait for the function to return
         std::unique_lock<std::mutex> lock(mutex);
-        status_cond.wait(lock, [&]() {
-            return status == ThreadStatus::dormant && to_do != ThreadToDo::run;
-        });
+        status_cond.wait(lock, [&]() { return status == ThreadStatus::dormant; });
     }
 
     entry_point = old_entry_point;
@@ -444,8 +410,8 @@ void ThreadState::update_status(ThreadStatus status, std::optional<ThreadStatus>
     if (expected)
         assert(expected.value() == this->status);
 
-    // Keep status as run after removal so handle_timeout's predicate is immediately satisfied
-    if (status == ThreadStatus::wait && to_do == ThreadToDo::remove)
+    // Don't apply the requested wait transition if being removed to not block deletion
+    if (status == ThreadStatus::wait && delete_requested)
         return;
 
     this->status = status;
@@ -461,22 +427,21 @@ Address ThreadState::stack_top() const {
 }
 
 void ThreadState::suspend() {
-    assert(to_do == ThreadToDo::run);
+    assert(status == ThreadStatus::run);
     {
         const std::lock_guard<std::mutex> lock(mutex);
-        to_do = ThreadToDo::suspend;
+        suspend_requested = true;
     }
     stop(*cpu);
 }
 
 void ThreadState::resume(bool step) {
-    assert(to_do == ThreadToDo::wait || to_do == ThreadToDo::suspend);
-
+    assert(status == ThreadStatus::suspend || status == ThreadStatus::dormant);
     {
-        const auto thread_lock = std::lock_guard(mutex);
-        to_do = step ? ThreadToDo::step : ThreadToDo::run;
+        const std::lock_guard<std::mutex> lock(mutex);
+        single_stepping = step;
+        update_status(ThreadStatus::run);
     }
-    something_to_do.notify_one();
 }
 
 std::string ThreadState::log_stack_traceback() const {


### PR DESCRIPTION
Replace `ThreadToDo` and the `something_to_do` condvar with four boolean flags: `exit_requested`, `delete_requested`, `suspend_requested`, `single_stepping`. `run_loop()` returns void.

`call_level` brackets each frame: incremented on entry, decremented just before return.

All call-level exits (normal exit, guest return, delete) converge on a single block at the top of the loop that fires the end callback and parks dormant. This wakes `wait_thread_end` waiters on every exit path.
If deleted, return completely from all `run_loop()` nested levels.