### PR TITLE
Re-organize CI 

### DIFF
--- a/.ci/build-android.sh
+++ b/.ci/build-android.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="${1:-}"
+if [[ -z "$OUTPUT_DIR" ]]; then
+    echo "Usage: $0 <output-dir>" >&2
+    exit 1
+fi
+
+mkdir -p android/app/assets
+rm -rf android/app/assets/data android/app/assets/shaders-builtin
+cp -r data android/app/assets/data
+cp -r vita3k/shaders-builtin android/app/assets/shaders-builtin
+
+export JAVA_HOME="${JAVA_HOME_17_X64}"
+chmod +x android/gradlew
+
+if [[ -e "${SIGNING_STORE_PATH:-}" ]]; then
+    BUILD_TYPE="Release"
+else
+    BUILD_TYPE="Reldebug"
+fi
+
+pushd android > /dev/null
+./gradlew --stacktrace --configuration-cache --build-cache --parallel --configure-on-demand ":app:assemble${BUILD_TYPE}"
+popd > /dev/null
+
+APK_PATH="android/app/build/outputs/apk/${BUILD_TYPE,,}/app-${BUILD_TYPE,,}.apk"
+mkdir -p "$OUTPUT_DIR"
+cp "$APK_PATH" "$OUTPUT_DIR/app.apk"

--- a/.ci/build-desktop.sh
+++ b/.ci/build-desktop.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+PRESET=""
+CONFIG=""
+RUN_TESTS="true"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --preset)
+            PRESET="$2"
+            shift 2
+            ;;
+        --config)
+            CONFIG="$2"
+            shift 2
+            ;;
+        --skip-tests)
+            RUN_TESTS="false"
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+require_arg "$PRESET" "preset"
+require_arg "$CONFIG" "config"
+
+cmake --preset "$PRESET"
+cmake --build "build/$PRESET" --config "$CONFIG"
+
+if [[ "$RUN_TESTS" == "true" ]]; then
+    ctest --test-dir "build/$PRESET" --build-config "$CONFIG" --output-on-failure
+fi

--- a/.ci/build-windows-msys2.sh
+++ b/.ci/build-windows-msys2.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+PRESET=""
+CONFIG=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --preset)
+            PRESET="$2"
+            shift 2
+            ;;
+        --config)
+            CONFIG="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+require_arg "$PRESET" "preset"
+require_arg "$CONFIG" "config"
+
+export CCACHE_DIR
+CCACHE_DIR="$(cygpath -u "C:/msys2-ccache")"
+
+cmake --preset "$PRESET"
+cmake --build "build/$PRESET" --config "$CONFIG"
+
+BINDIR="build/${PRESET}/bin/${CONFIG}"
+MSYS2_BINDIR="/${MSYSTEM,,}/bin"
+for dll in libc++.dll libunwind.dll; do
+    if [[ -f "$MSYS2_BINDIR/$dll" ]]; then
+        cp "$MSYS2_BINDIR/$dll" "$BINDIR/"
+    fi
+done

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_arg() {
+    local value="${1:-}"
+    local name="${2:-argument}"
+    if [[ -z "$value" ]]; then
+        echo "Missing required argument: $name" >&2
+        exit 1
+    fi
+}
+
+git_short_sha() {
+    git rev-parse --short HEAD
+}

