### PR TITLE
fix(config): prevent crash on early CLI exit caused by uninitialized vita_fs_path

### DIFF
--- a/vita3k/main.cpp
+++ b/vita3k/main.cpp
@@ -122,8 +122,6 @@ int main(int argc, char *argv[]) {
     EmuEnvState emuenv;
     const auto config_err = config::init_config(cfg, argc, argv, root_paths, portable);
 
-    fs::create_directories(cfg.get_vita_fs_path());
-
     if (config_err != Success) {
         if (config_err == QuitRequested) {
             if (cfg.recompile_shader_path.has_value()) {
@@ -138,12 +136,14 @@ int main(int argc, char *argv[]) {
                 fs::remove_all(root_paths.get_cache_path() / "shaders" / *cfg.delete_title_id);
             }
             if (cfg.pup_path.has_value()) {
+                fs::create_directories(cfg.get_vita_fs_path());
                 LOG_INFO("Installing firmware file {}", *cfg.pup_path);
                 install_pup(cfg.get_vita_fs_path(), *cfg.pup_path, [](uint32_t progress) {
                     LOG_INFO("Firmware installation progress: {}%", progress);
                 });
             }
             if (cfg.pkg_path.has_value() && cfg.pkg_zrif.has_value()) {
+                fs::create_directories(cfg.get_vita_fs_path());
                 LOG_INFO("Installing pkg from {} ", *cfg.pkg_path);
                 emuenv.cache_path = root_paths.get_cache_path().generic_path();
                 emuenv.vita_fs_path = cfg.get_vita_fs_path();
@@ -155,6 +155,8 @@ int main(int argc, char *argv[]) {
         LOG_ERROR("Failed to initialise config");
         return InitConfigFailed;
     }
+
+    fs::create_directories(cfg.get_vita_fs_path());
 
     gui::i18n::apply_ui_language(app, cfg.user_lang, emuenv.static_assets_path);
 


### PR DESCRIPTION
## Description
When running Vita3K from the command line with early-exit flags such as `--help`, `--version`, `--firmware <pup>`, or `--pkg <pkg> --zrif <zrif>` (particularly on a fresh install before `config.yml` exists), the emulator crashes immediately with:
```
boost::filesystem::create_directories: Invalid argument [generic:22]
```

## Root Cause
In PR #4012 (`Rename pref_path to vita_fs_path`), `cfg.set_vita_fs_path()` was moved to the very end of `config::init_config`. When an early-exit option is supplied, `init_config` returns `QuitRequested` before reaching line 458, leaving `cfg.vita_fs_path` empty.
In `main.cpp`, `fs::create_directories(cfg.get_vita_fs_path())` was called unconditionally before checking `config_err`, causing Boost.Filesystem to throw `EINVAL` when passed an empty path `""`.

## Solution
1. In `vita3k/config/src/config.cpp`: Ensure `cfg.vita_fs_path` is initialized with `root_paths.get_vita_fs_path()` right at the beginning of `init_config` if currently empty.
2. In `vita3k/main.cpp`: Move the general `fs::create_directories` call down after `config_err == Success`, and explicitly ensure directory creation when actually installing firmware or packages under `QuitRequested`.

## Testing
- Verified `./Vita3K.exe --version` exits with code 0 and prints version without crashing.
- Verified `./Vita3K.exe --help` prints CLI options cleanly with exit code 0.
- Verified `./Vita3K.exe --firmware <PUP>` successfully unpacks and installs PlayStation Vita firmware 3.74.
- Verified `./Vita3K.exe --pkg <PKG> --zrif <zRIF>` successfully decrypts and installs packages.
