### PR TITLE
gui-qt: fix string/path/QString conversion for non ASCII strings

### DIFF
--- a/vita3k/app/src/app.cpp
+++ b/vita3k/app/src/app.cpp
@@ -276,7 +276,7 @@ void prepare_game_launch_overlay(EmuEnvState &emuenv) {
 
     const auto bg_path = emuenv.pref_path / "ux0/app" / emuenv.io.app_path / "sce_sys/pic0.png";
     if (fs::exists(bg_path))
-        renderer.precompile_bg_path = bg_path.string();
+        renderer.precompile_bg_path = fs_utils::path_to_utf8(bg_path);
 
     if (renderer::get_shaders_cache_hashs(renderer) && emuenv.cfg.shader_cache) {
         renderer.precompile_queue = renderer.shaders_cache_hashs;

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -623,7 +623,7 @@ void apply_renderer_config(EmuEnvState &emuenv) {
         }
         if (grade_name) {
             const auto icon_path = emuenv.static_assets_path / "icons" / (std::string(grade_name) + ".png");
-            std::ifstream file(icon_path.string(), std::ios::binary | std::ios::ate);
+            std::ifstream file(icon_path.c_str(), std::ios::binary | std::ios::ate);
             if (file) {
                 const auto size = file.tellg();
                 file.seekg(0);

--- a/vita3k/app/src/apps_list.cpp
+++ b/vita3k/app/src/apps_list.cpp
@@ -58,7 +58,7 @@ static int64_t get_path_write_time(const fs::path &path) {
     try {
         return static_cast<int64_t>(fs::last_write_time(path));
     } catch (const std::exception &e) {
-        LOG_WARN("Failed to read timestamp for '{}': {}", path.string(), e.what());
+        LOG_WARN("Failed to read timestamp for '{}': {}", path, e.what());
         return -1;
     }
 }
@@ -173,7 +173,7 @@ static bool write_apps_cache_file(const EmuEnvState &emuenv, const std::vector<A
         write_app_cache_entry(apps_node, app);
 
     if (!doc.save_file(cache_path.c_str())) {
-        LOG_ERROR("Failed to write apps cache to {}", cache_path.string());
+        LOG_ERROR("Failed to write apps cache to {}", cache_path);
         return false;
     }
 
@@ -272,13 +272,13 @@ bool load_cached_apps(EmuEnvState &emuenv) {
 
     pugi::xml_document doc;
     if (!doc.load_file(cache_path.c_str())) {
-        LOG_WARN("Apps cache at '{}' is unreadable; rebuilding.", cache_path.string());
+        LOG_WARN("Apps cache at '{}' is unreadable; rebuilding.", cache_path);
         return false;
     }
 
     const auto root = doc.child("apps-cache");
     if (root.empty()) {
-        LOG_WARN("Apps cache at '{}' is malformed; rebuilding.", cache_path.string());
+        LOG_WARN("Apps cache at '{}' is malformed; rebuilding.", cache_path);
         return false;
     }
 
@@ -367,7 +367,7 @@ void load_app_times(EmuEnvState &emuenv) {
 
     pugi::xml_document doc;
     if (!doc.load_file(time_path.c_str())) {
-        LOG_ERROR("time.xml is corrupted at {}; removing.", time_path.string());
+        LOG_ERROR("time.xml is corrupted at {}; removing.", time_path);
         fs::remove(time_path);
         return;
     }
@@ -416,7 +416,7 @@ void save_app_times(EmuEnvState &emuenv) {
 
     const auto time_path{ emuenv.pref_path / "ux0/user/time.xml" };
     if (!doc.save_file(time_path.c_str()))
-        LOG_ERROR("Failed to write {}", time_path.string());
+        LOG_ERROR("Failed to write {}", time_path);
 }
 
 void update_last_time_app_used(EmuEnvState &emuenv, const std::string &app_path) {

--- a/vita3k/compat/src/compat.cpp
+++ b/vita3k/compat/src/compat.cpp
@@ -18,6 +18,7 @@
 #include <compat/functions.h>
 #include <compat/state.h>
 #include <config/state.h>
+#include <fmt/std.h>
 #include <util/log.h>
 
 #include <miniz.h>
@@ -127,13 +128,13 @@ bool load_from_disk(CompatState &state, const std::filesystem::path &cache_path)
     const auto db_path = cache_path / "app_compat_db.xml";
 
     if (!std::filesystem::exists(db_path)) {
-        LOG_WARN("DB not found at {}", db_path.string());
+        LOG_WARN("DB not found at {}", db_path);
         return false;
     }
 
     std::ifstream file(db_path, std::ios::binary | std::ios::ate);
     if (!file) {
-        LOG_ERROR("Could not open {}", db_path.string());
+        LOG_ERROR("Could not open {}", db_path);
         return false;
     }
 
@@ -142,7 +143,7 @@ bool load_from_disk(CompatState &state, const std::filesystem::path &cache_path)
 
     std::vector<uint8_t> buffer(size);
     if (!file.read(reinterpret_cast<char *>(buffer.data()), size)) {
-        LOG_ERROR("Failed to read {}", db_path.string());
+        LOG_ERROR("Failed to read {}", db_path);
         return false;
     }
 
@@ -167,7 +168,7 @@ bool install_db(CompatState &state, const std::filesystem::path &cache_path,
         }
 
         const auto out_path = cache_path / stat.m_filename;
-        if (!mz_zip_reader_extract_to_file(&zip, i, out_path.string().c_str(), 0)) {
+        if (!mz_zip_reader_extract_to_file(&zip, i, reinterpret_cast<const char *>(out_path.u8string().c_str()), 0)) {
             LOG_ERROR("Failed to extract {} from zip", stat.m_filename);
             mz_zip_reader_end(&zip);
             return false;

--- a/vita3k/config/src/settings.cpp
+++ b/vita3k/config/src/settings.cpp
@@ -157,7 +157,7 @@ bool load_custom_config(Config::CurrentConfig &out, const fs::path &config_path,
 
     pugi::xml_document doc;
     if (!doc.load_file(custom_cfg_path.c_str()) || doc.child("config").empty()) {
-        LOG_ERROR("Custom config at {} is corrupted or invalid.", custom_cfg_path.string());
+        LOG_ERROR("Custom config at {} is corrupted or invalid.", custom_cfg_path);
         fs::remove(custom_cfg_path);
         return false;
     }

--- a/vita3k/gui-qt/include/gui-qt/qt_utils.h
+++ b/vita3k/gui-qt/include/gui-qt/qt_utils.h
@@ -46,9 +46,10 @@ struct MessageDialogResult {
     bool checkbox_checked = false;
 };
 
-void open_dir(const std::string &path);
+void open_dir(const fs::path &path);
 
 fs::path to_fs_path(const QString &path);
+QString to_qt_path(const fs::path &path);
 
 QColor get_foreground_color(QWidget *widget = nullptr);
 

--- a/vita3k/gui-qt/src/apps_list.cpp
+++ b/vita3k/gui-qt/src/apps_list.cpp
@@ -68,7 +68,7 @@ void AppsList::refresh(bool from_disk) {
 
     m_apps = app::get_apps(m_emuenv);
     const auto user_times = app::get_user_app_times(m_emuenv);
-    m_table->populate(m_apps, user_times, m_emuenv.compat, fs::path(m_emuenv.pref_path.string()), m_emuenv.config_path);
+    m_table->populate(m_apps, user_times, m_emuenv.compat, m_emuenv.pref_path, m_emuenv.config_path);
 
     if (!m_search_text.isEmpty())
         set_search_text(m_search_text);

--- a/vita3k/gui-qt/src/apps_list_context_menu.cpp
+++ b/vita3k/gui-qt/src/apps_list_context_menu.cpp
@@ -174,7 +174,7 @@ void AppsListContextMenu::build_multi(const std::vector<const app::AppEntry *> &
                 try {
                     fs::remove_all(path);
                 } catch (const std::exception &e) {
-                    LOG_WARN("Failed to remove {}: {}", path.string(), e.what());
+                    LOG_WARN("Failed to remove {}: {}", path, e.what());
                 }
             }
         }
@@ -369,41 +369,41 @@ void AppsListContextMenu::add_open_folder_actions(const app::AppEntry &app) {
 
     auto *open_app = open_menu->addAction(tr("Application"));
     connect(open_app, &QAction::triggered, this, [this] {
-        gui::utils::open_dir(m_paths.app.string());
+        gui::utils::open_dir(m_paths.app);
     });
 
     if (fs::exists(m_paths.save_data)) {
         auto *a = open_menu->addAction(tr("Save Data"));
         connect(a, &QAction::triggered, this, [this] {
-            gui::utils::open_dir(m_paths.save_data.string());
+            gui::utils::open_dir(m_paths.save_data);
         });
     }
 
     if (fs::exists(m_paths.patch)) {
         auto *a = open_menu->addAction(tr("Patch"));
         connect(a, &QAction::triggered, this, [this] {
-            gui::utils::open_dir(m_paths.patch.string());
+            gui::utils::open_dir(m_paths.patch);
         });
     }
 
     if (fs::exists(m_paths.addcont)) {
         auto *a = open_menu->addAction(tr("DLC"));
         connect(a, &QAction::triggered, this, [this] {
-            gui::utils::open_dir(m_paths.addcont.string());
+            gui::utils::open_dir(m_paths.addcont);
         });
     }
 
     if (fs::exists(m_paths.license)) {
         auto *a = open_menu->addAction(tr("License"));
         connect(a, &QAction::triggered, this, [this] {
-            gui::utils::open_dir(m_paths.license.string());
+            gui::utils::open_dir(m_paths.license);
         });
     }
 
     if (fs::exists(m_paths.shader_cache)) {
         auto *a = open_menu->addAction(tr("Shader Cache"));
         connect(a, &QAction::triggered, this, [this] {
-            gui::utils::open_dir(m_paths.shader_cache.string());
+            gui::utils::open_dir(m_paths.shader_cache);
         });
     }
 
@@ -413,21 +413,21 @@ void AppsListContextMenu::add_open_folder_actions(const app::AppEntry &app) {
     if (!shader_log.empty()) {
         auto *a = open_menu->addAction(tr("Shader Log"));
         connect(a, &QAction::triggered, this, [shader_log] {
-            gui::utils::open_dir(shader_log.string());
+            gui::utils::open_dir(shader_log);
         });
     }
 
     if (fs::exists(m_paths.export_textures)) {
         auto *a = open_menu->addAction(tr("Export Textures"));
         connect(a, &QAction::triggered, this, [this] {
-            gui::utils::open_dir(m_paths.export_textures.string());
+            gui::utils::open_dir(m_paths.export_textures);
         });
     }
 
     if (fs::exists(m_paths.import_textures)) {
         auto *a = open_menu->addAction(tr("Import Textures"));
         connect(a, &QAction::triggered, this, [this] {
-            gui::utils::open_dir(m_paths.import_textures.string());
+            gui::utils::open_dir(m_paths.import_textures);
         });
     }
 }
@@ -462,7 +462,7 @@ void AppsListContextMenu::add_delete_actions(const app::AppEntry &app) {
                 try {
                     fs::remove_all(m_paths.save_data);
                 } catch (const std::exception &e) {
-                    LOG_WARN("Failed to remove {}: {}", m_paths.save_data.string(), e.what());
+                    LOG_WARN("Failed to remove {}: {}", m_paths.save_data, e.what());
                 }
             }
         });
@@ -479,7 +479,7 @@ void AppsListContextMenu::add_delete_actions(const app::AppEntry &app) {
                 try {
                     fs::remove_all(m_paths.patch);
                 } catch (const std::exception &e) {
-                    LOG_WARN("Failed to remove {}: {}", m_paths.patch.string(), e.what());
+                    LOG_WARN("Failed to remove {}: {}", m_paths.patch, e.what());
                 }
             }
         });
@@ -496,7 +496,7 @@ void AppsListContextMenu::add_delete_actions(const app::AppEntry &app) {
                 try {
                     fs::remove_all(m_paths.addcont);
                 } catch (const std::exception &e) {
-                    LOG_WARN("Failed to remove {}: {}", m_paths.addcont.string(), e.what());
+                    LOG_WARN("Failed to remove {}: {}", m_paths.addcont, e.what());
                 }
             }
         });
@@ -513,7 +513,7 @@ void AppsListContextMenu::add_delete_actions(const app::AppEntry &app) {
                 try {
                     fs::remove_all(m_paths.license);
                 } catch (const std::exception &e) {
-                    LOG_WARN("Failed to remove {}: {}", m_paths.license.string(), e.what());
+                    LOG_WARN("Failed to remove {}: {}", m_paths.license, e.what());
                 }
             }
         });
@@ -525,7 +525,7 @@ void AppsListContextMenu::add_delete_actions(const app::AppEntry &app) {
             try {
                 fs::remove_all(m_paths.shader_cache);
             } catch (const std::exception &e) {
-                LOG_WARN("Failed to remove {}: {}", m_paths.shader_cache.string(), e.what());
+                LOG_WARN("Failed to remove {}: {}", m_paths.shader_cache, e.what());
             }
         });
     }
@@ -536,7 +536,7 @@ void AppsListContextMenu::add_delete_actions(const app::AppEntry &app) {
             try {
                 fs::remove_all(m_paths.shader_log);
             } catch (const std::exception &e) {
-                LOG_WARN("Failed to remove {}: {}", m_paths.shader_log.string(), e.what());
+                LOG_WARN("Failed to remove {}: {}", m_paths.shader_log, e.what());
             }
         });
     }
