### PR TITLE
Fixed crash on android when exiting a game 

### DIFF
--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -64,6 +64,8 @@ struct ThreadState {
     SceUID id;
     Address entry_point;
 
+
+    CPUStatePtr cpu;
     Block stack;
     int stack_size;
     Block tls;
@@ -75,7 +77,6 @@ struct ThreadState {
     // set to true if thread is processing kernel callbacks
     bool is_processing_callbacks = false;
 
-    CPUStatePtr cpu;
     ThreadStatus status = ThreadStatus::dormant;
 
     ThreadSignal signal;

--- a/vita3k/kernel/include/kernel/thread/thread_state.h
+++ b/vita3k/kernel/include/kernel/thread/thread_state.h
@@ -64,8 +64,8 @@ struct ThreadState {
     SceUID id;
     Address entry_point;
 
-
     CPUStatePtr cpu;
+
     Block stack;
     int stack_size;
     Block tls;


### PR DESCRIPTION
#4069 fix to crash that occurs due to double free and thread race. Fixed by reordering destructors, might be fixed with #4003 but this works fine for now and is relatively cheap and quick fix.