--- a/.ci/package-desktop.sh
+++ b/.ci/package-desktop.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+PLATFORM=""
+PRESET=""
+CONFIG=""
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --platform)
+            PLATFORM="$2"
+            shift 2
+            ;;
+        --preset)
+            PRESET="$2"
+            shift 2
+            ;;
+        --config)
+            CONFIG="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+require_arg "$PLATFORM" "platform"
+require_arg "$PRESET" "preset"
+require_arg "$CONFIG" "config"
+require_arg "$OUTPUT_DIR" "output-dir"
+
+build_dir="build/$PRESET/bin/$CONFIG"
+repo_root="$(pwd)"
+mkdir -p "$OUTPUT_DIR"
+
+case "$PLATFORM" in
+    linux-*)
+        mkdir -p "$OUTPUT_DIR/bin"
+        shopt -s dotglob nullglob
+        for path in "$build_dir"/*; do
+            base_name="$(basename "$path")"
+            if [[ "$base_name" == *AppImage* ]]; then
+                cp -R "$path" "$OUTPUT_DIR/"
+            else
+                cp -R "$path" "$OUTPUT_DIR/bin/"
+            fi
+        done
+        shopt -u dotglob nullglob
+        ;;
+    macos-*)
+        dmg_name="vita3k-${GIT_SHORT_SHA:-$(git_short_sha)}-${PLATFORM}.dmg"
+        pushd "$build_dir" > /dev/null
+        create-dmg \
+            --volname "Vita3K Installer" \
+            --volicon Vita3K.app/Contents/Resources/Vita3K.icns \
+            --window-size 500 300 \
+            --icon-size 100 \
+            --icon Vita3K.app 120 115 \
+            --app-drop-link 360 115 \
+            "$dmg_name" \
+            Vita3K.app
+        mv -f "$dmg_name" "$repo_root/$OUTPUT_DIR/"
+        rm -rf Vita3K.app
+        popd > /dev/null
+        ;;
+    windows-*)
+        mkdir -p "$OUTPUT_DIR/bin"
+        cp -R "$build_dir/." "$OUTPUT_DIR/bin/"
+        ;;
+    *)
+        echo "Unsupported desktop platform: $PLATFORM" >&2
+        exit 1
+        ;;
+esac

--- a/.ci/release-collect.sh
+++ b/.ci/release-collect.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p artifacts-master artifacts-store
+
+repo_root="$(pwd)"
+artifacts_master_dir="$repo_root/artifacts-master"
+artifacts_store_dir="$repo_root/artifacts-store"
+
+mapfile -t artifact_dirs < <(find . -mindepth 1 -maxdepth 1 -type d -name 'vita3k-*' -print | sort)
+
+for dir in "${artifact_dirs[@]}"; do
+    abs_dir="$(cd "$dir" && pwd)"
+    bin_dir="$abs_dir/bin"
+    artifact_name="$(basename "$abs_dir")"
+
+    case "$artifact_name" in
+        vita3k-*-android)
+            cp "$abs_dir/app.apk" "$artifacts_master_dir/android-latest.apk"
+            cp "$abs_dir/app.apk" "$artifacts_store_dir/vita3k-${BUILD_VARIABLE}-${GIT_SHORT_SHA}-android.apk"
+            ;;
+        vita3k-*-macos-x64)
+            cp "$abs_dir"/*.dmg "$artifacts_master_dir/macos-latest.dmg"
+            cp "$abs_dir"/*.dmg "$artifacts_store_dir/vita3k-${BUILD_VARIABLE}-${GIT_SHORT_SHA}-macos-intel.dmg"
+            ;;
+        vita3k-*-macos-arm64)
+            cp "$abs_dir"/*.dmg "$artifacts_master_dir/macos-arm64-latest.dmg"
+            cp "$abs_dir"/*.dmg "$artifacts_store_dir/vita3k-${BUILD_VARIABLE}-${GIT_SHORT_SHA}-macos-arm64.dmg"
+            ;;
+        vita3k-*-linux-x64)
+            cp "$abs_dir"/*.AppImage* "$artifacts_master_dir/"
+            cp "$abs_dir"/*.AppImage* "$artifacts_store_dir/"
+            (cd "$bin_dir" && zip -r "$artifacts_master_dir/ubuntu-latest.zip" .)
+            (cd "$bin_dir" && 7z a -mx=9 "$artifacts_store_dir/vita3k-${BUILD_VARIABLE}-${GIT_SHORT_SHA}-ubuntu-x86_64.7z" .)
+            ;;
+        vita3k-*-linux-arm64)
+            cp "$abs_dir"/*.AppImage* "$artifacts_master_dir/"
+            cp "$abs_dir"/*.AppImage* "$artifacts_store_dir/"
+            (cd "$bin_dir" && zip -r "$artifacts_master_dir/ubuntu-aarch64-latest.zip" .)
+            (cd "$bin_dir" && 7z a -mx=9 "$artifacts_store_dir/vita3k-${BUILD_VARIABLE}-${GIT_SHORT_SHA}-ubuntu-aarch64.7z" .)
+            ;;
+        vita3k-*-windows-x64)
+            (cd "$bin_dir" && zip -r "$artifacts_master_dir/windows-latest.zip" .)
+            (cd "$bin_dir" && 7z a -mx=9 "$artifacts_store_dir/vita3k-${BUILD_VARIABLE}-${GIT_SHORT_SHA}-windows-x86_64.7z" .)
+            ;;
+        vita3k-*-windows-arm64)
+            (cd "$bin_dir" && zip -r "$artifacts_master_dir/windows-arm64-latest.zip" .)
+            (cd "$bin_dir" && 7z a -mx=9 "$artifacts_store_dir/vita3k-${BUILD_VARIABLE}-${GIT_SHORT_SHA}-windows-arm64.7z" .)
+            ;;
+        *)
+            echo "Unknown artifact directory: $artifact_name" >&2
+            exit 1
+            ;;
+    esac
+done
+
+echo "=== artifacts-master ==="
+ls -al artifacts-master/
+echo "=== artifacts-store ==="
+ls -al artifacts-store/

--- a/.ci/setup-android.sh
+++ b/.ci/setup-android.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y ninja-build
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+pushd "$repo_root" > /dev/null
+for triplet in arm64-android x64-android; do
+    vcpkg install --triplet "$triplet"
+done
+popd > /dev/null

--- a/.ci/setup-linux.sh
+++ b/.ci/setup-linux.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCH="${1:-x86_64}"
+APPIMAGE_MODE="${2:-with-appimage}"
+
+sudo add-apt-repository -y ppa:mhier/libboost-latest
+sudo add-apt-repository universe
+sudo apt update
+sudo apt -y install \
+    libboost-filesystem1.83-dev \
+    libboost-program-options1.83-dev \
+    libboost-system1.83-dev \
+    libgtk-3-dev \
+    ninja-build \
+    libfuse2 \
+    gnome-desktop-testing \
+    libasound2-dev \
+    libpulse-dev \
+    libaudio-dev \
+    libfribidi-dev \
+    libjack-dev \
+    libsndio-dev \
+    libx11-dev \
+    libxext-dev \
+    libxrandr-dev \
+    libxcursor-dev \
+    libxfixes-dev \
+    libxi-dev \
+    libxss-dev \
+    libxtst-dev \
+    libxkbcommon-dev \
+    libdrm-dev \
+    libgbm-dev \
+    libgl1-mesa-dev \
+    libgles2-mesa-dev \
+    libegl1-mesa-dev \
+    libdbus-1-dev \
+    libibus-1.0-dev \
+    libudev-dev \
+    libthai-dev \
+    libpipewire-0.3-dev \
+    libwayland-dev \
+    libdecor-0-dev \
+    liburing-dev
+
+if [[ "$APPIMAGE_MODE" == "with-appimage" ]]; then
+    curl -sLO "https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-${ARCH}.AppImage"
+    sudo cp -f "linuxdeploy-${ARCH}.AppImage" "/usr/local/bin/"
+    sudo chmod +x "/usr/local/bin/linuxdeploy-${ARCH}.AppImage"
+
+    curl -sLO "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/latest/download/linuxdeploy-plugin-qt-${ARCH}.AppImage"
+    sudo cp -f "linuxdeploy-plugin-qt-${ARCH}.AppImage" "/usr/local/bin/"
+    sudo chmod +x "/usr/local/bin/linuxdeploy-plugin-qt-${ARCH}.AppImage"
+fi

--- a/.ci/setup-macos.sh
+++ b/.ci/setup-macos.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+brew install ccache create-dmg
+echo "$(brew --prefix ccache)/libexec" >> "$GITHUB_PATH"
+ccache --set-config=compiler_check=content

--- a/.ci/setup-windows-msvc.ps1
+++ b/.ci/setup-windows-msvc.ps1
@@ -1,0 +1,16 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$VcpkgTriplet
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+Push-Location $repoRoot
+try {
+    vcpkg install --triplet $VcpkgTriplet
+}
+finally {
+    Pop-Location
+}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: Build CI
 
 on:
   push:
@@ -10,79 +10,69 @@ on:
 
 env:
   BUILD_CONFIG: Release
+  QT_VERSION: '6.11.0'
   SCCACHE_GHA_ENABLED: "true"
-  PACKAGES: boost-system boost-filesystem boost-program-options boost-icl boost-variant curl openssl zlib
 
 jobs:
-  format-check:
-    name: Format Check (${{ matrix.path }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        path:
-          - vita3k
-          - tools
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Format check
-        uses: jidicula/clang-format-action@v4.18.0
-        with:
-          clang-format-version: '22'
-          check-path: ${{ matrix.path }}
-
-  build:
-    name: Build (${{ matrix.os }})
-    needs: [format-check]
-    runs-on: ${{ matrix.runs_on || matrix.os }}
+  desktop-build:
+    name: Desktop (${{ matrix.platform }})
+    runs-on: ${{ matrix.runs_on }}
 
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
+            runs_on: ubuntu-latest
+            platform: linux-x64
             arch: x86_64
-            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DLINUXDEPLOY_COMMAND=/usr/local/bin/linuxdeploy-x86_64.AppImage
-            cmake_preset: linux-ninja-clang-appimage
+            cmake_preset: ci-linux-clang-appimage
+            linuxdeploy_command: /usr/local/bin/linuxdeploy-x86_64.AppImage
+            cache_path: ''
+            qt_install_deps: 'true'
 
           - os: ubuntu-24.04-arm
+            runs_on: ubuntu-24.04-arm
+            platform: linux-arm64
             arch: aarch64
-            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DLINUXDEPLOY_COMMAND=/usr/local/bin/linuxdeploy-aarch64.AppImage
-            cmake_preset: linux-ninja-clang-appimage
+            cmake_preset: ci-linux-clang-appimage
+            linuxdeploy_command: /usr/local/bin/linuxdeploy-aarch64.AppImage
+            cache_path: ''
+            qt_install_deps: 'true'
 
           - os: windows-latest
+            runs_on: windows-latest
+            platform: windows-x64
             arch: x86_64
+            cmake_preset: ci-windows-msvc
+            vcpkg_root: C:\vcpkg
+            vcpkg_triplet: x64-windows-static-md
             cache_path: |
               C:\vcpkg\installed
               C:\vcpkg\packages
-            vcpkg_triplet: x64-windows-static-md
-            extra_cmake_args: -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
-            cmake_preset: windows-ninja
+            qt_install_deps: 'false'
 
           - os: windows-11-arm
-            cache_path: C:\msys2-ccache
+            runs_on: windows-11-arm
+            platform: windows-arm64
+            cmake_preset: ci-windows-msys2-clang
             msys2_env: CLANGARM64
-            cmake_preset: windows-ninja
+            cache_path: C:\msys2-ccache
+            qt_install_deps: 'false'
 
           - os: macos-intel
+            platform: macos-x64
             runs_on: macos-latest
+            cmake_preset: ci-macos-x64
             cache_path: ~/Library/Caches/ccache
-            extra_cmake_args: -DCMAKE_OSX_ARCHITECTURES="x86_64" -DFORCE_BUILD_OPENSSL_MAC=ON -DVITA3K_FORCE_CUSTOM_BOOST=ON
-            cmake_preset: macos-ninja
+            qt_install_deps: 'false'
 
           - os: macos-arm64
+            platform: macos-arm64
             runs_on: macos-latest
+            cmake_preset: ci-macos-arm64
             cache_path: ~/Library/Caches/ccache
-            extra_cmake_args: -DCMAKE_OSX_ARCHITECTURES="arm64" -DFORCE_BUILD_OPENSSL_MAC=ON -DVITA3K_FORCE_CUSTOM_BOOST=ON
-            cmake_preset: macos-ninja
-
-          - os: android
-            runs_on: ubuntu-latest
-            cache_path: |
-              /usr/local/share/vcpkg/installed
-              /usr/local/share/vcpkg/packages
+            qt_install_deps: 'false'
 
     steps:
       - uses: actions/checkout@v6
@@ -90,68 +80,43 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - uses: actions/cache@v5
+      - name: Restore cache
+        uses: actions/cache@v5
+        if: ${{ matrix.cache_path != '' }}
         with:
           path: ${{ matrix.cache_path }}
-          key: cache-${{ matrix.os }}-${{ env.BUILD_CONFIG }}-${{ github.sha }}
+          key: cache-${{ matrix.platform }}-${{ env.BUILD_CONFIG }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', '.ci/**', '.github/workflows/c-cpp.yml', 'vcpkg.json') }}
           restore-keys: |
-            cache-${{ matrix.os }}-${{ env.BUILD_CONFIG }}-
-        if: ${{ ! startsWith(matrix.os, 'ubuntu') }}
-
-      - name: Set up build environment (macOS)
-        run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
-          brew install ccache create-dmg
-          echo "$(brew --prefix ccache)/libexec" >> $GITHUB_PATH
-          ccache --set-config=compiler_check=content
-        if: startsWith(matrix.os, 'macos')
+            cache-${{ matrix.platform }}-${{ env.BUILD_CONFIG }}-
 
       - name: Set up build environment (Linux)
-        run: |
-          sudo add-apt-repository -y ppa:mhier/libboost-latest # boost repo
-          sudo add-apt-repository universe
-          sudo apt update
-          sudo apt -y install libboost-filesystem1.83-dev libboost-program-options1.83-dev libboost-system1.83-dev libgtk-3-dev ninja-build libfuse2
-          sudo apt -y install gnome-desktop-testing libasound2-dev libpulse-dev libaudio-dev libfribidi-dev libjack-dev libsndio-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libthai-dev libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev
+        run: bash ./.ci/setup-linux.sh ${{ matrix.arch }} with-appimage
+        if: startsWith(matrix.platform, 'linux-')
 
-          # Set up linuxdeploy for AppImage
-          curl -sLO https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-${{ matrix.arch }}.AppImage
-          sudo cp -f linuxdeploy-${{ matrix.arch }}.AppImage /usr/local/bin/
-          sudo chmod +x /usr/local/bin/linuxdeploy-${{ matrix.arch }}.AppImage
+      - name: Set up build environment (macOS)
+        run: bash ./.ci/setup-macos.sh
+        if: startsWith(matrix.platform, 'macos-')
 
-          # Set up linuxdeploy-plugin-qt for Qt bundling in AppImage
-          curl -sLO https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/latest/download/linuxdeploy-plugin-qt-${{ matrix.arch }}.AppImage
-          sudo cp -f linuxdeploy-plugin-qt-${{ matrix.arch }}.AppImage /usr/local/bin/
-          sudo chmod +x /usr/local/bin/linuxdeploy-plugin-qt-${{ matrix.arch }}.AppImage
-        if: startsWith(matrix.os, 'ubuntu')
-
-      - name: Set up build environment (Windows)
-        run: |
-          vcpkg install ${{ env.PACKAGES }} --triplet=${{ matrix.vcpkg_triplet }}
-        if: startsWith(matrix.os, 'windows') && !matrix.msys2_env
+      - name: Set up build environment (Windows MSVC)
+        shell: pwsh
+        env:
+          VCPKG_ROOT: ${{ matrix.vcpkg_root }}
+        run: .\.ci\setup-windows-msvc.ps1 -VcpkgTriplet '${{ matrix.vcpkg_triplet }}'
+        if: matrix.platform == 'windows-x64'
 
       - uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: ${{ matrix.arch }}
-        if: startsWith(matrix.os, 'windows') && !matrix.msys2_env
-
-      - name: Set up build environment (Android)
-        run: |
-          sudo apt-get install -y ninja-build
-          vcpkg install ${{ env.PACKAGES }} --triplet=arm64-android
-          vcpkg install ${{ env.PACKAGES }} --triplet=x64-android
-        if: matrix.os == 'android'
-
-      - uses: hendrikmuhs/ccache-action@v1.2.23
-        if: matrix.os == 'android'
+        if: matrix.platform == 'windows-x64'
 
       - uses: mozilla-actions/sccache-action@v0.0.10
-        if: (startsWith(matrix.os, 'windows') && !matrix.msys2_env) || startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.platform, 'linux-') || matrix.platform == 'windows-x64'
         with:
           disable_annotations: true
 
       - name: Set up MSYS2 (Windows ARM)
         uses: msys2/setup-msys2@v2
+        if: matrix.platform == 'windows-arm64'
         with:
           msystem: ${{ matrix.msys2_env }}
           update: true
@@ -171,16 +136,118 @@ jobs:
             qt6-base:p
             qt6-svg:p
             qt6-tools:p
-        if: matrix.msys2_env
 
-      - name: Restore Gradle Cache
+      - name: Reset ccache statistics
+        run: ccache -z
+        if: startsWith(matrix.platform, 'macos-')
+
+      - name: Install Qt 6.11.0 (Windows MSVC)
+        uses: jurplel/install-qt-action@v4
+        if: matrix.platform == 'windows-x64'
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: windows
+          target: desktop
+          arch: win64_msvc2022_64
+          cache: true
+          install-deps: ${{ matrix.qt_install_deps }}
+          aqtsource: git+https://github.com/miurahr/aqtinstall.git@f383b3c7d9658e881bd8ce8810057393bd934ee1
+
+      - name: Install Qt 6.11.0
+        uses: jurplel/install-qt-action@v4
+        if: matrix.platform != 'windows-arm64' && matrix.platform != 'windows-x64'
+        with:
+          version: ${{ env.QT_VERSION }}
+          cache: true
+          install-deps: ${{ matrix.qt_install_deps }}
+
+      - name: Build desktop target (Linux/macOS)
+        env:
+          VITA3K_LINUXDEPLOY_COMMAND: ${{ matrix.linuxdeploy_command }}
+        run: bash ./.ci/build-desktop.sh --preset ${{ matrix.cmake_preset }} --config ${{ env.BUILD_CONFIG }}
+        if: startsWith(matrix.platform, 'linux-') || startsWith(matrix.platform, 'macos-')
+
+      - name: Build desktop target (Windows MSVC)
+        shell: bash
+        env:
+          VCPKG_ROOT: ${{ matrix.vcpkg_root }}
+        run: bash ./.ci/build-desktop.sh --preset ${{ matrix.cmake_preset }} --config ${{ env.BUILD_CONFIG }}
+        if: matrix.platform == 'windows-x64'
+
+      - name: Build desktop target (Windows ARM MSYS2)
+        shell: msys2 {0}
+        run: bash ./.ci/build-windows-msys2.sh --preset ${{ matrix.cmake_preset }} --config ${{ env.BUILD_CONFIG }}
+        if: matrix.platform == 'windows-arm64'
+
+      - name: Compute artifact paths
+        shell: bash
+        run: |
+          echo "GIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "ARTIFACT_NAME=vita3k-$(git rev-parse --short HEAD)-${{ matrix.platform }}" >> "$GITHUB_ENV"
+          echo "ARTIFACT_DIR=artifacts/vita3k-$(git rev-parse --short HEAD)-${{ matrix.platform }}" >> "$GITHUB_ENV"
+
+      - name: Stage desktop artifact (Linux/macOS)
+        run: bash ./.ci/package-desktop.sh --platform ${{ matrix.platform }} --preset ${{ matrix.cmake_preset }} --config ${{ env.BUILD_CONFIG }} --output-dir "${{ env.ARTIFACT_DIR }}"
+        if: startsWith(matrix.platform, 'linux-') || startsWith(matrix.platform, 'macos-')
+
+      - name: Stage desktop artifact (Windows MSVC)
+        shell: bash
+        run: bash ./.ci/package-desktop.sh --platform ${{ matrix.platform }} --preset ${{ matrix.cmake_preset }} --config ${{ env.BUILD_CONFIG }} --output-dir "${{ env.ARTIFACT_DIR }}"
+        if: matrix.platform == 'windows-x64'
+
+      - name: Stage desktop artifact (Windows ARM MSYS2)
+        shell: msys2 {0}
+        run: bash ./.ci/package-desktop.sh --platform ${{ matrix.platform }} --preset ${{ matrix.cmake_preset }} --config ${{ env.BUILD_CONFIG }} --output-dir "${{ env.ARTIFACT_DIR }}"
+        if: matrix.platform == 'windows-arm64'
+
+      - name: Print ccache statistics
+        run: ccache -s
+        if: startsWith(matrix.platform, 'macos-')
+
+      - name: Print sccache statistics
+        run: sccache --show-stats
+        if: startsWith(matrix.platform, 'linux-') || matrix.platform == 'windows-x64'
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+  android-build:
+    name: Android
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Restore native dependency cache
         uses: actions/cache@v5
         with:
-          path: '~/.gradle/'
+          path: |
+            /usr/local/share/vcpkg/installed
+            /usr/local/share/vcpkg/packages
+          key: cache-android-native-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.ci/**', 'android/app/build.gradle', 'vcpkg.json') }}
+          restore-keys: |
+            cache-android-native-
+
+      - name: Restore Gradle cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.gradle/
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle', 'android/**/*.properties', 'android/**/*.xml', 'android/**/*.java', 'android/**/*.kt') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-        if: matrix.os == 'android'
+
+      - name: Set up Android build environment
+        env:
+          VCPKG_ROOT: /usr/local/share/vcpkg
+        run: bash ./.ci/setup-android.sh
+
+      - uses: hendrikmuhs/ccache-action@v1.2.23
 
       - name: Decode Android keystore
         env:
