### PR TITLE
config: Only allow native buffer mapping on android

### DIFF
--- a/vita3k/gui-qt/src/settings_dialog.cpp
+++ b/vita3k/gui-qt/src/settings_dialog.cpp
@@ -33,6 +33,7 @@
 #include <io/state.h>
 #include <kernel/state.h>
 #include <renderer/functions.h>
+#include <renderer/state.h>
 #include <util/log.h>
 #include <util/system.h>
 
@@ -332,11 +333,11 @@ void SettingsDialog::load_config() {
             int bit;
         };
         static const MappingEntry all_methods[] = {
-            { "Disabled", "disabled", 0 },
-            { "Double Buffer", "double-buffer", 1 },
-            { "External Host", "external-host", 2 },
-            { "Page Table", "page-table", 3 },
-            { "Native Buffer", "native-buffer", 4 },
+            { "Disabled", "disabled", static_cast<int>(MappingMethod::Disabled) },
+            { "Double Buffer", "double-buffer", static_cast<int>(MappingMethod::DoubleBuffer) },
+            { "External Host", "external-host", static_cast<int>(MappingMethod::ExernalHost) },
+            { "Page Table", "page-table", static_cast<int>(MappingMethod::PageTable) },
+            { "Native Buffer", "native-buffer", static_cast<int>(MappingMethod::NativeBuffer) },
         };
 
         const int gpu_idx = m_config.gpu_idx;

--- a/vita3k/renderer/include/renderer/state.h
+++ b/vita3k/renderer/include/renderer/state.h
@@ -48,7 +48,7 @@ enum struct MappingMethod : int {
     DoubleBuffer,
     ExernalHost,
     PageTable,
-    NativeBuffer
+    NativeBuffer // Only available in android
 };
 
 namespace renderer {

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -951,8 +951,10 @@ void VKState::late_init(const Config &cfg, const std::string_view game_id, MemSt
         request_mapping = MappingMethod::ExernalHost;
     else if (config_mapping == "page-table")
         request_mapping = MappingMethod::PageTable;
+#ifdef __ANDROID__
     else if (config_mapping == "native-buffer")
         request_mapping = MappingMethod::NativeBuffer;
+#endif
     const std::string_view mapping_string[] = { "Disabled", "Double buffer", "External Host", "Page Table", "Native Buffer" };
 
     if ((1 << static_cast<int>(request_mapping)) & supported_mapping_methods_mask)
@@ -1392,7 +1394,7 @@ bool VKState::map_memory(MemState &mem, Ptr<void> address, uint32_t size) {
         add_external_mapping(mem, address.address(), size, reinterpret_cast<uint8_t *>(mapped_location));
         mapped_memories[address.address()] = { address.address(), ExternalBuffer{ device_memory, buffer }, mapped_buffer, size, buffer_address };
 #else
-        LOG_ERROR("Native buffer is only supported on Android!\n");
+        LOG_CRITICAL("Native buffer is only supported on Android!\n");
 #endif
         break;
     }


### PR DESCRIPTION
* Better entry for mapping methods in UI code, instead of magic numbers, it now correctly represents the enum values
* logging about native buffer being only available in android is now critical
* Dont parse native buffer in config if its not available, make it fallback to disabled
* Small comment about native buffer being only in android