### PR TITLE
gxm/renderer: Copy deferred command lists before execution

### DIFF
--- a/vita3k/modules/SceGxm/SceGxm.cpp
+++ b/vita3k/modules/SceGxm/SceGxm.cpp
@@ -2655,17 +2655,8 @@ EXPORT(int, sceGxmExecuteCommandList, SceGxmContext *context, SceGxmCommandList 
     if (!commandList || !commandList->list)
         return RET_ERROR(SCE_GXM_ERROR_INVALID_POINTER);
 
-    // Emit a jump to the first command of given command list
-    // Since only one immediate context exists per process, direct linking like this should be fine! (I hope)
-    renderer::CommandList &imm_cmds = context->renderer->command_list;
-
-    if (imm_cmds.last) {
-        imm_cmds.last->next = commandList->list->first;
-        imm_cmds.last = commandList->list->last;
-    } else {
-        imm_cmds.first = commandList->list->first;
-        imm_cmds.last = commandList->list->last;
-    }
+    // Deferred VDM buffers may be reused before the render thread consumes them.
+    renderer::append_command_list(*context->renderer, *commandList->list);
 
     // Restore back our GXM state
     gxmContextStateRestore(*emuenv.renderer, context, true);

--- a/vita3k/renderer/CMakeLists.txt
+++ b/vita3k/renderer/CMakeLists.txt
@@ -79,3 +79,13 @@ endif()
 if(TRACY_ENABLE_ON_CORE_COMPONENTS)
 	target_link_libraries(renderer PRIVATE tracy)
 endif()
+
+if(NOT ANDROID)
+	add_executable(
+		renderer-tests
+		tests/command_list_tests.cpp
+	)
+
+	target_link_libraries(renderer-tests PRIVATE renderer googletest)
+	add_test(NAME renderer COMMAND renderer-tests)
+endif()

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -109,6 +109,7 @@ void destroy_render_target_during_shutdown(State &state, std::unique_ptr<RenderT
 
 Command *generic_command_allocate();
 void generic_command_free(Command *cmd);
+void append_command_list(Context &destination, const CommandList &source);
 void destroy_command_payload(Command &cmd);
 
 template <typename... Args>

--- a/vita3k/renderer/src/scene.cpp
+++ b/vita3k/renderer/src/scene.cpp
@@ -31,6 +31,8 @@
 #include <util/log.h>
 #include <util/tracy.h>
 
+#include <cstring>
+
 #define DEBUG_FRAMEBUFFER 1
 
 #if DEBUG_FRAMEBUFFER
@@ -39,13 +41,74 @@
 #endif
 
 namespace renderer {
+template <typename T>
+static T get_command_data(const Command &command, const std::size_t offset) {
+    T value;
+    std::memcpy(&value, command.data + offset, sizeof(value));
+    return value;
+}
+
+template <typename T>
+static void set_command_data(Command &command, const std::size_t offset, const T value) {
+    std::memcpy(command.data + offset, &value, sizeof(value));
+}
+
+static Command *copy_command(Context &destination, const Command &source) {
+    Command *copy = destination.alloc_func();
+    const auto allocation_flags = copy->flags;
+
+    copy->opcode = source.opcode;
+    copy->flags = allocation_flags;
+    std::memcpy(copy->data, source.data, sizeof(copy->data));
+    copy->status = source.status;
+    copy->next = nullptr;
+
+    if (source.opcode == CommandOpcode::SetContext) {
+        constexpr std::size_t color_offset = sizeof(RenderTarget *);
+        constexpr std::size_t depth_offset = color_offset + sizeof(SceGxmColorSurface *);
+        const auto *color_surface = get_command_data<SceGxmColorSurface *>(source, color_offset);
+        const auto *depth_stencil_surface = get_command_data<SceGxmDepthStencilSurface *>(source, depth_offset);
+        auto *color_surface_copy = color_surface ? new SceGxmColorSurface(*color_surface) : nullptr;
+        auto *depth_stencil_surface_copy = depth_stencil_surface ? new SceGxmDepthStencilSurface(*depth_stencil_surface) : nullptr;
+        set_command_data(*copy, color_offset, color_surface_copy);
+        set_command_data(*copy, depth_offset, depth_stencil_surface_copy);
+    }
+
+    return copy;
+}
+
+void append_command_list(Context &destination, const CommandList &source) {
+    Command *first_copy = nullptr;
+    Command *last_copy = nullptr;
+    for (const Command *command = source.first; command; command = command->next) {
+        Command *copy = copy_command(destination, *command);
+        if (last_copy)
+            last_copy->next = copy;
+        else
+            first_copy = copy;
+        last_copy = copy;
+
+        if (command == source.last)
+            break;
+    }
+
+    if (!first_copy)
+        return;
+
+    if (destination.command_list.last)
+        destination.command_list.last->next = first_copy;
+    else
+        destination.command_list.first = first_copy;
+    destination.command_list.last = last_copy;
+}
+
 void destroy_command_payload(Command &cmd) {
     switch (cmd.opcode) {
     case CommandOpcode::SetContext: {
-        auto *color_surface = reinterpret_cast<SceGxmColorSurface **>(&cmd.data[sizeof(RenderTarget *)]);
-        auto *depth_stencil_surface = reinterpret_cast<SceGxmDepthStencilSurface **>(&cmd.data[sizeof(RenderTarget *) + sizeof(SceGxmColorSurface *)]);
-        delete *color_surface;
-        delete *depth_stencil_surface;
+        const auto *color_surface = get_command_data<SceGxmColorSurface *>(cmd, sizeof(RenderTarget *));
+        const auto *depth_stencil_surface = get_command_data<SceGxmDepthStencilSurface *>(cmd, sizeof(RenderTarget *) + sizeof(SceGxmColorSurface *));
+        delete color_surface;
+        delete depth_stencil_surface;
         break;
     }
 

--- a/vita3k/renderer/tests/command_list_tests.cpp
+++ b/vita3k/renderer/tests/command_list_tests.cpp
@@ -1,0 +1,69 @@
+// Vita3K emulator project
+// Copyright (C) 2026 Vita3K team
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+
+#include <renderer/functions.h>
+
+#include <gtest/gtest.h>
+
+TEST(command_list, append_copies_ownership_through_declared_tail) {
+    renderer::Command first{};
+    renderer::Command last{};
+    renderer::Command stale_tail{};
+    first.opcode = renderer::CommandOpcode::SetContext;
+    first.flags = renderer::Command::FLAG_NO_FREE;
+    first.next = &last;
+    renderer::RenderTarget *render_target = nullptr;
+    auto *color_surface = new SceGxmColorSurface{};
+    auto *depth_stencil_surface = new SceGxmDepthStencilSurface{};
+    color_surface->width = 960;
+    depth_stencil_surface->background_depth = 0.5f;
+    renderer::CommandHelper source_helper(&first);
+    source_helper.push(render_target);
+    source_helper.push(color_surface);
+    source_helper.push(depth_stencil_surface);
+    last.opcode = renderer::CommandOpcode::Nop;
+    last.flags = renderer::Command::FLAG_NO_FREE;
+    last.next = &stale_tail;
+
+    renderer::CommandList source{};
+    source.first = &first;
+    source.last = &last;
+
+    renderer::Context destination;
+    destination.alloc_func = []() {
+        auto *command = new renderer::Command;
+        command->flags = renderer::Command::FLAG_FROM_HOST;
+        return command;
+    };
+
+    renderer::append_command_list(destination, source);
+
+    ASSERT_NE(destination.command_list.first, nullptr);
+    EXPECT_NE(destination.command_list.first, &first);
+    EXPECT_EQ(destination.command_list.first->opcode, renderer::CommandOpcode::SetContext);
+    EXPECT_EQ(destination.command_list.first->flags, renderer::Command::FLAG_FROM_HOST);
+    renderer::CommandHelper copy_helper(destination.command_list.first);
+    EXPECT_EQ(copy_helper.pop<renderer::RenderTarget *>(), render_target);
+    const auto *color_surface_copy = copy_helper.pop<SceGxmColorSurface *>();
+    const auto *depth_stencil_surface_copy = copy_helper.pop<SceGxmDepthStencilSurface *>();
+    ASSERT_NE(color_surface_copy, nullptr);
+    EXPECT_NE(color_surface_copy, color_surface);
+    ASSERT_NE(depth_stencil_surface_copy, nullptr);
+    EXPECT_NE(depth_stencil_surface_copy, depth_stencil_surface);
+    renderer::destroy_command_payload(first);
+    EXPECT_EQ(color_surface_copy->width, 960);
+    EXPECT_EQ(depth_stencil_surface_copy->background_depth, 0.5f);
+    ASSERT_NE(destination.command_list.last, nullptr);
+    EXPECT_NE(destination.command_list.last, &last);
+    EXPECT_EQ(destination.command_list.last->opcode, renderer::CommandOpcode::Nop);
+    EXPECT_EQ(destination.command_list.last->next, nullptr);
+
+    renderer::destroy_command_payload(*destination.command_list.first);
+    delete destination.command_list.last;
+    delete destination.command_list.first;
+}


### PR DESCRIPTION
## Summary

- Copy executed deferred commands into the immediate context's allocator instead of linking the original nodes.
- Deep-copy the owned `SetContext` surface payloads while preserving destination allocation flags.
- Add a regression test for allocator ownership, payload lifetime, and the declared command-list tail.

## Root cause

`sceGxmExecuteCommandList` directly linked deferred commands into the immediate command chain. Deferred commands live in ranges associated with game-provided VDM buffers, so reusing an overlapping buffer can free or overwrite them before the render thread consumes the immediate chain. The chain then contains dangling command and `SetContext` payload pointers.

Copying at execution time gives the immediate context ownership of the queued commands and leaves the deferred list independently reusable.

## Validation

- `clang-format 19.1.1 --dry-run --Werror` on all changed C++ files.
- Built the Release `renderer-tests` target with MSVC.
- Ran the `renderer` CTest: 1/1 passed.
- Verified `PCSG00908` no longer crashes with a build using this command-list ownership fix.
