### PR TITLE
modules: introduce virtual modules (kubridge, fd_fix)

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -527,6 +527,9 @@ static ExitCode load_app_impl(SceUID &main_module_id, EmuEnvState &emuenv, const
     add_preload_module(0x01000000, SCE_SYSMODULE_INVALID, "libpvf", false);
     add_preload_module(0x02000000, SCE_SYSMODULE_PERF, "libperf", false); // if DEVELOPMENT_MODE dipsw is set
 
+    load_virtual_module(emuenv, "kubridge");
+    load_virtual_module(emuenv, "fd_fix");
+
     for (const auto &module_path : lib_load_list) {
         auto res = load_module(emuenv, module_path);
         if (res < 0)

--- a/vita3k/modules/CMakeLists.txt
+++ b/vita3k/modules/CMakeLists.txt
@@ -226,7 +226,7 @@ endif()
 add_library(modules STATIC ${SOURCE_LIST})
 target_include_directories(modules PUBLIC include)
 target_include_directories(modules PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/taiHEN)
-target_link_libraries(modules PRIVATE app audio camera codec ctrl dialog lang display dlmalloc gxm ime kernel mem motion net ngs np patch regmgr ssl packages printf renderer rtc SDL3::SDL3 substitute touch xxHash::xxhash)
+target_link_libraries(modules PRIVATE app audio camera codec ctrl dialog lang display dlmalloc gxm ime kernel mem motion net ngs np patch regmgr ssl packages patch printf renderer rtc SDL3::SDL3 substitute touch xxHash::xxhash vita-toolchain)
 target_link_libraries(modules PUBLIC module)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_LIST})
 

--- a/vita3k/modules/SceSysmem/SceSysmemForDriver.h
+++ b/vita3k/modules/SceSysmem/SceSysmemForDriver.h
@@ -51,3 +51,6 @@ constexpr SceUInt32 SCE_KERNEL_ALLOC_MEMBLOCK_ATTR_HAS_ALIGNMENT = 4;
 DECL_EXPORT(SceUID, ksceKernelAllocMemBlock, const char *name, SceKernelMemBlockType type, SceSize size, SceKernelAllocMemBlockKernelOpt *opt);
 DECL_EXPORT(int, ksceKernelGetMemBlockBase, SceUID uid, Ptr<void> *basep);
 DECL_EXPORT(int, ksceKernelFreeMemBlock, SceUID uid);
+DECL_EXPORT(int, ksceKernelMemcpyUserToKernel, Ptr<void> dst, Ptr<const void> src, SceSize len);
+DECL_EXPORT(SceInt32, ksceKernelStrncpyUserToKernel, Ptr<char> dst, Ptr<const char> src, SceSize len);
+DECL_EXPORT(SceUID, kscePUIDOpenByGUID, SceUID pid, SceUID guid);

--- a/vita3k/modules/include/modules/module_parent.h
+++ b/vita3k/modules/include/modules/module_parent.h
@@ -41,6 +41,7 @@ bool has_hle_implementation(uint32_t nid);
  */
 SceUID load_module(EmuEnvState &emuenv, const std::string &module_path);
 int unload_module(EmuEnvState &emuenv, SceUID module_id);
+SceUID load_virtual_module(EmuEnvState &emuenv, const std::string &module_name);
 
 uint32_t start_module(EmuEnvState &emuenv, const SceKernelModuleInfo &module, SceSize args = 0, Ptr<const void> argp = Ptr<const void>{});
 uint32_t stop_module(EmuEnvState &emuenv, const SceKernelModuleInfo &module, SceSize args = 0, Ptr<const void> argp = Ptr<const void>{});

--- a/vita3k/modules/kubridge/kubridge.cpp
+++ b/vita3k/modules/kubridge/kubridge.cpp
@@ -23,13 +23,17 @@
 
 #include <module/module.h>
 
+#include <../SceSysmem/SceSysmemForDriver.h>
 #include <cpu/functions.h>
 #include <kernel/state.h>
+#include <kernel/types.h>
 #include <mem/functions.h>
 #include <modules/sysmem_state.h>
 #include <util/align.h>
 #include <util/log.h>
 #include <util/tracy.h>
+
+#include <cstdlib>
 
 TRACY_MODULE_NAME(kubridge);
 
