### PR TITLE
vita3k: ignore errors on module preload.

### DIFF
--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -529,8 +529,7 @@ static ExitCode load_app_impl(SceUID &main_module_id, EmuEnvState &emuenv, const
 
     for (const auto &module_path : lib_load_list) {
         auto res = load_module(emuenv, module_path);
-        if (res < 0)
-            return FileNotFound;
+        LOG_ERROR_IF(res < 0, "Failed to load preloaded module: {}. Ignoring this error.", module_path);
     }
 
     // Load taiHEN plugins configured for this title


### PR DESCRIPTION
It allow to run programs without installed firmware (it's still not recommended, but now possible)