### PR TITLE
vita3k: add vci support

### DIFF
--- a/i18n/qt/vita3k_en.ts
+++ b/i18n/qt/vita3k_en.ts
@@ -446,7 +446,7 @@ This action cannot be undone.</source>
     </message>
     <message>
         <location filename="../../vita3k/gui-qt/src/archive_install_dialog.cpp" line="126"/>
-        <source>Select a file (.zip / .vpk)...</source>
+        <source>Select a file (.zip / .vpk / .vci)...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -466,7 +466,7 @@ This action cannot be undone.</source>
     </message>
     <message>
         <location filename="../../vita3k/gui-qt/src/archive_install_dialog.cpp" line="156"/>
-        <source>PlayStation Vita commercial software package (NoNpDrm/FAGDec) / PlayStation Vita homebrew software package (*zip, *.vpk);;PlayStation Vita commercial software package (NoNpDrm/FAGDec) (*.zip);;PlayStation Vita homebrew software package (*.vpk)</source>
+  <source>PlayStation Vita commercial software package(NoNpDrm / FAGDec) / PlayStation Vita homebrew software package(* zip, *.vpk, *.vci);;PlayStation Vita commercial software package(NoNpDrm / FAGDec)(*.zip);;PlayStation Vita homebrew software package(*.vpk);;Vita Cartridge Image(VCI) File(*.vci)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -481,7 +481,7 @@ This action cannot be undone.</source>
     </message>
     <message>
         <location filename="../../vita3k/gui-qt/src/archive_install_dialog.cpp" line="171"/>
-        <source>The selected directory contains no .zip or .vpk files.</source>
+        <source>The selected directory contains no .zip, .vpk, or .vci files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1343,7 +1343,7 @@ The key may be invalid.</source>
     </message>
     <message>
         <location filename="../../vita3k/gui-qt/src/main_window.ui" line="209"/>
-        <source>Install Archive (.zip / .vpk)</source>
+        <source>Install Archive (.zip / .vpk / .vci)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/vita3k/gui-qt/src/archive_install_dialog.cpp
+++ b/vita3k/gui-qt/src/archive_install_dialog.cpp
@@ -47,7 +47,7 @@ std::vector<fs::path> archives_in_dir(const fs::path &dir) {
         if (!entry.is_regular_file())
             continue;
         const auto ext = string_utils::tolower(entry.path().extension().string());
-        if (ext == ".zip" || ext == ".vpk")
+        if (ext == ".zip" || ext == ".vpk" || ext == ".vci")
             result.push_back(entry.path());
     }
     return result;
@@ -201,7 +201,7 @@ std::vector<fs::path> ArchiveInstallDialog::pick_archives() {
     auto *layout = new QVBoxLayout(&type_picker);
     layout->addWidget(new QLabel(tr("What would you like to install?"), &type_picker));
 
-    auto *btn_file = new QPushButton(tr("Select a file (.zip / .vpk)..."), &type_picker);
+    auto *btn_file = new QPushButton(tr("Select a file (.zip / .vpk / .vci)..."), &type_picker);
     auto *btn_dir = new QPushButton(tr("Select a directory (installs all archives inside)..."), &type_picker);
     auto *btn_cancel = new QPushButton(tr("Cancel"), &type_picker);
     layout->addWidget(btn_file);
@@ -231,7 +231,7 @@ std::vector<fs::path> ArchiveInstallDialog::pick_archives() {
             this,
             tr("Select Archive"),
             QString(),
-            tr("PlayStation Vita commercial software package (NoNpDrm/FAGDec) / PlayStation Vita homebrew software package (*.zip *.vpk);;PlayStation Vita commercial software package (NoNpDrm/FAGDec) (*.zip);;PlayStation Vita homebrew software package (*.vpk)"));
+            tr("PlayStation Vita commercial software package (NoNpDrm/FAGDec) / PlayStation Vita homebrew software package (*.zip *.vpk *.vci);;PlayStation Vita commercial software package (NoNpDrm/FAGDec) (*.zip);;PlayStation Vita homebrew software package (*.vpk);;Vita Cartridge Image (VCI) File (*.vci)"));
         if (path.isEmpty())
             return {};
         return { gui::utils::to_fs_path(path) };