@@ -231,4 +235,34 @@ EXPORT(void, kuKernelReleaseExceptionHandler, uint32_t exceptionType) {
         const Address old = emuenv.kernel.exception_handlers[exceptionType].exchange(0);
         LOG_INFO("kuKernelReleaseExceptionHandler: type={} old=0x{:08X}", exceptionType, old);
     }
+}
+
+EXPORT(void, kuKernelFlushCaches, const void *ptr, SceSize len) {
+    TRACY_FUNC(kuKernelFlushCaches, ptr, len);
+    STUBBED("Emulator has no real CPU caches");
+}
+
+EXPORT(SceUID, kuKernelAllocMemBlock, const char *name, SceKernelMemBlockType type, SceSize size, SceKernelAllocMemBlockKernelOpt *opt) {
+    TRACY_FUNC(kuKernelAllocMemBlock, name, type, size, opt);
+    SceUID res = CALL_EXPORT(ksceKernelAllocMemBlock, name, type, size, opt);
+    if (res < 0)
+        return res;
+
+    return CALL_EXPORT(kscePUIDOpenByGUID, 1, res);
+}
+
+EXPORT(int, kuKernelCpuUnrestrictedMemcpy, void *dst, const void *src, SceSize len) {
+    STUBBED("Regular memcpy used");
+    memcpy(dst, src, len);
+    return 0;
+}
+
+EXPORT(int, kuPowerGetSysClockFrequency) {
+    STUBBED("clock freq: 333");
+    return 333;
+}
+
+EXPORT(int, kuPowerSetSysClockFrequency, int freq) {
+    STUBBED("set clock freq success (0)");
+    return 0;
 }

--- a/vita3k/modules/module_parent.cpp
+++ b/vita3k/modules/module_parent.cpp
@@ -37,7 +37,15 @@
 #include <util/log.h>
 #include <util/string_utils.h>
 
+#include <cstring>
 #include <unordered_set>
+
+#include <util/elf.h>
+// clang-format off
+#define SCE_ELF_DEFS_TARGET
+#include <sce-elf-defs.h>
+#undef SCE_ELF_DEFS_TARGET
+// clang-format on
 
 static constexpr bool LOG_UNK_NIDS_ALWAYS = false;
 
@@ -304,6 +312,106 @@ SceUID load_module(EmuEnvState &emuenv, const std::string &module_path) {
     }
 
     return load_module_data(module_buffer.data());