@@ -189,136 +256,32 @@ jobs:
           if [ -n "$KEYSTORE_ENCODED" ]; then
             echo "$KEYSTORE_ENCODED" | base64 --decode > /home/runner/keystore.jks
           fi
-        if: matrix.os == 'android'
 
-      - name: Reset ccache statistics
-        run: ccache -z
-        if: startsWith(matrix.os, 'macos')
-
-      - name: Install Qt6
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: '6.8.2'
-          cache: true
-        if: matrix.os != 'android' && !matrix.msys2_env
-
-      - name: Build Vita3K
+      - name: Compute artifact paths
+        shell: bash
         run: |
-          cmake ${{ matrix.extra_cmake_args }} --preset ${{ matrix.cmake_preset }}
-          cmake --build build/${{ matrix.cmake_preset }} --config ${{ env.BUILD_CONFIG }}
-        if: matrix.os != 'android' && !matrix.msys2_env
+          echo "GIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "ARTIFACT_NAME=vita3k-$(git rev-parse --short HEAD)-android" >> "$GITHUB_ENV"
+          echo "ARTIFACT_DIR=artifacts/vita3k-$(git rev-parse --short HEAD)-android" >> "$GITHUB_ENV"
 
-      - name: Build Vita3K (MSYS2)
-        shell: msys2 {0}
-        run: |
-          export CCACHE_DIR=$(cygpath -u "C:/msys2-ccache")
-          cmake -G "Ninja Multi-Config" -B build/${{ matrix.cmake_preset }} \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          cmake --build build/${{ matrix.cmake_preset }} --config ${{ env.BUILD_CONFIG }}
-        if: matrix.msys2_env
-
-      - name: Deploy MSYS2 runtime libraries
-        shell: msys2 {0}
-        run: |
-          BINDIR="build/${{ matrix.cmake_preset }}/bin/${{ env.BUILD_CONFIG }}"
-          MSYS2_BINDIR="/${MSYSTEM,,}/bin"
-          for dll in libc++.dll libunwind.dll; do
-            if [ -f "$MSYS2_BINDIR/$dll" ]; then
-              cp "$MSYS2_BINDIR/$dll" "$BINDIR/"
-            fi
-          done
-        if: matrix.msys2_env
-
-      - name: Print ccache statistics
-        run: ccache -s
-        if: startsWith(matrix.os, 'macos')
-
-      - name: Print sccache statistics
-        run: sccache --show-stats
-        if: (startsWith(matrix.os, 'windows') && !matrix.msys2_env) || startsWith(matrix.os, 'ubuntu')
-
-      - name: Build Vita3K (Android)
+      - name: Build Android target
         env:
-          SIGNING_STORE_PATH: "/home/runner/keystore.jks"
+          SIGNING_STORE_PATH: /home/runner/keystore.jks
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
           JVM_OPTS: -Xmx6G
           VCPKG_ROOT: /usr/local/share/vcpkg
-        run: |
-          mkdir -p android/app/assets
-          rm -rf android/app/assets/data android/app/assets/shaders-builtin
-          cp -r data android/app/assets/data
-          cp -r vita3k/shaders-builtin android/app/assets/shaders-builtin
-          export JAVA_HOME="$JAVA_HOME_17_X64"
-          chmod +x android/gradlew
-          if [ -e "$SIGNING_STORE_PATH" ]; then
-            BUILD_TYPE=Release
-          else
-            BUILD_TYPE=Reldebug
-          fi
-          cd android
-          ./gradlew --stacktrace --configuration-cache --build-cache --parallel --configure-on-demand :app:assemble${BUILD_TYPE}
-          echo "APK_PATH=android/app/build/outputs/apk/${BUILD_TYPE,,}/app-${BUILD_TYPE,,}.apk" >> $GITHUB_ENV
-        if: matrix.os == 'android'
+        run: bash ./.ci/build-android.sh "${{ env.ARTIFACT_DIR }}"
 
-      - name: Run tests
-        working-directory: build/${{ matrix.cmake_preset }}
-        run: ctest --build-config ${{ env.BUILD_CONFIG }} --output-on-failure
-        if: matrix.os != 'android' && !matrix.msys2_env
-
-      - name: Compute git short SHA
-        shell: bash
-        run: echo "GIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-      - name: Create DMG (macOS)
-        run: |
-          cd build/${{ matrix.cmake_preset }}/bin/${{ env.BUILD_CONFIG }}
-          create-dmg \
-            --volname "Vita3K Installer" \
-            --volicon Vita3K.app/Contents/Resources/Vita3K.icns \
-            --window-size 500 300 \
-            --icon-size 100 \
-            --icon Vita3K.app 120 115 \
-            --app-drop-link 360 115 \
-            vita3k-${{ env.GIT_SHORT_SHA }}-${{ matrix.os }}.dmg \
-            Vita3K.app
-          rm -rf Vita3K.app
-        if: startsWith(matrix.os, 'macos')
-
-      - name: Prepare Linux AppImage artifact
-        run: |
-          cd build/${{ matrix.cmake_preset }}/bin/${{ env.BUILD_CONFIG }}
-          mkdir -p ../appimage
-          mv -f *AppImage* ../appimage/
-        if: startsWith(matrix.os, 'ubuntu')
-
-      - name: Upload artifact (Linux AppImage)
+      - name: Upload Android artifact
         uses: actions/upload-artifact@v7
         with:
