### PR TITLE
ci: Optimize format check workflow

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -3,10 +3,10 @@ name: Build CI
 on:
   push:
     paths-ignore:
-      - '**/*.md'
+      - '**.md'
   pull_request:
     paths-ignore:
-      - '**/*.md'
+      - '**.md'
 
 env:
   BUILD_CONFIG: Release

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,13 +9,13 @@ on:
   push:
     branches: [master]
     paths-ignore:
-      - '**/*.md'
+      - '**.md'
 
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
     paths-ignore:
-      - '**/*.md'
+      - '**.md'
 
   schedule:
     - cron: '0 1 * * 3'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,28 +2,36 @@ name: Format Check
 
 on:
   push:
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - .clang-format
+      - vita3k/**
+      - tools/**
+
   pull_request:
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - .clang-format
+      - vita3k/**
+      - tools/**
 
 jobs:
   format-check:
     name: Format Check (${{ matrix.path }})
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
         path:
           - vita3k
           - tools
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: ${{ matrix.path }}
 
       - name: Format check
         uses: jidicula/clang-format-action@v4.18.0
         with:
-          clang-format-version: '22'
           check-path: ${{ matrix.path }}


### PR DESCRIPTION
- Use `sparse-checkout` to fetch only the root files and `vita3k` and `tools` folder.