+}
+
+SceUID load_virtual_module(EmuEnvState &emuenv, const std::string &module_name) {
+    // A virtual module has no file on disk and is implemented entirely through HLE
+    // This allows homebrews that check for loaded modules to find them
+    // while still integrating with the module system :)
+
+    // check if module is already loaded
+    std::string module_path = "ur0:tai/" + module_name;
+    {
+        const std::lock_guard<std::mutex> lock(emuenv.kernel.mutex);
+        const auto &loaded_modules = emuenv.kernel.loaded_modules;
+        auto module_iter = std::find_if(loaded_modules.begin(), loaded_modules.end(), [&](const auto &p) {
+            return module_path == p.second->info.path;
+        });
+        if (module_iter != loaded_modules.end())
+            return module_iter->first; // already loaded, return existing UID
+    }
+
+    // generate a fake nid for the virtual module, or use known ones for known plugins
+    uint32_t module_nid = 0;
+    if (module_name == "kubridge") {
+        module_nid = 0xB623A402;
+    } else if (module_name == "fd_fix") {
+        module_nid = 0xDF089812;
+    } else {
+        // use crc32 to generate a fake nid
+        uint32_t crc = 0xFFFFFFFF;
+        for (char c : module_name) {
+            crc ^= static_cast<uint8_t>(c);
+            for (int i = 0; i < 8; ++i) {
+                crc = (crc >> 1) ^ (0xEDB88320 & (-(crc & 1)));
+            }
+        }
+        module_nid = ~crc;
+
+        // check for nid collision
+        {
+            const std::lock_guard<std::mutex> guard(emuenv.kernel.export_nids_mutex);
+            bool collision;
+            do {
+                collision = false;
+                for (const auto &[nid, mapped_uid] : emuenv.kernel.module_uid_by_nid) {
+                    if (nid == module_nid) {
+                        LOG_INFO("NID {} already in use, using different nid", module_nid);
+                        module_nid += 2;
+                        collision = true;
+                        break;
+                    }
+                }
+            } while (collision);
+        }
+    }
+
+    // Allocate guest memory for fake sce_module_info_raw
+    Address dummy_info_addr = alloc(emuenv.mem, sizeof(sce_module_info_raw), "virtual_module_info");
+    sce_module_info_raw *raw_info = Ptr<sce_module_info_raw>(dummy_info_addr).get(emuenv.mem);
+    std::memset(raw_info, 0, sizeof(sce_module_info_raw));
+    raw_info->module_nid = module_nid;
+    std::strncpy(raw_info->name, module_name.c_str(), 27);
+
+    // Populate KernelModule Info
+    const SceKernelModulePtr kernelModuleInfo = std::make_shared<KernelModule>();
+    std::memset(kernelModuleInfo.get(), 0, sizeof(KernelModule));
+
+    kernelModuleInfo->info_segment_address = Ptr<const uint8_t>(dummy_info_addr);
+    kernelModuleInfo->info_offset = 0;
+
+    auto *sceKernelModuleInfo = &kernelModuleInfo->info;
+    sceKernelModuleInfo->size = sizeof(*sceKernelModuleInfo);
+    std::strncpy(sceKernelModuleInfo->module_name, module_name.c_str(), 28);
+    // unk28
+    std::strncpy(sceKernelModuleInfo->path, module_path.c_str(), 255);
+
+    // set up a segment to point to the dummy info block so that
+    // when the module is unloaded, unload_self will free the block
+    sceKernelModuleInfo->segments[0].size = sizeof(SceKernelSegmentInfo);
+    sceKernelModuleInfo->segments[0].vaddr = Ptr<const void>(dummy_info_addr);
+    sceKernelModuleInfo->segments[0].memsz = sizeof(sce_module_info_raw);
+    sceKernelModuleInfo->segments[0].filesz = sizeof(sce_module_info_raw);
+    sceKernelModuleInfo->segments[0].perms = 0; // standard virtual memory segment
+
+    sceKernelModuleInfo->state = 6; // loaded and linked
+
+    const SceUID uid = emuenv.kernel.get_next_uid();
+    sceKernelModuleInfo->modid = uid;
+
+    {
+        const std::lock_guard<std::mutex> lock(emuenv.kernel.mutex);
+        emuenv.kernel.loaded_modules[uid] = kernelModuleInfo;
+    }
+
+    {
+        const std::lock_guard<std::mutex> guard(emuenv.kernel.export_nids_mutex);
+        emuenv.kernel.module_uid_by_nid[module_nid] = uid;
+    }
+
+    LOG_INFO("Loaded virtual module {} (NID: 0x{:08X})", module_name, module_nid);
+
+    return uid;
 }
 
 int unload_module(EmuEnvState &emuenv, SceUID module_id) {

--- a/vita3k/nids/include/nids/nids.inc
+++ b/vita3k/nids/include/nids/nids.inc
@@ -2494,6 +2494,11 @@ NID(SceThreadmgrForDriver_20C228E4, 0x20C228E4)
 NID(ksceKernelGetFaultingProcess, 0xD8B9AC8D)
 // Module "SceKubridge"
 // Library "SceKubridge"
+NID(kuKernelAllocMemBlock, 0x2EF7C290)
+NID(kuKernelFlushCaches, 0x38B70744)
+NID(kuKernelCpuUnrestrictedMemcpy, 0x91D9CABC)
+NID(kuPowerGetSysClockFrequency, 0x13371337)
+NID(kuPowerSetSysClockFrequency, 0x13371338)
 NID(kuKernelMemProtect, 0x566D2AF1)
 NID(kuKernelMemReserve, 0xCED3608C)
 NID(kuKernelMemCommit, 0x9C0CD758)


### PR DESCRIPTION
A virtual module is a module that is implemented wholly at an HLE level, that is, there is no file actually being loaded from disk. This is nice in certain scenarios where the behavior or fix from a module is something that isn't a problem on an emulator due to lack of memory boundaries (kubridge) and other fun stuff (like fd_fix, or maybe repatch in the future).

Nevertheless, some homebrew titles check if a given module has been loaded, and we should have a nice system that not only acknowledges the module as loaded, but also slots in nice with the rest of the module system. A "fake" module system works well for this.

The motivation behind this PR is to make it so that neither kubridge nor fd_fix (or other future plugins that can be implemented within the emulator) need to be downloaded.

A few concerns:
- Currently kubridge and fd_fix are ""loaded"" with preload modules. maybe an option for this would be better? I guess it's not hurting anything atm
- CRC32 may not be preferred, but it's simple. open to suggestions 