### PR TITLE
shader: Fix SMP fconv_type 0 converting the texel to F32

### DIFF
--- a/vita3k/shader/src/translator/texture.cpp
+++ b/vita3k/shader/src/translator/texture.cpp
@@ -248,8 +248,8 @@ bool USSETranslatorVisitor::smp(
     const SamplerInfo &sampler = is_texture_buffer_load ? m_spirv_params.samplers.begin()->second : m_spirv_params.samplers.at(inst.opr.src1.num);
 
     constexpr DataType tb_dest_fmt[] = {
-        DataType::F32,
-        DataType::UNK,
+        DataType::UNK, // The texel stays in the texture's integral format, packed.
+        DataType::UNK, // Never seen in any shader, meaning unknown. Falling back to the sampler type.
         DataType::F16,
         DataType::F32
     };


### PR DESCRIPTION
While trying to fix a strange bug where the output was incorrect even though the FFmpeg decoding process itself was working correctly, I discovered that the shader conversion was incorrect.

Before:
<img width="1444" height="863" alt="image" src="https://github.com/user-attachments/assets/dbe9a9ab-a6b4-476c-91b9-ddee473b4929" />

After:
<img width="1444" height="863" alt="image" src="https://github.com/user-attachments/assets/55bc2d95-1912-40da-8cef-d7df834357bc" />

`SMP`'s `fconv_type` selects the format the sampled texel is written in. `0` means no conversion, keeping the texture's own packed integral format, but we mapped it to `F32`. Shaders selecting it unpack the result with `VPCKF32U8`, which then read the bits of the float instead of the colour:

```glsl
pa[1] = texture(fragTex_texture_in, ...);       // normalized floats
internals[0].x = float(unpack4xU8(pa[1].x).x);  // x/y/z/w all come from pa[1].x
```

Hence 95% of the frame came out `(0, 0, 32)`: `floatBitsToUint(1.0) = 0x3F800000` blended with `alpha = 63/255`. 