### PR TITLE
shader: Fix one case of 'ids can't be 0'

### DIFF
--- a/vita3k/shader/src/spirv_recompiler.cpp
+++ b/vita3k/shader/src/spirv_recompiler.cpp
@@ -847,17 +847,17 @@ static void copy_uniform_block_to_register(spv::Builder &builder, spv::Id sa_ban
         } else {
             dest_friend = utils::create_access_chain(builder, spv::StorageClassPrivate, sa_bank, { builder.createBinOp(spv::OpIAdd, ite_type, ite_loaded, builder.makeIntConstant(start_in_vec4_granularity + 1)) });
 
-            std::vector<spv::Id> ops_copy_1 = { builder.createLoad(dest, spv::NoPrecision), to_copy };
-            std::vector<spv::Id> ops_copy_2 = { builder.createLoad(dest_friend, spv::NoPrecision), to_copy };
+            std::vector<spv::IdImmediate> ops_copy_1 = { { true, builder.createLoad(dest, spv::NoPrecision) }, { true, to_copy } };
+            std::vector<spv::IdImmediate> ops_copy_2 = { { true, builder.createLoad(dest_friend, spv::NoPrecision) }, { true, to_copy } };
 
             for (int i = 0; i < start % 4; i++) {
-                ops_copy_1.push_back(i);
-                ops_copy_2.push_back(4 + (4 - start % 4) + i);
+                ops_copy_1.push_back({ false, (unsigned)i });
+                ops_copy_2.push_back({ false, (unsigned)(4 + (4 - start % 4) + i) });
             }
 
             for (int i = 0; i < (4 - start % 4); i++) {
-                ops_copy_1.push_back(4 + i);
-                ops_copy_2.push_back((start % 4) + i);
+                ops_copy_1.push_back({ false, (unsigned)(4 + i) });
+                ops_copy_2.push_back({ false, (unsigned)((start % 4) + i) });
             }
 
             to_copy = builder.createOp(spv::OpVectorShuffle, builder.getTypeId(to_copy), ops_copy_1);


### PR DESCRIPTION
Commonly when debugging, I'll hit an assert from glslang, spvIR.h:106, that says "ids can't be 0". After backtracing the data provided by the presumably valid (since it's in a commercial game) but still problematic gxp shader, it became apparent that a literal component index of value '0' was being passed to the spv builder as if it were an ID, when it should have been emitted as an immediate operand.

The literal component index 0 also happens to correspond to spv::NoResult, which would cause the assert in addIdOperand. This probably went unchecked for so long due to people getting comfortable with "RelWithDebInfo" builds. Don't know what it does on release, though I assume it just continues to build the shader erroneously.

This fix changes the flat std::vector<spv::Id> type on ops_copy_1 and ops_copy_2 into an std::vector<spv::IdImmediate>. spv::IdImmediate should correctly distinguish between ID operands (source vectors) and literal immediate operands (component indicies), matching the expected OpVectorShuffle input.

I don't know what (if anything) this fixes other than malformed shaders being emitted, but is probably worth contributing nonetheless.

The shader causing the issues was shader 37e57f8a8fdf26bd910e90ec22d13a573bf8caad75abf93edf765a31fe2ed734.gxp from Gravity Rush, which seems to get processed pretty early on in the game booting/playing, so it should be able to be easily extracted for reproducing the error.