@@ -246,7 +246,7 @@ std::vector<fs::path> ArchiveInstallDialog::pick_archives() {
     auto archives = archives_in_dir(gui::utils::to_fs_path(dir));
     if (archives.empty()) {
         QMessageBox::information(this, tr("No Archives Found"),
-            tr("The selected directory contains no .zip or .vpk files."));
+            tr("The selected directory contains no .zip, .vpk, or .vci files."));
         return {};
     }
     return archives;

--- a/vita3k/gui-qt/src/main_window.ui
+++ b/vita3k/gui-qt/src/main_window.ui
@@ -213,7 +213,7 @@
   </action>
   <action name="install_zip_action">
    <property name="text">
-    <string>Install Archive (.zip / .vpk)</string>
+    <string>Install Archive (.zip / .vpk / .vci)</string>
    </property>
   </action>
   <action name="install_license_action">

--- a/vita3k/interface.cpp
+++ b/vita3k/interface.cpp
@@ -33,6 +33,7 @@
 #include <lang/state.h>
 #include <packages/pkg.h>
 #include <packages/sfo.h>
+#include <packages/vci.h>
 #include <renderer/state.h>
 #include <renderer/texture_cache.h>
 
@@ -277,6 +278,17 @@ static std::vector<std::string> get_archive_contents_path(const ZipPtr &zip) {
 }
 
 std::vector<ContentInfo> install_archive(EmuEnvState &emuenv, const fs::path &archive_path, const std::function<void(ArchiveContents)> &progress_callback, const ReinstallCallback &reinstall_callback) {
+    if (string_utils::tolower(archive_path.extension().string()) == ".vci") {
+        const auto vci_progress = [&](float pct) {
+            if (progress_callback)
+                progress_callback({ 1.f, 1.f, pct });
+        };
+        const bool state = install_vci(archive_path, emuenv, vci_progress);
+        std::vector<ContentInfo> content_installed{};
+        content_installed.push_back({ emuenv.app_info.app_title, emuenv.app_info.app_title_id, emuenv.app_info.app_category, emuenv.app_info.app_content_id, archive_path.string(), state });
+        return content_installed;
+    }
+
     FILE *vpk_fp = FOPEN(archive_path.c_str(), "rb");
     if (!vpk_fp) {
         LOG_CRITICAL("Failed to load archive file in path: {}", fs_utils::path_to_utf8(archive_path));

--- a/vita3k/packages/CMakeLists.txt
+++ b/vita3k/packages/CMakeLists.txt
@@ -5,12 +5,14 @@ add_library(packages STATIC
             src/pup.cpp
             src/sce_utils.cpp
             src/sfo.cpp
+            src/vci.cpp
             include/packages/exfat.h
             include/packages/license.h
             include/packages/functions.h
             include/packages/pkg.h
             include/packages/sce_types.h
             include/packages/sfo.h
+            include/packages/vci.h
 )
 target_include_directories(packages PUBLIC include)
 target_link_libraries(packages PUBLIC emuenv util)

--- a/vita3k/packages/include/packages/pkg.h
+++ b/vita3k/packages/include/packages/pkg.h
@@ -83,4 +83,4 @@ struct PkgEntry {
 
 bool install_pkg(const fs::path &pkg_path, EmuEnvState &emuenv, std::string &p_zRIF, const std::function<void(float)> &progress_callback = nullptr);
 std::string find_pkg_zrif(const fs::path &pkg_path, const fs::path &vita_fs_path);
-bool decrypt_install_nonpdrm(EmuEnvState &emuenv, const fs::path &drmlicpath, const fs::path &title_path);
+bool decrypt_install_nonpdrm(EmuEnvState &emuenv, const fs::path &drmlicpath, const fs::path &title_path, const std::function<void(float)> &progress_callback = nullptr);

--- a/vita3k/packages/include/packages/vci.h
+++ b/vita3k/packages/include/packages/vci.h
@@ -1,0 +1,98 @@
+// Vita3K emulator project
+// Copyright (C) 2026 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Credits to oestriot https://github.com/oestriot/VCI-TOOLS
+
+#pragma once
+
+#include <emuenv/state.h>
+#include <packages/license.h>
+
+#include <cstdint>
+#include <functional>
+
+constexpr uint32_t VCI_HEADER_SIZE = 0x200;
+constexpr uint16_t VCI_MAJOR_VER = 1;
+constexpr uint32_t SECTOR_SIZE = 0x200;
+static const char VCI_MAGIC[4] = { 'V', 'C', 'I', '\0' };
+static const char SCE_MBR_MAGIC[] = "Sony Computer Entertainment Inc.";
+
+const uint8_t BIND_KEY[0x10] = { 0x90, 0x1a, 0x84, 0xfb, 0x13, 0xa7, 0x44, 0xa3, 0x78, 0xc5, 0x01, 0x8a, 0x60, 0xf5, 0x8c, 0x22 };
+
+#pragma pack(push, 1)
+// CMD56 per-cartridge keys. sha256(GcCmd56Keys) == cart_secret — used to unwrap klicensee from the RIF.
+struct GcCmd56Keys {
+    uint8_t packet20_key[0x20];
+    uint8_t packet18_key[0x20];
+};
+static_assert(sizeof(GcCmd56Keys) == 0x40);
+
+struct VciHeader {
+    char magic[0x4]; // "VCI\0"
+    uint16_t major_version;
+    uint16_t minor_version;
+    uint64_t device_size; // physical card size in bytes (NOT the MBR-used size)
+    GcCmd56Keys keys; // 0x10
+    uint8_t padding[0x1B0]; // -> 0x200
+};
+static_assert(sizeof(VciHeader) == VCI_HEADER_SIZE);
+
+// SceMBR partition table. Block size is 0x200.
+enum ScePartitionCode : uint8_t {
+    ScePartitionCode_GRO0 = 0x9, // Game Card read-only
+    ScePartitionCode_GRW0 = 0xA, // Game Card read-write
+};
+
+enum ScePartitionType : uint8_t {
+    ScePartitionType_FAT16 = 0x6,
+    ScePartitionType_EXFAT = 0x7,
+    ScePartitionType_RAW = 0xDA,
+};
+
+struct ScePartition {
+    uint32_t offset; // in blocks (0x200)
+    uint32_t size; // in blocks (0x200)
+    uint8_t code;
+    uint8_t type;
+    uint8_t active;
+    uint32_t flags;
+    uint16_t unk;
+};
+static_assert(sizeof(ScePartition) == 0x11); // 17 bytes
+
+struct SceMbr {
+    char magic[0x20]; // "Sony Computer Entertainment Inc."
+    uint32_t version; // 0x3
+    uint32_t device_size; // in blocks
+    uint8_t unk1[0x28];
+    ScePartition partitions[0x10]; // 0x50 .. 0x160
+    uint8_t reserved[0x9E];
+    uint16_t boot_signature; // 0xAA55
+};
+static_assert(sizeof(SceMbr) == 0x200);
+
+struct VciBindData { // 0x90
+    uint8_t cart_secret[0x20];
+    uint8_t license[0x70];
+};
+static_assert(sizeof(VciBindData) == 0x90);
+#pragma pack(pop)
+
+// The on-card RIF and the NoNpDrm work.bin both use SceNpDrmLicense (license.h),
+static_assert(sizeof(SceNpDrmLicense) == 0x200);
+
+bool install_vci(const fs::path &vci_path, EmuEnvState &emuenv, const std::function<void(float)> &progress_callback = nullptr);

--- a/vita3k/packages/src/exfat.cpp
+++ b/vita3k/packages/src/exfat.cpp
@@ -54,8 +54,9 @@ static uint64_t get_cluster_offset(const ExFATSuperBlock &super_block, uint32_t 
     const uint64_t sectors_per_cluster = 1ULL << super_block.spc_bits;
     const uint64_t cluster_size = sector_size * sectors_per_cluster;
 
-    // The cluster number is 0-based, so we need to add 1
-    return (static_cast<uint64_t>(cluster) + 1) * cluster_size;
+    // exFAT data clusters are numbered from 2, and the cluster heap begins
+    // cluster_sector_start sectors into the volume.
+    return static_cast<uint64_t>(super_block.cluster_sector_start) * sector_size + (static_cast<uint64_t>(cluster) - 2) * cluster_size;
 }
 
 static void traverse_directory(fs::ifstream &img, const uint64_t img_size, std::vector<std::streampos> &offset_stack, const ExFATSuperBlock &super_block,

--- a/vita3k/packages/src/pkg.cpp
+++ b/vita3k/packages/src/pkg.cpp
@@ -50,13 +50,13 @@ static void ctr_init(uint8_t *counter, uint8_t *iv, uint64_t n) {
     }
 }
 
-static int execute(std::string &zrif, fs::path &title_src, fs::path &title_dst, F00DEncryptorTypes type, std::string &f00d_arg) {
+static int execute(std::string &zrif, fs::path &title_src, fs::path &title_dst, F00DEncryptorTypes type, std::string &f00d_arg, PfsProgressCallback progress = nullptr) {
     std::string title_src_str = title_src.string();
     std::string title_dst_str = title_dst.string();
-    return execute(zrif, title_src_str, title_dst_str, type, f00d_arg);
+    return execute(zrif, title_src_str, title_dst_str, type, f00d_arg, progress);
 }
 
-bool decrypt_install_nonpdrm(EmuEnvState &emuenv, const fs::path &drmlicpath, const fs::path &title_path) {
+bool decrypt_install_nonpdrm(EmuEnvState &emuenv, const fs::path &drmlicpath, const fs::path &title_path, const std::function<void(float)> &progress_callback) {
     fs::path title_id_src = title_path;
     fs::path title_id_dst = fs_utils::path_concat(title_path, "_dec");
     fs::ifstream binfile(drmlicpath, std::ios::in | std::ios::binary | std::ios::ate);
@@ -64,7 +64,14 @@ bool decrypt_install_nonpdrm(EmuEnvState &emuenv, const fs::path &drmlicpath, co
     F00DEncryptorTypes f00d_enc_type = F00DEncryptorTypes::native;
     std::string f00d_arg = std::string();
 
-    if ((execute(zRIF, title_id_src, title_id_dst, f00d_enc_type, f00d_arg) < 0) && (title_path.string().find("theme") == std::string::npos))
+    PfsProgressCallback pfs_progress = nullptr;
+    if (progress_callback) {
+        pfs_progress = [&progress_callback](std::uint64_t processed, std::uint64_t total, const std::string &) {
+            progress_callback(total ? static_cast<float>(processed) / static_cast<float>(total) : 1.f);
+        };
+    }
+
+    if ((execute(zRIF, title_id_src, title_id_dst, f00d_enc_type, f00d_arg, pfs_progress) < 0) && (title_path.string().find("theme") == std::string::npos))
         return false;
 
     if (!emuenv.app_info.app_category.contains("gp"))

--- a/vita3k/packages/src/vci.cpp
+++ b/vita3k/packages/src/vci.cpp
@@ -1,0 +1,286 @@
+// Vita3K emulator project
+// Copyright (C) 2026 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+/**
+ * @file vci.cpp
+ * @brief GcToolKit Vita Cartridge Image (`.vci`) handling
+ *
+ * Reference implementation: https://github.com/oestriot/VCI-TOOLS
+ * (gc2nonpdrm.c + lib/gcauthmgr.c + lib/npdrm.c). Pipeline:
+ *   VCI header -> cart_secret = SHA256(CMD56 keys) -> parse SceMBR ->
+ *   extract gro0 (exFAT) -> read on-card RIF -> derive klicensee ->
+ *   write a NoNpDrm work.bin -> reuse decrypt_install_nonpdrm() for the PFS.
+ */
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+
+#include <config/state.h>
+#include <emuenv/state.h>
+#include <io/functions.h>
+
+#include <packages/exfat.h>
+#include <packages/functions.h>
+#include <packages/license.h>
+#include <packages/pkg.h>
+#include <packages/sfo.h>
+#include <packages/vci.h>
+
+#include <util/bytes.h>
+#include <util/fs.h>
+#include <util/log.h>
+
+#include <cstring>
+#include <vector>
+
+// cart_secret = SHA256(packet20_key || packet18_key)  (0x40 -> 0x20)
+static void get_cart_secret(const GcCmd56Keys &keys, uint8_t out[0x20]) {
+    unsigned int len = 0;
+    EVP_Digest(&keys, sizeof(keys), out, &len, EVP_sha256(), nullptr);
+}
+
+static bool decrypt_klicensee(const uint8_t cart_secret[0x20], const SceNpDrmLicense &license, uint8_t klicensee[0x10]) {
+    VciBindData bind{};
+    memcpy(bind.cart_secret, cart_secret, sizeof(bind.cart_secret));
+    memcpy(bind.license, &license, sizeof(bind.license));
+
+    uint8_t bind_hmac[0x20] = {};
+    unsigned int hlen = 0;
+    if (!HMAC(EVP_sha256(), BIND_KEY, sizeof(BIND_KEY),
+            reinterpret_cast<const uint8_t *>(&bind), sizeof(bind), bind_hmac, &hlen)
+        || hlen != sizeof(bind_hmac))
+        return false;
+
+    const uint8_t *aes_key = bind_hmac;
+    const uint8_t *aes_iv = bind_hmac + 0x10;
+
+    uint8_t buf[0x20];
+    memcpy(buf, &license.key2, sizeof(buf));
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx)
+        return false;
+    int outl = 0;
+    bool ok = EVP_DecryptInit_ex(ctx, EVP_aes_128_cbc(), nullptr, aes_key, aes_iv) == 1;
+    if (ok) {
+        EVP_CIPHER_CTX_set_padding(ctx, 0);
+        ok = EVP_DecryptUpdate(ctx, buf, &outl, buf, sizeof(buf)) == 1;
+    }
+    EVP_CIPHER_CTX_free(ctx);
+    if (!ok || outl != sizeof(buf))
+        return false;
+
+    memcpy(klicensee, buf, 0x10); // klicensee is the first 16 bytes
+    return true;
+}
+
+// Locate the gro0 (exFAT) partition in the raw card image (byte offsets).
+static bool find_gro0(const SceMbr &mbr, uint64_t &offset, uint64_t &size) {
+    if (memcmp(mbr.magic, SCE_MBR_MAGIC, sizeof(mbr.magic)) != 0) {
+        LOG_ERROR("VCI image does not contain a valid SceMBR");
+        return false;
+    }
+    for (const auto &p : mbr.partitions) {
+        if (p.offset == 0 && p.size == 0)
+            break; // end of table
+        if (p.code == ScePartitionCode_GRO0 && p.type == ScePartitionType_EXFAT) {
+            offset = static_cast<uint64_t>(p.offset) * SECTOR_SIZE;
+            size = static_cast<uint64_t>(p.size) * SECTOR_SIZE;
+            return true;
+        }
+    }
+    LOG_ERROR("VCI: no gro0/exFAT partition found in partition table");
+    return false;
+}
+
+// Build a NoNpDrm work.bin from the on-card RIF + derived klicensee.
+static void write_nonpdrm_license(const SceNpDrmLicense &old_license, const uint8_t klicensee[0x10], const fs::path &work_bin_path) {
+    SceNpDrmLicense lic{};
+    lic.aid = 0x0123456789ABCDEFLL;
+    lic.version = byte_swap<uint16_t>(1);
+    lic.version_flag = byte_swap<uint16_t>(1);
+    lic.type = byte_swap<uint16_t>(1);
+    const uint16_t lf_host = byte_swap<uint16_t>(old_license.flags);
+    lic.flags = byte_swap<uint16_t>(static_cast<uint16_t>(lf_host & ~0x400u));
+    lic.flags2 = old_license.flags2;
+    const uint32_t sku = byte_swap<uint32_t>(static_cast<uint32_t>(old_license.sku_flag));
+    lic.sku_flag = static_cast<int32_t>(byte_swap<uint32_t>((sku == 1 || sku == 3) ? 3u : 0u));
+    memcpy(lic.content_id, old_license.content_id, sizeof(lic.content_id));
+    memcpy(lic.key, klicensee, sizeof(lic.key));
+
+    fs::create_directories(work_bin_path.parent_path());
+    fs::ofstream out(work_bin_path, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(&lic), sizeof(lic));
+}
+
+bool install_vci(const fs::path &vci_path, EmuEnvState &emuenv, const std::function<void(float)> &progress_callback) {
+    const auto progress = [&](float v) { if (progress_callback) progress_callback(v); };
+
+    // 1) Open the .vci image
+    fs::ifstream img(vci_path, std::ios::binary);
+    if (!img) {
+        LOG_CRITICAL("Failed to open VCI file: {}", fs_utils::path_to_utf8(vci_path));
+        return false;
+    }
+    progress(0);
+    LOG_INFO("Installing VCI: {}", fs_utils::path_to_utf8(vci_path));
+
+    // 2) Header: validate magic/version and derive cart_secret from the CMD56 keys
+    VciHeader hdr{};
+    img.read(reinterpret_cast<char *>(&hdr), sizeof(hdr));
+    if (memcmp(hdr.magic, VCI_MAGIC, sizeof(hdr.magic)) != 0 || hdr.major_version != VCI_MAJOR_VER) {
+        LOG_ERROR("Not a valid VCI file (bad magic/version)");
+        return false;
+    }
+    LOG_INFO("VCI header: version {}.{}, device size 0x{:X} bytes", hdr.major_version, hdr.minor_version, hdr.device_size);
+    uint8_t cart_secret[0x20];
+    get_cart_secret(hdr.keys, cart_secret);
+    LOG_INFO("Derived cart_secret from CMD56 keys");
+
+    // 3) SceMBR: locate the gro0 (exFAT) partition in the raw card image
+    SceMbr mbr{};
+    img.read(reinterpret_cast<char *>(&mbr), sizeof(mbr));
+    uint64_t gro_off = 0, gro_size = 0;
+    if (!find_gro0(mbr, gro_off, gro_size))
+        return false;
+    LOG_INFO("Found gro0 (exFAT) partition: card offset 0x{:X}, size 0x{:X} bytes ({} MiB)", gro_off, gro_size, gro_size >> 20);
+
+    // 4) Carve gro0 out into a standalone exFAT image (long step: 0..30%)
+    const auto staging = emuenv.cache_path / "VCI_TMP";
+    fs::remove_all(staging);
+    fs::create_directories(staging);
+    const auto gro_img = staging / "gro0.img"; // substr(0,3) -> "gro" output dir
+    {
+        fs::ofstream o(gro_img, std::ios::binary);
+        img.seekg(VCI_HEADER_SIZE + gro_off, std::ios::beg);
+        std::vector<char> buf(1 << 20);
+        uint64_t copied = 0;
+        while (copied < gro_size) {
+            const auto n = static_cast<std::streamsize>(std::min<uint64_t>(gro_size - copied, buf.size()));
+            img.read(buf.data(), n);
+            o.write(buf.data(), n);
+            copied += n;
+            progress(copied / static_cast<float>(gro_size) * 30.f);
+        }
+    }
+    LOG_INFO("Carved gro0 image: {} ({} bytes)", fs_utils::path_to_utf8(gro_img), gro_size);
+
+    // 5) Extract the exFAT tree (gives /app/<tid> + /license/app/<tid>/*.rif)
+    exfat::extract_exfat(staging, "gro0.img", staging);
+    const auto gro_root = staging / "gro"; // exfat::extract_exfat output root
+    if (fs::is_directory(gro_root)) {
+        std::string entries;
+        for (const auto &e : fs::directory_iterator(gro_root))
+            entries += (entries.empty() ? "" : ", ") + e.path().filename().string() + (e.is_directory() ? "/" : "");
+        LOG_INFO("Extracted gro0 root entries: [{}]", entries);
+    } else {
+        LOG_ERROR("VCI: exFAT extraction produced no output at {}", fs_utils::path_to_utf8(gro_root));
+    }
+    progress(40);
+
+    // 6) Resolve the title id from the extracted /app folder
+    std::string title_id;
+    const auto app_root = gro_root / "app";
+    if (fs::is_directory(app_root)) {
+        for (const auto &e : fs::directory_iterator(app_root)) {
+            if (e.is_directory()) {
+                title_id = e.path().filename().string();
+                break;
+            }
+        }
+    } else {
+        LOG_ERROR("VCI: expected app folder not found at {}", fs_utils::path_to_utf8(app_root));
+    }
+    if (title_id.empty()) {
+        LOG_ERROR("VCI: failed to determine title id from gro0:/app");
+        return false;
+    }
+    LOG_INFO("VCI title id: {}", title_id);
+    const auto title_src = app_root / title_id;
+
+    // 7) Load param.sfo to fill app_info (mirrors install_pkg)
+    const auto param_sfo = title_src / "sce_sys" / "param.sfo";
+    if (!fs::exists(param_sfo)) {
+        LOG_ERROR("VCI: param.sfo not found at {}", fs_utils::path_to_utf8(param_sfo));
+        return false;
+    }
+    vfs::FileBuffer param;
+    fs_utils::read_data(param_sfo, param);
+    sfo::get_param_info(emuenv.app_info, param, emuenv.cfg.sys_lang);
+    LOG_INFO("Found {} [{}], category: {}, content id: {}", emuenv.app_info.app_title, emuenv.app_info.app_title_id, emuenv.app_info.app_category, emuenv.app_info.app_content_id);
+
+    // 8) Choose the ux0 destination (a cart image is always a full app)
+    auto path{ emuenv.vita_fs_path / "ux0" };
+    path /= fs::path("app") / emuenv.app_info.app_title_id;
+    if (fs::exists(path))
+        fs::remove_all(path);
+    emuenv.app_info.app_title += " (App)";
+
+    // 9) Read the on-card RIF: gro0:/license/app/<title_id>/<*.rif>
+    SceNpDrmLicense card_license{};
+    bool have_license = false;
+    const auto lic_dir = gro_root / "license" / "app" / title_id;
+    if (fs::is_directory(lic_dir)) {
+        for (const auto &e : fs::directory_iterator(lic_dir)) {
+            if (e.is_regular_file()) {
+                fs::ifstream lf(e.path(), std::ios::binary);
+                lf.read(reinterpret_cast<char *>(&card_license), sizeof(card_license));
+                have_license = lf.gcount() == sizeof(card_license);
+                if (have_license)
+                    LOG_INFO("Found license file: {}", fs_utils::path_to_utf8(e.path()));
+                break;
+            }
+        }
+    }
+    if (!have_license) {
+        LOG_ERROR("VCI: failed to read on-card RIF for {} (looked in {})", title_id, fs_utils::path_to_utf8(lic_dir));
+        return false;
+    }
+
+    // 10) Derive klicensee and synthesize a NoNpDrm work.bin in the staged app
+    uint8_t klicensee[0x10];
+    if (!decrypt_klicensee(cart_secret, card_license, klicensee)) {
+        LOG_ERROR("VCI: failed to derive klicensee");
+        return false;
+    }
+    write_nonpdrm_license(card_license, klicensee, title_src / "sce_sys" / "package" / "work.bin");
+    progress(50);
+
+    // 11) Copy the staged app into ux0 (copy, not rename, so it works across volumes)
+    fs::create_directories(path);
+    if (!fs_utils::copy_directory_contents(title_src, path)) {
+        LOG_ERROR("VCI: failed to copy app into {}", fs_utils::path_to_utf8(path));
+        fs::remove_all(staging);
+        return false;
+    }
+    progress(60);
+
+    // 12) PFS stage: decrypt in place + install the license (shared NoNpDrm tail)
+    const fs::path drmlicpath = path / "sce_sys" / "package" / "work.bin";
+    const auto decrypt_progress = [&](float frac) { progress(60.f + frac * 40.f); };
+    if (!decrypt_install_nonpdrm(emuenv, drmlicpath, path, decrypt_progress)) {
+        LOG_ERROR("VCI: failed to decrypt {} [{}]", emuenv.app_info.app_title, emuenv.app_info.app_title_id);
+        fs::remove_all(path);
+        fs::remove_all(staging);
+        return false;
+    }
+
+    fs::remove_all(staging);
+    progress(100);
+    LOG_INFO("{} [{}] installed successfully!", emuenv.app_info.app_title, emuenv.app_info.app_title_id);
+    return true;
+}


### PR DESCRIPTION
Support has been added for the VCI format, which is suitable for storing Vita game cards and decrypting them.
nonpdrm is not a backup of a game card (a nonpdrm dump cannot be used to accurately restore a game card).
For now, limited to gro0.
I wrote the code from scratch up to the creation of `klicense` and am reusing `decrypt_install_nonpdrm`.
Closes: #3518 