### PR TITLE
apputil: Add safeguards to save slot ids

### DIFF
--- a/vita3k/emuenv/include/emuenv/app_util.h
+++ b/vita3k/emuenv/include/emuenv/app_util.h
@@ -87,6 +87,8 @@ struct SceAppUtilSaveDataRemoveItem {
     uint8_t reserved[36];
 };
 
+#define SCE_APPUTIL_SAVEDATA_SLOT_MAX 0x100
+
 enum SceAppUtilSaveDataSlotSearchType {
     SCE_APPUTIL_SAVEDATA_SLOT_SEARCH_TYPE_EXIST_SLOT = 0,
     SCE_APPUTIL_SAVEDATA_SLOT_SEARCH_TYPE_EMPTY_SLOT = 1

--- a/vita3k/modules/SceAppUtil/SceAppUtil.cpp
+++ b/vita3k/modules/SceAppUtil/SceAppUtil.cpp
@@ -248,6 +248,10 @@ std::string construct_slotparam_path(const unsigned int data) {
 
 EXPORT(int, sceAppUtilSaveDataDataRemove, SceAppUtilSaveDataFileSlot *slot, SceAppUtilSaveDataRemoveItem *files, unsigned int fileNum, SceAppUtilMountPoint *mountPoint) {
     TRACY_FUNC(sceAppUtilSaveDataDataRemove, slot, files, fileNum, mountPoint);
+
+    if (slot && (slot->id >= SCE_APPUTIL_SAVEDATA_SLOT_MAX))
+        return RET_ERROR(SCE_APPUTIL_ERROR_PARAMETER);
+
     for (unsigned int i = 0; i < fileNum; i++) {
         const auto file = fs::path(construct_savedata0_path(files[i].dataPath.get(emuenv.mem)));
         if (fs::is_regular_file(file)) {
@@ -270,6 +274,9 @@ EXPORT(int, sceAppUtilSaveDataDataSave, SceAppUtilSaveDataFileSlot *slot, SceApp
     if (requiredSizeKiB)
         // requiredSizeKiB must be set to 0 if there is enough space available
         *requiredSizeKiB = 0;
+
+    if (slot && (slot->id >= SCE_APPUTIL_SAVEDATA_SLOT_MAX))
+        return RET_ERROR(SCE_APPUTIL_ERROR_PARAMETER);
 
     for (unsigned int i = 0; i < fileNum; i++) {
         const auto file_path = construct_savedata0_path(files[i].dataPath.get(emuenv.mem));

--- a/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
+++ b/vita3k/modules/SceCommonDialog/SceCommonDialog.cpp
@@ -1350,6 +1350,10 @@ EXPORT(int, sceSaveDataDialogInit, const SceSaveDataDialogParam *p) {
 
         for (SceUInt i = 0; i < list_param->slotListSize; i++) {
             slot_list[i] = list_param->slotList.get(emuenv.mem)[i];
+            if (slot_list[i].id >= SCE_APPUTIL_SAVEDATA_SLOT_MAX) {
+                LOG_WARN("Invalid slot id {} in list, skipping slot", log_hex(slot_list[i].id));
+                continue; // TODO: is this the correct behavior for this function?
+            }
             emuenv.common_dialog.savedata.slot_id[i] = slot_list[i].id;
             emuenv.common_dialog.savedata.list_empty_param[i] = slot_list[i].emptyParam.get(emuenv.mem);
             check_save_file(i, emuenv, export_name);


### PR DESCRIPTION
On apputil there were some missing checks regarding the slot id so i decided to add them, they shouldnt change the compatibility of any game since it only disallows saves higher than 256, which i dont think any game does, but what happened was using the 32 uint max value, which this isnt valid and shouldnt even be checked