### PR TITLE
tracy: Add frame image & timings

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -420,7 +420,7 @@ if(NOT (CMAKE_BUILD_TYPE STREQUAL "Release"))
 		"Enable and require Tracy to compile core components such as the renderer, shader recompiler and
 			HLE modules"
 		ON)
-	option(TRACY_NO_FRAME_IMAGE, ON)
+	option(TRACY_NO_FRAME_IMAGE, OFF)
 
 	add_library(tracy STATIC tracy/public/TracyClient.cpp)
 	target_include_directories(tracy SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tracy/public>)

--- a/vita3k/mem/src/mem.cpp
+++ b/vita3k/mem/src/mem.cpp
@@ -27,6 +27,10 @@
 #include <mutex>
 #include <utility>
 
+#ifdef TRACY_ENABLE
+#include <tracy/Tracy.hpp>
+#endif
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -194,6 +198,16 @@ static Address alloc_inner(MemState &state, uint32_t start_page, uint32_t page_c
         state.page_name_map.emplace(page_num, name);
     }
 
+#ifdef TRACY_ENABLE
+    if (TracyIsConnected) {
+        const char *alloc_name = (name && *name) ? name : "Guest Memory";
+        TracyAllocN(reinterpret_cast<void *>(static_cast<uintptr_t>(addr)), size, alloc_name);
+        const uint64_t total_allocated = (static_cast<uint64_t>(state.allocator.max_offset) * STANDARD_PAGE_SIZE) - mem_available(state);
+        TracyPlotConfig("Game Memory: Total Allocated", tracy::PlotFormatType::Memory, true, true, 0);
+        TracyPlot("Game Memory: Total Allocated", static_cast<int64_t>(total_allocated));
+    }
+#endif
+
     return addr;
 }
 
@@ -216,6 +230,16 @@ Address alloc_aligned(MemState &state, uint32_t size, const char *name, unsigned
         page.allocated = 0;
         align_page.allocated = 1;
         align_page.size = page.size - remnant_front;
+
+#ifdef TRACY_ENABLE
+        if (TracyIsConnected) {
+            const char *alloc_name = (name && *name) ? name : "Guest Memory";
+            TracyFreeN(reinterpret_cast<void *>(static_cast<uintptr_t>(addr)), alloc_name);
+            TracyAllocN(reinterpret_cast<void *>(static_cast<uintptr_t>(align_addr)), align_page.size * STANDARD_PAGE_SIZE, alloc_name);
+            const uint64_t total_allocated = (static_cast<uint64_t>(state.allocator.max_offset) * STANDARD_PAGE_SIZE) - mem_available(state);
+            TracyPlot("Game Memory: Total Allocated", static_cast<int64_t>(total_allocated));
+        }
+#endif
     }
 
     return align_addr;
