### PR TITLE
modules/sceJpegEncUser: Add BGRA8888 CSC input support

### DIFF
--- a/vita3k/codec/include/codec/state.h
+++ b/vita3k/codec/include/codec/state.h
@@ -282,7 +282,7 @@ struct PlayerState {
     ~PlayerState();
 };
 
-void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, int32_t in_pitch);
+void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, bool is_bgra, int32_t in_pitch);
 void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t frame_width, const DecoderColorSpace color_space, bool is_bgra, MJpegPitch pitch[4]);
 int convert_yuv_to_jpeg(const uint8_t *yuv, uint8_t *jpeg, uint32_t width, uint32_t height, uint32_t max_size, const DecoderColorSpace color_space, int32_t compress_ratio);
 void copy_yuv_data_from_frame(AVFrame *frame, uint8_t *dest, const uint32_t width, const uint32_t height, bool is_p3);

--- a/vita3k/codec/src/mjpeg.cpp
+++ b/vita3k/codec/src/mjpeg.cpp
@@ -76,8 +76,9 @@ void convert_yuv_to_rgb(const uint8_t *yuv, uint8_t *rgba, uint32_t frame_width,
     sws_freeContext(context);
 }
 
-void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, int32_t in_pitch) {
+void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint32_t height, const DecoderColorSpace color_space, bool is_bgra, int32_t in_pitch) {
     AVPixelFormat format = AV_PIX_FMT_NONE;
+    const AVPixelFormat input_format = is_bgra ? AV_PIX_FMT_BGRA : AV_PIX_FMT_RGBA;
     int strides_divisor = 1;
     int slice_position = 8;
 
@@ -102,7 +103,7 @@ void convert_rgb_to_yuv(const uint8_t *rgba, uint8_t *yuv, uint32_t width, uint3
         return;
     }
 
-    SwsContext *context = sws_getContext(width, height, AV_PIX_FMT_RGBA, width, height, format,
+    SwsContext *context = sws_getContext(width, height, input_format, width, height, format,
         SWS_FULL_CHR_H_INT | SWS_ACCURATE_RND, nullptr, nullptr, nullptr);
     assert(context);
 

--- a/vita3k/modules/SceJpegEnc/SceJpegEncUser.cpp
+++ b/vita3k/modules/SceJpegEnc/SceJpegEncUser.cpp
@@ -55,6 +55,7 @@ EXPORT(int, sceJpegEncoderCsc, SceJpegEncoderContext *context, Ptr<uint8_t> outB
     auto outBufferData = outBuffer.get(emuenv.mem);
 
     DecoderColorSpace color_space = COLORSPACE_UNKNOWN;
+    bool is_bgra;
 
     switch (context->pixelFormat & 0xF) {
     case SCE_JPEGENC_PIXEL_YCBCR422:
@@ -67,11 +68,18 @@ EXPORT(int, sceJpegEncoderCsc, SceJpegEncoderContext *context, Ptr<uint8_t> outB
         return SCE_JPEGENC_ERROR_INVALID_PIXELFORMAT;
     }
 
-    if (inPixelFormat != SCE_JPEGENC_PIXEL_RGBA8888) {
-        return STUBBED("Only RGBA8888 to YCbCr is implemented.");
+    switch (inPixelFormat) {
+    case SCE_JPEGENC_PIXEL_RGBA8888:
+        is_bgra = false;
+        break;
+    case SCE_JPEGENC_PIXEL_BGRA8888:
+        is_bgra = true;
+        break;
+    default:
+        return SCE_JPEGENC_ERROR_INVALID_PIXELFORMAT;
     }
 
-    convert_rgb_to_yuv(inBufferData, outBufferData, context->inWidth, context->inHeight, color_space, inPitch);
+    convert_rgb_to_yuv(inBufferData, outBufferData, context->inWidth, context->inHeight, color_space, is_bgra, inPitch);
 
     return 0;
 }


### PR DESCRIPTION
Add support for the SCE_JPEGENC_PIXEL_BGRA8888 pixel format to sceJpegEncoderCsc. Previously, the function only handled the SCE_JPEGENC_PIXEL_RGBA8888 pixel format.

This PR partially addresses #4093.