### PR TITLE
emuenv/app: Remove base_path

### DIFF
--- a/vita3k/android/jni/native_bootstrap.cpp
+++ b/vita3k/android/jni/native_bootstrap.cpp
@@ -54,7 +54,6 @@ bool initialize_session(const fs::path &storage_path, Root &root_paths, std::uni
     try {
         const fs::path vita_path = storage_path / "vita" / "";
 
-        root_paths.set_base_path(storage_path);
         root_paths.set_static_assets_path({});
         root_paths.set_vita_fs_path(vita_path);
         root_paths.set_log_path(storage_path);

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -246,8 +246,6 @@ void init_paths(Root &root_paths) {
     fs::path internal_storage_path = fs::path(SDL_GetAndroidExternalStoragePath()) / "";
     fs::path vita_storage_path = internal_storage_path / "vita/";
 
-    root_paths.set_base_path(internal_storage_path);
-
     // On Android, static assets are bundled inside the APK and accessed via SDL_IOFromFile.
     root_paths.set_static_assets_path({});
 
@@ -258,18 +256,17 @@ void init_paths(Root &root_paths) {
     root_paths.set_cache_path(internal_storage_path / "cache" / "");
     root_paths.set_patch_path(internal_storage_path / "patch" / "");
 #else
-    auto sdl_base_path = SDL_GetBasePath();
-    auto base_path = fs_utils::utf8_to_path(sdl_base_path);
+    auto sdl_exe_path = SDL_GetBasePath();
+    auto exe_path = fs_utils::utf8_to_path(sdl_exe_path);
 
-    root_paths.set_base_path(base_path);
-    root_paths.set_static_assets_path(base_path);
+    root_paths.set_static_assets_path(exe_path);
 
 #if defined(__APPLE__)
-    // On Apple platforms, base_path is "Contents/Resources/" inside the app bundle.
+    // On Apple platforms, exe_path is "Contents/Resources/" inside the app bundle.
     // An extra parent_path is apparently needed because of the trailing slash.
-    auto portable_path = base_path.parent_path().parent_path().parent_path().parent_path() / "portable" / "";
+    auto portable_path = exe_path.parent_path().parent_path().parent_path().parent_path() / "portable" / "";
 #else
-    auto portable_path = base_path / "portable" / "";
+    auto portable_path = exe_path / "portable" / "";
 #endif
 
     if (fs::is_directory(portable_path)) {
@@ -294,9 +291,9 @@ void init_paths(Root &root_paths) {
         // This will typically be "~/Library/Application Support/Vita3K/Vita3K/".
         // Check for config.yml first, though, to maintain backwards compatibility,
         // even though storing user data inside the app bundle is not a good idea.
-        auto existing_config = base_path / "config.yml";
+        auto existing_config = exe_path / "config.yml";
         if (!fs::exists(existing_config)) {
-            base_path = vita_fs_path;
+            exe_path = vita_fs_path;
         }
 
         // vita_fs_path should not be the same as the other paths.
@@ -308,11 +305,11 @@ void init_paths(Root &root_paths) {
 #endif
 
         root_paths.set_vita_fs_path(vita_fs_path);
-        root_paths.set_log_path(base_path);
-        root_paths.set_config_path(base_path);
-        root_paths.set_shared_path(base_path);
-        root_paths.set_cache_path(base_path / "cache" / "");
-        root_paths.set_patch_path(base_path / "patch" / "");
+        root_paths.set_log_path(exe_path);
+        root_paths.set_config_path(exe_path);
+        root_paths.set_shared_path(exe_path);
+        root_paths.set_cache_path(exe_path / "cache" / "");
+        root_paths.set_patch_path(exe_path / "patch" / "");
 
 #if defined(__linux__)
         // XDG Data Dirs.
@@ -367,8 +364,8 @@ void init_paths(Root &root_paths) {
         }
 
         // Only really used in standalone (rare) or development
-        if (fs::exists(root_paths.get_base_path() / "shaders-builtin"))
-            root_paths.set_static_assets_path(root_paths.get_base_path());
+        if (fs::exists(exe_path / "shaders-builtin"))
+            root_paths.set_static_assets_path(exe_path);
 
         // AppImage root
         if (APPDIR != NULL && fs::exists(fs::path(APPDIR) / "usr/share/Vita3K"))
@@ -405,7 +402,6 @@ void init_paths(Root &root_paths) {
 bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
     state.cfg = std::move(cfg);
 
-    state.base_path = root_paths.get_base_path();
     state.default_path = root_paths.get_vita_fs_path();
     state.log_path = root_paths.get_log_path();
     state.config_path = root_paths.get_config_path();
@@ -426,7 +422,8 @@ bool init(EmuEnvState &state, Config &cfg, const Root &root_paths) {
 
     set_current_config(state, state.cfg.run_app_path.has_value() ? *state.cfg.run_app_path : "");
 
-    LOG_INFO("Base path: {}", state.base_path);
+    // Here any path can be used since they are all the same in windows/macos
+    LOG_INFO("Base path: {}", state.static_assets_path);
 #if defined(__linux__) && !defined(__ANDROID__)
     LOG_INFO("Static assets path: {}", state.static_assets_path);
     LOG_INFO("Shared path: {}", state.shared_path);

--- a/vita3k/emuenv/include/emuenv/state.h
+++ b/vita3k/emuenv/include/emuenv/state.h
@@ -124,7 +124,6 @@ public:
     std::string license_content_id{};
     std::string license_title_id{};
     std::string current_app_title{};
-    fs::path base_path{}; // Base for the path of binaries/executable
     fs::path default_path{};
     fs::path config_path{}; // Path for config files
     fs::path log_path{}; // Path for log file
@@ -203,7 +202,6 @@ public:
 
     Root get_root_paths() const {
         Root r;
-        r.set_base_path(base_path);
         r.set_vita_fs_path(vita_fs_path);
         r.set_patch_path(patch_path);
         r.set_log_path(log_path);

--- a/vita3k/util/include/util/fs.h
+++ b/vita3k/util/include/util/fs.h
@@ -88,7 +88,6 @@ template <>
 struct fmt::formatter<boost::filesystem::path> : ostream_formatter {};
 
 class Root {
-    fs::path base_path;
     fs::path vita_fs_path;
     fs::path patch_path;
     fs::path log_path;
@@ -98,13 +97,6 @@ class Root {
     fs::path static_assets_path;
 
 public:
-    void set_base_path(const fs::path &p) {
-        base_path = p;
-    }
-    fs::path get_base_path() const {
-        return base_path;
-    }
-
     void set_vita_fs_path(const fs::path &p) {
         vita_fs_path = p;
     }


### PR DESCRIPTION
base_path is only used by other paths to create them, it is never used by emuenv or roots_paths by the emulator at all
So remove it to avoid confusion, like it already happened before

Plus it SHOULDNT be hardcoded used in the first place :D