### PR TITLE
io: replace better-enums lib to boost::describe

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "external/better-enums"]
-	path = external/better-enums
-	url = https://github.com/aantron/better-enums
 [submodule "external/boost"]
 	path = external/boost
 	url = https://github.com/Vita3K/ext-boost

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -70,10 +70,6 @@ target_include_directories(cppcommon PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/CppComm
 add_library(glad STATIC "${CMAKE_CURRENT_SOURCE_DIR}/glad/src/glad.c")
 target_include_directories(glad PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/glad/include")
 
-add_library(better-enums INTERFACE)
-target_include_directories(better-enums INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/better-enums")
-target_compile_definitions(better-enums INTERFACE BETTER_ENUMS_STRICT_CONVERSION=1)
-
 add_library(googletest STATIC googletest/googletest/src/gtest_main.cc googletest/googletest/src/gtest-all.cc)
 target_include_directories(googletest PUBLIC googletest/googletest/include)
 target_include_directories(googletest PRIVATE googletest/googletest)

--- a/vita3k/io/CMakeLists.txt
+++ b/vita3k/io/CMakeLists.txt
@@ -19,4 +19,4 @@ add_library(
 )
 
 target_include_directories(io PUBLIC include)
-target_link_libraries(io PUBLIC better-enums dirent mem rtc util emuenv)
+target_link_libraries(io PUBLIC dirent mem rtc util emuenv)

--- a/vita3k/io/include/io/VitaIoDevice.h
+++ b/vita3k/io/include/io/VitaIoDevice.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
-#include <enum.h>
+#include <boost/describe/enum.hpp>
+#include <boost/describe/enum_from_string.hpp>
+#include <boost/describe/enum_to_string.hpp>
 
-BETTER_ENUM(VitaIoDevice, int,
+enum class VitaIoDevice : int {
     addcont0 = 0,
     app0,
     host0,
@@ -47,4 +49,34 @@ BETTER_ENUM(VitaIoDevice, int,
     video0,
     vs0,
     xmc0,
-    _INVALID = -1)
+    _INVALID = -1
+};
+
+BOOST_DESCRIBE_ENUM(VitaIoDevice,
+    addcont0,
+    app0,
+    host0,
+    grw0,
+    imc0,
+    music0,
+    os0,
+    pd0,
+    photo0,
+    sa0,
+    savedata0,
+    savedata1,
+    sd0,
+    tm0,
+    tty0,
+    tty1,
+    tty2,
+    tty3,
+    ud0,
+    uma0,
+    ur0,
+    ux0,
+    vd0,
+    video0,
+    vs0,
+    xmc0,
+    _INVALID)

--- a/vita3k/io/include/io/device.h
+++ b/vita3k/io/include/io/device.h
@@ -41,20 +41,6 @@ VitaIoDevice get_device(const std::string &path);
 std::string get_device_string(const VitaIoDevice dev, const bool with_colon = false);
 
 /**
- * \brief Check if the device is a valid output path.
- * \param device Input device to be checked.
- * \return True if valid, False otherwise.
- */
-bool is_valid_output_path(const VitaIoDevice device);
-
-/**
- * \brief Check if the device string is valid.
- * \param device Input device to be checked.
- * \return True if valid, False otherwise.
- */
-bool is_valid_output_path(const std::string &device);
-
-/**
  * \brief Construct a normalized path (optionally with an extension) to be outputted onto the Vita.
  * \param dev The input Vita device.
  * \param path The Vita location needed.

--- a/vita3k/io/include/io/vfs.h
+++ b/vita3k/io/include/io/vfs.h
@@ -20,7 +20,7 @@
 #include <util/fs.h>
 #include <util/types.h>
 
-class VitaIoDevice;
+enum class VitaIoDevice : int;
 
 namespace vfs {
 

--- a/vita3k/io/src/device.cpp
+++ b/vita3k/io/src/device.cpp
@@ -44,11 +44,10 @@ std::string construct_normalized_path(const VitaIoDevice dev, const std::string 
 }
 
 std::string remove_device_from_path(const std::string &path, const VitaIoDevice device, const std::string &mod_path) {
+    if (device == VitaIoDevice::_INVALID)
+        return {};
     // Trim the path to include only the substring after the device string
     const auto device_length = get_device_string(device, true).length();
-    if (device == VitaIoDevice::_INVALID)
-        return std::string{};
-
     auto out = path;
     out = out.substr(device_length, out.size());
     if (!mod_path.empty())
@@ -69,28 +68,15 @@ VitaIoDevice get_device(const std::string &path) {
 
     auto p = path.substr(0, colon);
     std::transform(p.begin(), p.end(), p.begin(), tolower);
-    if (VitaIoDevice::_is_valid_nocase(p.c_str()))
-        return VitaIoDevice::_from_string(p.c_str());
-
-    return VitaIoDevice::_INVALID;
+    VitaIoDevice result;
+    if (boost::describe::enum_from_string(p.c_str(), result))
+        return result;
+    else
+        return VitaIoDevice::_INVALID;
 }
 
 std::string get_device_string(const VitaIoDevice dev, const bool with_colon) {
-    return with_colon ? std::string(dev._to_string()).append(":") : dev._to_string();
-}
-
-bool is_valid_output_path(const VitaIoDevice device) {
-    return !(device == VitaIoDevice::savedata0 || device == VitaIoDevice::savedata1 || device == VitaIoDevice::app0
-        || device == VitaIoDevice::_INVALID || device == VitaIoDevice::addcont0 || device == VitaIoDevice::tty0
-        || device == VitaIoDevice::tty1 || device == VitaIoDevice::tty2 || device == VitaIoDevice::tty3
-        || device == VitaIoDevice::music0 || device == VitaIoDevice::photo0 || device == VitaIoDevice::video0);
-}
-
-bool is_valid_output_path(const std::string &device) {
-    return !(device == (+VitaIoDevice::savedata0)._to_string() || device == (+VitaIoDevice::savedata1)._to_string() || device == (+VitaIoDevice::app0)._to_string()
-        || device == (+VitaIoDevice::_INVALID)._to_string() || device == (+VitaIoDevice::addcont0)._to_string() || device == (+VitaIoDevice::tty0)._to_string()
-        || device == (+VitaIoDevice::tty1)._to_string() || device == (+VitaIoDevice::tty2)._to_string() || device == (+VitaIoDevice::tty3)._to_string()
-        || device == (+VitaIoDevice::music0)._to_string() || device == (+VitaIoDevice::photo0)._to_string() || device == (+VitaIoDevice::video0)._to_string());
+    return with_colon ? std::string(boost::describe::enum_to_string(dev, "")).append(":") : boost::describe::enum_to_string(dev, "");
 }
 
 std::string remove_duplicate_device(const std::string &path, VitaIoDevice &device) {
@@ -106,7 +92,7 @@ std::string remove_duplicate_device(const std::string &path, VitaIoDevice &devic
 }
 
 fs::path construct_emulated_path(const VitaIoDevice dev, const fs::path &path, const fs::path &base_path, const bool redirect_pwd, const std::string &ext) {
-    if (redirect_pwd && dev == +VitaIoDevice::host0) {
+    if (redirect_pwd && dev == VitaIoDevice::host0) {
         return fs::current_path() / path;
     }
     return fs_utils::construct_file_name(base_path, get_device_string(dev, false), path, ext);

--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -91,17 +91,23 @@ SceSize get_directory_used_size(const VitaIoDevice device, const std::string &vf
 // * End utility functions *
 // ****************************
 
+static bool is_valid_output_path(const VitaIoDevice device) {
+    return !(device == VitaIoDevice::savedata0 || device == VitaIoDevice::savedata1 || device == VitaIoDevice::app0
+        || device == VitaIoDevice::_INVALID || device == VitaIoDevice::addcont0 || device == VitaIoDevice::tty0
+        || device == VitaIoDevice::tty1 || device == VitaIoDevice::tty2 || device == VitaIoDevice::tty3
+        || device == VitaIoDevice::music0 || device == VitaIoDevice::photo0 || device == VitaIoDevice::video0);
+}
+
 bool init(IOState &io, const fs::path &cache_path, const fs::path &log_path, const fs::path &pref_path, bool redirect_stdio) {
     // Iterate through the entire list of devices and create the subdirectories if they do not exist
-    for (auto i : VitaIoDevice::_names()) {
-        if (!device::is_valid_output_path(i))
-            continue;
-        fs::create_directories(pref_path / i);
-    }
+    boost::mp11::mp_for_each<boost::describe::describe_enumerators<VitaIoDevice>>([&pref_path](auto i) {
+        if (is_valid_output_path(i.value))
+            fs::create_directories(pref_path / i.name);
+    });
 
-    const fs::path ux0{ pref_path / (+VitaIoDevice::ux0)._to_string() };
-    const fs::path uma0{ pref_path / (+VitaIoDevice::uma0)._to_string() };
-    const fs::path vd0{ pref_path / (+VitaIoDevice::vd0)._to_string() };
+    const fs::path ux0{ pref_path / "ux0" };
+    const fs::path uma0{ pref_path / "uma0" };
+    const fs::path vd0{ pref_path / "vd0" };
 
     fs::create_directories(ux0 / "data");
     fs::create_directories(ux0 / "app");
@@ -157,7 +163,7 @@ void init_device_paths(IOState &io) {
 }
 
 bool init_savedata_app_path(IOState &io, const fs::path &pref_path) {
-    const fs::path user_id_path{ pref_path / (+VitaIoDevice::ux0)._to_string() / "user" / io.user_id };
+    const fs::path user_id_path{ pref_path / "ux0" / "user" / io.user_id };
     const fs::path savedata_path{ user_id_path / "savedata" };
     const fs::path savedata_game_path{ savedata_path / io.savedata };
 
@@ -172,17 +178,17 @@ bool find_case_isens_path(IOState &io, VitaIoDevice &device, const fs::path &tra
     std::string final_path{};
 
     switch (device) {
-    case +VitaIoDevice::app0: {
+    case VitaIoDevice::app0: {
         std::string app_id = translated_path.string().substr(0, 14);
         final_path = system_path.string().substr(0, system_path.string().find(app_id)) + app_id;
         break;
     }
-    case +VitaIoDevice::addcont0: {
+    case VitaIoDevice::addcont0: {
         std::string addcont_id = translated_path.string().substr(0, 18);
         final_path = system_path.string().substr(0, system_path.string().find(addcont_id)) + addcont_id;
         break;
     }
-    case +VitaIoDevice::vs0: {
+    case VitaIoDevice::vs0: {
         // This only works if ALL the parent folders of the path are the correct case or are in a case insensitive fs
         // Only the file's name is searched for, not the parent folders
         final_path = system_path.string().substr(0, system_path.string().find_last_of('/'));
@@ -223,61 +229,61 @@ std::string translate_path(const char *path, VitaIoDevice &device, const IOState
     // TODO: Handle dot-dot paths
 
     switch (device) {
-    case +VitaIoDevice::savedata0: // Redirect savedata0: to ux0:user/00/savedata/<title_id>
-    case +VitaIoDevice::savedata1: {
+    case VitaIoDevice::savedata0: // Redirect savedata0: to ux0:user/00/savedata/<title_id>
+    case VitaIoDevice::savedata1: {
         relative_path = device::remove_device_from_path(relative_path, device, device_paths.savedata0);
         device = VitaIoDevice::ux0;
         break;
     }
-    case +VitaIoDevice::app0: { // Redirect app0: to ux0:app/<title_id>
+    case VitaIoDevice::app0: { // Redirect app0: to ux0:app/<title_id>
         relative_path = device::remove_device_from_path(relative_path, device, device_paths.app0);
         device = VitaIoDevice::ux0;
         break;
     }
-    case +VitaIoDevice::addcont0: { // Redirect addcont0: to ux0:addcont/<title_id>
+    case VitaIoDevice::addcont0: { // Redirect addcont0: to ux0:addcont/<title_id>
         relative_path = device::remove_device_from_path(relative_path, device, device_paths.addcont0);
         device = VitaIoDevice::ux0;
         break;
     }
-    case +VitaIoDevice::music0: { // Redirect music0: to ux0:music
+    case VitaIoDevice::music0: { // Redirect music0: to ux0:music
         relative_path = device::remove_device_from_path(relative_path, device, "music");
         device = VitaIoDevice::ux0;
         break;
     }
-    case +VitaIoDevice::photo0: { // Redirect photo0: to ux0:picture
+    case VitaIoDevice::photo0: { // Redirect photo0: to ux0:picture
         relative_path = device::remove_device_from_path(relative_path, device, "picture");
         device = VitaIoDevice::ux0;
         break;
     }
-    case +VitaIoDevice::video0: { // Redirect video0: to ux0:video
+    case VitaIoDevice::video0: { // Redirect video0: to ux0:video
         relative_path = device::remove_device_from_path(relative_path, device, "video");
         device = VitaIoDevice::ux0;
         break;
     }
 
-    case +VitaIoDevice::host0:
-    case +VitaIoDevice::gro0:
-    case +VitaIoDevice::grw0:
-    case +VitaIoDevice::imc0:
-    case +VitaIoDevice::os0:
-    case +VitaIoDevice::pd0:
-    case +VitaIoDevice::sa0:
-    case +VitaIoDevice::sd0:
-    case +VitaIoDevice::tm0:
-    case +VitaIoDevice::ud0:
-    case +VitaIoDevice::uma0:
-    case +VitaIoDevice::ur0:
-    case +VitaIoDevice::ux0:
-    case +VitaIoDevice::vd0:
-    case +VitaIoDevice::vs0:
-    case +VitaIoDevice::xmc0: {
+    case VitaIoDevice::host0:
+    case VitaIoDevice::gro0:
+    case VitaIoDevice::grw0:
+    case VitaIoDevice::imc0:
+    case VitaIoDevice::os0:
+    case VitaIoDevice::pd0:
+    case VitaIoDevice::sa0:
+    case VitaIoDevice::sd0:
+    case VitaIoDevice::tm0:
+    case VitaIoDevice::ud0:
+    case VitaIoDevice::uma0:
+    case VitaIoDevice::ur0:
+    case VitaIoDevice::ux0:
+    case VitaIoDevice::vd0:
+    case VitaIoDevice::vs0:
+    case VitaIoDevice::xmc0: {
         relative_path = device::remove_device_from_path(relative_path, device);
         break;
     }
-    case +VitaIoDevice::tty0:
-    case +VitaIoDevice::tty1:
-    case +VitaIoDevice::tty2:
-    case +VitaIoDevice::tty3: {
+    case VitaIoDevice::tty0:
+    case VitaIoDevice::tty1:
+    case VitaIoDevice::tty2:
+    case VitaIoDevice::tty3: {
         return std::string{};
     }
     default: {
@@ -323,7 +329,7 @@ SceUID open_file(IOState &io, const char *path, const int flags, const fs::path 
         const auto fd = io.next_fd++;
         io.tty_files.emplace(fd, tty_type);
 
-        LOG_TRACE_IF(log_file_op, "{}: Opening terminal {}:", export_name, device._to_string());
+        LOG_TRACE_IF(log_file_op, "{}: Opening terminal {}:", export_name, device);
         return fd;
     }
 

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -162,7 +162,7 @@ EXPORT(int, sceAppUtilBgdlGetStatus) {
 }
 
 static bool is_addcont_exist(EmuEnvState &emuenv, const SceChar8 *path) {
-    const auto drm_content_id_path{ emuenv.pref_path / (+VitaIoDevice::ux0)._to_string() / emuenv.io.device_paths.addcont0 / reinterpret_cast<const char *>(path) };
+    const auto drm_content_id_path{ emuenv.pref_path / "ux0" / emuenv.io.device_paths.addcont0 / reinterpret_cast<const char *>(path) };
     return (fs::exists(drm_content_id_path) && (!fs::is_empty(drm_content_id_path)));
 }
 

--- a/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
+++ b/vita3k/modules/SceDriverUser/SceAppMgrUser.cpp
@@ -264,7 +264,7 @@ EXPORT(int, sceAppMgrGetDevInfo, const char *dev, uint64_t *max_size, uint64_t *
         return RET_ERROR(SCE_ERROR_ERRNO_ENOENT);
     }
 
-    fs::path dev_path = device._to_string();
+    fs::path dev_path = boost::describe::enum_to_string(device, "");
     fs::path path = emuenv.pref_path / dev_path;
     fs::space_info space = fs::space(path);
 

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -535,7 +535,7 @@ EXPORT(int, sceIoDevctl, const char *dev, SceInt cmd, const void *indata, SceSiz
             return RET_ERROR(SCE_ERROR_ERRNO_ENOENT);
         }
 
-        fs::path dev_path = device._to_string();
+        fs::path dev_path = boost::describe::enum_to_string(device, "");
         fs::path path = emuenv.pref_path / dev_path;
         fs::space_info space = fs::space(path);
 


### PR DESCRIPTION
Including an entire library for a single enum feels excessive.