### PR TITLE
ci: Add AppImage zsync update

### DIFF
--- a/.ci/setup-linux.sh
+++ b/.ci/setup-linux.sh
@@ -54,4 +54,8 @@ if [[ "$APPIMAGE_MODE" == "with-appimage" ]]; then
     curl -sLO "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/latest/download/linuxdeploy-plugin-qt-${ARCH}.AppImage"
     sudo cp -f "linuxdeploy-plugin-qt-${ARCH}.AppImage" "/usr/local/bin/"
     sudo chmod +x "/usr/local/bin/linuxdeploy-plugin-qt-${ARCH}.AppImage"
+
+    curl -sLO "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/latest/download/linuxdeploy-plugin-appimage-${ARCH}.AppImage"
+    sudo cp -f "linuxdeploy-plugin-appimage-${ARCH}.AppImage" "/usr/local/bin/"
+    sudo chmod +x "/usr/local/bin/linuxdeploy-plugin-appimage-${ARCH}.AppImage"
 fi

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -1,5 +1,28 @@
 #!/bin/sh
 
-echo "Executing linuxdeploy with cmdline: LDAI_VERBOSE=1 $@"
+export LDAI_VERBOSE=1
 
-LDAI_VERBOSE=1 $@
+# Try to detect the target architecture from environment or fallback to host
+if [ -n "$ARCH" ]; then
+	DETECTED_ARCH="$ARCH"
+elif [ -n "$CMAKE_APPIMAGE_ARCH" ]; then
+	DETECTED_ARCH="$CMAKE_APPIMAGE_ARCH"
+elif [ -n "$APPIMAGE_ARCH" ]; then
+	DETECTED_ARCH="$APPIMAGE_ARCH"
+else
+	# Fallback to host architecture
+	UNAME_ARCH=$(uname -m)
+	case "$UNAME_ARCH" in
+		x86_64)
+			DETECTED_ARCH="x86_64" ;;
+		aarch64|arm64)
+			DETECTED_ARCH="aarch64" ;;
+		*)
+			DETECTED_ARCH="$UNAME_ARCH" ;;
+	esac
+fi
+
+echo "Detected architecture: $DETECTED_ARCH"
+export LDAI_UPDATE_INFORMATION="gh-releases-zsync|Vita3K|Vita3K|continuous|Vita3K-$(echo "$DETECTED_ARCH").AppImage.zsync"
+
+$@


### PR DESCRIPTION
Adds the zsync update information to appimages, so they can be updated with any appimage manager automatically or manually without manually going to the downloads or manual download.
No change should be needed on the release-collect side of things

Both arm and x86 are supported 