### PR TITLE
appimage: Use Vita3K.png instead of data/image/icon.png

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ build
 CMakeUserPresets.json
 compile_commands.json
 # AppImage builder
-appimage/linuxdeploy.AppImage
+appimage/linuxdeploy*.AppImage
 /.gdbinit
 
 # Built application files

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 export LDAI_VERBOSE=1
+export NO_STRIP=1
 
 # Try to detect the target architecture from environment or fallback to host
 if [ -n "$ARCH" ]; then

--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -344,7 +344,7 @@ elseif(LINUX)
 		POST_BUILD
 		COMMAND ${LINUXDEPLOY_WRAPPER} ${LINUXDEPLOY_COMMAND} --appdir="${APPDIR}"
 			-e "$<TARGET_FILE:vita3k>" --icon-filename="vita3k"
-			-i "${CMAKE_CURRENT_SOURCE_DIR}/../data/image/icon.png" -d "${CMAKE_CURRENT_SOURCE_DIR}/../appimage/vita3k.desktop"
+			-i "${CMAKE_CURRENT_SOURCE_DIR}/Vita3K.png" -d "${CMAKE_CURRENT_SOURCE_DIR}/../appimage/vita3k.desktop"
 			--custom-apprun="${CMAKE_CURRENT_SOURCE_DIR}/../appimage/apprun.sh" --plugin qt --output=appimage ${DISCORD_LIB_APPIMAGE}
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/*.AppImage*" "$<TARGET_FILE_DIR:vita3k>/"
 		COMMAND ${CMAKE_COMMAND} -E rm "${CMAKE_CURRENT_BINARY_DIR}/*.AppImage*")


### PR DESCRIPTION
Makes the appimage use the already present and better quality Vita3K.png instead of icon.png
https://github.com/linuxdeploy/linuxdeploy/issues/334