### PR TITLE
build: Increase macOS deployment target to 13.3

### DIFF
--- a/.ci/setup-macos.sh
+++ b/.ci/setup-macos.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
 brew install ccache create-dmg
 echo "$(brew --prefix ccache)/libexec" >> "$GITHUB_PATH"
 ccache --set-config=compiler_check=content

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include("external/dynarmic/CMakeModules/DetectArchitecture.cmake")
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 13.3)
 
 # workaround for SDL due to cmake bug
 # https://github.com/libsdl-org/SDL/issues/6454


### PR DESCRIPTION
- Increase [macOS deployment target](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html) (minimum required version) from 11.0 to 13.3.
- Due to [weak linking](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WeakLinking.html), `std::to_chars` for floating-point types, used in `std::format("{:x}", /* floating-point */)` in Vulkan-Headers, requires a minimum version of 13.3 (just like [this comment](https://github.com/Vita3K/Vita3K/pull/3655#issuecomment-3234315053)); #3661 bypassed this requirement by setting the Xcode app version to 16.2, but as [GitHub updated the runner](https://github.com/actions/runner-images/issues/14167), Xcode 16.2 is no longer available on `macos-latest`.