### PR TITLE
io: stop reporting regular files as executable

### DIFF
--- a/vita3k/io/src/io.cpp
+++ b/vita3k/io/src/io.cpp
@@ -584,7 +584,8 @@ int stat_file(IOState &io, const char *file, SceIoStat *statp, const fs::path &p
 #undef st_ctime
 #endif
 
-    statp->st_mode = SCE_S_IRUSR | SCE_S_IRGRP | SCE_S_IROTH | SCE_S_IXUSR | SCE_S_IXGRP | SCE_S_IXOTH;
+    // report regular files as readable but not executable
+    statp->st_mode = SCE_S_IRUSR | SCE_S_IRGRP | SCE_S_IROTH;
 
     if (fs::is_regular_file(file_path)) {
         statp->st_size = fs::file_size(file_path);
@@ -593,7 +594,7 @@ int stat_file(IOState &io, const char *file, SceIoStat *statp, const fs::path &p
     }
     if (fs::is_directory(file_path)) {
         statp->st_attr = SCE_SO_IFDIR;
-        statp->st_mode |= SCE_S_IFDIR;
+        statp->st_mode |= SCE_S_IFDIR | SCE_S_IXUSR | SCE_S_IXGRP | SCE_S_IXOTH;
     }
 
     __RtcTicksToPspTime(&statp->st_atime, last_access_time_ticks);

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -298,10 +298,20 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
         }
     }
 
-    if (slot && slot->slotParam) {
+    if (slot) {
+        SceAppUtilSaveDataSlotParam param{};
+        auto *slot_param = slot->slotParam ? slot->slotParam.get(emuenv.mem) : &param;
         SceDateTime modified_time;
         std::time_t time = std::time(0);
         tm local = {};
+
+        if (!slot->slotParam) {
+            fd = open_file(emuenv.io, construct_slotparam_path(slot->id).c_str(), SCE_O_RDONLY, emuenv.pref_path, export_name);
+            if (fd < 0)
+                return 0;
+            read_file(slot_param, emuenv.io, fd, sizeof(SceAppUtilSaveDataSlotParam), export_name);
+            close_file(emuenv.io, fd, export_name);
+        }
 
         SAFE_LOCALTIME(&time, &local);
         modified_time.year = local.tm_year + 1900;
@@ -310,9 +320,9 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
         modified_time.hour = local.tm_hour;
         modified_time.minute = local.tm_min;
         modified_time.second = local.tm_sec;
-        slot->slotParam.get(emuenv.mem)->modifiedTime = modified_time;
+        slot_param->modifiedTime = modified_time;
         fd = open_file(emuenv.io, construct_slotparam_path(slot->id).c_str(), SCE_O_WRONLY | SCE_O_CREAT, emuenv.pref_path, export_name);
-        write_file(fd, slot->slotParam.get(emuenv.mem), sizeof(SceAppUtilSaveDataSlotParam), emuenv.io, export_name);
+        write_file(fd, slot_param, sizeof(SceAppUtilSaveDataSlotParam), emuenv.io, export_name);
         close_file(emuenv.io, fd, export_name);
     }
 

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -1038,10 +1038,10 @@ static void handle_sys_message(SceSaveDataDialogSystemMessageParam *sys_message,
     case SCE_SAVEDATA_DIALOG_SYSMSG_TYPE_CONFIRM_CANCEL:
         switch (emuenv.common_dialog.savedata.display_type) {
         case SCE_SAVEDATA_DIALOG_TYPE_SAVE:
-            emuenv.common_dialog.savedata.msg = lang::get(lang::str::cancel_loading);
+            emuenv.common_dialog.savedata.msg = lang::get(lang::str::cancel_saving);
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_LOAD:
-            emuenv.common_dialog.savedata.msg = lang::get(lang::str::cancel_saving);
+            emuenv.common_dialog.savedata.msg = lang::get(lang::str::cancel_loading);
             break;
         case SCE_SAVEDATA_DIALOG_TYPE_DELETE:
             emuenv.common_dialog.savedata.msg = lang::get(lang::str::cancel_deleting);


### PR DESCRIPTION
Stop reporting execute bits on regular files, only applying them towards directories. Fixes save/load bug and death softlock bug on uncharted. 
Still refresh save metadata if `slotParam` is missing.
Fix swapped save/load cancel confirmation strings in common dialog. 