### PR TITLE
gui: fix keyboard input on macOS

### DIFF
--- a/vita3k/gui-qt/src/physical_key_qt.cpp
+++ b/vita3k/gui-qt/src/physical_key_qt.cpp
@@ -41,5 +41,13 @@ input::NativeScanCodeSet qt_native_scan_code_set() {
 } // namespace
 
 input::PhysicalKeyCode physical_key_from_qt_event(const QKeyEvent &event) {
+#if defined(Q_OS_MACOS)
+    const auto native_virtual_key = event.nativeVirtualKey();
+    if (native_virtual_key == 0x0000)
+        return input::PhysicalKeyCode::KeyA;
+
+    return input::physical_key_from_native_scan_code(qt_native_scan_code_set(), native_virtual_key);
+#else
     return input::physical_key_from_native_scan_code(qt_native_scan_code_set(), event.nativeScanCode());
+#endif
 }


### PR DESCRIPTION
## Summary

Fix keyboard input on macOS by using `QKeyEvent::nativeVirtualKey()` for physical key mapping.

Previous versions could not use keyboard input correctly on macOS because `nativeScanCode()` does not provide the macOS virtual key code
expected by `NativeScanCodeSet::MacOS`. This changes only the macOS path; other platforms continue to use `nativeScanCode()` unchanged.

## Testing

- Built and tested on macOS.
- Verified keyboard input works on macOS after this change.