### PR TITLE
overlay: Add missing break statement in font loading logic

### DIFF
--- a/vita3k/overlay/src/font.cpp
+++ b/vita3k/overlay/src/font.cpp
@@ -221,6 +221,7 @@ glyph_load_setup font::get_glyph_files(language_class class_) const {
         result.font_names.emplace_back("NotoSansCJK-Regular.ttc");
         result.font_names.emplace_back("NotoSansSC-Regular.otf");
         result.font_names.emplace_back("wqy-microhei.ttc");
+        break;
 #endif
     }
     case language_class::hangul: {


### PR DESCRIPTION
My bad caused by #3974, it was falling trough the list and clearing and ended up using the korean character set instead of cjk