### PR TITLE
building.md: added Arch Linux building dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ You can download the latest builds from [here](https://github.com/Vita3K/Vita3K/
     * [vita3k-git](https://aur.archlinux.org/packages/vita3k-git)<sup><small>AUR</small></sup>
   * Requirements:
     * xdg-desktop-portal
-    * pipewire-pulse
     * OpenGL or Vulkan runtime libraries
 * Android
     * [Adreno drivers](https://github.com/K11MCH1/AdrenoToolsDrivers/releases/)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ You can download the latest builds from [here](https://github.com/Vita3K/Vita3K/
     * [vita3k-git](https://aur.archlinux.org/packages/vita3k-git)<sup><small>AUR</small></sup>
   * Requirements:
     * xdg-desktop-portal
+    * pipewire-pulse
+    * OpenGL or Vulkan runtime libraries
 * Android
     * [Adreno drivers](https://github.com/K11MCH1/AdrenoToolsDrivers/releases/)
 * Others

--- a/building.md
+++ b/building.md
@@ -125,6 +125,12 @@ If you aren't satisfied with the way the Visual Studio integrates CMake projects
   sudo dnf install git cmake ninja-build SDL2-devel pkg-config gtk3-devel clang lld xdg-desktop-portal openssl openssl-devel libstdc++-static qt6-qtbase-devel
   ```
 
+### Arch Linux
+
+  ```sh
+  sudo pacman -Syu --needed dbus python qt6-base qt6-multimedia qt6-svg qt6-tools sdl3 boost boost-libs clang cmake git lld ninja pkgconf openssl which
+  ```
+
 Note: Your Qt packages must provide Qt 6.11 or newer. If your distro ships an older Qt, install the official Qt 6.11 package and set `Qt6_ROOT` before running CMake.
 
 Note: The CMake preset `linux-ninja-clang` makes use of the LLD linker, which will need to be installed in your system along with Clang.


### PR DESCRIPTION
README.md: added dependencies required to execute on Linux.

I used a Arch Linux container using Distrobox (because is easier to get Qt 6.11). This is the reason that have a lot of packages: ninja failed because many elemental packages are not in the system.

Thanks to the *vita3k-bin* and *vita4k-git* AUR packages (from  EXtremeExploit ), I found the names of the Qt dependencies.