### PR TITLE
kernel: Resolve imports by library, not just NID

### DIFF
--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -62,6 +62,8 @@ typedef std::map<SceUID, CallbackPtr> CallbackPtrs;
 typedef unordered_map_fast<uint32_t, Address> ExportNids;
 // A NID hashes the function name alone, so same-named exports from different libraries collide.
 typedef unordered_map_fast<uint64_t, Address> LibExportNids;
+// The plain NID entry outlives taiHEN and HLE redirects, so its owner is tracked apart from its address.
+typedef unordered_map_fast<uint32_t, uint32_t> ExportNidOwners;
 constexpr uint64_t lib_export_key(uint32_t library_nid, uint32_t nid) {
     return (static_cast<uint64_t>(library_nid) << 32) | nid;
 }
@@ -142,6 +144,7 @@ struct KernelState {
     std::mutex export_nids_mutex;
     ExportNids export_nids;
     LibExportNids export_nids_by_lib;
+    ExportNidOwners export_nid_owners;
     FuncBindingInfos func_binding_infos;
     VarBindingInfos var_binding_infos;
     ModuleUidByNid module_uid_by_nid;

--- a/vita3k/kernel/include/kernel/state.h
+++ b/vita3k/kernel/include/kernel/state.h
@@ -60,6 +60,11 @@ typedef std::map<SceUID, ThreadStatePtr> ThreadStatePtrs;
 typedef std::map<SceUID, SceKernelModulePtr> SceKernelModuleInfoPtrs;
 typedef std::map<SceUID, CallbackPtr> CallbackPtrs;
 typedef unordered_map_fast<uint32_t, Address> ExportNids;
+// A NID hashes the function name alone, so same-named exports from different libraries collide.
+typedef unordered_map_fast<uint64_t, Address> LibExportNids;
+constexpr uint64_t lib_export_key(uint32_t library_nid, uint32_t nid) {
+    return (static_cast<uint64_t>(library_nid) << 32) | nid;
+}
 
 typedef std::map<Address, uint32_t> NotFoundVars;
 typedef std::function<void(CPUState &cpu, uint32_t nid, SceUID thread_id)> CallImportFunc;
@@ -88,8 +93,13 @@ struct VarBindingInfo {
     uint32_t module_nid;
 };
 
+struct FuncBindingInfo {
+    Address entry_address;
+    uint32_t library_nid;
+};
+
 typedef std::multimap<uint32_t, VarBindingInfo> VarBindingInfos;
-typedef std::multimap<uint32_t, Address> FuncBindingInfos;
+typedef std::multimap<uint32_t, FuncBindingInfo> FuncBindingInfos;
 
 typedef std::map<uint32_t, uint32_t> ModuleUidByNid;
 
@@ -131,6 +141,7 @@ struct KernelState {
     // the variables in this block must be accessed by first locking export_nids_mutex
     std::mutex export_nids_mutex;
     ExportNids export_nids;
+    LibExportNids export_nids_by_lib;
     FuncBindingInfos func_binding_infos;
     VarBindingInfos var_binding_infos;
     ModuleUidByNid module_uid_by_nid;

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -239,6 +239,7 @@ void KernelState::deinit(MemState &mem) {
     {
         std::lock_guard<std::mutex> lock(export_nids_mutex);
         export_nids.clear();
+        export_nids_by_lib.clear();
         func_binding_infos.clear();
         var_binding_infos.clear();
         module_uid_by_nid.clear();

--- a/vita3k/kernel/src/kernel.cpp
+++ b/vita3k/kernel/src/kernel.cpp
@@ -240,6 +240,7 @@ void KernelState::deinit(MemState &mem) {
         std::lock_guard<std::mutex> lock(export_nids_mutex);
         export_nids.clear();
         export_nids_by_lib.clear();
+        export_nid_owners.clear();
         func_binding_infos.clear();
         var_binding_infos.clear();
         module_uid_by_nid.clear();

--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -271,7 +271,9 @@ static bool load_func_exports(SceKernelModuleInfo *kernel_module_info, const uin
             continue;
         }
 
-        kernel.export_nids.emplace(nid, entry.address());
+        // Only the library that actually took the plain NID entry may drop it again.
+        if (kernel.export_nids.emplace(nid, entry.address()).second)
+            kernel.export_nid_owners.insert_or_assign(nid, library_nid);
         kernel.export_nids_by_lib.insert_or_assign(lib_export_key(library_nid, nid), entry.address());
         // substitute supervisor calls to direct function calls in loaded modules
         auto range = kernel.func_binding_infos.equal_range(nid);
@@ -297,7 +299,13 @@ static bool load_func_exports(SceKernelModuleInfo *kernel_module_info, const uin
     return true;
 }
 
-static bool unload_func_exports(const uint32_t *nids, size_t count, uint32_t library_nid, KernelState &kernel, MemState &mem) {
+// An import stub resolved to an export branches through MOVW/MOVT of its address.
+static bool stub_targets(const uint32_t *stub, Address address) {
+    return stub[0] == encode_arm_inst(INSTRUCTION_MOVW, (uint16_t)address, 12)
+        && stub[1] == encode_arm_inst(INSTRUCTION_MOVT, (uint16_t)(address >> 16), 12);
+}
+
+static bool unload_func_exports(const uint32_t *nids, const Ptr<uint32_t> *entries, size_t count, uint32_t library_nid, KernelState &kernel, MemState &mem) {
     const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
     for (size_t i = 0; i < count; ++i) {
         const uint32_t nid = nids[i];
@@ -305,15 +313,23 @@ static bool unload_func_exports(const uint32_t *nids, size_t count, uint32_t lib
         if (nid == NID_MODULE_START || nid == NID_MODULE_STOP || nid == NID_MODULE_EXIT)
             continue;
 
-        kernel.export_nids.erase(nid);
-        kernel.export_nids_by_lib.erase(lib_export_key(library_nid, nid));
+        const Address unloaded_address = entries[i].address();
+        // Another module may have taken this library key since, and its export is still live.
+        if (const auto lib_it = kernel.export_nids_by_lib.find(lib_export_key(library_nid, nid)); lib_it != kernel.export_nids_by_lib.end() && lib_it->second == unloaded_address)
+            kernel.export_nids_by_lib.erase(lib_it);
+        // Redirects move the address but not the ownership, so only the owner may drop the plain entry.
+        if (const auto owner_it = kernel.export_nid_owners.find(nid); owner_it != kernel.export_nid_owners.end() && owner_it->second == library_nid) {
+            kernel.export_nids.erase(nid);
+            kernel.export_nid_owners.erase(owner_it);
+        }
         // invalidate all lle nid calls
         auto range = kernel.func_binding_infos.equal_range(nid);
         for (auto it = range.first; it != range.second; ++it) {
-            if (it->second.library_nid != library_nid)
-                continue;
             Address entry = it->second.entry_address;
             uint32_t *stub = Ptr<uint32_t>(entry).get(mem);
+            // A stub bound through the plain NID fallback names another library but still branches here.
+            if (it->second.library_nid != library_nid && !stub_targets(stub, unloaded_address))
+                continue;
 
             stub[0] = 0xef000000; // svc #0 - Call our interrupt hook.
             stub[1] = 0xe1a0f00e; // mov pc, lr - Return to the caller.
@@ -465,7 +481,7 @@ static bool load_exports(SceKernelModuleInfo *kernel_module_info, const sce_modu
         const Ptr<uint32_t> *const entries = Ptr<Ptr<uint32_t>>(exports->entry_table).get(mem);
         if (!is_unload && !load_func_exports(kernel_module_info, nids, entries, exports->num_syms_funcs, exports->library_nid, kernel, mem))
             return false;
-        if (is_unload && !unload_func_exports(nids, exports->num_syms_funcs, exports->library_nid, kernel, mem))
+        if (is_unload && !unload_func_exports(nids, entries, exports->num_syms_funcs, exports->library_nid, kernel, mem))
             return false;
 
         const auto var_count = exports->num_syms_vars;

--- a/vita3k/kernel/src/load_self.cpp
+++ b/vita3k/kernel/src/load_self.cpp
@@ -124,7 +124,7 @@ static bool unload_var_imports(const uint32_t *nids, const Ptr<uint32_t> *entrie
     return true;
 }
 
-static bool load_func_imports(const uint32_t *nids, const Ptr<uint32_t> *entries, size_t count, const SegmentInfosForReloc &segments, KernelState &kernel, const MemState &mem) {
+static bool load_func_imports(const uint32_t *nids, const Ptr<uint32_t> *entries, size_t count, uint32_t library_nid, const SegmentInfosForReloc &segments, KernelState &kernel, const MemState &mem) {
     const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
     for (size_t i = 0; i < count; ++i) {
         const uint32_t nid = nids[i];
@@ -135,16 +135,21 @@ static bool load_func_imports(const uint32_t *nids, const Ptr<uint32_t> *entries
             LOG_DEBUG("\tNID {} ({}) at {}", log_hex(nid), name, log_hex(entry.address()));
         }
 
-        const ExportNids::iterator export_address = kernel.export_nids.find(nid);
+        // Fall back to the plain NID for exports registered without library information.
+        Address func_address = 0;
+        if (const auto it = kernel.export_nids_by_lib.find(lib_export_key(library_nid, nid)); it != kernel.export_nids_by_lib.end()) {
+            func_address = it->second;
+        } else if (const auto nid_it = kernel.export_nids.find(nid); nid_it != kernel.export_nids.end()) {
+            func_address = nid_it->second;
+        }
         uint32_t *const stub = entry.get(mem);
 
-        kernel.func_binding_infos.emplace(nid, entry.address());
-        if (export_address == kernel.export_nids.end()) {
+        kernel.func_binding_infos.emplace(nid, FuncBindingInfo{ entry.address(), library_nid });
+        if (!func_address) {
             stub[0] = 0xef000000; // svc #0 - Call our interrupt hook.
             stub[1] = 0xe1a0f00e; // mov pc, lr - Return to the caller.
             stub[2] = nid; // Our interrupt hook will read this.
         } else {
-            Address func_address = export_address->second;
             stub[0] = encode_arm_inst(INSTRUCTION_MOVW, (uint16_t)func_address, 12);
             stub[1] = encode_arm_inst(INSTRUCTION_MOVT, (uint16_t)(func_address >> 16), 12);
             stub[2] = encode_arm_inst(INSTRUCTION_BRANCH, 0, 12);
@@ -172,7 +177,7 @@ static bool unload_func_imports(const uint32_t *nids, const Ptr<uint32_t> *entri
         // remove the stub from the table
         auto range = kernel.func_binding_infos.equal_range(nid);
         for (auto it = range.first; it != range.second; ++it) {
-            if (it->second == entry.address()) {
+            if (it->second.entry_address == entry.address()) {
                 kernel.func_binding_infos.erase(it);
                 break;
             }
@@ -190,6 +195,7 @@ static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segm
         assert(imports->num_syms_tls_vars == 0);
 
         Address library_name{};
+        uint32_t library_nid{};
         Address func_nid_table{};
         Address func_entry_table{};
         Address var_nid_table{};
@@ -197,6 +203,7 @@ static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segm
 
         if (imports->size == 0x24) {
             auto short_imports = reinterpret_cast<const sce_module_imports_short_raw *>(imports);
+            library_nid = short_imports->library_nid;
             library_name = short_imports->library_name;
             func_nid_table = short_imports->func_nid_table;
             func_entry_table = short_imports->func_entry_table;
@@ -204,6 +211,7 @@ static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segm
             var_entry_table = short_imports->var_entry_table;
         } else if (imports->size == 0x34) {
             auto long_imports = imports;
+            library_nid = long_imports->library_nid;
             library_name = long_imports->library_name;
             func_nid_table = long_imports->func_nid_table;
             func_entry_table = long_imports->func_entry_table;
@@ -221,7 +229,7 @@ static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segm
         const Ptr<uint32_t> *const entries = Ptr<Ptr<uint32_t>>(func_entry_table).get(mem);
 
         const size_t num_syms_funcs = imports->num_syms_funcs;
-        if (!is_unload && !load_func_imports(nids, entries, num_syms_funcs, segments, kernel, mem))
+        if (!is_unload && !load_func_imports(nids, entries, num_syms_funcs, library_nid, segments, kernel, mem))
             return false;
         if (is_unload && !unload_func_imports(nids, entries, num_syms_funcs, kernel))
             return false;
@@ -243,7 +251,7 @@ static bool load_imports(const sce_module_info_raw &module, Ptr<const void> segm
     return true;
 }
 
-static bool load_func_exports(SceKernelModuleInfo *kernel_module_info, const uint32_t *nids, const Ptr<uint32_t> *entries, size_t count, KernelState &kernel, MemState &mem) {
+static bool load_func_exports(SceKernelModuleInfo *kernel_module_info, const uint32_t *nids, const Ptr<uint32_t> *entries, size_t count, uint32_t library_nid, KernelState &kernel, MemState &mem) {
     const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
     for (size_t i = 0; i < count; ++i) {
         const uint32_t nid = nids[i];
@@ -264,10 +272,14 @@ static bool load_func_exports(SceKernelModuleInfo *kernel_module_info, const uin
         }
 
         kernel.export_nids.emplace(nid, entry.address());
+        kernel.export_nids_by_lib.insert_or_assign(lib_export_key(library_nid, nid), entry.address());
         // substitute supervisor calls to direct function calls in loaded modules
         auto range = kernel.func_binding_infos.equal_range(nid);
         for (auto it = range.first; it != range.second; ++it) {
-            auto address = it->second;
+            // A same-named export from an unrelated library must not hijack these importers.
+            if (it->second.library_nid != library_nid)
+                continue;
+            auto address = it->second.entry_address;
             uint32_t *const stub = Ptr<uint32_t>(address).get(mem);
             stub[0] = encode_arm_inst(INSTRUCTION_MOVW, (uint16_t)entry.address(), 12);
             stub[1] = encode_arm_inst(INSTRUCTION_MOVT, (uint16_t)(entry.address() >> 16), 12);
@@ -285,7 +297,7 @@ static bool load_func_exports(SceKernelModuleInfo *kernel_module_info, const uin
     return true;
 }
 
-static bool unload_func_exports(const uint32_t *nids, size_t count, KernelState &kernel, MemState &mem) {
+static bool unload_func_exports(const uint32_t *nids, size_t count, uint32_t library_nid, KernelState &kernel, MemState &mem) {
     const std::lock_guard<std::mutex> guard(kernel.export_nids_mutex);
     for (size_t i = 0; i < count; ++i) {
         const uint32_t nid = nids[i];
@@ -294,10 +306,13 @@ static bool unload_func_exports(const uint32_t *nids, size_t count, KernelState 
             continue;
 
         kernel.export_nids.erase(nid);
+        kernel.export_nids_by_lib.erase(lib_export_key(library_nid, nid));
         // invalidate all lle nid calls
         auto range = kernel.func_binding_infos.equal_range(nid);
         for (auto it = range.first; it != range.second; ++it) {
-            Address entry = it->second;
+            if (it->second.library_nid != library_nid)
+                continue;
+            Address entry = it->second.entry_address;
             uint32_t *stub = Ptr<uint32_t>(entry).get(mem);
 
             stub[0] = 0xef000000; // svc #0 - Call our interrupt hook.
@@ -448,9 +463,9 @@ static bool load_exports(SceKernelModuleInfo *kernel_module_info, const sce_modu
 
         const uint32_t *const nids = Ptr<const uint32_t>(exports->nid_table).get(mem);
         const Ptr<uint32_t> *const entries = Ptr<Ptr<uint32_t>>(exports->entry_table).get(mem);
-        if (!is_unload && !load_func_exports(kernel_module_info, nids, entries, exports->num_syms_funcs, kernel, mem))
+        if (!is_unload && !load_func_exports(kernel_module_info, nids, entries, exports->num_syms_funcs, exports->library_nid, kernel, mem))
             return false;
-        if (is_unload && !unload_func_exports(nids, exports->num_syms_funcs, kernel, mem))
+        if (is_unload && !unload_func_exports(nids, exports->num_syms_funcs, exports->library_nid, kernel, mem))
             return false;
 
         const auto var_count = exports->num_syms_vars;

--- a/vita3k/modules/taiHEN/taiHEN.cpp
+++ b/vita3k/modules/taiHEN/taiHEN.cpp
@@ -1317,6 +1317,8 @@ static void register_hle_override(EmuEnvState &emuenv, uint32_t nid) {
     const Address lle_addr = kernel.export_nids[nid];
     kernel.export_nids[nid] = stub_addr;
     redirect_export(kernel, nid, lle_addr, stub_addr);
+    // The stub outlives the plugin module, so the plain entry stops belonging to its library.
+    kernel.export_nid_owners.erase(nid);
 
     // Re-patch any existing import stubs that already point to kubridge's ARM code
     auto range = kernel.func_binding_infos.equal_range(nid);

--- a/vita3k/modules/taiHEN/taiHEN.cpp
+++ b/vita3k/modules/taiHEN/taiHEN.cpp
@@ -165,6 +165,28 @@ static bool is_svc_stub(const uint32_t *stub) {
     return stub[0] == 0xef000000 && stub[1] == 0xe1a0f00e;
 }
 
+// A NID names a function, not a library, so prefer the library-keyed export when we know the library.
+static Address find_export_address(KernelState &kernel, uint32_t library_nid, uint32_t func_nid) {
+    if (library_nid) {
+        const auto lib_it = kernel.export_nids_by_lib.find(lib_export_key(library_nid, func_nid));
+        if (lib_it != kernel.export_nids_by_lib.end())
+            return lib_it->second;
+    }
+    const auto it = kernel.export_nids.find(func_nid);
+    return (it != kernel.export_nids.end()) ? it->second : 0;
+}
+
+// Imports resolve through export_nids_by_lib first, so a redirection must move every alias of the export.
+static void redirect_export(KernelState &kernel, uint32_t func_nid, Address from, Address to) {
+    const auto it = kernel.export_nids.find(func_nid);
+    if (it != kernel.export_nids.end() && it->second == from)
+        it->second = to;
+    for (auto &[key, address] : kernel.export_nids_by_lib) {
+        if (static_cast<uint32_t>(key) == func_nid && address == from)
+            address = to;
+    }
+}
+
 // Find the import stub address for a given NID within a specific module
 static Address find_import_stub_in_module(EmuEnvState &emuenv, const char *module_name, uint32_t func_nid) {
     // Find the module UID
@@ -191,7 +213,7 @@ static Address find_import_stub_in_module(EmuEnvState &emuenv, const char *modul
     }
 
     for (auto it = range.first; it != range.second; ++it) {
-        Address addr = it->second;
+        Address addr = it->second.entry_address;
         // Check if this stub address falls within the module's segments
         for (int seg = 0; seg < MODULE_INFO_NUM_SEGMENTS; seg++) {
             Address seg_start = mod->info.segments[seg].vaddr.address();
@@ -413,8 +435,7 @@ static SceUID create_export_hook(EmuEnvState &emuenv, TaihenState *state, SceUID
     // Try inline hook first
     SceUID uid = create_inline_hook(emuenv, state, thread_id, original_addr, hook_func, func_nid);
     if (uid >= 0) {
-        // Update export_nids to point to hook
-        emuenv.kernel.export_nids[func_nid] = hook_func;
+        redirect_export(emuenv.kernel, func_nid, original_addr, hook_func);
         return uid;
     }
 
@@ -440,14 +461,13 @@ static SceUID create_export_hook(EmuEnvState &emuenv, TaihenState *state, SceUID
     hook_user->func = hook_func;
     hook_user->old = trampoline_addr;
 
-    // Update export_nids
-    emuenv.kernel.export_nids[func_nid] = hook_func;
+    redirect_export(emuenv.kernel, func_nid, original_addr, hook_func);
 
     // Patch all resolved import stubs for this NID
     int patched_count = 0;
     auto range = emuenv.kernel.func_binding_infos.equal_range(func_nid);
     for (auto it = range.first; it != range.second; ++it) {
-        Address stub_addr = it->second;
+        Address stub_addr = it->second.entry_address;
         uint32_t *stub = Ptr<uint32_t>(stub_addr).get(emuenv.mem);
         if (!is_svc_stub(stub)) {
             Address current = decode_lle_stub_target(stub);
@@ -501,10 +521,7 @@ EXPORT(SceUID, taiHookFunctionExportForUser, Ptr<uint32_t> p_hook, Ptr<void> arg
     Address export_addr = 0;
     {
         const std::lock_guard<std::mutex> guard(emuenv.kernel.export_nids_mutex);
-        auto it = emuenv.kernel.export_nids.find(func_nid);
-        if (it != emuenv.kernel.export_nids.end()) {
-            export_addr = it->second;
-        }
+        export_addr = find_export_address(emuenv.kernel, hargs->library_nid, func_nid);
     }
 
     if (!export_addr) {
@@ -712,7 +729,7 @@ EXPORT(int, taiHookRelease, SceUID tai_uid, uint32_t hook_ref) {
         if (hook->func_nid != 0) {
             const std::lock_guard<std::mutex> guard(emuenv.kernel.export_nids_mutex);
             Address original_addr = hook->target_addr | (hook->is_thumb ? 1 : 0);
-            emuenv.kernel.export_nids[hook->func_nid] = original_addr;
+            redirect_export(emuenv.kernel, hook->func_nid, hook->hook_func, original_addr);
         }
     } else if (hook->target_addr != 0) {
         // Import hook: restore original bytes at the patched stub
@@ -726,17 +743,17 @@ EXPORT(int, taiHookRelease, SceUID tai_uid, uint32_t hook_ref) {
             // Find the original address from the trampoline (it branches there)
             uint32_t *tramp = Ptr<uint32_t>(hook->trampoline).get(emuenv.mem);
             Address original_addr = decode_lle_stub_target(tramp);
-            emuenv.kernel.export_nids[hook->func_nid] = original_addr;
+            redirect_export(emuenv.kernel, hook->func_nid, hook->hook_func, original_addr);
 
             // Re-patch import stubs back to original
             auto range = emuenv.kernel.func_binding_infos.equal_range(hook->func_nid);
             for (auto bi = range.first; bi != range.second; ++bi) {
-                uint32_t *stub = Ptr<uint32_t>(bi->second).get(emuenv.mem);
+                uint32_t *stub = Ptr<uint32_t>(bi->second.entry_address).get(emuenv.mem);
                 if (!is_svc_stub(stub)) {
                     Address current = decode_lle_stub_target(stub);
                     if (current == hook->hook_func) {
                         write_arm_stub(stub, original_addr);
-                        emuenv.kernel.invalidate_jit_cache(bi->second, 12);
+                        emuenv.kernel.invalidate_jit_cache(bi->second.entry_address, 12);
                     }
                 }
             }
@@ -872,9 +889,8 @@ EXPORT(int, taiGetModuleExportFunc, const char *modname, uint32_t libnid, uint32
     // Search runtime export_nids
     {
         const std::lock_guard<std::mutex> guard(emuenv.kernel.export_nids_mutex);
-        auto it = emuenv.kernel.export_nids.find(funcnid);
-        if (it != emuenv.kernel.export_nids.end()) {
-            *func.get(emuenv.mem) = it->second;
+        if (const Address addr = find_export_address(emuenv.kernel, libnid, funcnid)) {
+            *func.get(emuenv.mem) = addr;
             return 0;
         }
     }
@@ -1004,10 +1020,7 @@ EXPORT(SceUID, taiHookFunctionExportForKernel, SceUID pid, Ptr<uint32_t> p_hook,
     Address export_addr = 0;
     {
         const std::lock_guard<std::mutex> guard(emuenv.kernel.export_nids_mutex);
-        auto it = emuenv.kernel.export_nids.find(func_nid);
-        if (it != emuenv.kernel.export_nids.end()) {
-            export_addr = it->second;
-        }
+        export_addr = find_export_address(emuenv.kernel, library_nid, func_nid);
     }
 
     if (!export_addr) {
@@ -1206,9 +1219,8 @@ EXPORT(int, module_get_export_func, SceUID pid, const char *modname, uint32_t li
     // First, check runtime export_nids (LLE exports and previously created dynamic stubs)
     {
         const std::lock_guard<std::mutex> guard(emuenv.kernel.export_nids_mutex);
-        auto it = emuenv.kernel.export_nids.find(funcnid);
-        if (it != emuenv.kernel.export_nids.end()) {
-            *func.get(emuenv.mem) = it->second;
+        if (const Address addr = find_export_address(emuenv.kernel, libnid, funcnid)) {
+            *func.get(emuenv.mem) = addr;
             return 0;
         }
     }
@@ -1301,13 +1313,15 @@ static void register_hle_override(EmuEnvState &emuenv, uint32_t nid) {
     stub[1] = 0xe1a0f00e; // mov pc, lr
     stub[2] = nid;
 
-    // Overwrite (or insert) the export_nids entry
+    // Imports resolve through export_nids_by_lib first, so move every alias to the stub too.
+    const Address lle_addr = kernel.export_nids[nid];
     kernel.export_nids[nid] = stub_addr;
+    redirect_export(kernel, nid, lle_addr, stub_addr);
 
     // Re-patch any existing import stubs that already point to kubridge's ARM code
     auto range = kernel.func_binding_infos.equal_range(nid);
     for (auto it = range.first; it != range.second; ++it) {
-        auto address = it->second;
+        const Address address = it->second.entry_address;
         uint32_t *caller_stub = Ptr<uint32_t>(address).get(mem);
         caller_stub[0] = encode_arm_inst(INSTRUCTION_MOVW, (uint16_t)stub_addr, 12);
         caller_stub[1] = encode_arm_inst(INSTRUCTION_MOVT, (uint16_t)(stub_addr >> 16), 12);


### PR DESCRIPTION
A NID hashes the function name alone, so two modules exporting the same name collided in export_nids and the second was silently dropped. Omega Labyrinth hung on "Now Loading" because UnityNpToolkit's PrxInitialize lost to an unrelated one. Key function exports by (library NID, NID) as well and resolve imports against that first, falling back to the plain NID lookup.

| Master | PR |
| -- | -- |
| <img width="1444" height="863" alt="image" src="https://github.com/user-attachments/assets/f7aaf59e-c0b7-4887-93e0-98c4a4746405" /> |  <img width="1444" height="863" alt="image" src="https://github.com/user-attachments/assets/f0aa9f1a-50a9-4637-abb1-e83a77eaaa1b" />  | 