### PR TITLE
codec: Handle invalid Atrac9 config

### DIFF
--- a/vita3k/codec/CMakeLists.txt
+++ b/vita3k/codec/CMakeLists.txt
@@ -15,3 +15,14 @@ add_library(
 
 target_include_directories(codec PUBLIC include)
 target_link_libraries(codec PRIVATE ffmpeg libatrac9 util) 
+
+if(NOT ANDROID)
+	add_executable(
+		codec-tests
+		tests/atrac9_tests.cpp
+	)
+
+	target_include_directories(codec-tests PRIVATE include)
+	target_link_libraries(codec-tests PRIVATE codec googletest util)
+	add_test(NAME codec COMMAND codec-tests)
+endif()

--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -156,16 +156,18 @@ struct Atrac9DecoderSavedState {
 };
 
 struct Atrac9DecoderState : public DecoderState {
-    uint32_t config_data;
-    void *decoder_handle;
-    void *atrac9_info;
-    uint32_t es_size_used;
+    uint32_t config_data = 0;
+    void *decoder_handle = nullptr;
+    void *atrac9_info = nullptr;
+    uint32_t es_size_used = 0;
     std::vector<uint8_t> result;
-    int superframe_frame_idx;
-    int superframe_data_left;
+    int superframe_frame_idx = 0;
+    int superframe_data_left = 0;
+    bool initialized = false;
 
     uint32_t get(DecoderQuery query) override;
     uint32_t get_es_size() override;
+    bool is_initialized() const;
 
     bool send(const uint8_t *data, uint32_t size = 0) override;
     bool receive(uint8_t *data, DecoderSize *size) override;

--- a/vita3k/codec/src/atrac9.cpp
+++ b/vita3k/codec/src/atrac9.cpp
@@ -39,11 +39,22 @@ struct FFMPEGAtrac9Info {
 
 uint32_t Atrac9DecoderState::get(DecoderQuery query) {
     Atrac9CodecInfo *info = static_cast<Atrac9CodecInfo *>(atrac9_info);
+    if (!info) {
+        return 0;
+    }
 
     switch (query) {
     case DecoderQuery::CHANNELS: return info->channels;
     // The bit rate is the size of a superframe times the number of superframes per second (times 8)
-    case DecoderQuery::BIT_RATE: return static_cast<uint32_t>((info->superframeSize * 8ULL * info->samplingRate) / (info->frameSamples * info->framesInSuperframe));
+    case DecoderQuery::BIT_RATE: {
+        const int samples_per_superframe = info->frameSamples * info->framesInSuperframe;
+        if (samples_per_superframe <= 0) {
+            LOG_ERROR("Invalid Atrac9 codec info when querying bitrate.");
+            return 0;
+        }
+
+        return static_cast<uint32_t>((info->superframeSize * 8ULL * info->samplingRate) / samples_per_superframe);
+    }
     case DecoderQuery::SAMPLE_RATE: return info->samplingRate;
     case DecoderQuery::AT9_SAMPLE_PER_FRAME: return info->frameSamples;
     case DecoderQuery::AT9_SAMPLE_PER_SUPERFRAME: return info->frameSamples * info->framesInSuperframe;
@@ -57,7 +68,15 @@ uint32_t Atrac9DecoderState::get_es_size() {
     return es_size_used;
 }
 
+bool Atrac9DecoderState::is_initialized() const {
+    return initialized;
+}
+
 void Atrac9DecoderState::flush() {
+    if (!initialized) {
+        return;
+    }
+
     Atrac9CodecInfo *info = static_cast<Atrac9CodecInfo *>(atrac9_info);
     superframe_frame_idx = 0;
     superframe_data_left = info->superframeSize;
@@ -71,6 +90,10 @@ void Atrac9DecoderState::flush() {
 }
 
 void Atrac9DecoderState::export_state(Atrac9DecoderSavedState *dest) {
+    if (!initialized) {
+        return;
+    }
+
     Frame &frame = static_cast<Atrac9Handle *>(decoder_handle)->Frame;
     if (frame.Channels[0])
         std::copy_n(frame.Channels[0]->Mdct.ImdctPrevious, 256, dest->prev_values[0]);
@@ -79,6 +102,10 @@ void Atrac9DecoderState::export_state(Atrac9DecoderSavedState *dest) {
 }
 
 void Atrac9DecoderState::load_state(const Atrac9DecoderSavedState *src) {
+    if (!initialized) {
+        return;
+    }
+
     Frame &frame = static_cast<Atrac9Handle *>(decoder_handle)->Frame;
     if (frame.Channels[0])
         std::copy_n(src->prev_values[0], 256, frame.Channels[0]->Mdct.ImdctPrevious);
@@ -87,6 +114,10 @@ void Atrac9DecoderState::load_state(const Atrac9DecoderSavedState *src) {
 }
 
 bool Atrac9DecoderState::send(const uint8_t *data, uint32_t size) {
+    if (!initialized) {
+        return false;
+    }
+
     Atrac9CodecInfo *info = static_cast<Atrac9CodecInfo *>(atrac9_info);
 
     int decode_used = 0;
@@ -111,6 +142,10 @@ bool Atrac9DecoderState::send(const uint8_t *data, uint32_t size) {
 }
 
 bool Atrac9DecoderState::receive(uint8_t *data, DecoderSize *size) {
+    if (!initialized) {
+        return false;
+    }
+
     Atrac9CodecInfo *info = static_cast<Atrac9CodecInfo *>(atrac9_info);
 
     if (data) {
@@ -125,26 +160,35 @@ bool Atrac9DecoderState::receive(uint8_t *data, DecoderSize *size) {
 }
 
 Atrac9DecoderState::Atrac9DecoderState(uint32_t config_data)
-    : config_data(config_data) {
-    decoder_handle = Atrac9GetHandle();
+    : config_data(config_data)
+    , decoder_handle(Atrac9GetHandle())
+    , atrac9_info(new Atrac9CodecInfo{}) {
     const int err = Atrac9InitDecoder(decoder_handle, reinterpret_cast<uint8_t *>(&config_data));
 
     if (err != At9Status::ERR_SUCCESS) {
         LOG_ERROR("Error initializing decoder. Error code: {}", log_hex(err));
+        return;
     }
 
-    Atrac9CodecInfo *info = new Atrac9CodecInfo;
-    atrac9_info = info;
+    Atrac9CodecInfo *info = static_cast<Atrac9CodecInfo *>(atrac9_info);
     Atrac9GetCodecInfo(decoder_handle, info);
+    if (info->frameSamples <= 0 || info->framesInSuperframe <= 0 || info->channels <= 0
+        || info->superframeSize <= 0 || info->samplingRate <= 0) {
+        LOG_ERROR("Invalid Atrac9 codec info.");
+        return;
+    }
 
     result.resize(info->frameSamples * info->channels * sizeof(uint16_t));
 
     superframe_frame_idx = 0;
     superframe_data_left = info->superframeSize;
+    initialized = true;
 }
 
 Atrac9DecoderState::~Atrac9DecoderState() {
-    Atrac9ReleaseHandle(decoder_handle);
+    if (decoder_handle) {
+        Atrac9ReleaseHandle(decoder_handle);
+    }
     delete static_cast<Atrac9CodecInfo *>(atrac9_info);
     context = nullptr;
 }

--- a/vita3k/codec/tests/atrac9_tests.cpp
+++ b/vita3k/codec/tests/atrac9_tests.cpp
@@ -1,0 +1,27 @@
+// Vita3K emulator project
+// Copyright (C) 2026 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <codec/state.h>
+
+#include <gtest/gtest.h>
+
+TEST(atrac9_decoder, invalid_config_does_not_crash_bitrate_query) {
+    Atrac9DecoderState decoder(0);
+
+    EXPECT_FALSE(decoder.is_initialized());
+    EXPECT_EQ(decoder.get(DecoderQuery::BIT_RATE), 0);
+}

--- a/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
+++ b/vita3k/modules/SceAudiodec/SceAudiodecUser.cpp
@@ -30,6 +30,7 @@ enum {
     SCE_AUDIODEC_ERROR_NOT_INITIALIZED = 0x807F0005,
     SCE_AUDIODEC_ERROR_INVALID_HANDLE = 0x807F0009,
     SCE_AUDIODEC_ERROR_NOT_HANDLE_IN_USE = 0x807F000A,
+    SCE_AUDIODEC_AT9_ERROR_INVALID_CONFIG = 0x807F2000,
     SCE_AUDIODEC_MP3_ERROR_INVALID_MPEG_VERSION = 0x807F2801,
 };
 
@@ -149,7 +150,13 @@ static int create_decoder(EmuEnvState &emuenv, SceAudiodecCtrl *ctrl, SceAudiode
     switch (codec) {
     case SCE_AUDIODEC_TYPE_AT9: {
         SceAudiodecInfoAt9 &info = ctrl->info.get(emuenv.mem)->at9;
-        DecoderPtr decoder = std::make_shared<Atrac9DecoderState>(info.config_data);
+        auto decoder = std::make_shared<Atrac9DecoderState>(info.config_data);
+        if (!decoder->is_initialized()) {
+            state->codecs[codec].erase(handle);
+            ctrl->handle = 0;
+            return SCE_AUDIODEC_AT9_ERROR_INVALID_CONFIG;
+        }
+
         state->decoders[handle] = decoder;
 
         info.channels = decoder->get(DecoderQuery::CHANNELS);


### PR DESCRIPTION
Fixes #3323.

## Summary

This fixes a crash when an Atrac9 decoder is created with invalid config data.

Previously, `Atrac9DecoderState` continued constructing the decoder even when `Atrac9InitDecoder` failed. After that, `Atrac9GetCodecInfo` could leave codec fields such as `frameSamples` or `framesInSuperframe` as zero.

Later, when `SceAudiodecUser` queried `DecoderQuery::BIT_RATE`, the bitrate calculation divided by `info->frameSamples * info->framesInSuperframe`. With invalid config data this could become zero and crash with a divide-by-zero.

The fix makes `Atrac9DecoderState` track whether initialization completed successfully. Invalid Atrac9 codec info is rejected before the decoder is registered, and `sceAudiodecCreateDecoder` now returns `SCE_AUDIODEC_AT9_ERROR_INVALID_CONFIG` instead of continuing with an invalid decoder state.

The bitrate query also guards against invalid codec info, so it will not divide by zero if queried on an uninitialized or invalid decoder.

## Tests

Added `codec-tests` with an Atrac9 regression test covering invalid config data.

The test verifies that:

- an Atrac9 decoder created with invalid config is not marked initialized
- querying `DecoderQuery::BIT_RATE` does not crash
- the invalid bitrate query returns `0`

Verified locally:

- `git diff --check`
- `cmake --build build/macos-ninja --config Debug --target codec-tests`
- `ctest --test-dir build/macos-ninja --build-config Debug -R codec --output-on-failure`

Result: `1/1 Test #1: codec Passed`