### PR TITLE
vita3k/audio: Set the master volume limit to 200%

### DIFF
--- a/android/app/src/main/java/org/vita3k/emulator/ui/screens/settings/SettingsSections.kt
+++ b/android/app/src/main/java/org/vita3k/emulator/ui/screens/settings/SettingsSections.kt
@@ -1110,9 +1110,9 @@ private fun AudioSettingsSection(
         SettingsSliderRow(
             title = stringResource(R.string.settings_audio_volume),
             valueLabel = stringResource(R.string.settings_audio_volume_value, cfg.audioVolume),
-            value = cfg.audioVolume.toFloat().coerceIn(0f, 100f),
-            onValueChange = { onUpdate { audioVolume = it.roundToInt().coerceIn(0, 100) } },
-            valueRange = 0f..100f,
+            value = cfg.audioVolume.toFloat().coerceIn(0f, 200f),
+            onValueChange = { onUpdate { audioVolume = it.roundToInt().coerceIn(0, 200) } },
+            valueRange = 0f..200f,
             steps = 0,
             help = SettingsHelpEntry(
                 title = stringResource(R.string.settings_audio_volume),

--- a/vita3k/audio/include/audio/impl/cubeb_audio.h
+++ b/vita3k/audio/include/audio/impl/cubeb_audio.h
@@ -19,6 +19,7 @@
 
 #include "../state.h"
 
+#include <atomic>
 #include <condition_variable>
 
 #include <cubeb/cubeb.h>
@@ -39,6 +40,9 @@ struct CubebAudioOutPort : AudioOutPort {
     // position of the next audio buffer to put audio
     int next_audio_buffer = 0;
     int nb_buffers_ready = 0;
+    // cubeb_stream_set_volume rejects anything above 1.0, so gain beyond that
+    // is applied to the samples in software by the audio callback
+    std::atomic<float> extra_gain{ 1.0f };
 
     // use the destructor to destroy the cubeb stream
     ~CubebAudioOutPort();

--- a/vita3k/audio/src/impl/cubeb_audio.cpp
+++ b/vita3k/audio/src/impl/cubeb_audio.cpp
@@ -18,6 +18,22 @@
 #include "audio/impl/cubeb_audio.h"
 #include "util/log.h"
 
+#include <algorithm>
+#include <cstdint>
+
+// scales S16LE samples in place, used to push the volume past the 1.0 ceiling cubeb enforces natively
+static void apply_extra_gain(uint8_t *buffer, int nb_bytes, float gain) {
+    if (gain == 1.0f)
+        return;
+
+    int16_t *samples = reinterpret_cast<int16_t *>(buffer);
+    const int nb_samples = nb_bytes / sizeof(int16_t);
+    for (int i = 0; i < nb_samples; i++) {
+        const float amplified = samples[i] * gain;
+        samples[i] = static_cast<int16_t>(std::clamp(amplified, static_cast<float>(INT16_MIN), static_cast<float>(INT16_MAX)));
+    }
+}
+
 static long impl_cubeb_audio_callback(cubeb_stream *stream, void *user_data, const void *input, void *output, long nframes) {
     assert(user_data != nullptr);
     assert(stream != nullptr);
@@ -50,6 +66,15 @@ static long impl_cubeb_audio_callback(cubeb_stream *stream, void *user_data, con
 
         bytes_given += bytes_to_copy;
     }
+
+    if (bytes_given < bytes_to_give) {
+        // buffer underrun (e.g. at game startup before any audio has been produced yet):
+        // output silence for the rest instead of leaving stale/uninitialized memory, which
+        // would otherwise be played back as an audible glitch
+        memset(&output_buffer[bytes_given], 0, bytes_to_give - bytes_given);
+    }
+
+    apply_extra_gain(output_buffer, bytes_given, port->extra_gain.load(std::memory_order_relaxed));
 
     return nframes;
 }
@@ -149,7 +174,10 @@ void CubebAudioAdapter::audio_output(AudioOutPort &out_port, const void *buffer)
 
 void CubebAudioAdapter::set_volume(AudioOutPort &out_port, float volume) {
     CubebAudioOutPort &port = static_cast<CubebAudioOutPort &>(out_port);
-    cubeb_stream_set_volume(port.out_stream, volume);
+    // cubeb rejects volumes outside [0.0, 1.0]. Anything past that is instead
+    // applied to the samples in software by the audio callback (extra_gain).
+    cubeb_stream_set_volume(port.out_stream, std::min(volume, 1.0f));
+    port.extra_gain.store(std::max(volume, 1.0f), std::memory_order_relaxed);
 }
 
 void CubebAudioAdapter::switch_state(const bool pause) {

--- a/vita3k/gui-qt/src/main_window.cpp
+++ b/vita3k/gui-qt/src/main_window.cpp
@@ -1944,7 +1944,7 @@ void MainWindow::setup_status_bar() {
         layout->setContentsMargins(12, 8, 12, 8);
 
         auto *slider = new QSlider(Qt::Horizontal, container);
-        slider->setRange(0, 100);
+        slider->setRange(0, 200);
         slider->setValue(emuenv.cfg.current_config.audio_volume);
         slider->setMinimumWidth(180);
 

--- a/vita3k/gui-qt/src/settings_dialog.ui
+++ b/vita3k/gui-qt/src/settings_dialog.ui
@@ -1204,7 +1204,7 @@ QGroupBox[flat=&quot;true&quot;]::title {
                       <number>0</number>
                      </property>
                      <property name="maximum">
-                      <number>100</number>
+                      <number>200</number>
                      </property>
                      <property name="value">
                       <number>100</number>
@@ -1216,7 +1216,7 @@ QGroupBox[flat=&quot;true&quot;]::title {
                       <enum>QSlider::TickPosition::TicksBelow</enum>
                      </property>
                      <property name="tickInterval">
-                      <number>25</number>
+                      <number>50</number>
                      </property>
                     </widget>
                    </item>


### PR DESCRIPTION
Set the master volume limit to 200%.
SDL supports up to 200% by default, while cubeb requires manual scaling to 200%.
I also fixed the stuttering at game startup caused by a buffer-underrun in cubeb.