@@ -497,6 +521,15 @@ void free(MemState &state, Address address) {
     if (PAGE_NAME_TRACKING) {
         state.page_name_map.erase(page_num);
     }
+
+#ifdef TRACY_ENABLE
+    if (TracyIsConnected) {
+        TracyFreeN(reinterpret_cast<void *>(static_cast<uintptr_t>(address)), "Guest Memory");
+        const uint64_t total_allocated = (static_cast<uint64_t>(state.allocator.max_offset) * STANDARD_PAGE_SIZE) - mem_available(state);
+        TracyPlotConfig("Game Memory: Total Allocated", tracy::PlotFormatType::Memory, true, true, 0);
+        TracyPlot("Game Memory: Total Allocated", static_cast<int64_t>(total_allocated));
+    }
+#endif
 
     assert(!state.use_page_table || state.page_table[address / KiB(4)] == state.memory.get());
     const Address region_start = page_num * STANDARD_PAGE_SIZE;

--- a/vita3k/renderer/include/renderer/functions.h
+++ b/vita3k/renderer/include/renderer/functions.h
@@ -68,7 +68,7 @@ void reset_command_list(CommandList &command_list);
 void submit_command_list(State &state, renderer::Context *context, CommandList &command_list);
 bool is_cmd_ready(MemState &mem, CommandList &command_list);
 void process_batch(State &state, MemState &mem, Config &config, CommandList &command_list);
-void process_batches(State &state, const FeatureState &features, MemState &mem, Config &config, int64_t max_wait_ms = 500);
+size_t process_batches(State &state, const FeatureState &features, MemState &mem, Config &config, int64_t max_wait_ms = 500);
 void start_render_thread(State &state, DisplayState &display, GxmState &gxm, MemState &mem, Config &config);
 void stop_render_thread(State &state);
 bool init(FrameHost &frame, std::unique_ptr<State> &state, Backend backend, const Config &config, const Root &root_paths);

--- a/vita3k/renderer/src/batch.cpp
+++ b/vita3k/renderer/src/batch.cpp
@@ -26,6 +26,8 @@
 #include <config/state.h>
 #include <display/state.h>
 #include <functional>
+#include <mem/functions.h>
+#include <mem/state.h>
 #include <overlay/display_manager.h>
 #include <overlay/shader_precompile_progress.h>
 #include <util/log.h>
@@ -35,6 +37,7 @@
 
 #ifdef TRACY_ENABLE
 #include <tracy/Tracy.hpp>
+#include <util/tracy.h>
 #endif
 
 struct FeatureState;
@@ -76,6 +79,17 @@ static renderer::SyncWaitResult wait_cmd(MemState &mem, CommandList &command_lis
 }
 
 static void process_batch(renderer::State &state, const FeatureState &features, MemState &mem, Config &config, CommandList &command_list) {
+#ifdef TRACY_ENABLE
+    TRACY_FUNC_COMMANDS(process_batch);
+    if (_tracy_activation_state) {
+        size_t cmd_count = 0;
+        for (Command *c = command_list.first; c != nullptr; c = c->next) {
+            cmd_count++;
+        }
+        ZoneTextF("Commands: %zu", cmd_count);
+    }
+#endif
+
     using CommandHandlerFunc = decltype(cmd_handle_set_context);
 
     const static std::map<CommandOpcode, CommandHandlerFunc *> handlers = {
@@ -128,16 +142,17 @@ static void process_batch(renderer::State &state, const FeatureState &features, 
     } while (true);
 }
 
-void process_batches(renderer::State &state, const FeatureState &features, MemState &mem, Config &config, int64_t max_wait_ms) {
+size_t process_batches(renderer::State &state, const FeatureState &features, MemState &mem, Config &config, int64_t max_wait_ms) {
     auto max_time = duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() + max_wait_ms;
+    size_t batches_processed = 0;
 
     while (!state.should_display) {
         if (state.render_abort.load(std::memory_order_relaxed))
-            return;
+            return batches_processed;
 
         // overlay requested an async present
         if (state.async_flip_requested.load(std::memory_order_relaxed))
-            return;
+            return batches_processed;
 
         // Try to wait for a batch (about 2 or 3ms, game should be fast for this)
         auto cmd_list = state.command_buffer_queue.top(3);
@@ -145,35 +160,44 @@ void process_batches(renderer::State &state, const FeatureState &features, MemSt
         if (!cmd_list || !is_cmd_ready(mem, *cmd_list)) {
             // beginning of the game or homebrew not using gxm
             if (state.context == nullptr)
-                return;
+                return batches_processed;
 
             // keep the old behavior for opengl with vsync as it looks like the new one causes some issues
             if (state.current_backend == Backend::OpenGL && config.current_config.v_sync)
-                return;
+                return batches_processed;
 
             renderer::SyncWaitResult wait_result = renderer::SyncWaitResult::TimedOut;
             if (cmd_list)
                 wait_result = wait_cmd(mem, *cmd_list);
             if (!cmd_list || wait_result != renderer::SyncWaitResult::Ready) {
                 if (wait_result == renderer::SyncWaitResult::Shutdown)
-                    return;
+                    return batches_processed;
 
                 if (state.async_flip_requested.load(std::memory_order_relaxed))
-                    return;
+                    return batches_processed;
 
                 auto curr_time = duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
                 if (curr_time >= max_time)
                     // display a frame even though the game is not diplaying anything
-                    return;
+                    return batches_processed;
 
                 // this mean the command is still not ready, check if we can display it again
                 continue;
             }
         }
 
+#ifdef TRACY_ENABLE
+        if (TracyIsConnected) {
+            TracyPlot("Command Queue Depth", static_cast<int64_t>(state.command_buffer_queue.size()));
+        }
+#endif
+
         state.command_buffer_queue.pop();
         process_batch(state, features, mem, config, *cmd_list);
+        batches_processed++;
     }
+
+    return batches_processed;
 }
 
 void reset_command_list(CommandList &command_list) {
@@ -242,6 +266,12 @@ static void render_loop(renderer::State &state, DisplayState &display, GxmState 
             state.swap_window();
         }
     }
+
+#ifdef TRACY_ENABLE
+    uint64_t last_vblank_count = display.vblank_count.load(std::memory_order_relaxed);
+    auto last_frame_time = std::chrono::steady_clock::now();
+#endif
+
     while (!state.render_abort.load(std::memory_order_relaxed)) {
 #ifdef TRACY_ENABLE
         ZoneScopedN("Game rendering");
@@ -249,7 +279,7 @@ static void render_loop(renderer::State &state, DisplayState &display, GxmState 
         if (!state.set_current())
             break;
 
-        process_batches(state, state.features, mem, config, 500);
+        size_t batches_processed = process_batches(state, state.features, mem, config, 500);
 
         if (state.render_abort.load(std::memory_order_relaxed))
             break;
@@ -273,6 +303,42 @@ static void render_loop(renderer::State &state, DisplayState &display, GxmState 
         state.async_flip_requested.store(false, std::memory_order_relaxed);
 
 #ifdef TRACY_ENABLE
+        if (TracyIsConnected) {
+            const uint64_t current_vblank = display.vblank_count.load(std::memory_order_relaxed);
+            const uint64_t delta_vblank = current_vblank - last_vblank_count;
+            last_vblank_count = current_vblank;
+
+            const auto now = std::chrono::steady_clock::now();
+            const double frame_time_ms = std::chrono::duration<double, std::milli>(now - last_frame_time).count();
+            last_frame_time = now;
+
+            const uint64_t total_mapped = (static_cast<uint64_t>(mem.allocator.max_offset) * 4096U) - mem_available(mem);
+
+            TracyPlotConfig("Frame Time (ms)", tracy::PlotFormatType::Number, false, true, 0);
+            TracyPlotConfig("VBlanks / Frame", tracy::PlotFormatType::Number, true, false, 0);
+            TracyPlotConfig("Batches / Frame", tracy::PlotFormatType::Number, true, false, 0);
+            TracyPlotConfig("Game Memory: Total Allocated", tracy::PlotFormatType::Memory, true, true, 0);
+
+            TracyPlot("Frame Time (ms)", frame_time_ms);
+            TracyPlot("VBlanks / Frame", static_cast<int64_t>(delta_vblank));
+            TracyPlot("Batches / Frame", static_cast<int64_t>(batches_processed));
+            TracyPlot("Game Memory: Total Allocated", static_cast<int64_t>(total_mapped));
+
+            ZoneTextF("VBlanks: %llu | Batches: %zu | Frame Time: %.2f ms", static_cast<unsigned long long>(delta_vblank), batches_processed, frame_time_ms);
+
+            uint32_t width = 0, height = 0;
+            std::vector<uint32_t> frame_buf = state.dump_frame(display, width, height);
+            if (!frame_buf.empty() && width > 0 && height > 0) {
+                for (uint32_t &pixel : frame_buf) {
+                    pixel |= 0xFF000000;
+                }
+                const uint16_t img_w = static_cast<uint16_t>(width & ~3);
+                const uint16_t img_h = static_cast<uint16_t>(height & ~3);
+                if (img_w > 0 && img_h > 0) {
+                    FrameImage(frame_buf.data(), img_w, img_h, 0, false);
+                }
+            }
+        }
         FrameMark;
 #endif
     }


### PR DESCRIPTION
* Adds the current frame to the tracy frame zone, which makes it appear in the connection summary
<img width="517" height="475" alt="image" src="https://github.com/user-attachments/assets/8e4cd1e4-e862-4ca1-9826-0750836ff950" />

And each frame can be seen individually in the timeline and you can know exactly when a frame happened

<img width="1027" height="692" alt="image" src="https://github.com/user-attachments/assets/192640f2-1655-438b-835c-4fbe76c08ff4" />

* Also adds info about the frame timings, like framtime, vblank count and how many batches were processed for the frame
<img width="637" height="210" alt="image" src="https://github.com/user-attachments/assets/409a4dcc-abda-44f2-a093-5ec6e535a0a7" />


* Also adds plot lines for command queue depth, Frame time, vblanks per frame, batches per frame and guest memory usage/allocated

<img width="1899" height="597" alt="image" src="https://github.com/user-attachments/assets/20985802-88d7-4afb-bbc3-984219a25604" />

Also update tracy to 0.14.1
