### PR TITLE
vulkan: fix macOS swapchain setup with Qt 6.11

### DIFF
--- a/vita3k/renderer/src/vulkan/metal_layer.mm
+++ b/vita3k/renderer/src/vulkan/metal_layer.mm
@@ -19,5 +19,30 @@
 #import <QuartzCore/CAMetalLayer.h>
 
 extern "C" void *get_metal_layer_from_view(void *nsview) {
-    return (__bridge void *)((__bridge NSView *)nsview).layer;
+    NSView *view = (__bridge NSView *)nsview;
+    if (!view)
+        return nullptr;
+
+    view.wantsLayer = YES;
+    CALayer *layer = view.layer;
+    if (![layer isKindOfClass:[CAMetalLayer class]]) {
+        CAMetalLayer *metal_layer = [CAMetalLayer layer];
+        NSScreen *screen = view.window.screen ?: NSScreen.mainScreen;
+        metal_layer.contentsScale = screen ? screen.backingScaleFactor : 1.0;
+        view.layer = metal_layer;
+        layer = metal_layer;
+    }
+
+    CAMetalLayer *metal_layer = (CAMetalLayer *)layer;
+    NSScreen *screen = view.window.screen ?: NSScreen.mainScreen;
+    const CGFloat scale = screen ? screen.backingScaleFactor : view.window.backingScaleFactor;
+    const CGRect bounds = view.bounds;
+    metal_layer.frame = bounds;
+    metal_layer.contentsScale = scale > 0.0 ? scale : 1.0;
+    if (bounds.size.width > 0.0 && bounds.size.height > 0.0) {
+        metal_layer.drawableSize = CGSizeMake(bounds.size.width * metal_layer.contentsScale,
+            bounds.size.height * metal_layer.contentsScale);
+    }
+
+    return (__bridge void *)layer;
 }

--- a/vita3k/renderer/src/vulkan/screen_renderer.cpp
+++ b/vita3k/renderer/src/vulkan/screen_renderer.cpp
@@ -232,6 +232,12 @@ bool ScreenRenderer::setup() {
     create_render_pass();
 
     create_swapchain();
+    if (!swapchain || swapchain_size == 0) {
+        const renderer::WindowSize size = state.window_callbacks.get_size();
+        LOG_ERROR("Failed to create Vulkan swapchain. Window size: {}x{}, surface extent: {}x{}",
+            size.width, size.height, extent.width, extent.height);
+        return false;
+    }
 
     // these functions do not need to be called when the swapchain is resized
     create_surface_image();
@@ -253,8 +259,12 @@ void ScreenRenderer::create_swapchain() {
         extent.height = std::clamp<uint32_t>(static_cast<uint32_t>(size.height), surface_capabilities.minImageExtent.height, surface_capabilities.maxImageExtent.height);
     }
 
-    if (extent.width == 0 || extent.height == 0)
+    if (extent.width == 0 || extent.height == 0) {
+        const renderer::WindowSize size = state.window_callbacks.get_size();
+        LOG_WARN("Skipping Vulkan swapchain creation for zero-sized surface. Window size: {}x{}, surface extent: {}x{}",
+            size.width, size.height, extent.width, extent.height);
         return;
+    }
 
     swapchain_size = surface_capabilities.minImageCount + 1;
     if (surface_capabilities.maxImageCount != 0)


### PR DESCRIPTION
## Summary

Fixes a macOS Vulkan startup crash seen with newer Qt versions when booting a game.

On macOS, the Vulkan surface is backed by MoltenVK and requires a valid `CAMetalLayer` on the native Qt view. Newer Qt versions can leave the native view
layer in a state that is not suitable for swapchain creation, so this patch explicitly ensures that the view uses a configured `CAMetalLayer`.

This also adds a defensive swapchain validation check so Vita3K does not continue with an empty or invalid swapchain.

## Scope

This is macOS-specific for the Metal layer setup path. Windows and Linux do not use `CAMetalLayer` or MoltenVK's macOS surface path.

## Testing

- Built on macOS with Qt 6.11.1
- Verified game boot on macOS with Qt 6.10.0, 6.11.0, and 6.11.1