### PR TITLE
ci: Use default Xcode

### DIFF
--- a/.ci/setup-macos.sh
+++ b/.ci/setup-macos.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
 brew install ccache create-dmg
 echo "$(brew --prefix ccache)/libexec" >> "$GITHUB_PATH"
 ccache --set-config=compiler_check=content

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -60,14 +60,14 @@ jobs:
 
           - os: macos-intel
             platform: macos-x64
-            runs_on: macos-latest
+            runs_on: macos-26
             cmake_preset: ci-macos-x64
             cache_path: ~/Library/Caches/ccache
             qt_install_deps: 'false'
 
           - os: macos-arm64
             platform: macos-arm64
-            runs_on: macos-latest
+            runs_on: macos-26
             cmake_preset: ci-macos-arm64
             cache_path: ~/Library/Caches/ccache
             qt_install_deps: 'false'


### PR DESCRIPTION
- Pin runner label at `macos-26`.
- On `macos-26`, the default Xcode is 26.4.1.
- ~According to actions/runner-images#14167, `macos-latest` will completely use `macos-26` by July 15th 2026.~
- As an alternative solution of #4035.