### PR TITLE
cmake: Dynamic link libc and stdc++

### DIFF
--- a/vita3k/CMakeLists.txt
+++ b/vita3k/CMakeLists.txt
@@ -217,10 +217,6 @@ if(USE_DISCORD_RICH_PRESENCE)
 	target_link_libraries(vita3k PRIVATE discord-rpc)
 endif()
 
-if(LINUX)
-	target_link_libraries(vita3k PRIVATE -static-libgcc -static-libstdc++)
-endif()
-
 if(NOT ANDROID)
 	file(GLOB VITA3K_QT_TS_FILES CONFIGURE_DEPENDS
 		"${CMAKE_SOURCE_DIR}/i18n/qt/*.ts")


### PR DESCRIPTION
Brings back the normal way to link with stdc++ and libc
Originally it was static linking to avoid the missing libc version errors
But this only happened on standalone and we didnt have appimage back then

AppImage handles the libc stuff for us now, by having it normally linked again we might avoid some dependency bugs like #2175

So now the standalone will have a new requirement, to use a relatively modern libc version (either latest one or the same CI uses), which its fine as standalone is very rarely used, and if someone wants to use Vita3K the AppImage comes first

Need testing on super outdated systems (Ubuntu 22.04 LTS would be a good test since its the oldest ubuntu version thats still desktop supported)