### PR TITLE
Readd option to create a game specific shortcut to the android ui

### DIFF
--- a/android/app/src/main/java/org/vita3k/emulator/Emulator.java
+++ b/android/app/src/main/java/org/vita3k/emulator/Emulator.java
@@ -639,31 +639,44 @@ public class Emulator extends SDLActivity
     }
 
     @Keep
-    public boolean createShortcut(String game_id, String game_name){
-        if(!ShortcutManagerCompat.isRequestPinShortcutSupported(getContext()))
+    public static boolean createShortcut(Context context, String game_id, String game_name, File icon_file){
+        if(context == null || game_id == null || game_id.isEmpty())
             return false;
 
+        if(!ShortcutManagerCompat.isRequestPinShortcutSupported(context))
+            return false;
+
+        String shortcut_label = game_name != null && !game_name.isEmpty() ? game_name : game_id;
+
         // first look at the icon, its location should always be the same
-        File src_icon = new File(getExternalFilesDir(null), "cache/icons/" + game_id + ".png");
+        File src_icon = icon_file != null && icon_file.exists()
+                ? icon_file
+                : new File(context.getExternalFilesDir(null), "cache/icons/" + game_id + ".png");
         Bitmap icon;
         if(src_icon.exists())
             icon = BitmapFactory.decodeFile(src_icon.getPath());
         else
-            icon = BitmapFactory.decodeResource(getResources(), R.mipmap.ic_launcher);
+            icon = BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher);
+        if(icon == null)
+            icon = BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher);
 
         // intent to directly start the game
-        Intent game_intent = createLaunchIntent(getContext(), game_id, game_name);
+        Intent game_intent = createLaunchIntent(context, game_id, shortcut_label);
+        game_intent.setAction("LAUNCH_" + game_id);
 
         // now create the pinned shortcut
-        ShortcutInfoCompat shortcut = new ShortcutInfoCompat.Builder(getContext(), game_id)
-                .setShortLabel(game_name)
-                .setLongLabel(game_name)
+        ShortcutInfoCompat shortcut = new ShortcutInfoCompat.Builder(context, game_id)
+                .setShortLabel(shortcut_label)
+                .setLongLabel(shortcut_label)
                 .setIcon(IconCompat.createWithBitmap(icon))
                 .setIntent(game_intent)
                 .build();
-        ShortcutManagerCompat.requestPinShortcut(getContext(), shortcut, null);
+        return ShortcutManagerCompat.requestPinShortcut(context, shortcut, null);
+    }
 
-        return true;
+    @Keep
+    public boolean createShortcut(String game_id, String game_name){
+        return createShortcut(getContext(), game_id, game_name, null);
     }
 
     @Keep

--- a/android/app/src/main/java/org/vita3k/emulator/MainActivity.kt
+++ b/android/app/src/main/java/org/vita3k/emulator/MainActivity.kt
@@ -2,10 +2,12 @@ package org.vita3k.emulator
 
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import org.vita3k.emulator.data.AppInfo
 import org.vita3k.emulator.data.AppStorage
 import org.vita3k.emulator.ui.navigation.AppNavigation
 import org.vita3k.emulator.ui.theme.Vita3KTheme
@@ -114,7 +116,8 @@ class MainActivity : AppCompatActivity() {
                     installViewModel = installViewModel,
                     settingsViewModel = settingsViewModel,
                     userManagementViewModel = userManagementViewModel,
-                    onAppLaunch = { app -> launchApp(app.titleId, app.title) }
+                    onAppLaunch = { app -> launchApp(app.titleId, app.title) },
+                    onCreateAppShortcut = { app -> createAppShortcut(app) }
                 )
             }
         }
