### PR TITLE
Harden HTTP URL and response parsing & More

### DIFF
--- a/vita3k/cpu/src/dynarmic_cpu.cpp
+++ b/vita3k/cpu/src/dynarmic_cpu.cpp
@@ -36,6 +36,14 @@ class ArmDynarmicCP15 : public Dynarmic::A32::Coprocessor {
     uint32_t sctlr;
     uint32_t dacr;
 
+    static uint64_t IgnoreOperation(void *, uint32_t, uint32_t) {
+        return 0;
+    }
+
+    static Callback IgnoreCallback() {
+        return Callback{ IgnoreOperation, std::optional<void *>{ nullptr } };
+    }
+
 public:
     using CoprocReg = Dynarmic::A32::CoprocReg;
 
@@ -55,9 +63,19 @@ public:
 
     CallbackOrAccessOneWord CompileSendOneWord(bool two, unsigned opc1, CoprocReg CRn,
         CoprocReg CRm, unsigned opc2) override {
-        // MCR p15, 0, Rt, c13, c0, 3 — write TPIDRURO
-        if (CRn == CoprocReg::C13 && CRm == CoprocReg::C0 && opc1 == 0 && opc2 == 3) {
+        // MCR p15, 0, Rt, c13, c0, 2/3 — write TPIDRURW/TPIDRURO
+        if (!two && CRn == CoprocReg::C13 && CRm == CoprocReg::C0 && opc1 == 0 && (opc2 == 2 || opc2 == 3)) {
             return &tpidruro;
+        }
+
+        // MCR p15, 0, Rt, c7, c5, 4 — ISB / flush prefetch buffer
+        if (!two && CRn == CoprocReg::C7 && CRm == CoprocReg::C5 && opc1 == 0 && opc2 == 4) {
+            return IgnoreCallback();
+        }
+
+        // MCR p15, 0, Rt, c7, c10, 4/5 — DSB/DMB
+        if (!two && CRn == CoprocReg::C7 && CRm == CoprocReg::C10 && opc1 == 0 && (opc2 == 4 || opc2 == 5)) {
+            return IgnoreCallback();
         }
 
         // MCR p15, 0, Rt, c1, c0, 0 — write SCTLR
@@ -80,8 +98,8 @@ public:
 
     CallbackOrAccessOneWord CompileGetOneWord(bool two, unsigned opc1, CoprocReg CRn, CoprocReg CRm,
         unsigned opc2) override {
-        // MRC p15, 0, Rt, c13, c0, 3 — read TPIDRURO (thread-local storage)
-        if (CRn == CoprocReg::C13 && CRm == CoprocReg::C0 && opc1 == 0 && opc2 == 3) {
+        // MRC p15, 0, Rt, c13, c0, 2/3 — read TPIDRURW/TPIDRURO (thread-local storage)
+        if (!two && CRn == CoprocReg::C13 && CRm == CoprocReg::C0 && opc1 == 0 && (opc2 == 2 || opc2 == 3)) {
             return &tpidruro;
         }
 

--- a/vita3k/modules/SceHttp/SceHttp.cpp
+++ b/vita3k/modules/SceHttp/SceHttp.cpp
@@ -17,6 +17,7 @@
 
 #include <module/module.h>
 
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <http/state.h>
@@ -42,6 +43,7 @@
 #include <util/tracy.h>
 
 #include <string>
+#include <string_view>
 #include <thread>
 
 TRACY_MODULE_NAME(SceHttp);
@@ -624,6 +626,9 @@ EXPORT(SceInt, sceHttpGetAllResponseHeaders, SceInt reqId, Ptr<char> *header, Sc
     TRACY_FUNC(sceHttpGetAllResponseHeaders, reqId, header, headerSize);
     if (!emuenv.http.inited)
         return RET_ERROR(SCE_HTTP_ERROR_BEFORE_INIT);
+
+    if (!header || !headerSize)
+        return RET_ERROR(SCE_HTTP_ERROR_INVALID_VALUE);
 
     if (!emuenv.http.requests.contains(reqId))
         return RET_ERROR(SCE_HTTP_ERROR_INVALID_ID);
@@ -1469,7 +1474,7 @@ EXPORT(SceInt, sceHttpUriParse, SceHttpUriElement *out, const char *srcUrl, Ptr<
     if (require) {
         *require = internal_require;
     }
-    if (prepare < internal_require)
+    if (pool && out && prepare < internal_require)
         return RET_ERROR(SCE_HTTP_ERROR_OUT_OF_MEMORY);
 
     if (pool && out) {
@@ -1503,17 +1508,16 @@ EXPORT(SceInt, sceHttpUriSweepPath, char *dst, const char *src, SceSize srcSize)
     if (!dst || !src)
         return RET_ERROR(SCE_HTTP_ERROR_INVALID_VALUE);
 
-    auto srcStr = std::string(src);
-
-    unsigned int srcStrLen = srcSize - 1;
+    const std::string_view srcStr(src, srcSize - 1);
     if (srcStr[0] == '/') {
-        auto lex = std::filesystem::path(src).lexically_normal();
+        auto lex = std::filesystem::path(std::string(srcStr)).lexically_normal();
         const std::string lexStr = lex.string();
-        const char *realPath = lexStr.c_str();
-        strcpy(dst, realPath);
+        const auto copyLen = std::min<std::size_t>(lexStr.length(), srcSize - 1);
+        memcpy(dst, lexStr.data(), copyLen);
+        dst[copyLen] = 0;
     } else {
         // Nicely copy the contents of src into dst
-        memcpy(dst, src, srcStrLen);
+        memcpy(dst, srcStr.data(), srcStr.length());
         dst[srcSize - 1] = 0;
     }
 

--- a/vita3k/modules/SceHttp/SceHttp.cpp
+++ b/vita3k/modules/SceHttp/SceHttp.cpp
@@ -733,10 +733,7 @@ EXPORT(SceInt, sceHttpGetResponseContentLength, SceInt reqId, SceULong64 *conten
     if (length_it == req->second.res.headers.end())
         return RET_ERROR(SCE_HTTP_ERROR_NO_CONTENT_LENGTH);
 
-    SceULong64 length = string_utils::stoi_def(length_it->second);
-    *contentLength = length;
-
-    req->second.res.contentLength = length;
+    *contentLength = req->second.res.contentLength;
 
     return 0;
 }
@@ -745,6 +742,9 @@ EXPORT(SceInt, sceHttpGetStatusCode, SceInt reqId, SceInt *statusCode) {
     TRACY_FUNC(sceHttpGetStatusCode, reqId, statusCode);
     if (!emuenv.http.inited)
         return RET_ERROR(SCE_HTTP_ERROR_BEFORE_INIT);
+
+    if (!statusCode)
+        return RET_ERROR(SCE_HTTP_ERROR_INVALID_VALUE);
 
     if (!emuenv.http.requests.contains(reqId))
         return RET_ERROR(SCE_HTTP_ERROR_INVALID_ID);
@@ -786,7 +786,7 @@ EXPORT(SceInt, sceHttpParseResponseHeader, Ptr<const char> headers, SceSize head
 
     *valueLen = 0; // reset to 0 to check after
 
-    std::string headerStr = std::string(headers.get(emuenv.mem));
+    std::string headerStr(headers.get(emuenv.mem), headersLen);
     HeadersMapType parsedHeaders;
     if (!net_utils::parseHeaders(headerStr, parsedHeaders))
         return RET_ERROR(SCE_HTTP_ERROR_PARSE_HTTP_INVALID_RESPONSE);
@@ -824,10 +824,7 @@ EXPORT(SceInt, sceHttpParseStatusLine, const char *statusLine, SceSize lineLen, 
     if (lineLen < 8)
         return RET_ERROR(SCE_HTTP_ERROR_PARSE_HTTP_INVALID_RESPONSE);
 
-    STUBBED("Ignore lineLen");
-
-    // TODO: test
-    auto line = std::string(statusLine);
+    auto line = std::string(statusLine, lineLen);
     auto cleanLine = line.substr(0, line.find("\r\n"));
     // even if there is no \r\n, the result will still be the whole string
 
@@ -845,10 +842,9 @@ EXPORT(SceInt, sceHttpParseStatusLine, const char *statusLine, SceSize lineLen, 
         *httpMinorVer = 0;
     }
 
-    auto statusCodeLine = cleanLine.substr(cleanLine.find(' ') + 1, 3);
     *responseCode = code;
 
-    auto h = Ptr<char>(alloc(emuenv.mem, sizeof(char), "reasonPhrase"));
+    auto h = Ptr<char>(alloc(emuenv.mem, reason.length() + 1, "reasonPhrase"));
     memcpy(h.get(emuenv.mem), reason.data(), reason.length() + 1);
     emuenv.http.guestPointers.emplace_back(h);
     *reasonPhrase = h;
@@ -863,6 +859,9 @@ EXPORT(SceInt, sceHttpReadData, SceInt reqId, void *data, SceSize size) {
     if (!emuenv.http.inited)
         return RET_ERROR(SCE_HTTP_ERROR_BEFORE_INIT);
 
+    if (!data && size != 0)
+        return RET_ERROR(SCE_HTTP_ERROR_INVALID_VALUE);
+
     if (!emuenv.http.requests.contains(reqId))
         return RET_ERROR(SCE_HTTP_ERROR_INVALID_ID);
 
@@ -870,6 +869,9 @@ EXPORT(SceInt, sceHttpReadData, SceInt reqId, void *data, SceSize size) {
 
     // These methods have no body
     if (req->second.method == SCE_HTTP_METHOD_HEAD || req->second.method == SCE_HTTP_METHOD_OPTIONS)
+        return 0;
+
+    if (size == 0)
         return 0;
 
     // If the game wants to read more than whats available, change the read ammount to what is available
@@ -920,6 +922,9 @@ EXPORT(SceInt, sceHttpRequestGetAllHeaders, SceInt reqId, Ptr<char> *header, Sce
     if (!emuenv.http.inited)
         return RET_ERROR(SCE_HTTP_ERROR_BEFORE_INIT);
 
+    if (!header || !headerSize)
+        return RET_ERROR(SCE_HTTP_ERROR_INVALID_VALUE);
+
     if (!emuenv.http.requests.contains(reqId))
         return RET_ERROR(SCE_HTTP_ERROR_INVALID_ID);
 
@@ -927,7 +932,7 @@ EXPORT(SceInt, sceHttpRequestGetAllHeaders, SceInt reqId, Ptr<char> *header, Sce
 
     auto headers = net_utils::constructHeaders(req->second.headers);
 
-    auto h = Ptr<char>(alloc(emuenv.mem, sizeof(char), "headers"));
+    auto h = Ptr<char>(alloc(emuenv.mem, headers.length() + 1, "headers"));
     memcpy(h.get(emuenv.mem), headers.data(), headers.length() + 1);
     req->second.guestPointers.emplace_back(h);
     *header = h;

--- a/vita3k/modules/SceHttp/SceHttp.cpp
+++ b/vita3k/modules/SceHttp/SceHttp.cpp
@@ -1119,7 +1119,7 @@ EXPORT(SceInt, sceHttpSendRequest, SceInt reqId, const char *postData, SceSize s
     }
 
     // TODO: does a HEAD/OPTIONS request need content-length to exist?
-    if (req->second.res.headers.find("content-length") == req->second.headers.end()) {
+    if (req->second.res.headers.find("content-length") == req->second.res.headers.end()) {
         delete[] resHeaders;
         return RET_ERROR(SCE_HTTP_ERROR_NO_CONTENT_LENGTH);
     }

--- a/vita3k/renderer/include/renderer/vulkan/gxm_to_vulkan.h
+++ b/vita3k/renderer/include/renderer/vulkan/gxm_to_vulkan.h
@@ -49,6 +49,7 @@ vk::Format translate_format(SceGxmTextureBaseFormat base_format);
 vk::ComponentMapping translate_swizzle(SceGxmTextureFormat format);
 vk::SamplerAddressMode translate_address_mode(SceGxmTextureAddrMode src);
 vk::Filter translate_filter(SceGxmTextureFilter src);
+vk::SamplerMipmapMode translate_mipmap_mode(SceGxmTextureFilter src, bool mip_filter_enabled);
 } // namespace texture
 
 } // namespace renderer::vulkan

--- a/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
+++ b/vita3k/renderer/src/vulkan/gxm_to_vulkan.cpp
@@ -878,5 +878,22 @@ vk::Filter translate_filter(SceGxmTextureFilter src) {
         return vk::Filter::eNearest;
     }
 }
+
+vk::SamplerMipmapMode translate_mipmap_mode(SceGxmTextureFilter src, bool mip_filter_enabled) {
+    if (!mip_filter_enabled)
+        return vk::SamplerMipmapMode::eNearest;
+
+    switch (src) {
+    case SCE_GXM_TEXTURE_FILTER_MIPMAP_LINEAR:
+        return vk::SamplerMipmapMode::eLinear;
+    case SCE_GXM_TEXTURE_FILTER_POINT:
+    case SCE_GXM_TEXTURE_FILTER_LINEAR:
+    case SCE_GXM_TEXTURE_FILTER_MIPMAP_POINT:
+        return vk::SamplerMipmapMode::eNearest;
+    default:
+        LOG_ERROR("Unknown texture filter {}", log_hex(src));
+        return vk::SamplerMipmapMode::eNearest;
+    }
+}
 } // namespace texture
 } // namespace renderer::vulkan

--- a/vita3k/renderer/src/vulkan/sync_state.cpp
+++ b/vita3k/renderer/src/vulkan/sync_state.cpp
@@ -24,7 +24,27 @@
 
 #include <util/log.h>
 
+#include <algorithm>
+#include <cstdint>
+
 namespace renderer::vulkan {
+
+static void clamp_scissor_to_render_target(vk::Rect2D &scissor, const uint32_t width, const uint32_t height) {
+    const int64_t target_width = width;
+    const int64_t target_height = height;
+    const int64_t left = std::clamp<int64_t>(scissor.offset.x, 0, target_width);
+    const int64_t top = std::clamp<int64_t>(scissor.offset.y, 0, target_height);
+    const int64_t right = std::clamp<int64_t>(static_cast<int64_t>(scissor.offset.x) + scissor.extent.width, 0, target_width);
+    const int64_t bottom = std::clamp<int64_t>(static_cast<int64_t>(scissor.offset.y) + scissor.extent.height, 0, target_height);
+
+    if ((right <= left) || (bottom <= top)) {
+        scissor = vk::Rect2D{};
+        return;
+    }
+
+    scissor.offset = vk::Offset2D{ static_cast<int32_t>(left), static_cast<int32_t>(top) };
+    scissor.extent = vk::Extent2D{ static_cast<uint32_t>(right - left), static_cast<uint32_t>(bottom - top) };
+}
 
 void sync_clipping(VKContext &context) {
     if (!context.render_target)
@@ -59,16 +79,7 @@ void sync_clipping(VKContext &context) {
         break;
     }
 
-    // Vulkan does not allow the offset to be negative
-    if (context.scissor.offset.x < 0) {
-        context.scissor.extent.width = std::max(context.scissor.extent.width - context.scissor.offset.x, 0U);
-        context.scissor.offset.x = 0;
-    }
-
-    if (context.scissor.offset.y < 0) {
-        context.scissor.extent.height = std::max(context.scissor.extent.height - context.scissor.offset.y, 0U);
-        context.scissor.offset.y = 0;
-    }
+    clamp_scissor_to_render_target(context.scissor, context.render_target->width, context.render_target->height);
 
     if (!context.is_recording)
         return;

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -575,11 +575,13 @@ void VKTextureCache::configure_sampler(size_t index, const SceGxmTexture &textur
         mag_filter = SCE_GXM_TEXTURE_FILTER_POINT;
     }
 
+    const bool mip_filter_enabled = texture.mip_filter && !no_linear;
+
     // create sampler
     vk::SamplerCreateInfo sampler_info{
         .magFilter = texture::translate_filter(mag_filter),
         .minFilter = texture::translate_filter(min_filter),
-        .mipmapMode = texture.mip_filter ? vk::SamplerMipmapMode::eLinear : vk::SamplerMipmapMode::eNearest,
+        .mipmapMode = texture::translate_mipmap_mode(min_filter, mip_filter_enabled),
         .addressModeU = texture::translate_address_mode(uaddr),
         .addressModeV = texture::translate_address_mode(vaddr),
         .addressModeW = vk::SamplerAddressMode::eRepeat,

--- a/vita3k/util/src/net_utils.cpp
+++ b/vita3k/util/src/net_utils.cpp
@@ -31,152 +31,133 @@
 #include <netinet/in.h>
 #endif
 
+#include <algorithm>
+#include <cctype>
+#include <charconv>
 #include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
 #include <mutex>
+#include <string_view>
+#include <system_error>
 
 namespace net_utils {
 
+namespace {
+
+bool parse_decimal(std::string_view str, SceULong64 &out) {
+    if (str.empty())
+        return false;
+
+    SceULong64 value = 0;
+    const auto *begin = str.data();
+    const auto *end = begin + str.size();
+    const auto [ptr, ec] = std::from_chars(begin, end, value);
+    if (ec != std::errc() || ptr != end)
+        return false;
+
+    out = value;
+    return true;
+}
+
+bool is_digit(char ch) {
+    return std::isdigit(static_cast<unsigned char>(ch)) != 0;
+}
+
+} // namespace
+
 // 0 is ok, negative is bad
 SceHttpErrorCode parse_url(const std::string &url, parsedUrl &out) {
-    out.scheme = url.substr(0, url.find(':'));
+    out = {};
 
+    const auto scheme_end = url.find(':');
+    if (scheme_end == std::string::npos) {
+        out.scheme = url;
+        if (out.scheme == "http" || out.scheme == "https") {
+            out.invalid = true;
+            return (SceHttpErrorCode)0;
+        }
+        return SCE_HTTP_ERROR_UNKNOWN_SCHEME;
+    }
+
+    out.scheme = url.substr(0, scheme_end);
     if (out.scheme != "http" && out.scheme != "https")
         return SCE_HTTP_ERROR_UNKNOWN_SCHEME;
 
-    // Check if URL is opaque, if it is opaque then its invalid
-    // http://
-    //+    012
-    //      ^^ Check these 2
-    char url1Slash = *(url.c_str() + (out.scheme.length() + 1)); // get uint8 value
-    char url2Slash = *(url.c_str() + (out.scheme.length() + 2)); // get next uint8 value
-    // Compare the 2 characters that are supposed to be slahses
-    if (url1Slash != '/' || url2Slash != '/') {
+    // Check if URL is opaque. HTTP URLs accepted by this parser must use //.
+    if (url.size() < scheme_end + 3 || url[scheme_end + 1] != '/' || url[scheme_end + 2] != '/') {
         out.invalid = true;
         return (SceHttpErrorCode)0;
     }
 
-    auto end_scheme_pos = url.find(':');
-    auto has_path = url.find('/', end_scheme_pos + 3) != std::string::npos;
+    const auto authority_start = scheme_end + strlen("://");
+    const auto path_start = url.find_first_of("/?#", authority_start);
+    const std::string_view authority(url.data() + authority_start,
+        (path_start == std::string::npos ? url.size() : path_start) - authority_start);
+    if (authority.empty()) {
+        out.invalid = true;
+        return (SceHttpErrorCode)0;
+    }
 
-    auto full_wo_scheme = url.substr(end_scheme_pos + 3);
+    std::string_view host_port = authority;
+    const auto userinfo_end = authority.rfind('@');
+    if (userinfo_end != std::string_view::npos) {
+        const auto userinfo = authority.substr(0, userinfo_end);
+        host_port = authority.substr(userinfo_end + 1);
 
-    if (has_path) {
-        // username:password@lttstore.com:727/wysi/cookie.php?pog=gers#extremeexploit
+        const auto password_start = userinfo.find(':');
+        const auto username = userinfo.substr(0, password_start);
+        const auto password = password_start == std::string_view::npos
+            ? std::string_view()
+            : userinfo.substr(password_start + 1);
 
-        {
-            auto path_pos = std::string(full_wo_scheme).find('/');
-            auto full_no_scheme_path = full_wo_scheme.substr(0, path_pos);
-            // full_no_scheme_path = username:password@lttstore.com:727
-            auto c = full_no_scheme_path.find('@');
-            if (c != std::string::npos) { // we have credentials
-                auto credentials = full_no_scheme_path.substr(0, c);
-                // credentials = username:password
-                auto semicolon_pos = credentials.find(':');
+        if (username.length() >= SCE_HTTP_USERNAME_MAX_SIZE)
+            return SCE_HTTP_ERROR_OUT_OF_SIZE;
+        if (password.length() >= SCE_HTTP_PASSWORD_MAX_SIZE)
+            return SCE_HTTP_ERROR_OUT_OF_SIZE;
 
-                if (semicolon_pos != std::string::npos) { // we have password?
-                    auto username = credentials.substr(0, semicolon_pos);
-                    auto password = credentials.substr(semicolon_pos + 1);
+        out.username = std::string(username);
+        out.password = std::string(password);
+    }
 
-                    if (username.length() >= SCE_HTTP_USERNAME_MAX_SIZE)
-                        return SCE_HTTP_ERROR_OUT_OF_SIZE;
-                    if (password.length() >= SCE_HTTP_USERNAME_MAX_SIZE)
-                        return SCE_HTTP_ERROR_OUT_OF_SIZE;
+    if (host_port.empty()) {
+        out.invalid = true;
+        return (SceHttpErrorCode)0;
+    }
 
-                    out.username = username;
-                    out.password = password;
-                } else { // we don't have password
-                    out.username = credentials;
-                }
-            } else { // no credentials
-                // lttstore.com:727
-                auto semicolon_pos = full_no_scheme_path.find(':');
-
-                if (semicolon_pos != std::string::npos) { // we have port
-                    auto hostname = full_no_scheme_path.substr(0, semicolon_pos);
-                    auto port = full_no_scheme_path.substr(semicolon_pos + 1);
-
-                    out.hostname = hostname;
-                    out.port = port;
-                } else { // no port
-                    out.hostname = full_no_scheme_path;
-                }
-            }
-        }
-        {
-            auto path_pos = std::string(full_wo_scheme).find('/');
-            auto full_no_scheme_hostname = full_wo_scheme.substr(path_pos);
-            // /wysi/cookie.php?pog=gers#extremeexploit
-
-            auto query_pos = full_no_scheme_hostname.find('?');
-            if (query_pos != std::string::npos) { // we have query
-                auto path = full_no_scheme_hostname.substr(0, query_pos);
-                out.path = path;
-
-                auto query_frag = full_no_scheme_hostname.substr(query_pos);
-
-                auto frag_pos = query_frag.find('#');
-                if (frag_pos != std::string::npos) {
-                    // query and fragment
-
-                    auto query = query_frag.substr(0, frag_pos);
-                    auto fragment = query_frag.substr(frag_pos);
-
-                    out.query = query;
-                    out.fragment = fragment;
-                } else { // no fragment
-                    out.query = query_frag;
-                }
-
-            } else { // no query, dunno about fragment
-                auto frag_pos = full_no_scheme_hostname.find('#');
-
-                if (frag_pos != std::string::npos) { // we have fragment
-                    auto path = full_no_scheme_hostname.substr(0, frag_pos);
-                    auto fragment = full_no_scheme_hostname.substr(frag_pos);
-
-                    out.path = path;
-                    out.fragment = fragment;
-                } else { // no fragment, only path
-                    out.path = full_no_scheme_hostname;
-                }
-            }
-        }
+    const auto port_start = host_port.rfind(':');
+    if (port_start != std::string_view::npos) {
+        out.hostname = std::string(host_port.substr(0, port_start));
+        out.port = std::string(host_port.substr(port_start + 1));
     } else {
-        // username:password@lttstore.com:727
-        auto c = full_wo_scheme.find('@');
-        if (c != std::string::npos) { // we have credentials
-            auto credentials = full_wo_scheme.substr(0, c);
-            // credentials = username:password
-            auto semicolon_pos = credentials.find(':');
+        out.hostname = std::string(host_port);
+    }
 
-            if (semicolon_pos != std::string::npos) { // we have password?
-                auto username = credentials.substr(0, semicolon_pos);
-                auto password = credentials.substr(semicolon_pos + 1);
+    if (out.hostname.empty()) {
+        out.invalid = true;
+        return (SceHttpErrorCode)0;
+    }
 
-                if (username.length() >= SCE_HTTP_USERNAME_MAX_SIZE)
-                    return SCE_HTTP_ERROR_OUT_OF_SIZE;
-                if (password.length() >= SCE_HTTP_USERNAME_MAX_SIZE)
-                    return SCE_HTTP_ERROR_OUT_OF_SIZE;
+    if (path_start != std::string::npos) {
+        auto query_start = url.find('?', path_start);
+        const auto fragment_start = url.find('#', path_start);
+        if (query_start != std::string::npos && fragment_start != std::string::npos && fragment_start < query_start)
+            query_start = std::string::npos;
 
-                out.username = username;
-                out.password = password;
-            } else { // we don't have password
-                out.username = credentials;
-            }
-        } else { // no credentials
-            // lttstore.com:727
-            auto semicolon_pos = full_wo_scheme.find(':');
+        const auto path_end = std::min(query_start == std::string::npos ? url.size() : query_start,
+            fragment_start == std::string::npos ? url.size() : fragment_start);
 
-            if (semicolon_pos != std::string::npos) { // we have port
-                auto hostname = full_wo_scheme.substr(0, semicolon_pos);
-                auto port = full_wo_scheme.substr(semicolon_pos + 1);
+        if (url[path_start] == '/')
+            out.path = url.substr(path_start, path_end - path_start);
 
-                out.hostname = hostname;
-                out.port = port;
-            } else { // no port
-                out.hostname = full_wo_scheme;
-            }
+        if (query_start != std::string::npos) {
+            const auto query_end = fragment_start == std::string::npos ? url.size() : fragment_start;
+            out.query = url.substr(query_start, query_end - query_start);
         }
+
+        if (fragment_start != std::string::npos)
+            out.fragment = url.substr(fragment_start);
     }
 
     return (SceHttpErrorCode)0;
@@ -236,9 +217,9 @@ std::string constructHeaders(const HeadersMapType &headers) {
 bool parseStatusLine(const std::string &line, std::string &httpVer, int &statusCode, std::string &reason) {
     auto lineClean = line.substr(0, line.find("\r\n"));
 
-    // do this check just in case the server is drunk or retarded, would be nice to do more checks with some regex
+    // Do a light sanity check before parsing the status line fields.
     if (!lineClean.starts_with("HTTP/"))
-        return false; // what
+        return false;
 
     const auto firstSpace = lineClean.find(' ');
     if (firstSpace == std::string::npos)
@@ -247,18 +228,21 @@ bool parseStatusLine(const std::string &line, std::string &httpVer, int &statusC
     const std::string fullHttpVerStr = lineClean.substr(0, firstSpace);
     const std::string httpVerStr = fullHttpVerStr.substr(strlen("HTTP/"));
 
-    if (!std::isdigit(httpVerStr[0]))
+    if (httpVerStr.empty() || !is_digit(httpVerStr[0]))
         return false;
 
     if (lineClean.length() < fullHttpVerStr.length() + strlen(" XXX"))
-        return false; // the rest of the line is less than 3 characters in length, what the fuck happened also abort
+        return false; // the rest of the line is shorter than a 3-digit status code
 
     const auto codeAndReason = lineClean.substr(firstSpace + 1);
     const auto statusCodeStr = codeAndReason.substr(0, 3);
-    if (!std::isdigit(statusCodeStr[0]) || !std::isdigit(statusCodeStr[1]) || !std::isdigit(statusCodeStr[2]))
+    if (!is_digit(statusCodeStr[0]) || !is_digit(statusCodeStr[1]) || !is_digit(statusCodeStr[2]))
         return false; // status code contains non digit characters, abort
 
-    const int statusCodeInt = std::stoi(statusCodeStr);
+    SceULong64 parsedStatusCode = 0;
+    if (!parse_decimal(statusCodeStr, parsedStatusCode) || parsedStatusCode > std::numeric_limits<int>::max())
+        return false;
+    const int statusCodeInt = static_cast<int>(parsedStatusCode);
 
     std::string reasonStr = "";
     bool hasReason = codeAndReason.find(' ') != std::string::npos;
@@ -299,11 +283,18 @@ bool parseHeaders(std::string &headersRaw, HeadersMapType &headersOut) {
 }
 
 bool parseResponse(const std::string &res, SceRequestResponse &reqres) {
-    auto statusLine = res.substr(0, res.find("\r\n"));
+    const auto status_line_end = res.find("\r\n");
+    if (status_line_end == std::string::npos)
+        return false;
+
+    auto statusLine = res.substr(0, status_line_end);
     if (!parseStatusLine(statusLine, reqres.httpVer, reqres.statusCode, reqres.reasonPhrase))
         return false;
 
-    auto headersRaw = res.substr(res.find("\r\n") + strlen("\r\n"), res.find("\r\n\r\n"));
+    const auto headers_start = status_line_end + strlen("\r\n");
+    const auto headers_end = res.find("\r\n\r\n", headers_start);
+    auto headersRaw = res.substr(headers_start,
+        headers_end == std::string::npos ? std::string::npos : headers_end - headers_start);
 
     if (!parseHeaders(headersRaw, reqres.headers))
         return false;
@@ -312,7 +303,10 @@ bool parseResponse(const std::string &res, SceRequestResponse &reqres) {
     if (contLenIt == reqres.headers.end()) {
         reqres.contentLength = 0;
     } else {
-        reqres.contentLength = std::stoi(contLenIt->second);
+        SceULong64 contentLength = 0;
+        if (!parse_decimal(contLenIt->second, contentLength))
+            return false;
+        reqres.contentLength = contentLength;
     }
 
     return true;


### PR DESCRIPTION
- Reworked HTTP URL parsing to avoid out-of-bounds reads on malformed or short URLs.
- Fixed parsing for URLs with credentials, query strings, fragments, and missing paths.
- Replaced throwing numeric conversions in HTTP status/content-length parsing with checked parsing.
- Fixed a Content-Length lookup bug that compared against the wrong header map.