-          name: vita3k-${{ env.GIT_SHORT_SHA }}-${{ matrix.os }}-appimage
-          path: build/${{ matrix.cmake_preset }}/bin/appimage
-        if: startsWith(matrix.os, 'ubuntu')
-
-      - name: Upload artifact (Android apk)
-        uses: actions/upload-artifact@v7
-        with:
-          name: vita3k-${{ env.GIT_SHORT_SHA }}-android
-          path: ${{ env.APK_PATH }}
-        if: matrix.os == 'android'
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: vita3k-${{ env.GIT_SHORT_SHA }}-${{ matrix.os }}
-          path: build/${{ matrix.cmake_preset }}/bin/${{ env.BUILD_CONFIG }}
-        if: matrix.os != 'android'
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACT_DIR }}
 
   create-release:
-    needs: [build]
+    needs: [desktop-build, android-build]
     runs-on: ubuntu-latest
     concurrency:
       group: create-release
@@ -331,14 +294,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v8
 
       - name: Get commit info
         run: |
-          echo "GIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "BUILD_VARIABLE=$(git rev-list --count HEAD)" >> $GITHUB_ENV
-          echo "LAST_COMMIT_MESSAGE=$(git log -1 --pretty=format:'%s')" >> $GITHUB_ENV
+          echo "GIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "BUILD_VARIABLE=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
+          echo "LAST_COMMIT_MESSAGE=$(git log -1 --pretty=format:'%s')" >> "$GITHUB_ENV"
 
       - name: Get last committer
         env:
@@ -347,58 +310,12 @@ jobs:
           COMMITTER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
           https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} \
           | jq -r '.commit.author.name')
-          echo "COMMITTER_NAME=$COMMITTER" >> $GITHUB_ENV
+          echo "COMMITTER_NAME=$COMMITTER" >> "$GITHUB_ENV"
 
-      - name: Prepare artifacts
-        run: |
-          mkdir -p artifacts-master artifacts-store
-          files=$(find . -maxdepth 1 -type d -name "vita3k-*")
-          for f in $files; do
-            dir=$(basename $f)
-            if [[ $dir == *-android ]]; then
-              echo "Processing $dir (Android)"
-              cp $dir/*.apk artifacts-master/android-latest.apk
-              cp $dir/*.apk artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-android.apk
-            elif [[ $dir == *-macos-intel ]]; then
-              echo "Processing $dir (macOS Intel)"
-              cp $dir/*.dmg artifacts-master/macos-latest.dmg
-              cp $dir/*.dmg artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-macos-intel.dmg
-            elif [[ $dir == *-macos-arm64 ]]; then
-              echo "Processing $dir (macOS ARM64)"
-              cp $dir/*.dmg artifacts-master/macos-arm64-latest.dmg
-              cp $dir/*.dmg artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-macos-arm64.dmg
-            elif [[ $dir == *-ubuntu-latest-appimage ]]; then
-              echo "Processing $dir (x86_64 AppImage)"
-              cp $dir/*.AppImage* artifacts-master/
-              cp $dir/*.AppImage* artifacts-store/
-            elif [[ $dir == *-ubuntu-24.04-arm-appimage ]]; then
-              echo "Processing $dir (ARM64 AppImage)"
-              cp $dir/*.AppImage* artifacts-master/
-              cp $dir/*.AppImage* artifacts-store/
-            elif [[ $dir == *-ubuntu-latest ]]; then
-              echo "Processing $dir (Ubuntu x86_64)"
-              (cd $dir && zip -r ../artifacts-master/ubuntu-latest.zip *)
-              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-ubuntu-x86_64.7z $dir
-            elif [[ $dir == *-ubuntu-24.04-arm ]]; then
-              echo "Processing $dir (Ubuntu ARM64)"
-              (cd $dir && zip -r ../artifacts-master/ubuntu-aarch64-latest.zip *)
-              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-ubuntu-aarch64.7z $dir
-            elif [[ $dir == *-windows-latest ]]; then
-              echo "Processing $dir (Windows x86_64)"
-              (cd $dir && zip -r ../artifacts-master/windows-latest.zip *)
-              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-windows-x86_64.7z $dir
-            elif [[ $dir == *-windows-11-arm ]]; then
-              echo "Processing $dir (Windows ARM64)"
-              (cd $dir && zip -r ../artifacts-master/windows-arm64-latest.zip *)
-              7z a -mx=9 artifacts-store/vita3k-${{ env.BUILD_VARIABLE }}-${{ env.GIT_SHORT_SHA }}-windows-arm64.7z $dir
-            fi
-          done
-          echo "=== artifacts-master ==="
-          ls -al artifacts-master/
-          echo "=== artifacts-store ==="
-          ls -al artifacts-store/
+      - name: Prepare release artifacts
+        run: bash ./.ci/release-collect.sh
 
-      - name: "Upload to store repository"
+      - name: Upload to store repository
         uses: tcnksm/ghr@v0
         with:
           tag: ${{ env.BUILD_VARIABLE }}
@@ -409,7 +326,7 @@ jobs:
           body: "Corresponding commit: [${{ env.LAST_COMMIT_MESSAGE }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) (${{ env.COMMITTER_NAME }})"
           token: ${{ secrets.STORE_TOKEN }}
 
-      - name: "Upload to master repository"
+      - name: Upload to master repository
         uses: tcnksm/ghr@v0
         with:
           tag: continuous

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,8 @@ on:
     - cron: '0 1 * * 3'
 
 env:
+  BUILD_CONFIG: Release
+  QT_VERSION: '6.11.0'
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
@@ -38,7 +40,7 @@ jobs:
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
         os: [ubuntu-latest]
         config: [Release]
-        cmake_preset: [linux-ninja-clang]
+        cmake_preset: [ci-linux-clang]
 
     steps:
       - name: Checkout repository
@@ -47,10 +49,7 @@ jobs:
           submodules: recursive
 
       - name: Set up build environment (ubuntu-latest)
-        run: |
-          sudo add-apt-repository -y ppa:mhier/libboost-latest
-          sudo apt update
-          sudo apt -y install ccache libboost-filesystem1.83-dev libboost-program-options1.83-dev libboost-system1.83-dev libgtk-3-dev ninja-build
+        run: bash ./.ci/setup-linux.sh x86_64 without-appimage
 
       - uses: mozilla-actions/sccache-action@v0.0.10
         with:
@@ -59,7 +58,7 @@ jobs:
       - name: Install Qt6
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.8.2'
+          version: ${{ env.QT_VERSION }}
           cache: true
           install-deps: 'true'
 
@@ -75,8 +74,7 @@ jobs:
 
       - name: Build
         run: |
-         cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache --preset ${{ matrix.cmake_preset }}
-         cmake --build build/${{ matrix.cmake_preset }} --config ${{ matrix.config }}
+         bash ./.ci/build-desktop.sh --preset ${{ matrix.cmake_preset }} --config ${{ matrix.config }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,29 @@
+name: Format Check
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  format-check:
+    name: Format Check (${{ matrix.path }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        path:
+          - vita3k
+          - tools
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Format check
+        uses: jidicula/clang-format-action@v4.18.0
+        with:
+          clang-format-version: '22'
+          check-path: ${{ matrix.path }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,6 +65,28 @@
       }
     },
     {
+      "name": "ci-windows-msvc",
+      "inherits": "windows-ninja",
+      "description": "CI preset for Windows MSVC builds",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
+      }
+    },
+    {
+      "name": "ci-windows-msys2-clang",
+      "inherits": "windows-ninja",
+      "description": "CI preset for Windows MSYS2 Clang builds",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+      }
+    },
+    {
       "name": "linux",
       "inherits": "base",
       "displayName": "Linux default",
@@ -109,6 +131,25 @@
       }
     },
     {
+      "name": "ci-linux-clang",
+      "inherits": "linux-ninja-clang",
+      "description": "CI preset for Linux Clang builds",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache"
+      }
+    },
+    {
+      "name": "ci-linux-clang-appimage",
+      "inherits": "ci-linux-clang",
+      "description": "CI preset for Linux Clang AppImage builds",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "/usr",
+        "BUILD_APPIMAGE": true,
+        "LINUXDEPLOY_COMMAND": "$env{VITA3K_LINUXDEPLOY_COMMAND}"
+      }
+    },
+    {
       "name": "linux-ninja-gnu",
       "inherits": "linux-ninja",
       "displayName": "Linux with Ninja and GNU GCC",
@@ -135,6 +176,30 @@
       "displayName": "macOS with Ninja",
       "description": "Linux native build using Ninja Multi-Config generator and default compiler",
       "generator": "Ninja Multi-Config"
+    },
+    {
+      "name": "ci-macos-x64",
+      "inherits": "macos-ninja",
+      "description": "CI preset for macOS x86_64 builds",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_OSX_ARCHITECTURES": "x86_64",
+        "FORCE_BUILD_OPENSSL_MAC": true,
+        "VITA3K_FORCE_CUSTOM_BOOST": true
+      }
+    },
+    {
+      "name": "ci-macos-arm64",
+      "inherits": "macos-ninja",
+      "description": "CI preset for macOS arm64 builds",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_OSX_ARCHITECTURES": "arm64",
+        "FORCE_BUILD_OPENSSL_MAC": true,
+        "VITA3K_FORCE_CUSTOM_BOOST": true
+      }
     },
     {
       "name": "macos-xcode",

--- a/building.md
+++ b/building.md
@@ -27,7 +27,7 @@ For convenience, the following building instructions are given as examples:
 
 - Install `git` to `clone` the project. Download and install `git` from [here](https://git-scm.com).
 
-- Install [Qt](https://www.qt.io/download) (6.7 or later), and select the `MSVC 2022 64-bit` component during installation.
+- Install [Qt](https://www.qt.io/download) (6.11.x or later), and select the `MSVC 2022 64-bit` component during installation.
 
 - Clone this repo.
 
@@ -62,7 +62,7 @@ If you aren't satisfied with the way the Visual Studio integrates CMake projects
 
 - Generate the project:
   ```cmd
-  set CMAKE_PREFIX_PATH=C:\Qt\6.x.x\msvc2022_64
+  set Qt6_ROOT=C:\Qt\6.11.0\msvc2022_64
   cmake --preset windows-vs2022
   ```
   The line above will generate a Visual Studio 2022 project inside a folder called `build/windows-vs2022`.
@@ -83,6 +83,8 @@ If you aren't satisfied with the way the Visual Studio integrates CMake projects
   ```sh
   brew install git cmake molten-vk openssl qt
   ```
+
+  Ensure `brew` provides Qt 6.11 or newer. If it does not, install the official Qt 6.11 package and set `Qt6_ROOT` before configuring.
 
 - Clone this repo.
 
@@ -123,6 +125,8 @@ If you aren't satisfied with the way the Visual Studio integrates CMake projects
   sudo dnf install git cmake ninja-build SDL2-devel pkg-config gtk3-devel clang lld xdg-desktop-portal openssl openssl-devel libstdc++-static qt6-base-devel
   ```
 
+Note: Your Qt packages must provide Qt 6.11 or newer. If your distro ships an older Qt, install the official Qt 6.11 package and set `Qt6_ROOT` before running CMake.
+
 Note: The CMake preset `linux-ninja-clang` makes use of the LLD linker, which will need to be installed in your system along with Clang.
 
 - Clone this repo.
@@ -150,9 +154,10 @@ Note: The CMake preset `linux-ninja-clang` makes use of the LLD linker, which wi
 
 - The Android version of Vita3K relies on [vcpkg](https://vcpkg.io/en/) to build some of its dependencies.
   ```sh
-  vcpkg install boost-system:arm64-android boost-filesystem:arm64-android boost-program-options:arm64-android boost-icl:arm64-android boost-variant:arm64-android openssl:arm64-android zlib:arm64-android
+  vcpkg install --triplet arm64-android
+  vcpkg install --triplet x64-android
   ```
-  You will also need to set the environment variable VCPKG_ROOT to its proper location.
+  Run these commands from the repository root so `vcpkg` can consume the repository's `vcpkg.json` manifest. You will also need to set the environment variable `VCPKG_ROOT` to its proper location.
 
 - Building can be done with Android studio: select the Vita3K Android folder and click on the build icon or by command line:
   ```sh

--- a/cmake/qt6.cmake
+++ b/cmake/qt6.cmake
@@ -2,7 +2,7 @@
 # Provides the vita3k::qt6 INTERFACE target.
 add_library(vita3k_qt6 INTERFACE)
 
-set(VITA3K_QT_MIN_VER 6.7.0)
+set(VITA3K_QT_MIN_VER 6.11.0)
 
 set(VITA3K_QT_COMPONENTS Core Gui Widgets Network Concurrent Svg LinguistTools)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "vita3k",
+  "version-string": "0.0.0",
+  "dependencies": [
+    "boost-filesystem",
+    "boost-icl",
+    "boost-program-options",
+    "boost-system",
+    "boost-variant",
+    "curl",
+    "openssl",
+    "zlib"
+  ]
+}


### PR DESCRIPTION
Organize CI into shared `.ci` scripts for setup/build/package steps. Move desktop/android installs to vcpkg manifest mode where possible. Move format check to it's own workflow. Move as much "policy" out of the workflow and into cmake presets (what do any of these words even mean?). Enforce and pin Qt version 6.11. There is further room for cleanup that I think is out of scope for this PR, like getting rid of our configure time download scripts for random deps (or making it only available for local dev) and improving android build times. So this is just part 1 of ???. 