### PR TITLE
ci: update android build/ci

### DIFF
--- a/.ci/build-android.sh
+++ b/.ci/build-android.sh
@@ -12,7 +12,6 @@ rm -rf android/app/assets/data android/app/assets/shaders-builtin
 cp -r data android/app/assets/data
 cp -r vita3k/shaders-builtin android/app/assets/shaders-builtin
 
-export JAVA_HOME="${JAVA_HOME_17_X64}"
 chmod +x android/gradlew
 
 if [[ -e "${SIGNING_STORE_PATH:-}" ]]; then
@@ -22,7 +21,7 @@ else
 fi
 
 pushd android > /dev/null
-./gradlew --stacktrace --configuration-cache --build-cache --parallel --configure-on-demand ":app:assemble${BUILD_TYPE}"
+./gradlew --stacktrace ":app:assemble${BUILD_TYPE}"
 popd > /dev/null
 
 APK_PATH="android/app/build/outputs/apk/${BUILD_TYPE,,}/app-${BUILD_TYPE,,}.apk"

--- a/.ci/setup-android.sh
+++ b/.ci/setup-android.sh
@@ -1,10 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+android_api_level="${ANDROID_API_LEVEL:-35}"
+android_build_tools="${ANDROID_BUILD_TOOLS:-36.0.0}"
+android_ndk_version="${ANDROID_NDK_VERSION:-29.0.14206865}"
+
 sudo apt-get update
 sudo apt-get install -y ninja-build
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+if command -v sdkmanager > /dev/null; then
+    set +o pipefail
+    yes | sdkmanager --licenses > /dev/null
+    set -o pipefail
+    sdkmanager --install \
+        "platforms;android-${android_api_level}" \
+        "build-tools;${android_build_tools}" \
+        "ndk;${android_ndk_version}"
+
+    sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+    if [[ -n "${sdk_root:-}" ]]; then
+        export ANDROID_NDK_HOME="${sdk_root}/ndk/${android_ndk_version}"
+        if [[ -n "${GITHUB_ENV:-}" ]]; then
+            echo "ANDROID_NDK_HOME=${ANDROID_NDK_HOME}" >> "${GITHUB_ENV}"
+        fi
+    fi
+fi
 
 pushd "$repo_root" > /dev/null
 for triplet in arm64-android x64-android; do

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -234,13 +234,21 @@ jobs:
           restore-keys: |
             cache-android-native-
 
-      - name: Restore Gradle cache
-        uses: actions/cache@v5
+      - name: Set up Java
+        uses: actions/setup-java@v5
         with:
-          path: ~/.gradle/
-          key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle', 'android/**/*.properties', 'android/**/*.xml', 'android/**/*.java', 'android/**/*.kt') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          add-job-summary: on-failure
+          cache-provider: basic
+          validate-wrappers: false
+
+      - name: Set up Android SDK tools
+        uses: android-actions/setup-android@v4
 
       - name: Set up Android build environment
         env:
@@ -270,9 +278,12 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          JVM_OPTS: -Xmx6G
           VCPKG_ROOT: /usr/local/share/vcpkg
+          ANDROID_NDK_HOME: ${{ env.ANDROID_NDK_HOME }}
         run: bash ./.ci/build-android.sh "${{ env.ARTIFACT_DIR }}"
+
+      - name: Print Android ccache statistics
+        run: ccache -s
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v7

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,6 +1,7 @@
-apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+plugins {
+	id 'com.android.application'
+	id 'org.jetbrains.kotlin.plugin.compose'
+}
 
 def signingStorePath = System.getenv("SIGNING_STORE_PATH")
 def signingStorePassword = System.getenv("SIGNING_STORE_PASSWORD")
