### PR TITLE
renderer/gl: add workaroud for amd igpu

### DIFF
--- a/vita3k/renderer/src/gl/renderer.cpp
+++ b/vita3k/renderer/src/gl/renderer.cpp
@@ -238,6 +238,24 @@ bool create(std::unique_ptr<State> &state, const Config &config) {
     gl_state.features.use_mask_bit = false;
 #else
     gl_state.features.use_mask_bit = true;
+
+    // Workaround for AMD integrated GPUs. sync_mask() fills the mask texture with
+    // glClearTexImage, which is a fast clear there: it writes the clear value into the
+    // surface's compression metadata instead of into the texels, and a read-only image
+    // binding does not resolve that metadata. imageLoad(f_mask) then returns zero, the
+    // mask test in frag_output_finalize() discards every fragment, and the whole frame
+    // comes out black. Measured on a Radeon Vega iGPU with driver 25.8.1; clearing to a
+    // value a fast clear cannot encode, or binding the image read-write, both avoid it.
+    //
+    // The mask bit is only used by a handful of titles, so switching the emulation off
+    // costs far less than a black screen. This is a heuristic on the driver's renderer
+    const char *gl_vendor = reinterpret_cast<const char *>(glGetString(GL_VENDOR));
+    const std::string_view vendor = gl_vendor ? gl_vendor : "";
+    const std::string_view gpu_name = state->get_gpu_name();
+    if ((vendor.contains("ATI") || vendor.contains("AMD")) && gpu_name.ends_with("Graphics")) {
+        gl_state.features.use_mask_bit = false;
+        LOG_WARN("Mask bit emulation disabled on {}: this driver does not make glClearTexImage visible to image loads", gpu_name);
+    }
 #endif
 
     return gl_state.init();


### PR DESCRIPTION
I went on vacation and tried to do some OpenGL development at my parents' house, but the screen was black for every game...
After debugging for a few hours with the help of Claude and RenderDoc, I discovered—as usual—that the problem was caused by some strange behavior in the AMD OpenGL driver. While this isn't a fundamental fix, disabling mask_bit emulation prevents the black screen from appearing.

I'll leave this as an open PR. I'd like to see if anyone else is experiencing the same problem so I can confirm that it's been fixed.

| Master | PR |
| -- | -- |
| <img width="1444" height="863" alt="image" src="https://github.com/user-attachments/assets/f19c3c2b-7012-4fe1-a996-6837172300d3" /> |  <img width="1444" height="863" alt="image" src="https://github.com/user-attachments/assets/96875644-19c1-460c-8cb2-cb199ac92f71" /> | 