@@ -547,7 +547,7 @@ void AppsListContextMenu::add_delete_actions(const app::AppEntry &app) {
             try {
                 fs::remove_all(m_paths.export_textures);
             } catch (const std::exception &e) {
-                LOG_WARN("Failed to remove {}: {}", m_paths.export_textures.string(), e.what());
+                LOG_WARN("Failed to remove {}: {}", m_paths.export_textures, e.what());
             }
         });
     }
@@ -558,7 +558,7 @@ void AppsListContextMenu::add_delete_actions(const app::AppEntry &app) {
             try {
                 fs::remove_all(m_paths.import_textures);
             } catch (const std::exception &e) {
-                LOG_WARN("Failed to remove {}: {}", m_paths.import_textures.string(), e.what());
+                LOG_WARN("Failed to remove {}: {}", m_paths.import_textures, e.what());
             }
         });
     }
@@ -661,7 +661,7 @@ void AppsListContextMenu::add_information_actions(const app::AppEntry &app) {
     auto *info = addAction(tr("Information"));
     connect(info, &QAction::triggered, this, [this, &app] {
         const auto APP_PATH = m_emuenv.pref_path / "ux0/app" / app.path;
-        const auto app_dir = QString::fromStdString(APP_PATH.string());
+        const auto app_dir = gui::utils::to_qt_path(APP_PATH);
 
         const bool has_report = m_emuenv.compat.compat_db_loaded
             && m_emuenv.compat.app_compat_db.contains(app.title_id);

--- a/vita3k/gui-qt/src/apps_list_table.cpp
+++ b/vita3k/gui-qt/src/apps_list_table.cpp
@@ -15,6 +15,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include "gui-qt/qt_utils.h"
+
 #include <gui-qt/app_icon_item.h>
 #include <gui-qt/apps_list_delegate.h>
 #include <gui-qt/apps_list_table.h>
@@ -428,7 +430,7 @@ void AppsListTable::populate(const std::vector<app::AppEntry> &apps,
             new SortableItem(QString::fromStdString(app.parental_level),
                 QVariant(parental_level_sort_key(app.parental_level))));
 
-        const QString app_dir = QString::fromStdString((pref_path / "ux0/app" / app.path).string());
+        const QString app_dir = gui::utils::to_qt_path(pref_path / "ux0/app" / app.path);
         const auto size_it = m_size_cache.find(app.path);
         const quint64 cached_size = (size_it != m_size_cache.end()) ? size_it->second : 0;
         auto *size_item = new SortableItem(

--- a/vita3k/gui-qt/src/archive_install_dialog.cpp
+++ b/vita3k/gui-qt/src/archive_install_dialog.cpp
@@ -115,8 +115,7 @@ QFrame *make_result_row(const ArchiveInstallResult &result, QWidget *parent) {
     const QColor status_fg = result.success
         ? gui::utils::get_label_color(QColor(0x1f, 0x7a, 0x1f), QColor(0xb9, 0xf5, 0xbf))
         : gui::utils::get_label_color(QColor(0xa3, 0x2a, 0x1c), QColor(0xff, 0xb1, 0xaa));
-    status->setStyleSheet(QStringLiteral("border-radius: 10px; padding: 4px 10px; background-color: %1; color: %2;")
-                              .arg(status_bg.name(), status_fg.name()));
+    status->setStyleSheet(QStringLiteral("border-radius: 10px; padding: 4px 10px; background-color: %1; color: %2;").arg(status_bg.name(), status_fg.name()));
     layout->addWidget(status, 0, Qt::AlignTop);
 
     return row;
@@ -129,7 +128,7 @@ void ArchiveWorker::run() {
     int done = 0;
 
     for (const auto &archive_path : m_archives) {
-        const QString archive_name = QString::fromStdString(archive_path.filename().string());
+        const QString archive_name = gui::utils::to_qt_path(archive_path.filename());
         Q_EMIT current_title_changed(archive_name);
         Q_EMIT global_progress(done + 1, total);
 

--- a/vita3k/gui-qt/src/live_area_widget.cpp
+++ b/vita3k/gui-qt/src/live_area_widget.cpp
@@ -15,6 +15,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include "gui-qt/qt_utils.h"
+
 #include <gui-qt/live_area_widget.h>
 
 #include <config/state.h>
@@ -141,8 +143,7 @@ LiveAreaWidget::LiveAreaWidget(EmuEnvState &emuenv, const std::string &app_path,
     resize(960, 544);
     setFlags(Qt::Window);
 
-    const auto pref = QString::fromStdString(emuenv.pref_path.string());
-    m_app_fs_path = pref + "/ux0/app/" + QString::fromStdString(app_path);
+    m_app_fs_path = gui::utils::to_qt_path(emuenv.pref_path / "ux0/app" / app_path);
 
     load_contents();
 
@@ -235,7 +236,7 @@ void LiveAreaWidget::load_contents() {
     QString template_path = contents_dir + "/template.xml";
 
     if (!QFile::exists(template_path)) {
-        const auto pref = QString::fromStdString(m_emuenv.pref_path.string());
+        const auto pref = gui::utils::to_qt_path(m_emuenv.pref_path);
         contents_dir = pref + "/vs0/data/internal/livearea/default/sce_sys/livearea/contents";
         template_path = contents_dir + "/template.xml";
     }

--- a/vita3k/gui-qt/src/main_window.cpp
+++ b/vita3k/gui-qt/src/main_window.cpp
@@ -380,7 +380,7 @@ void MainWindow::initialize() {
     this->setWindowTitle(QString::fromStdString(window_title));
 
     emuenv.compat.log_compat_warn = emuenv.cfg.log_compat_warn;
-    m_game_compat = new GameCompatibility(emuenv.compat, emuenv.cache_path.string(), this);
+    m_game_compat = new GameCompatibility(emuenv.compat, emuenv.cache_path.native(), this);
 
     emuenv.vulkan_device_info = std::make_unique<renderer::VulkanDeviceInfo>(renderer::enumerate_vulkan_devices());
 
@@ -712,7 +712,7 @@ void MainWindow::handle_drop(const QString &path) {
 
     } else if (ext == ".bin" || ext == ".rif" || drop_path.filename() == "work.bin") {
         if (copy_license(emuenv, drop_path))
-            LOG_INFO("License installed via drop: {}", drop_path.string());
+            LOG_INFO("License installed via drop: {}", drop_path);
         else
             QMessageBox::critical(this, tr("Install Failed"),
                 tr("Failed to install the dropped license file.\n"
@@ -1009,7 +1009,7 @@ std::optional<AppLaunchRequest> MainWindow::boot_game_once(const AppLaunchReques
         const QStringList locations = QStandardPaths::standardLocations(QStandardPaths::FontsLocation);
         std::vector<std::string> font_dirs;
         for (const QString &location : locations) {
-            std::string font_dir = location.toStdString();
+            std::string font_dir = location.toUtf8().constData();
             if (!font_dir.ends_with('/') && !font_dir.ends_with('\\'))
                 font_dir += '/';
             font_dirs.push_back(font_dir);
@@ -1231,7 +1231,7 @@ bool MainWindow::prompt_admin_privileges_warning_if_needed() {
         "This can create files owned by the wrong user and cause permission problems later.\n"
         "Please close Vita3K and relaunch it without elevated privileges.");
 
-    LOG_WARN("{}", text.toStdString());
+    LOG_WARN("{}", text.toUtf8().constData());
 
     const auto result = gui::utils::show_message_box(
         this,
@@ -1503,19 +1503,19 @@ void MainWindow::setup_toolbar() {
 
         QMenu menu(this);
         menu.addAction(tr("Open Emulated Storage Path"), this, [this] {
-            gui::utils::open_dir(emuenv.pref_path.string());
+            gui::utils::open_dir(emuenv.pref_path);
         });
 
         const auto patch_path = emuenv.shared_path / "patch";
         menu.addAction(tr("Open Patch Path"), this, [patch_path] {
-            gui::utils::open_dir(patch_path.string());
+            gui::utils::open_dir(patch_path);
         });
 
         const auto textures_path = emuenv.shared_path / "textures";
         menu.addAction(tr("Open Textures Path"), this, [textures_path] {
             if (!fs::exists(textures_path))
                 fs::create_directories(textures_path);
-            gui::utils::open_dir(textures_path.string());
+            gui::utils::open_dir(textures_path);
         });
 
         menu.exec(pos);
@@ -1659,10 +1659,10 @@ void MainWindow::apply_stylesheet() {
                 QStringLiteral("url(\"gui-configs/"),
                 QStringLiteral("url(\"") + settings_dir + QStringLiteral("/"));
 
-            LOG_INFO("Loaded stylesheet '{}' from {}", stylesheet_name.toStdString(), stylesheet_path.toStdString());
+            LOG_INFO("Loaded stylesheet '{}' from {}", stylesheet_name.toUtf8().constData(), stylesheet_path.toUtf8().constData());
             qApp->setStyleSheet(qss);
         } else {
-            LOG_ERROR("Could not find stylesheet '{}', falling back to light", stylesheet_name.toStdString());
+            LOG_ERROR("Could not find stylesheet '{}', falling back to light", stylesheet_name.toUtf8().constData());
             qApp->setStyleSheet(gui::stylesheets::light_style_sheet);
         }
     }

--- a/vita3k/gui-qt/src/pkg_install_dialog.cpp
+++ b/vita3k/gui-qt/src/pkg_install_dialog.cpp
@@ -256,7 +256,7 @@ void PkgInstallDialog::run_install(const fs::path &pkg_path,
     title_label->setAlignment(Qt::AlignCenter);
     main_layout->addWidget(title_label);
 
-    auto *pkg_label = new QLabel(QString::fromStdString(pkg_path.filename().string()), this);
+    auto *pkg_label = new QLabel(gui::utils::to_qt_path(pkg_path.filename()), this);
     pkg_label->setAlignment(Qt::AlignCenter);
     main_layout->addWidget(pkg_label);
 

--- a/vita3k/gui-qt/src/qt_utils.cpp
+++ b/vita3k/gui-qt/src/qt_utils.cpp
@@ -37,12 +37,16 @@
 
 namespace gui::utils {
 
-void open_dir(const std::string &path) {
-    QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(path)));
+void open_dir(const fs::path &path) {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(to_qt_path(path)));
 }
 
 fs::path to_fs_path(const QString &path) {
-    return fs_utils::utf8_to_path(path.toUtf8().toStdString());
+    return fs::path(path.toStdWString());
+}
+
+QString to_qt_path(const fs::path &path) {
+    return QString::fromStdWString(path.wstring());
 }
 
 QColor get_foreground_color(QWidget *widget) {

--- a/vita3k/gui-qt/src/settings_dialog.cpp
+++ b/vita3k/gui-qt/src/settings_dialog.cpp
@@ -809,9 +809,9 @@ void SettingsDialog::populate_cameras_list() {
     m_ui->back_camera_image_path->setText(tr("No image selected"));
 
     if (!emuenv.cfg.front_camera_image.empty())
-        m_ui->front_camera_image_path->setText(QString::fromStdString(emuenv.cfg.front_camera_image));
+        m_ui->front_camera_image_path->setText(QString::fromUtf8(emuenv.cfg.front_camera_image));
     if (!emuenv.cfg.back_camera_image.empty())
-        m_ui->back_camera_image_path->setText(QString::fromStdString(emuenv.cfg.back_camera_image));
+        m_ui->back_camera_image_path->setText(QString::fromUtf8(emuenv.cfg.back_camera_image));
 }
 
 void SettingsDialog::populate_adhoc_list() {
@@ -1009,20 +1009,20 @@ void SettingsDialog::setup_connections() {
     connect(m_ui->front_camera_image_btn, &QPushButton::clicked, this, [this] {
         const QString file = QFileDialog::getOpenFileName(
             this, tr("Select Front Camera Image"),
-            QString::fromStdString(emuenv.cfg.front_camera_image),
+            QString::fromUtf8(emuenv.cfg.front_camera_image),
             tr("Images (*.png *.jpg *.jpeg *.bmp)"));
         if (!file.isEmpty()) {
-            emuenv.cfg.front_camera_image = file.toStdString();
+            emuenv.cfg.front_camera_image = file.toUtf8();
             m_ui->front_camera_image_path->setText(file);
         }
     });
     connect(m_ui->back_camera_image_btn, &QPushButton::clicked, this, [this] {
         const QString file = QFileDialog::getOpenFileName(
             this, tr("Select Back Camera Image"),
-            QString::fromStdString(emuenv.cfg.back_camera_image),
+            QString::fromUtf8(emuenv.cfg.back_camera_image),
             tr("Images (*.png *.jpg *.jpeg *.bmp)"));
         if (!file.isEmpty()) {
-            emuenv.cfg.back_camera_image = file.toStdString();
+            emuenv.cfg.back_camera_image = file.toUtf8();
             m_ui->back_camera_image_path->setText(file);
         }
     });
@@ -1034,9 +1034,9 @@ void SettingsDialog::setup_connections() {
     connect(m_ui->change_emu_path, &QPushButton::clicked, this, [this] {
         const QString dir = QFileDialog::getExistingDirectory(
             this, tr("Select Emulator Storage Folder"),
-            QString::fromStdString(m_pending_pref_path.string()));
+            gui::utils::to_qt_path(m_pending_pref_path));
         if (!dir.isEmpty())
-            set_pending_pref_path(fs::path(dir.toStdString()));
+            set_pending_pref_path(gui::utils::to_fs_path(dir));
     });
     connect(m_ui->reset_emu_path, &QPushButton::clicked, this, [this] {
         if (emuenv.default_path != m_pending_pref_path)
@@ -1339,7 +1339,7 @@ void SettingsDialog::set_pending_pref_path(const fs::path &pref_path) {
 
 void SettingsDialog::update_current_emu_path_label() {
     m_ui->current_emu_path->setText(
-        tr("Current emulator path: %1").arg(QString::fromStdString(m_pending_pref_path.string())));
+        tr("Current emulator path: %1").arg(gui::utils::to_qt_path(m_pending_pref_path)));
 }
 
 void SettingsDialog::setup_dirty_tracking() {

--- a/vita3k/gui-qt/src/trophy_collection_dialog.cpp
+++ b/vita3k/gui-qt/src/trophy_collection_dialog.cpp
@@ -15,6 +15,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#include "gui-qt/qt_utils.h"
+
 #include <gui-qt/trophy_collection_dialog.h>
 
 #include <config/state.h>
@@ -308,7 +310,7 @@ void TrophyCollectionDialog::load_all_apps() {
     QStringList dirs;
     for (const auto &entry : fs::directory_iterator(trophy_conf)) {
         if (fs::is_directory(entry))
-            dirs << QString::fromStdString(entry.path().filename().string());
+            dirs << gui::utils::to_qt_path(entry.path().filename());
     }
 
     if (dirs.isEmpty()) {
@@ -371,8 +373,8 @@ bool TrophyCollectionDialog::load_app_data(const QString &np_com_id_str) {
         : conf_path / "TROP.SFM";
 
     pugi::xml_document doc;
-    if (!doc.load_file(sfm.string().c_str())) {
-        LOG_ERROR("Failed to parse {}", sfm.string());
+    if (!doc.load_file(sfm.c_str())) {
+        LOG_ERROR("Failed to parse {}", sfm);
         return false;
     }
 
@@ -380,10 +382,10 @@ bool TrophyCollectionDialog::load_app_data(const QString &np_com_id_str) {
     data->title = QString::fromStdString(root.child("title-name").text().as_string());
 
     const auto icon_locale = fmt::format("ICON0_{:0>2d}.PNG", m_emuenv.cfg.sys_lang);
-    data->icon_path = QString::fromStdString(
+    data->icon_path = gui::utils::to_qt_path(
         fs::exists(conf_path / icon_locale)
-            ? (conf_path / icon_locale).string()
-            : (conf_path / "ICON0.PNG").string());
+            ? (conf_path / icon_locale)
+            : (conf_path / "ICON0.PNG"));
 
     for (const auto &node : root.children("trophy")) {
         TrophyEntry e;
@@ -494,8 +496,8 @@ void TrophyCollectionDialog::populate_trophy_table(int app_idx) {
         m_trophy_model->appendRow({ icon_item, name_item, detail_item,
             grade_item, status_item, id_item, time_item });
 
-        const QString icon_path = QString::fromStdString(
-            (conf_path / fmt::format("TROP{:0>3d}.PNG", t.id)).string());
+        const QString icon_path = gui::utils::to_qt_path(
+            conf_path / fmt::format("TROP{:0>3d}.PNG", t.id));
         load_trophy_icon_async(row, icon_path);
     }
 

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -55,6 +55,8 @@
 #include <tracy/Tracy.hpp>
 #endif
 
+#include "gui-qt/qt_utils.h"
+
 #include <SDL3/SDL_cpuinfo.h>
 #include <SDL3/SDL_gamepad.h>
 #include <SDL3/SDL_hints.h>
@@ -245,7 +247,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    const QString gui_configs_dir = QString::fromStdString((emuenv.config_path / "gui-configs").string());
+    const QString gui_configs_dir = gui::utils::to_qt_path(emuenv.config_path / "gui-configs");
     auto gui_settings = std::make_shared<GuiSettings>(gui_configs_dir);
     auto persistent_settings = std::make_shared<PersistentSettings>(gui_configs_dir);
 

--- a/vita3k/renderer/src/renderer.cpp
+++ b/vita3k/renderer/src/renderer.cpp
@@ -119,7 +119,7 @@ void State::init_overlay_font_dirs() {
     }
 
     if (!pref_path.empty()) {
-        auto fw_dir = (pref_path / "sa0" / "data" / "font" / "pvf").string();
+        auto fw_dir = fs_utils::path_to_utf8(pref_path / "sa0" / "data" / "font" / "pvf");
         if (!fw_dir.empty()) {
             if (fw_dir.back() != '/' && fw_dir.back() != '\\')
                 fw_dir += '/';
@@ -128,7 +128,7 @@ void State::init_overlay_font_dirs() {
     }
 
     {
-        auto dir = (static_assets / "data" / "fonts").string();
+        auto dir = fs_utils::path_to_utf8(static_assets / "data" / "fonts");
         if (!dir.empty()) {
             if (dir.back() != '/' && dir.back() != '\\')
                 dir += '/';
@@ -137,7 +137,7 @@ void State::init_overlay_font_dirs() {
     }
 
     {
-        auto icons_dir = (static_assets / "icons").string();
+        auto icons_dir = fs_utils::path_to_utf8(static_assets / "icons");
         if (!icons_dir.empty()) {
             if (icons_dir.back() != '/' && icons_dir.back() != '\\')
                 icons_dir += '/';


### PR DESCRIPTION
It's important for old Windows before 2019 (win8 and earlier)