@@ -9,74 +10,68 @@ def signingKeyPassword = System.getenv("SIGNING_KEY_PASSWORD")
 def hasCiSigning = signingStorePath && signingStorePassword && signingKeyAlias && signingKeyPassword
 
 android {
-	namespace "org.vita3k.emulator"
-	compileSdk 35
-	ndkVersion "27.3.13750724"
+	namespace = "org.vita3k.emulator"
+	compileSdk = 35
+	ndkVersion = "29.0.14206865"
 	buildFeatures {
-		buildConfig true
-		compose true
+		buildConfig = true
+		compose = true
 	}
 
 	defaultConfig {
-		applicationId "org.vita3k.emulator"
-		minSdk 28
-		targetSdk 35
-		versionCode 21
-		versionName "0.2.1"
+		applicationId = "org.vita3k.emulator"
+		minSdk = 28
+		targetSdk = 35
+		versionCode = 21
+		versionName = "0.2.1"
 
 		ndk {
 			abiFilters "arm64-v8a", "x86_64"
-		}
-
-		externalNativeBuild {
-			cmake {
-				arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON" // required until NDK r28
-			}
 		}
 	}
 
 	signingConfigs {
 		ci {
 			if (hasCiSigning) {
-				storeFile file(signingStorePath)
-				storePassword signingStorePassword
-				keyAlias signingKeyAlias
-				keyPassword signingKeyPassword
+				storeFile = file(signingStorePath)
+				storePassword = signingStorePassword
+				keyAlias = signingKeyAlias
+				keyPassword = signingKeyPassword
 			}
 		}
 	}
 
 	buildTypes {
 		debug {
-			debuggable true
-			jniDebuggable true
-			applicationIdSuffix '.debug'
+			debuggable = true
+			jniDebuggable = true
+			applicationIdSuffix = '.debug'
 		}
 
 		reldebug {
-			debuggable true
-			jniDebuggable true
+			debuggable = true
+			jniDebuggable = true
 			externalNativeBuild {
 				cmake {
 					arguments "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
 				}
 			}
-			minifyEnabled false
-			shrinkResources false
-			applicationIdSuffix '.debug'
+			minifyEnabled = false
+			shrinkResources = false
+			applicationIdSuffix = '.debug'
 			signingConfig = signingConfigs.debug
 		}
 
 		release {
-			debuggable false
-			jniDebuggable false
+			debuggable = false
+			jniDebuggable = false
 			externalNativeBuild {
 				cmake {
 					arguments "-DCMAKE_BUILD_TYPE=Release"
 				}
 			}
-			minifyEnabled true
-			shrinkResources true
+			minifyEnabled = true
+			shrinkResources = true
 			proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 			signingConfig = hasCiSigning ? signingConfigs.ci : signingConfigs.debug
 		}
@@ -85,9 +80,6 @@ android {
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_17
 		targetCompatibility JavaVersion.VERSION_17
-	}
-	kotlinOptions {
-		jvmTarget = '17'
 	}
 
 	sourceSets {
@@ -104,20 +96,20 @@ android {
 
 	externalNativeBuild {
 		cmake {
-			path '../../CMakeLists.txt'
-			version '3.22.1+'
-		} 
+			path = '../../CMakeLists.txt'
+			version = '3.22.1+'
+		}
 	}
 
-    lint {
-        abortOnError false
-        checkReleaseBuilds false
-    }
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
+	lint {
+		abortOnError = false
+		checkReleaseBuilds = false
+	}
+	packaging {
+		jniLibs {
+			useLegacyPackaging = true
+		}
+	}
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,8 @@
 plugins {
-	id 'com.android.application' version '8.13.0' apply false
-	id 'com.android.library' version '8.13.0' apply false
-	id 'org.jetbrains.kotlin.android' version '2.1.20' apply false
-	id 'org.jetbrains.kotlin.plugin.compose' version '2.1.20' apply false
+	id 'com.android.application' version '9.2.1' apply false
+	id 'org.jetbrains.kotlin.plugin.compose' version '2.3.21' apply false
 }
 
-task clean(type: Delete) {
-	delete rootProject.buildDir
+tasks.register('clean', Delete) {
+	delete(rootProject.layout.buildDirectory)
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,6 +7,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC
+org.gradle.caching=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -17,11 +18,7 @@ org.gradle.daemon=true
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Android NDK verbose build output
 android.native.buildOutput=verbose
 # Gradle Configuration Cache
-org.gradle.unsafe.configuration-cache=true
-android.nonTransitiveRClass=false
-android.nonFinalResIds=false
+org.gradle.configuration-cache=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/building.md
+++ b/building.md
@@ -161,7 +161,7 @@ Note: The CMake preset `linux-ninja-clang` makes use of the LLD linker, which wi
 
 - Building can be done with Android studio: select the Vita3K Android folder and click on the build icon or by command line:
   ```sh
-  ./gradlew --stacktrace --configuration-cache --build-cache --parallel --configure-on-demand assembleReldebug
+  ./gradlew --stacktrace assembleReldebug
   ```
 
 ## Note

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vita3k",
   "version-string": "0.0.0",
+  "builtin-baseline": "77df67cfff9c12ccfdb52284e07c87c75092f723",
   "dependencies": [
     "boost-filesystem",
     "boost-icl",


### PR DESCRIPTION
Update a bunch of android stuff (AGP/NDK/Gradle), bigger number = better right? 
Remove old jetifier/config-cache from gradle properties. Migrate to built-in kotlin with AGP 9. Clear all Groovy DSL deprecation warnings. Drop flexible page size flag. 
Pinned vcpkg to a baseline. 
Yes I made a typo in the commit...