### PR TITLE
Add Flatpak equivalent of `/usr/share` to asset paths for potential future Flatpak builds

### DIFF
--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -358,6 +358,7 @@ void init_paths(Root &root_paths) {
         const constexpr char *static_asset_paths[] = {
             "/usr/local/share/Vita3K",
             "/usr/share/Vita3K",
+            "/app/share/Vita3K",
         };
 
         // Check both normal case and all lowercase paths


### PR DESCRIPTION
This will support #1418. Using the regular cmake build+install process in a Flatpak bundle will get all the static assets deployed to the Flatpak sandbox's `/app/share/Vita3K` directory so a Flatpak-built vita3k currently cannot find e.g. the builtin shader files.