### PR TITLE
kernel: read an uncompressed segment from where the segment info says

### DIFF
--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -586,8 +586,13 @@ SceUID load_self(KernelState &kernel, MemState &mem, const void *self, const std
 
     for (Elf_Half seg_index = 0; seg_index < elf.e_phnum; ++seg_index) {
         const Elf32_Phdr &seg_header = segments[seg_index];
+        // A SELF says where each segment is in the segment info, and the
+        // program header's p_offset describes the ELF the SELF was made from
+        // rather than the SELF itself. The two agree only when the whole ELF
+        // was embedded at header_len, which is what fake SELFs used to do and
+        // no real one does.
         const uint8_t *const seg_bytes = is_self
-            ? (image_bytes + self_header.header_len + seg_header.p_offset)
+            ? (image_bytes + seg_infos[seg_index].offset)
             : (elf_bytes + seg_header.p_offset);
 
         const auto uncompress_segment = [&](void *dst) {


### PR DESCRIPTION
### The bug

A SELF's segment info says where each segment is **in the file**. The program header beside it describes the ELF the SELF was made from, so its `p_offset` is an offset into *that ELF*, not into this file. The two agree only when the whole ELF happens to be embedded at `header_len`.

`load_self.cpp` reads the segment info for a compressed segment and computes `header_len + p_offset` for an uncompressed one:

```cpp
const uint8_t *const seg_bytes = is_self
    ? (image_bytes + self_header.header_len + seg_header.p_offset)
    : (elf_bytes + seg_header.p_offset);
```

That worked because the only things with uncompressed segments are fake SELFs, and vitasdk's `vita-make-fself` did embed the whole ELF. It stopped in [eacff34](https://github.com/vitasdk/vita-toolchain/commit/eacff34d18e9872a78c0e520e1997ef71900ebb4), so its segments come out aligned the way `authmgr` wants them and the eboot is ~3.5× smaller. Homebrew built with any vitasdk since then **runs on a console and dies here** with an unhandled access before its first instruction:

```
[load_module]: Loading module "app0:eboot.bin"
[signal_handler]: Unhandled access to 0x0
```

No job, no log, nothing pointing at the loader — which is why this took a while to find.

### Nothing already published changes

- **Firmware is unaffected.** Every real module is compressed: across 20 modules from `vs0/sys/external` and `os0`, there are **zero** uncompressed segments, so this branch is only ever reached by homebrew.
- **Old-shape fake SELFs read identically.** They embed the whole ELF, so the segment info holds exactly `header_len + p_offset`. Measured on a 7.3 MB eboot built with the previous `vita-make-fself`:

  | | `segment_info.offset` | `header_len + p_offset` | |
  |---|---|---|---|
  | seg[0] | `0x2000` | `0x2000` | same |
  | seg[1] | `0x184fd0` | `0x184fd0` | same |
  | seg[2] | `0x682710` | `0x682710` | same |

  The same eboot from the current tool, byte-identical payload, differs only in those three `p_offset` fields — six bytes in 2 MB — and is what fails today.

### Reproducing

Any vitasdk from 2026-08-26 on:

```sh
arm-vita-eabi-gcc -Wl,-q hello.c -o hello.elf -lSceKernelThreadMgr_stub
vita-elf-create hello.elf hello.velf
vita-make-fself hello.velf eboot.bin      # dies in Vita3K, runs on hardware
vita-make-fself -c hello.velf eboot.bin   # works, the compressed path already reads the segment info
```

That `-c` difference is the whole bug in one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)