### PR TITLE
vita3k/renderer/gl: Implement Nearest and Bicubic

### DIFF
--- a/vita3k/gui-qt/src/main_window.cpp
+++ b/vita3k/gui-qt/src/main_window.cpp
@@ -1848,7 +1848,8 @@ void MainWindow::setup_status_bar() {
             return { QStringLiteral("Nearest"), QStringLiteral("Bilinear"),
                 QStringLiteral("Bicubic"), QStringLiteral("FXAA"), QStringLiteral("FSR") };
         else
-            return { QStringLiteral("Bilinear"), QStringLiteral("FXAA") };
+            return { QStringLiteral("Nearest"), QStringLiteral("Bilinear"),
+                QStringLiteral("Bicubic"), QStringLiteral("FXAA") };
     };
 
     auto apply_screen_filter = [this](const std::string &filter) {
@@ -2024,7 +2025,8 @@ void MainWindow::update_screen_filter_button() {
     const QStringList valid = (cc.backend_renderer == "Vulkan")
         ? QStringList{ QStringLiteral("Nearest"), QStringLiteral("Bilinear"),
               QStringLiteral("Bicubic"), QStringLiteral("FXAA"), QStringLiteral("FSR") }
-        : QStringList{ QStringLiteral("Bilinear"), QStringLiteral("FXAA") };
+        : QStringList{ QStringLiteral("Nearest"), QStringLiteral("Bilinear"),
+              QStringLiteral("Bicubic"), QStringLiteral("FXAA") };
 
     const QString current = QString::fromStdString(cc.screen_filter);
     if (!valid.contains(current)) {

--- a/vita3k/gui-qt/src/settings_dialog.cpp
+++ b/vita3k/gui-qt/src/settings_dialog.cpp
@@ -1482,7 +1482,8 @@ void SettingsDialog::update_gpu_visibility() {
             m_ui->screen_filter_box->addItems({ QStringLiteral("Nearest"), QStringLiteral("Bilinear"),
                 QStringLiteral("Bicubic"), QStringLiteral("FXAA"), QStringLiteral("FSR") });
         } else {
-            m_ui->screen_filter_box->addItems({ QStringLiteral("Bilinear"), QStringLiteral("FXAA") });
+            m_ui->screen_filter_box->addItems({ QStringLiteral("Nearest"), QStringLiteral("Bilinear"),
+                QStringLiteral("Bicubic"), QStringLiteral("FXAA") });
         }
 
         const int idx = m_ui->screen_filter_box->findText(previous);

--- a/vita3k/renderer/include/renderer/gl/screen_render.h
+++ b/vita3k/renderer/include/renderer/gl/screen_render.h
@@ -67,6 +67,12 @@ private:
     GLuint m_sampler_linear{ 0 };
     GLuint m_sampler_nearest{ 0 };
 
+    // Intermediate target for running FXAA at the rendering resolution
+    GLuint m_fxaa_fbo{ 0 };
+    GLuint m_fxaa_texture{ 0 };
+    int m_fxaa_width{ 0 };
+    int m_fxaa_height{ 0 };
+
     const SharedGLObject &current_shader() const;
     GLuint current_sampler() const;
 

--- a/vita3k/renderer/include/renderer/gl/screen_render.h
+++ b/vita3k/renderer/include/renderer/gl/screen_render.h
@@ -39,7 +39,13 @@ public:
         return m_screen_texture;
     }
 
-    bool enable_fxaa;
+    enum class Filter {
+        Bilinear,
+        Nearest,
+        FXAA,
+        Bicubic
+    };
+    Filter filter = Filter::Bilinear;
 
 private:
     struct screen_vertex {
@@ -56,7 +62,13 @@ private:
     GLuint m_vbo{ 0 };
     SharedGLObject m_render_shader_nofilter;
     SharedGLObject m_render_shader_fxaa;
+    SharedGLObject m_render_shader_bicubic;
     GLuint m_screen_texture{ 0 };
+    GLuint m_sampler_linear{ 0 };
+    GLuint m_sampler_nearest{ 0 };
+
+    const SharedGLObject &current_shader() const;
+    GLuint current_sampler() const;
 
     float last_uvs[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
 };

--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -794,14 +794,19 @@ std::vector<uint32_t> GLState::dump_frame(DisplayState &display, uint32_t &width
 }
 
 int GLState::get_supported_filters() {
-    // actually it's not even bilinear, it's either bilinear or nearest depending on the last use of the texture..
-    // TODO: add bicubic filter and allow disabling bilinear.
-    return static_cast<int>(Filter::BILINEAR) | static_cast<int>(Filter::FXAA);
+    return static_cast<int>(Filter::NEAREST) | static_cast<int>(Filter::BILINEAR)
+        | static_cast<int>(Filter::BICUBIC) | static_cast<int>(Filter::FXAA);
 }
 
 void GLState::set_screen_filter(const std::string_view &filter) {
-    // we only support bilinear and fxaa
-    screen_renderer.enable_fxaa = (filter == "FXAA");
+    if (filter == "Nearest")
+        screen_renderer.filter = ScreenRenderer::Filter::Nearest;
+    else if (filter == "FXAA")
+        screen_renderer.filter = ScreenRenderer::Filter::FXAA;
+    else if (filter == "Bicubic")
+        screen_renderer.filter = ScreenRenderer::Filter::Bicubic;
+    else
+        screen_renderer.filter = ScreenRenderer::Filter::Bilinear;
 }
 
 int GLState::get_max_anisotropic_filtering() {

--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -21,6 +21,18 @@
 
 namespace renderer::gl {
 
+const SharedGLObject &ScreenRenderer::current_shader() const {
+    switch (filter) {
+    case Filter::FXAA: return m_render_shader_fxaa;
+    case Filter::Bicubic: return m_render_shader_bicubic;
+    default: return m_render_shader_nofilter; // Bilinear / Nearest
+    }
+}
+
+GLuint ScreenRenderer::current_sampler() const {
+    return (filter == Filter::Nearest) ? m_sampler_nearest : m_sampler_linear;
+}
+
 bool ScreenRenderer::init(const fs::path &static_assets) {
     glGenTextures(1, &m_screen_texture);
 
@@ -29,13 +41,27 @@ bool ScreenRenderer::init(const fs::path &static_assets) {
     const auto render_main_path_vert = builtin_shaders_path / "render_main.vert";
     const auto render_main_path_frag = builtin_shaders_path / "render_main.frag";
     const auto render_main_path_fxaa_frag = builtin_shaders_path / "render_main_fxaa.frag";
+    const auto render_main_path_bicubic_frag = builtin_shaders_path / "render_main_bicubic.frag";
 
     m_render_shader_nofilter = ::gl::load_shaders(render_main_path_vert, render_main_path_frag);
     m_render_shader_fxaa = ::gl::load_shaders(render_main_path_vert, render_main_path_fxaa_frag);
-    if (!m_render_shader_nofilter || !m_render_shader_fxaa) {
+    m_render_shader_bicubic = ::gl::load_shaders(render_main_path_vert, render_main_path_bicubic_frag);
+    if (!m_render_shader_nofilter || !m_render_shader_fxaa || !m_render_shader_bicubic) {
         LOG_CRITICAL("Couldn't compile essential shaders for rendering. Exiting");
         return false;
     }
+
+    glGenSamplers(1, &m_sampler_linear);
+    glSamplerParameteri(m_sampler_linear, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glSamplerParameteri(m_sampler_linear, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glSamplerParameteri(m_sampler_linear, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glSamplerParameteri(m_sampler_linear, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glGenSamplers(1, &m_sampler_nearest);
+    glSamplerParameteri(m_sampler_nearest, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glSamplerParameteri(m_sampler_nearest, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glSamplerParameteri(m_sampler_nearest, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glSamplerParameteri(m_sampler_nearest, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     glGenVertexArrays(1, &m_vao);
     glBindVertexArray(m_vao);
@@ -51,7 +77,7 @@ bool ScreenRenderer::init(const fs::path &static_assets) {
     glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
     glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_buffer_data), vertex_buffer_data, GL_DYNAMIC_DRAW);
 
-    const auto &shader = enable_fxaa ? m_render_shader_fxaa : m_render_shader_nofilter;
+    const auto &shader = current_shader();
 
     GLint posAttrib = glGetAttribLocation(*shader, "position_vertex");
     GLint uvAttrib = glGetAttribLocation(*shader, "uv_vertex");
@@ -133,7 +159,7 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
     // should not be needed, but just in case
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 
-    const auto &shader = enable_fxaa ? m_render_shader_fxaa : m_render_shader_nofilter;
+    const auto &shader = current_shader();
 
     const GLint posAttrib = glGetAttribLocation(*shader, "position_vertex");
     const GLint uvAttrib = glGetAttribLocation(*shader, "uv_vertex");
@@ -201,12 +227,13 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
     );
     glEnableVertexAttribArray(uvAttrib);
 
-    if (enable_fxaa) {
+    if (filter == Filter::FXAA) {
         const GLint invScreenLocation = glGetUniformLocation(*shader, "inv_frame_size");
         glUniform2f(invScreenLocation, 1 / texture_size.x, 1 / texture_size.y);
     }
 
     glBindTexture(GL_TEXTURE_2D, texture);
+    glBindSampler(0, current_sampler());
 #ifndef __ANDROID__
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 #endif
@@ -245,6 +272,15 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
 }
 
 void ScreenRenderer::destroy() {
+    m_render_shader_nofilter.reset();
+    m_render_shader_fxaa.reset();
+    m_render_shader_bicubic.reset();
+
+    glDeleteSamplers(1, &m_sampler_linear);
+    m_sampler_linear = 0;
+    glDeleteSamplers(1, &m_sampler_nearest);
+    m_sampler_nearest = 0;
+
     glDeleteBuffers(1, &m_vbo);
     m_vbo = 0;
 

--- a/vita3k/renderer/src/gl/screen_render.cpp
+++ b/vita3k/renderer/src/gl/screen_render.cpp
@@ -153,6 +153,7 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
     glViewport(static_cast<GLint>(viewport_pos.x), static_cast<GLint>(viewport_pos.y), static_cast<GLsizei>(viewport_size.x),
         static_cast<GLsizei>(viewport_size.y));
 
+    // Clear the whole default framebuffer (covers the letterbox area as well).
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClearDepthf(1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -227,17 +228,61 @@ void ScreenRenderer::render(const SceFVector2 &viewport_pos, const SceFVector2 &
     );
     glEnableVertexAttribArray(uvAttrib);
 
-    if (filter == Filter::FXAA) {
-        const GLint invScreenLocation = glGetUniformLocation(*shader, "inv_frame_size");
-        glUniform2f(invScreenLocation, 1 / texture_size.x, 1 / texture_size.y);
-    }
-
     glBindTexture(GL_TEXTURE_2D, texture);
     glBindSampler(0, current_sampler());
 #ifndef __ANDROID__
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 #endif
-    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+    if (filter == Filter::FXAA) {
+        // FXAA must run at the input (render) resolution, 1:1 with the source texture,
+        // otherwise it operates on an already upscaled (blurred) image.
+        // Pass 1: run FXAA into an intermediate FBO sized to the render resolution.
+        // Pass 2: blit that result to the screen with GL_NEAREST (no bilinear upscale).
+        const int fxaa_w = static_cast<int>(texture_size.x);
+        const int fxaa_h = static_cast<int>(texture_size.y);
+
+        // (Re)create the intermediate target when the render resolution changes.
+        if (fxaa_w != m_fxaa_width || fxaa_h != m_fxaa_height) {
+            if (!m_fxaa_fbo) {
+                glGenFramebuffers(1, &m_fxaa_fbo);
+                glGenTextures(1, &m_fxaa_texture);
+            }
+            glBindTexture(GL_TEXTURE_2D, m_fxaa_texture);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, fxaa_w, fxaa_h, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+            glBindFramebuffer(GL_FRAMEBUFFER, m_fxaa_fbo);
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_fxaa_texture, 0);
+            m_fxaa_width = fxaa_w;
+            m_fxaa_height = fxaa_h;
+
+            // restore the source texture binding for the FXAA pass below
+            glBindTexture(GL_TEXTURE_2D, texture);
+        }
+
+        // Pass 1: FXAA at render resolution
+        glBindFramebuffer(GL_FRAMEBUFFER, m_fxaa_fbo);
+        glViewport(0, 0, fxaa_w, fxaa_h);
+        glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        const GLint invScreenLocation = glGetUniformLocation(*shader, "inv_frame_size");
+        glUniform2f(invScreenLocation, 1.0f / texture_size.x, 1.0f / texture_size.y);
+
+        glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+        // Pass 2: nearest-blit to the screen (no bilinear)
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fxaa_fbo);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, default_fbo);
+        glBlitFramebuffer(
+            0, 0, fxaa_w, fxaa_h,
+            static_cast<GLint>(viewport_pos.x), static_cast<GLint>(viewport_pos.y),
+            static_cast<GLint>(viewport_pos.x + viewport_size.x),
+            static_cast<GLint>(viewport_pos.y + viewport_size.y),
+            GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    } else {
+        // Bilinear / Nearest / Bicubic draw directly to the screen.
+        glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+    }
 
     // Restore modified GL state
     glUseProgram(last_program);
@@ -281,6 +326,17 @@ void ScreenRenderer::destroy() {
     glDeleteSamplers(1, &m_sampler_nearest);
     m_sampler_nearest = 0;
 
+    if (m_fxaa_fbo) {
+        glDeleteFramebuffers(1, &m_fxaa_fbo);
+        m_fxaa_fbo = 0;
+    }
+    if (m_fxaa_texture) {
+        glDeleteTextures(1, &m_fxaa_texture);
+        m_fxaa_texture = 0;
+    }
+    m_fxaa_width = 0;
+    m_fxaa_height = 0;
+
     glDeleteBuffers(1, &m_vbo);
     m_vbo = 0;
 
@@ -289,9 +345,6 @@ void ScreenRenderer::destroy() {
 
     glDeleteTextures(1, &m_screen_texture);
     m_screen_texture = 0;
-
-    m_render_shader_nofilter.reset();
-    m_render_shader_fxaa.reset();
 }
 
 ScreenRenderer::~ScreenRenderer() {

--- a/vita3k/shaders-builtin/opengl/render_main_bicubic.frag
+++ b/vita3k/shaders-builtin/opengl/render_main_bicubic.frag
@@ -5,8 +5,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#version 410 core
-
 in vec2 uv_frag;
 out vec4 color_frag;
 

--- a/vita3k/shaders-builtin/opengl/render_main_fxaa.frag
+++ b/vita3k/shaders-builtin/opengl/render_main_fxaa.frag
@@ -20,31 +20,31 @@ void main( void ) {
         vec3 rgbSW=texture(fb,uv_frag+(vec2(-1.0,1.0)*inv_frame_size)).xyz;
         vec3 rgbSE=texture(fb,uv_frag+(vec2(1.0,1.0)*inv_frame_size)).xyz;
         vec3 rgbM=texture(fb,uv_frag).xyz;
-        
+
         vec3 luma=vec3(0.299, 0.587, 0.114);
         float lumaNW = dot(rgbNW, luma);
         float lumaNE = dot(rgbNE, luma);
         float lumaSW = dot(rgbSW, luma);
         float lumaSE = dot(rgbSE, luma);
         float lumaM  = dot(rgbM,  luma);
-        
+
         float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
         float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
-        
+
         vec2 dir;
         dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));
         dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));
-        
+
         float dirReduce = max(
                 (lumaNW + lumaNE + lumaSW + lumaSE) * (0.25 * FXAA_REDUCE_MUL),
                 FXAA_REDUCE_MIN);
-          
+
         float rcpDirMin = 1.0/(min(abs(dir.x), abs(dir.y)) + dirReduce);
-        
+
         dir = min(vec2( FXAA_SPAN_MAX,  FXAA_SPAN_MAX),
                   max(vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX),
                   dir * rcpDirMin)) * inv_frame_size;
-                
+
         vec3 rgbA = (1.0/2.0) * (
                 texture(fb, uv_frag.xy + dir * (1.0/3.0 - 0.5)).xyz +
                 texture(fb, uv_frag.xy + dir * (2.0/3.0 - 0.5)).xyz);

--- a/vita3k/shaders-builtin/vulkan/render_main_fxaa.frag
+++ b/vita3k/shaders-builtin/vulkan/render_main_fxaa.frag
@@ -25,31 +25,31 @@ void main( void ) {
         vec3 rgbSW=texture(fb,uv_frag+(vec2(-1.0,1.0)*pc.inv_frame_size)).xyz;
         vec3 rgbSE=texture(fb,uv_frag+(vec2(1.0,1.0)*pc.inv_frame_size)).xyz;
         vec3 rgbM=texture(fb,uv_frag).xyz;
-        
+
         vec3 luma=vec3(0.299, 0.587, 0.114);
         float lumaNW = dot(rgbNW, luma);
         float lumaNE = dot(rgbNE, luma);
         float lumaSW = dot(rgbSW, luma);
         float lumaSE = dot(rgbSE, luma);
         float lumaM  = dot(rgbM,  luma);
-        
+
         float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
         float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
-        
+
         vec2 dir;
         dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));
         dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));
-        
+
         float dirReduce = max(
                 (lumaNW + lumaNE + lumaSW + lumaSE) * (0.25 * FXAA_REDUCE_MUL),
                 FXAA_REDUCE_MIN);
-          
+
         float rcpDirMin = 1.0/(min(abs(dir.x), abs(dir.y)) + dirReduce);
-        
+
         dir = min(vec2( FXAA_SPAN_MAX,  FXAA_SPAN_MAX),
                   max(vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX),
                   dir * rcpDirMin)) * pc.inv_frame_size;
-                
+
         vec3 rgbA = (1.0/2.0) * (
                 texture(fb, uv_frag.xy + dir * (1.0/3.0 - 0.5)).xyz +
                 texture(fb, uv_frag.xy + dir * (2.0/3.0 - 0.5)).xyz);


### PR DESCRIPTION
90% AI code.
I don't know anything about graphics, but the results seem to be an improvement over what we have now, at least.


| NEAREST | Bilinear |
|----------|----------|
| <img width="600" alt="image" src="https://github.com/user-attachments/assets/4dd98ef1-6057-4975-92e1-5e30f1d2ec9b" /> | <img width="600" alt="image" src="https://github.com/user-attachments/assets/d45b8eb0-06e0-4bc5-8f67-28fa9b74de75" /> |

| Bicubic | FXAA |
|----------|----------|
| <img width="600" alt="image" src="https://github.com/user-attachments/assets/d07997c2-7fa4-43a6-8f0e-d77ddb5405b0" /> | <img width="600" alt="image" src="https://github.com/user-attachments/assets/8e7af154-7750-4615-bc1a-944b066d08aa" /> |