### PR TITLE
util: Use "Vita3k" as tag for spdlog Android sink

### DIFF
--- a/vita3k/glutil/src/shader.cpp
+++ b/vita3k/glutil/src/shader.cpp
@@ -37,7 +37,7 @@ UniqueGLObject gl::load_shaders(const fs::path &vertex_file_path, const fs::path
     GLuint vs = glCreateShader(GL_VERTEX_SHADER);
     GLuint fs = glCreateShader(GL_FRAGMENT_SHADER);
 
-#ifdef ANDROID
+#ifdef __ANDROID__
     const std::string gl_version = "#version 300 es\nprecision highp float;\n";
 #else
     const std::string gl_version = "#version 410 core\n";

--- a/vita3k/util/src/logging.cpp
+++ b/vita3k/util/src/logging.cpp
@@ -87,7 +87,7 @@ ExitCode init(const Root &root_paths, bool use_stdout) {
     sinks.clear();
     if (use_stdout)
 #ifdef __ANDROID__
-        sinks.push_back(std::make_shared<spdlog::sinks::android_sink_mt>());
+        sinks.push_back(std::make_shared<spdlog::sinks::android_sink_mt>("Vita3K"));
 #else
         sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
 #endif


### PR DESCRIPTION
- Use tag `Vita3k` (the same tag used in the [Java code](https://github.com/Vita3K/Vita3K/blob/master/android%2Fapp%2Fsrc%2Fmain%2Fjava%2Forg%2Fvita3k%2Femulator%2FEmulator.java#L69-L69)) for spdlog Android sink instead of the default tag `spdlog`, to distinguish it from other apps that might use the default tag too.
- Use the macro `__ANDROID__` instead of `ANDROID`. `__ANDROID__` is a [pre-defined compiler macro](https://sourceforge.net/p/predef/wiki/Home/), but `ANDROID` is just defined by CMake Android toolchain.