### PR TITLE
renderer/vulkan: Fix early staging buffer reuse

### DIFF
--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -32,9 +32,15 @@ struct VKRenderTarget;
 constexpr int MAX_FRAMES_RENDERING = 3;
 constexpr int NB_TEXTURE_STAGING_BUFFERS = 16;
 
+constexpr bool is_frame_timestamp_in_flight(const uint64_t frame_timestamp, const uint64_t current_frame_timestamp) {
+    return frame_timestamp != ~uint64_t { 0 }
+        && frame_timestamp <= current_frame_timestamp
+        && current_frame_timestamp - frame_timestamp < MAX_FRAMES_RENDERING;
+}
+
 struct TextureStagingBuffer {
     vkutil::Buffer buffer;
-    uint32_t used_so_far;
+    uint32_t used_so_far = 0;
     uint64_t scene_timestamp = ~0;
     uint64_t frame_timestamp = ~0;
     vk::Fence waiting_fence;

--- a/vita3k/renderer/include/renderer/vulkan/types.h
+++ b/vita3k/renderer/include/renderer/vulkan/types.h
@@ -33,8 +33,8 @@ constexpr int MAX_FRAMES_RENDERING = 3;
 constexpr int NB_TEXTURE_STAGING_BUFFERS = 16;
 
 constexpr bool is_frame_timestamp_in_flight(const uint64_t frame_timestamp, const uint64_t current_frame_timestamp) {
-    return frame_timestamp != ~uint64_t { 0 }
-        && frame_timestamp <= current_frame_timestamp
+    return frame_timestamp != ~uint64_t{ 0 }
+    && frame_timestamp <= current_frame_timestamp
         && current_frame_timestamp - frame_timestamp < MAX_FRAMES_RENDERING;
 }
 

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -184,8 +184,7 @@ void VKTextureCache::prepare_staging_buffer(bool is_configure) {
     // if we are not using the previous buffer, we wait if the buffer was used at least once,
     // less than MAX_FRAMES_RENDERING frames ago and we have not yet waited for its fence
     const bool need_wait = !use_previous_buffer
-        && staging_buffer->frame_timestamp != ~0
-        && staging_buffer->frame_timestamp > context->frame_timestamp - MAX_FRAMES_RENDERING
+        && is_frame_timestamp_in_flight(staging_buffer->frame_timestamp, context->frame_timestamp)
         && staging_buffer->scene_timestamp > last_waited_scene;
     const vk::Fence current_fence = context->next_fence;
 


### PR DESCRIPTION
Avoid unsigned timestamp underflow when checking whether a texture staging buffer is still in flight, and initialize its allocation offset before first use. This prevents early-frame texture uploads from reusing buffers that the GPU may still be consuming.

This fixes texture corruptions I was experiencing while working on my PS Vita Amnesia port. Hope it helps overall.