@@ -191,6 +194,16 @@ class MainActivity : AppCompatActivity() {
 
     private fun launchApp(titleId: String, appTitle: String) {
         emulatorLauncher.launch(Emulator.createLaunchIntent(this, titleId, appTitle))
+    }
+
+    private fun createAppShortcut(app: AppInfo) {
+        val created = Emulator.createShortcut(this, app.titleId, app.title, app.iconFile)
+        val messageResId = if (created) {
+            R.string.shortcut_create_requested
+        } else {
+            R.string.shortcut_create_unsupported
+        }
+        Toast.makeText(this, getString(messageResId), Toast.LENGTH_SHORT).show()
     }
 
     private fun launchFilePicker(mimeTypes: Array<String>) {

--- a/android/app/src/main/java/org/vita3k/emulator/ui/navigation/AppNavigation.kt
+++ b/android/app/src/main/java/org/vita3k/emulator/ui/navigation/AppNavigation.kt
@@ -72,7 +72,8 @@ fun AppNavigation(
     installViewModel: InstallViewModel,
     settingsViewModel: SettingsViewModel,
     userManagementViewModel: UserManagementViewModel,
-    onAppLaunch: (AppInfo) -> Unit
+    onAppLaunch: (AppInfo) -> Unit,
+    onCreateAppShortcut: (AppInfo) -> Unit
 ) {
     val navController = rememberNavController()
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
@@ -313,7 +314,8 @@ fun AppNavigation(
                     navController.navigate(customConfigRoute(app.titleId, app.title)) {
                         launchSingleTop = true
                     }
-                }
+                },
+                onCreateAppShortcut = onCreateAppShortcut
             )
         }
 

--- a/android/app/src/main/java/org/vita3k/emulator/ui/screens/AppsListScreen.kt
+++ b/android/app/src/main/java/org/vita3k/emulator/ui/screens/AppsListScreen.kt
@@ -111,7 +111,8 @@ fun AppsListScreen(
     onOpenTrophyManager: () -> Unit = {},
     onOpenUserManagement: () -> Unit = {},
     onOpenWelcomeScreen: () -> Unit = {},
-    onOpenCustomConfig: (AppInfo) -> Unit = {}
+    onOpenCustomConfig: (AppInfo) -> Unit = {},
+    onCreateAppShortcut: (AppInfo) -> Unit = {}
 ) {
     var showSearchBar by remember { mutableStateOf(false) }
     var showFilterSheet by remember { mutableStateOf(false) }
@@ -331,6 +332,10 @@ fun AppsListScreen(
             onCustomConfig = {
                 selectedAppForActions = null
                 onOpenCustomConfig(app)
+            },
+            onCreateShortcut = {
+                selectedAppForActions = null
+                onCreateAppShortcut(app)
             }
         )
     }
@@ -1148,7 +1153,8 @@ private fun AppActionsDialog(
     onDismiss: () -> Unit,
     onActionSelected: (AppAction) -> Unit,
     onShowInfo: () -> Unit,
-    onCustomConfig: () -> Unit = {}
+    onCustomConfig: () -> Unit = {},
+    onCreateShortcut: () -> Unit = {}
 ) {
     var showDeleteSubmenu by remember { mutableStateOf(false) }
 
@@ -1217,6 +1223,18 @@ private fun AppActionsDialog(
                 )
             },
             onClick = { onCustomConfig() }
+        )
+        AppMenuRow(
+            label = stringResource(R.string.app_menu_create_shortcut),
+            icon = {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            },
+            onClick = { onCreateShortcut() }
         )
 
         // Other actions (reset last played, etc.)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -80,6 +80,9 @@
     <string name="app_menu_information">Information</string>
     <string name="app_menu_delete">Delete\u2026</string>
     <string name="app_menu_custom_config">Custom Config</string>
+    <string name="app_menu_create_shortcut">Create Home Screen Shortcut</string>
+    <string name="shortcut_create_requested">Shortcut request sent.</string>
+    <string name="shortcut_create_unsupported">Your launcher does not support creating shortcuts.</string>
 
     <!-- User management -->
     <string name="user_management_title">User Management</string>


### PR DESCRIPTION
Readd this feature the way it was present inside the old Android UI, because it was really useful on Android handhelds with custom frontends like Cocoon.
<img width="1920" height="1080" alt="Screenshot_20260808-033300" src="https://github.com/user-attachments/assets/e4e15c89-ae9f-4754-8974-2e8988de8a3e" />
