### PR TITLE
renderer/vulkan: fix FSR swapchain flicker

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/screen_filters.h
+++ b/vita3k/renderer/include/renderer/vulkan/screen_filters.h
@@ -136,6 +136,8 @@ class FSRScreenFilter : public ScreenFilter {
 private:
     // dst of the easu shader, src of the rcas shader
     std::vector<vkutil::Image> intermediate_images;
+    // dst of the rcas shader, copied to the swapchain after sharpening
+    std::vector<vkutil::Image> rcas_images;
 
     vk::ShaderModule easu_shader;
     vk::ShaderModule rcas_shader;

--- a/vita3k/renderer/src/vulkan/renderer.cpp
+++ b/vita3k/renderer/src/vulkan/renderer.cpp
@@ -913,7 +913,15 @@ bool VKState::create(std::unique_ptr<renderer::State> &state, const Config &conf
         LOG_WARN("Failed to initialize Vulkan overlay renderer, overlays will be disabled");
     }
 
-    support_fsr &= static_cast<bool>(screen_renderer.surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eStorage);
+    support_fsr &= static_cast<bool>(screen_renderer.surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransferDst);
+
+    const auto fsr_image_features = physical_device.getFormatProperties(vk::Format::eR8G8B8A8Unorm).optimalTilingFeatures;
+    const auto swapchain_format_features = physical_device.getFormatProperties(screen_renderer.surface_format.format).optimalTilingFeatures;
+    const auto required_fsr_image_features = vk::FormatFeatureFlagBits::eSampledImage
+        | vk::FormatFeatureFlagBits::eStorageImage
+        | vk::FormatFeatureFlagBits::eBlitSrc;
+    support_fsr &= (fsr_image_features & required_fsr_image_features) == required_fsr_image_features;
+    support_fsr &= static_cast<bool>(swapchain_format_features & vk::FormatFeatureFlagBits::eBlitDst);
 
     return true;
 }

