### PR TITLE
main: add --no-gui flag to boot an app without the main window

### DIFF
--- a/vita3k/config/include/config/state.h
+++ b/vita3k/config/include/config/state.h
@@ -43,6 +43,7 @@ struct Config {
     bool load_config = false;
     bool fullscreen = false;
     bool console = false;
+    bool no_gui = false;
     bool load_app_list = false;
 
     fs::path get_pref_path() const {

--- a/vita3k/config/src/config.cpp
+++ b/vita3k/config/src/config.cpp
@@ -164,6 +164,7 @@ static void check_members(Config &self, const Config &rhs) {
     self.load_config = rhs.load_config;
     self.fullscreen = rhs.fullscreen;
     self.console = rhs.console;
+    self.no_gui = rhs.no_gui;
     self.app_args = rhs.app_args;
     self.load_app_list = rhs.load_app_list;
     self.self_path = rhs.self_path;
@@ -353,6 +354,8 @@ ExitCode init_config(Config &cfg, int argc, char **argv, const Root &root_paths)
         ->default_str("eboot.bin")->group("Input");
     input->add_option("--installed-path,-r", command_line.run_app_path, "Path to the installed app to run")
         ->default_str({})->check(CLI::IsMember(get_file_set(cfg.get_pref_path() / "ux0/app")))->group("Input");
+    input->add_flag("--no-gui", command_line.no_gui, "Boot the app given by --installed-path without the main window and exit once it closes.")
+        ->default_val(false)->group("Input");
     input->add_option("--recompile-shader,-s", command_line.recompile_shader_path, "Recompile the given PS Vita shader (GXP format) to SPIR_V / GLSL and quit")
         ->default_str({})->group("Input");
     input->add_option("--deleted-id,-d", command_line.delete_title_id, "Title ID of installed app to delete")

--- a/vita3k/gui-qt/CMakeLists.txt
+++ b/vita3k/gui-qt/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(gui-qt STATIC
     src/license_install_dialog.cpp
     src/live_area_widget.cpp
     src/log_widget.cpp
+    src/no_gui_runner.cpp
     src/persistent_settings.cpp
     src/pkg_install_dialog.cpp
     src/physical_key_qt.cpp
@@ -63,6 +64,7 @@ add_library(gui-qt STATIC
     include/gui-qt/license_install_dialog.h
     include/gui-qt/live_area_widget.h
     include/gui-qt/log_widget.h
+    include/gui-qt/no_gui_runner.h
     include/gui-qt/persistent_settings.h
     include/gui-qt/pkg_install_dialog.h
     include/gui-qt/physical_key_qt.h

--- a/vita3k/gui-qt/include/gui-qt/no_gui_runner.h
+++ b/vita3k/gui-qt/include/gui-qt/no_gui_runner.h
@@ -1,0 +1,56 @@
+// Vita3K emulator project
+// Copyright (C) 2026 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#pragma once
+
+#include <app/session_controller.h>
+#include <emuenv/state.h>
+
+#include <QObject>
+
+#include <memory>
+#include <optional>
+
+class GameWindow;
+class GuiSettings;
+class QTimer;
+
+class NoGuiRunner : public QObject {
+    Q_OBJECT
+
+public:
+    NoGuiRunner(EmuEnvState &emuenv, std::shared_ptr<GuiSettings> gui_settings, QObject *parent = nullptr);
+    ~NoGuiRunner() override;
+
+    bool start(const AppLaunchRequest &request);
+
+private slots:
+    void pump_sdl_events();
+    void on_game_closed();
+
+private:
+    bool run_boot_chain(AppLaunchRequest request);
+    std::optional<AppLaunchRequest> boot_once(const AppLaunchRequest &request);
+    void stop_session();
+    void ensure_active_user();
+
+    EmuEnvState &emuenv;
+    app::AppSessionController m_app_session;
+    std::shared_ptr<GuiSettings> m_gui_settings;
+    GameWindow *m_game_window = nullptr;
+    QTimer *m_sdl_pump_timer = nullptr;
+};

--- a/vita3k/gui-qt/src/no_gui_runner.cpp
+++ b/vita3k/gui-qt/src/no_gui_runner.cpp
@@ -1,0 +1,244 @@
+// Vita3K emulator project
+// Copyright (C) 2026 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <gui-qt/no_gui_runner.h>
+
+#include <gui-qt/ctrl_keyboard_filter.h>
+#include <gui-qt/game_window.h>
+#include <gui-qt/ime_keyboard_filter.h>
+
+#include <app/functions.h>
+#include <config/functions.h>
+#include <ctrl/functions.h>
+#include <ctrl/state.h>
+#include <io/state.h>
+#include <kernel/state.h>
+#include <motion/event_handler.h>
+#include <renderer/state.h>
+#include <touch/functions.h>
+#include <util/log.h>
+
+#include <QCoreApplication>
+#include <QString>
+#include <QTimer>
+
+#if USE_DISCORD
+#include <app/discord.h>
+#endif
+
+#include <SDL3/SDL_events.h>
+#include <SDL3/SDL_gamepad.h>
+#include <SDL3/SDL_sensor.h>
+
+#include <utility>
+
+NoGuiRunner::NoGuiRunner(EmuEnvState &emuenv, std::shared_ptr<GuiSettings> gui_settings, QObject *parent)
+    : QObject(parent)
+    , emuenv(emuenv)
+    , m_app_session(emuenv)
+    , m_gui_settings(std::move(gui_settings)) {
+}
+
+NoGuiRunner::~NoGuiRunner() {
+    stop_session();
+}
+
+bool NoGuiRunner::start(const AppLaunchRequest &request) {
+    ensure_active_user();
+
+    if (!run_boot_chain(request))
+        return false;
+
+    m_sdl_pump_timer = new QTimer(this);
+    m_sdl_pump_timer->setInterval(4);
+    connect(m_sdl_pump_timer, &QTimer::timeout, this, &NoGuiRunner::pump_sdl_events);
+    m_sdl_pump_timer->start();
+    return true;
+}
+
+bool NoGuiRunner::run_boot_chain(AppLaunchRequest request) {
+    while (true) {
+        auto next = boot_once(request);
+        if (!next)
+            break;
+        request = std::move(*next);
+    }
+
+    return m_game_window != nullptr;
+}
+
+std::optional<AppLaunchRequest> NoGuiRunner::boot_once(const AppLaunchRequest &request) {
+    refresh_controllers(emuenv.ctrl, emuenv);
+
+    const bool update_last_time_used = request.reason != AppLaunchReason::LoadExec;
+    if (!m_app_session.begin_launch(request, update_last_time_used)) {
+        LOG_ERROR("Failed to begin launch of '{}'", request.app_path);
+        return std::nullopt;
+    }
+
+    const bool fullscreen = emuenv.cfg.fullscreen || emuenv.cfg.boot_apps_full_screen;
+
+    m_game_window = new GameWindow(emuenv, m_gui_settings, emuenv.backend_renderer);
+    m_game_window->setTitle(QString::fromStdString(emuenv.current_app_title));
+    m_game_window->create();
+    if (fullscreen)
+        m_game_window->showFullScreen();
+    else
+        m_game_window->show();
+
+    connect(m_game_window, &GameWindow::closed, this, &NoGuiRunner::on_game_closed);
+
+    const auto abort = [this](const char *message) -> std::optional<AppLaunchRequest> {
+        LOG_ERROR("{}", message);
+        stop_session();
+        return std::nullopt;
+    };
+
+    if (emuenv.backend_renderer == renderer::Backend::OpenGL) {
+        if (!m_game_window->create_gl_context())
+            return abort("Could not create OpenGL context");
+        if (!m_game_window->make_current())
+            return abort("Could not make OpenGL context current");
+    }
+
+    if (!m_app_session.initialize_renderer(*m_game_window))
+        return abort("Failed to initialise the renderer");
+    if (!m_app_session.initialize_runtime())
+        return abort("Failed to initialise emulator state");
+    if (!m_app_session.load_and_run())
+        return abort("Failed to start game threads");
+
+    auto *kb_filter = new CtrlKeyboardFilter(emuenv, m_game_window);
+    m_game_window->installEventFilter(kb_filter);
+    connect(kb_filter, &CtrlKeyboardFilter::fullscreen_toggled,
+        this, [this]() { m_game_window->toggle_fullscreen(); });
+
+    auto *ime_filter = new ImeKeyboardFilter(emuenv, m_game_window);
+    m_game_window->installEventFilter(ime_filter);
+
+    if (auto pending = emuenv.take_app_launch_request()) {
+        stop_session();
+        if (pending->reason == AppLaunchReason::ProcessExit)
+            return std::nullopt;
+        return pending;
+    }
+
+    m_game_window->start_ui_updates();
+    LOG_INFO("Game started: {} ({})", emuenv.current_app_title, request.app_path);
+    return std::nullopt;
+}
+
+void NoGuiRunner::pump_sdl_events() {
+#if USE_DISCORD
+    discordrpc::run_callbacks();
+#endif
+
+    if (auto request = emuenv.take_app_launch_request()) {
+        LOG_INFO("Handling in-process app relaunch for {} ({})", request->self_path, request->app_path);
+        stop_session();
+
+        if (request->reason == AppLaunchReason::ProcessExit) {
+            QCoreApplication::quit();
+            return;
+        }
+
+        if (!run_boot_chain(std::move(*request)))
+            QCoreApplication::quit();
+        return;
+    }
+
+    SDL_Event event;
+    while (SDL_PollEvent(&event)) {
+        switch (event.type) {
+        case SDL_EVENT_GAMEPAD_ADDED:
+        case SDL_EVENT_GAMEPAD_REMOVED:
+            refresh_controllers(emuenv.ctrl, emuenv);
+            break;
+
+        case SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN:
+        case SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION:
+        case SDL_EVENT_GAMEPAD_TOUCHPAD_UP:
+            handle_touchpad_event(emuenv.touch, event.gtouchpad);
+            break;
+
+        case SDL_EVENT_GAMEPAD_SENSOR_UPDATE:
+            handle_motion_event(emuenv, event.gsensor.sensor, event.gsensor);
+            break;
+
+        case SDL_EVENT_SENSOR_UPDATE:
+            handle_motion_event(emuenv, SDL_GetSensorTypeForID(event.sensor.which), event.sensor);
+            break;
+
+        case SDL_EVENT_FINGER_DOWN:
+        case SDL_EVENT_FINGER_MOTION:
+        case SDL_EVENT_FINGER_UP:
+            handle_touch_event(emuenv.touch, event.tfinger);
+            break;
+
+        case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+            if (m_game_window && !emuenv.kernel.is_threads_paused()
+                && event.gbutton.button == SDL_GAMEPAD_BUTTON_TOUCHPAD)
+                toggle_touchscreen(emuenv.touch);
+            break;
+
+        default:
+            break;
+        }
+    }
+}
+
+void NoGuiRunner::on_game_closed() {
+    stop_session();
+    QCoreApplication::quit();
+}
+
+void NoGuiRunner::stop_session() {
+    if (!m_game_window)
+        return;
+
+    LOG_INFO("Game closed: {}", emuenv.current_app_title);
+
+    m_game_window->stop_ui_updates();
+    m_app_session.stop(app::AppSessionStopReason::FrontendShutdown);
+    refresh_controllers(emuenv.ctrl, emuenv);
+
+    GameWindow *closed_window = m_game_window;
+    m_game_window = nullptr;
+    delete closed_window;
+}
+
+void NoGuiRunner::ensure_active_user() {
+    const auto &users = emuenv.app.user_list.users;
+
+    if (users.empty()) {
+        const std::string id = app::create_user(emuenv, "Vita3K");
+        app::activate_user(emuenv, id);
+        emuenv.cfg.user_id = id;
+        config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+        return;
+    }
+
+    if (!emuenv.cfg.user_id.empty() && users.contains(emuenv.cfg.user_id)) {
+        app::activate_user(emuenv, emuenv.cfg.user_id);
+        return;
+    }
+
+    const auto &first = users.begin();
+    app::activate_user(emuenv, first->first);
+    emuenv.cfg.user_id = first->first;
+    config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+}

--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -26,6 +26,7 @@
 #include <gui-qt/gui_settings.h>
 #include <gui-qt/log_widget.h>
 #include <gui-qt/main_window.h>
+#include <gui-qt/no_gui_runner.h>
 #include <gui-qt/persistent_settings.h>
 #include <include/cpu.h>
 #include <include/environment.h>
@@ -256,11 +257,26 @@ int main(int argc, char *argv[]) {
     auto gui_settings = std::make_shared<GuiSettings>(gui_configs_dir);
     auto persistent_settings = std::make_shared<PersistentSettings>(gui_configs_dir);
 
-    MainWindow mainwindow(emuenv, gui_settings, persistent_settings, admin_priv);
+    if (cfg.no_gui) {
+        if (!emuenv.cfg.run_app_path.has_value()) {
+            LOG_ERROR("--no-gui requires an app to run (pass --installed-path or a content path)");
+            return InitConfigFailed;
+        }
 
-    mainwindow.show();
-    if (mainwindow.prompt_startup_warnings())
-        app.exec();
+        QApplication::setQuitOnLastWindowClosed(false);
+
+        NoGuiRunner runner(emuenv, gui_settings);
+        const AppLaunchRequest request{ .app_path = *emuenv.cfg.run_app_path };
+        emuenv.cfg.run_app_path.reset();
+        if (runner.start(request))
+            app.exec();
+    } else {
+        MainWindow mainwindow(emuenv, gui_settings, persistent_settings, admin_priv);
+
+        mainwindow.show();
+        if (mainwindow.prompt_startup_warnings())
+            app.exec();
+    }
 
 #ifdef _WIN32
     CoUninitialize();


### PR DESCRIPTION
boots the app given by --installed-path directly into a game window and exits the emulator once that app is gone, for launcher/frontend integration (e.g. steam). a dedicated headless runner reuses the existing app session, game window and input filters instead of creating the main window, so the gui path is left untouched. a sceAppMgr relaunch boots the next app instead of exiting, fullscreen is taken from the config rather than forced, and the game window screen is left to the window manager.