--- a/vita3k/renderer/src/vulkan/screen_filters.cpp
+++ b/vita3k/renderer/src/vulkan/screen_filters.cpp
@@ -498,9 +498,14 @@ void FSRScreenFilter::init() {
         LOG_ERROR("Failed to create compute pipeline");
     pipeline_rcas = result.value;
 
-    // create intermediate images
+    // Create separate EASU and RCAS images. Writing RCAS directly into a
+    // swapchain image is not portable: the drawable may have a BGRA format
+    // and some presentation implementations do not support storage writes.
     intermediate_images.resize(screen.swapchain_size);
+    rcas_images.resize(screen.swapchain_size);
     for (auto &img : intermediate_images)
+        img.format = vk::Format::eR8G8B8A8Unorm;
+    for (auto &img : rcas_images)
         img.format = vk::Format::eR8G8B8A8Unorm;
 
     on_resize();
@@ -538,6 +543,12 @@ void FSRScreenFilter::on_resize() {
         img.height = output_size.height;
         img.init_image(vk::ImageUsageFlagBits::eStorage | vk::ImageUsageFlagBits::eSampled);
     }
+    for (auto &img : rcas_images) {
+        img.destroy();
+        img.width = output_size.width;
+        img.height = output_size.height;
+        img.init_image(vk::ImageUsageFlagBits::eStorage | vk::ImageUsageFlagBits::eTransferSrc);
+    }
 
     // update the descriptor sets (except the first sampler image as it is not fixed)
     std::vector<vk::DescriptorImageInfo> descr_images(screen.swapchain_size * 3);
@@ -562,7 +573,7 @@ void FSRScreenFilter::on_resize() {
             .setDescriptorType(vk::DescriptorType::eSampledImage);
         // rcas dst
         descr_images[i * 3 + 2]
-            .setImageView(screen.swapchain_views[i])
+            .setImageView(rcas_images[i].view)
             .setImageLayout(vk::ImageLayout::eGeneral);
         write_descr[i * 3 + 2]
             .setDstSet(descriptor_sets[i * 2 + 1])
@@ -609,9 +620,28 @@ void FSRScreenFilter::render(bool is_pre_renderpass, vk::ImageView src_img, vk::
     const int dispatch_y = (output_size.height + 15) / 16;
     cmd_buffer.dispatch(dispatch_x, dispatch_y, 1);
 
-    // meanwhile, we need to clear the swapchain surface
+    // then transition the read texture to sampled // wait for the previous compute shader to be done
+    intermediate_images[screen.swapchain_image_idx].transition_to(cmd_buffer, vkutil::ImageLayout::SampledImage);
+    rcas_images[screen.swapchain_image_idx].transition_to_discard(cmd_buffer, vkutil::ImageLayout::StorageImage);
+
+    // sharpening pass
+    cmd_buffer.bindPipeline(vk::PipelineBindPoint::eCompute, pipeline_rcas);
+    cmd_buffer.bindDescriptorSets(vk::PipelineBindPoint::eCompute, pipeline_layout_rcas, 0, descriptor_sets[2 * screen.swapchain_image_idx + 1], {});
+    RcasConstant rcas_constant{
+        .offset = { 0, 0 },
+        // some default value for sharpening
+        .sharpening = 0.2f
+    };
+    cmd_buffer.pushConstants(pipeline_layout_rcas, vk::ShaderStageFlagBits::eCompute, 0, sizeof(RcasConstant), &rcas_constant);
+    cmd_buffer.dispatch(dispatch_x, dispatch_y, 1);
+
+    // Copy the finished RGBA image into the acquired drawable. A blit performs
+    // any required RGBA-to-BGRA conversion and avoids storage access to the
+    // presentation image.
+    rcas_images[screen.swapchain_image_idx].transition_to(cmd_buffer, vkutil::ImageLayout::TransferSrc);
+
     vk::ImageMemoryBarrier barrier{
-        .srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite,
+        .srcAccessMask = {},
         .dstAccessMask = vk::AccessFlagBits::eTransferWrite,
         .oldLayout = vk::ImageLayout::eUndefined,
         .newLayout = vk::ImageLayout::eTransferDstOptimal,
@@ -620,41 +650,32 @@ void FSRScreenFilter::render(bool is_pre_renderpass, vk::ImageView src_img, vk::
         .image = screen.swapchain_images[screen.swapchain_image_idx],
         .subresourceRange = vkutil::color_subresource_range
     };
-    cmd_buffer.pipelineBarrier(vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eTransfer,
+    cmd_buffer.pipelineBarrier(vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eTransfer,
         vk::DependencyFlags(), {}, {}, barrier);
 
-    vk::ClearColorValue clear_color{ std::array<float, 4>({ 0.0f, 0.0f, 0.0f, 0.0f }) };
+    vk::ClearColorValue clear_color{ std::array<float, 4>({ 0.0f, 0.0f, 0.0f, 1.0f }) };
     cmd_buffer.clearColorImage(screen.swapchain_images[screen.swapchain_image_idx], vk::ImageLayout::eTransferDstOptimal, clear_color, vkutil::color_subresource_range);
 
-    // then transition the read texture to sampled // wait for the previous compute shader to be done
-    intermediate_images[screen.swapchain_image_idx].transition_to(cmd_buffer, vkutil::ImageLayout::SampledImage);
-
-    // also transition the swapchain image to general
-    barrier = {
-        .srcAccessMask = vk::AccessFlagBits::eTransferWrite,
-        .dstAccessMask = vk::AccessFlagBits::eShaderWrite,
-        .oldLayout = vk::ImageLayout::eTransferDstOptimal,
-        .newLayout = vk::ImageLayout::eGeneral,
-        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .image = screen.swapchain_images[screen.swapchain_image_idx],
-        .subresourceRange = vkutil::color_subresource_range
+    vk::ImageBlit blit_region{};
+    blit_region.srcSubresource = { vk::ImageAspectFlagBits::eColor, 0, 0, 1 };
+    blit_region.srcOffsets[1] = { static_cast<int32_t>(output_size.width), static_cast<int32_t>(output_size.height), 1 };
+    blit_region.dstSubresource = { vk::ImageAspectFlagBits::eColor, 0, 0, 1 };
+    blit_region.dstOffsets[0] = { static_cast<int32_t>(output_offset.width), static_cast<int32_t>(output_offset.height), 0 };
+    blit_region.dstOffsets[1] = {
+        static_cast<int32_t>(output_offset.width + output_size.width),
+        static_cast<int32_t>(output_offset.height + output_size.height), 1
     };
-    cmd_buffer.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eComputeShader,
+    cmd_buffer.blitImage(rcas_images[screen.swapchain_image_idx].image, vk::ImageLayout::eTransferSrcOptimal,
+        screen.swapchain_images[screen.swapchain_image_idx], vk::ImageLayout::eTransferDstOptimal,
+        blit_region, vk::Filter::eNearest);
+
+    barrier
+        .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
+        .setDstAccessMask(vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite)
+        .setOldLayout(vk::ImageLayout::eTransferDstOptimal)
+        .setNewLayout(vk::ImageLayout::eGeneral);
+    cmd_buffer.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eColorAttachmentOutput,
         vk::DependencyFlags(), {}, {}, barrier);
-
-    // sharpening pass
-    cmd_buffer.bindPipeline(vk::PipelineBindPoint::eCompute, pipeline_rcas);
-    cmd_buffer.bindDescriptorSets(vk::PipelineBindPoint::eCompute, pipeline_layout_rcas, 0, descriptor_sets[2 * screen.swapchain_image_idx + 1], {});
-    RcasConstant rcas_constant{
-        .offset = output_offset,
-        // some default value for sharpening
-        .sharpening = 0.2f
-    };
-    cmd_buffer.pushConstants(pipeline_layout_rcas, vk::ShaderStageFlagBits::eCompute, 0, sizeof(RcasConstant), &rcas_constant);
-    cmd_buffer.dispatch(dispatch_x, dispatch_y, 1);
-
-    // the barrier for the render pass will be handled by the renderpass external dependencies
 }
 
 } // namespace renderer::vulkan

--- a/vita3k/renderer/src/vulkan/screen_renderer.cpp
+++ b/vita3k/renderer/src/vulkan/screen_renderer.cpp
@@ -262,15 +262,9 @@ void ScreenRenderer::create_swapchain() {
     // Create Swapchain
     {
         vk::ImageUsageFlags surface_usage = vk::ImageUsageFlagBits::eColorAttachment;
-        vk::ImageUsageFlags fsr_flags = vk::ImageUsageFlagBits::eTransferDst;
-        if (!state.is_adreno_turnip)
-            // workaround for a Turnip driver bug: adding storage flag here breaks the swapchain
-            // and fsr works fine without this flag on Adreno
-            fsr_flags |= vk::ImageUsageFlagBits::eStorage;
-
-        if (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eStorage)
-            // needed for FSR
-            surface_usage |= fsr_flags;
+        if (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransferDst)
+            // FSR renders into an intermediate image, then blits to the swapchain.
+            surface_usage |= vk::ImageUsageFlagBits::eTransferDst;
 
         vk::CompositeAlphaFlagBitsKHR comp_alpha = vk::CompositeAlphaFlagBitsKHR::eOpaque;
         if (!(surface_capabilities.supportedCompositeAlpha & comp_alpha))
@@ -652,9 +646,11 @@ void ScreenRenderer::create_render_pass() {
     vk::SubpassDependency dependency{
         .srcSubpass = VK_SUBPASS_EXTERNAL,
         .dstSubpass = 0,
-        .srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eComputeShader,
+        .srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eTransfer,
         .dstStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput,
-        .srcAccessMask = vk::AccessFlags(),
+        // FSR blits the completed image to the swapchain before this render
+        // pass loads it for UI composition.
+        .srcAccessMask = vk::AccessFlagBits::eTransferWrite,
         // don't forget blending
         .dstAccessMask = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite
     };

--- a/vita3k/shaders-builtin/vulkan/fsr_filter_easu.comp
+++ b/vita3k/shaders-builtin/vulkan/fsr_filter_easu.comp
@@ -39,7 +39,7 @@ uvec4 con3;
 #define A_HALF
 #include "../../../external/GPUOpen/ffx_a.h"
 layout(set=0,binding=1) uniform texture2D InputTexture;
-layout(set=0,binding=2,rgba16f) uniform image2D OutputTexture;
+layout(set=0,binding=2,rgba8) writeonly uniform image2D OutputTexture;
 layout(set=0,binding=3) uniform sampler InputSampler;
 #define FSR_EASU_H 1
 AH4 FsrEasuRH(AF2 p) { AH4 res = AH4(textureGather(sampler2D(InputTexture,InputSampler), p, 0)); return res; }
@@ -50,6 +50,11 @@ AH4 FsrEasuBH(AF2 p) { AH4 res = AH4(textureGather(sampler2D(InputTexture,InputS
 
 void CurrFilter(AU2 pos)
 {
+	// Each workgroup covers a 16x16 tile, while the dispatch is rounded up.
+	// Ignore invocations outside the actual output image.
+	if (any(greaterThanEqual(pos, output_dim)))
+		return;
+
 	AH3 c;
 	FsrEasuH(c, pos, con0, con1, con2, con3);
 	imageStore(OutputTexture, ASU2(pos), AH4(c, 1));
@@ -69,4 +74,3 @@ void main()
 	gxy.x -= 8u;
 	CurrFilter(gxy);
 }
-

--- a/vita3k/shaders-builtin/vulkan/fsr_filter_rcas.comp
+++ b/vita3k/shaders-builtin/vulkan/fsr_filter_rcas.comp
@@ -34,7 +34,7 @@ uvec4 con0;
 #define A_HALF
 #include "../../../external/GPUOpen/ffx_a.h"
 layout(set=0,binding=1) uniform texture2D InputTexture;
-layout(set=0,binding=2,rgba16f) uniform image2D OutputTexture;
+layout(set=0,binding=2,rgba8) writeonly uniform image2D OutputTexture;
 layout(set=0,binding=3) uniform sampler InputSampler;
 #define FSR_RCAS_H
 AH4 FsrRcasLoadH(ASW2 p) { return AH4(texelFetch(sampler2D(InputTexture,InputSampler), ASU2(p), 0)); }
@@ -44,6 +44,12 @@ void FsrRcasInputH(inout AH1 r,inout AH1 g,inout AH1 b){}
 
 void CurrFilter(AU2 pos)
 {
+	// Each workgroup covers a 16x16 tile, while the dispatch is rounded up.
+	// Avoid out-of-bounds reads and writes at the right and bottom edges.
+	const AU2 input_dim = AU2(textureSize(sampler2D(InputTexture, InputSampler), 0));
+	if (any(greaterThanEqual(pos, input_dim)))
+		return;
+
 	AH3 c;
 	FsrRcasH(c.r, c.g, c.b, pos, con0);
 	imageStore(OutputTexture, ASU2(pos) + ASU2(offset), AH4(c, 1));
@@ -63,4 +69,3 @@ void main()
 	gxy.x -= 8u;
 	CurrFilter(gxy);
 }
-


### PR DESCRIPTION
## What changed

- render EASU and RCAS into separate `R8G8B8A8_UNORM` images
- blit the completed RCAS image into the acquired swapchain image before UI composition
- require the transfer/blit format capabilities used by the new path
- use matching `rgba8` storage image declarations in both FSR shaders
- guard rounded-up 16x16 compute tiles against out-of-bounds reads and writes
- synchronize the transfer write before the post-filter render pass loads the swapchain image

## Why

The RCAS pass previously wrote directly to the presentation image as a storage image while declaring the output as `rgba16f`. Swapchain images can instead be RGBA8 or BGRA8, and direct compute writes to presentation images are not portable across Vulkan implementations.

On macOS with MoltenVK this produced rapidly alternating valid and black frames when FSR was enabled. Rendering RCAS into a regular RGBA8 image and blitting it into the drawable avoids storage access to the presentation image and lets the blit perform any required RGBA/BGRA conversion.

The additional bounds checks also prevent the rounded-up compute dispatch from accessing pixels beyond output sizes that are not multiples of 16.

## Validation

- built the complete macOS app successfully with `cmake --build build/macos --parallel 8`
- `git diff --check` passes
- tested on Apple M4 Pro / MoltenVK at 2.25x resolution (`1620x918`) with FSR
- completed approximately 45 minutes of gameplay without the previous flicker
- temporarily instrumented `FSRScreenFilter::render` and confirmed EASU, RCAS, and the swapchain blit executed; the diagnostic was removed before this commit

The previous implementation reproduced the issue consistently in the same scene and resolution.
